### PR TITLE
Move JSON callers onto JsonCodec

### DIFF
--- a/docs/coherence-substrate/form-stdlib-expression-audit.md
+++ b/docs/coherence-substrate/form-stdlib-expression-audit.md
@@ -26,7 +26,7 @@ The authored source shall be the closest expression of intent:
 
 | Area | Current Tissue | Closest Ideal | First Rewrite Move |
 | --- | --- | --- | --- |
-| JSON codec | `json.fk` still carries a hand parser; older tests and clients call `parse-json` directly. | `json-codec.fk` declares JSON as a structured codec; parse/emit enter through `JsonCodec`, and lower Form is generated or generic runtime execution. | Move all stdlib callers from `parse-json` to `json_parse_body`; then compost the old parser or make it generated output. |
+| JSON codec | `json.fk` still carries a hand parser for compiler/bootstrap and older seedbank/test paths; i18n and channel-query now enter through `JsonCodec`. | `json-codec.fk` declares JSON as a structured codec; parse/emit enter through `JsonCodec`, and lower Form is generated or generic runtime execution. | Remove the compiler/bootstrap cycle that keeps `parse-json` live; then compost the old parser or make it generated output. |
 | HTTP stack | `http-parse.fk`, `http-render.fk`, `http-serve.fk`, `http-server.fk`, `http-socket.fk`, `http-adapter.fk`, and `kernel-http.fk` split protocol, routing, rendering, and serving across hand-authored functions. | HTTP is a protocol grammar plus route graph: request grammar, response grammar, route classes, observation cells, and socket/listener lifecycle as one front door. | Declare HTTP/1.1 parse/render as a protocol codec, then route serving consumes request/response cells only. |
 | Route catalog | `router-routes.fk`, `kernel-http.fk`, and route tests still describe routes with low-level constructors. | Routes are high-grammar `RouteCell<Request, Response>` declarations with choice/fail/dispatch observation attached. | Convert the highest-traffic API routes into route classes that return codec-backed response cells. |
 | Source compiler | `source-compiler.fk`, `compiler.fk`, `engine.fk`, `bmf-core.fk`, `bmf-grammar.fk`, `grammar-chars.fk`, and `runtime-grammar.fk` overlap as compiler, grammar, runtime, emitter, and registry layers. | One grammar-of-grammars pipeline: source declaration -> grammar cells -> lowering cells -> executable recipes -> reversible source/trace. | Name one canonical compiler pipeline and mark overlapping engines as candidates to merge, generate, or release. |
@@ -34,8 +34,8 @@ The authored source shall be the closest expression of intent:
 | Python bridge | `python-bmf-lift.fk`, `python-bmf-eval.fk`, `grammars/python-bmf.fk`, and `emits/python-native*` are major bridge tissue. | Python is one optional grammar among many; no special runtime status, no privileged fallback. | Classify every Python bridge entry as: release now, compile through BML/BMF, or temporary call-out with a named compost gate. |
 | Emitters | `emit-engine.fk`, `seedbank/emits/*`, `emits/python-native*`, and self-witness emitters overlap. | Emitters are codec/target declarations over cell shapes with one reusable engine and target-specific declarations. | Promote the useful seedbank emit templates into codec declarations or compost them. |
 | Query/path languages | `xpath.fk`, `doc-xpath.fk`, and `concept-xpath.fk` hand-parse path strings and walk trees. | Query is a graph/path grammar with typed selectors, predicates, and substrate coordinates. | Replace split-loop path parsing with a reusable query grammar and lens registry. |
-| i18n and corpus loading | `i18n.fk` carries static locale lists and direct JSON parser calls. | Locales are discovered corpus cells; JSON is only a codec selector. | Use `json_parse_body` and replace static locale lists with a manifest/corpus query. |
-| Channel JSON bridge | `channel-query-json.fk` manually maps channel/query cells to JSON strings and parses JSON back. | Channel query has a native cell protocol; JSON is a codec projection at the boundary. | Rebuild the bridge as channel-query cells + `JsonCodec` projection, then delete bespoke JSON wiring. |
+| i18n and corpus loading | `i18n.fk` now loads through `json_parse_body`; static locale lists remain. | Locales are discovered corpus cells; JSON is only a codec selector. | Replace static locale lists with a manifest/corpus query. |
+| Channel JSON bridge | `channel-query-json.fk` now projects query/response values into JSON cells and emits/parses through `JsonCodec`; response decode and richer item schemas remain. | Channel query has a native cell protocol; JSON is a codec projection at the boundary. | Add response decode as cell projection and move mixed item schemas into declarations. |
 | Storage and carriers | `storage-port*.fk`, `persistence.fk`, `cell-log-store.fk`, and carrier integration files encode carriers with lists and callbacks. | Carriers are capability cells with protocol laws, observation, and interchangeable persistence grammars. | Name carrier specs and move list offsets into typed carrier cells. |
 | Field model | `field-model-form.fk` and `field-model-form-runtime.fk` contain many list/accessor and symbolic math helpers. | Field concepts are model cells with algebraic laws, observation, and reusable dimensional operators. | Split authored domain declarations from generic numeric/topology runtime support. |
 | Algorithms and encodings | `base64.fk`, `hex.fk`, `url-encode.fk`, `rle.fk`, `uuid.fk`, `ulid.fk`, `sha256.fk`, `hmac-sha256.fk`, `crc32.fk`, `adler32.fk`, `dns.fk`. | Algorithm families are law declarations with reference vectors, possible native primitive realization, and generated runners. | Keep exact algorithms where needed, but wrap them in law/spec declarations and mark hot ones for native primitive/JIT treatment. |
@@ -56,11 +56,10 @@ For each stdlib file touched on a hot path:
 
 ## First Rewrite Sequence
 
-1. Finish JSON as the pattern: `JsonCodec` is the only route-facing JSON surface;
-   direct `parse-json` callers move to `json_parse_body`; old parser tissue is
-   either generated or released.
-2. Move `channel-query-json.fk` and `i18n.fk` onto `JsonCodec`, because they keep
-   JSON duplication alive.
+1. Finish JSON as the pattern: `JsonCodec` is the only route-facing and corpus
+   JSON surface; old parser tissue is either generated or released.
+2. Move the compiler/bootstrap ontology loader off `parse-json` by removing the
+   source-compiler cycle that currently needs it while compiling codec sections.
 3. Lift HTTP parse/render into a protocol codec, then make native route classes
    consume only request and response cells.
 4. Consolidate compiler/grammar engines by naming one source-to-recipe pipeline

--- a/docs/system_audit/commit_evidence_2026-06-08_json_codec_callers.json
+++ b/docs/system_audit/commit_evidence_2026-06-08_json_codec_callers.json
@@ -1,0 +1,126 @@
+{
+  "date": "2026-06-08",
+  "thread_branch": "codex/json-codec-callers-20260608",
+  "commit_scope": "Move i18n and channel-query JSON callers onto the BML JsonCodec surface, replacing direct parse-json and bespoke JSON string emission with codec-backed JSON cell projection.",
+  "files_owned": [
+    "docs/coherence-substrate/form-stdlib-expression-audit.md",
+    "docs/system_audit/commit_evidence_2026-06-08_json_codec_callers.json",
+    "form/form-samples/cross-modal/36-channel-query-json/channel-query-json.fk",
+    "form/form-stdlib/cache.fk",
+    "form/form-stdlib/channel-query-json.fk",
+    "form/form-stdlib/form-ontology-loader.fk",
+    "form/form-stdlib/i18n.fk",
+    "form/form-stdlib/tests/channel-query-json-band.fk",
+    "form/form-stdlib/tests/concept-i18n-band.fk",
+    "form/form-stdlib/tests/i18n-extensions-band.fk",
+    "form/form-stdlib/tests/nl-emit-band.fk",
+    "form/form-stdlib/tests/self-witness-band.fk"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "make wellness",
+      "find form/form-stdlib/.cache -maxdepth 1 -type f \\( -name 'i18n-*.fkb' -o -name 'cli-i18n-*.fkb' -o -name 'presence-walk-i18n-*.fkb' \\) -delete",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/tests/i18n-extensions-band.fk",
+      "cd form && ./validate.sh --binary form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/tests/i18n-extensions-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/sha256.fk form-stdlib/channel-query.fk form-stdlib/channel-query-json.fk form-stdlib/tests/channel-query-json-band.fk",
+      "cd form && ./validate.sh --binary form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/sha256.fk form-stdlib/channel-query.fk form-stdlib/channel-query-json.fk form-stdlib/tests/channel-query-json-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/concept-corpus.fk form-stdlib/concept-i18n-bridge.fk form-stdlib/tests/concept-i18n-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/nl-emit.fk form-stdlib/tests/nl-emit-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/self-witness.fk form-stdlib/tests/self-witness-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/sha256.fk form-stdlib/channel-query.fk form-stdlib/channel-query-json.fk form-samples/cross-modal/36-channel-query-json/channel-query-json.fk",
+      "cd form && ./validate.sh --binary form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/sha256.fk form-stdlib/channel-query.fk form-stdlib/channel-query-json.fk form-samples/cross-modal/36-channel-query-json/channel-query-json.fk",
+      "git diff --check"
+    ],
+    "results": {
+      "prompt_guide": "pass",
+      "wellness": "pass; kernel-native API reading remains 22/812 kernel-served and 0 front-door kernel-first",
+      "i18n_source": "117; 1 ok, 0 divergent after clearing generated i18n .fkb caches",
+      "i18n_binary": "117; 1 ok, 0 divergent",
+      "channel_query_source": "4; 1 ok, 0 divergent",
+      "channel_query_binary": "4; 1 ok, 0 divergent",
+      "concept_i18n_source": "1710; 1 ok, 0 divergent",
+      "nl_emit_source": "550; 1 ok, 0 divergent",
+      "self_witness_source": "1120; 1 ok, 0 divergent",
+      "channel_sample_source": "query-json-match: 1; response-json-match: 1; verdict 2; 1 ok, 0 divergent",
+      "channel_sample_binary": "query-json-match: 1; response-json-match: 1; verdict 2; 1 ok, 0 divergent",
+      "diff_check": "pass"
+    }
+  },
+  "ci_validation": {
+    "status": "pass",
+    "notes": "Local source and binary sibling-kernel gates pass for this stacked Form/runtime slice; external PR checks rerun after push and remain the merge gate."
+  },
+  "deploy_validation": {
+    "status": "pass",
+    "notes": "No public deployment changed in this commit; behavior is covered by Form source and binary sibling validation."
+  },
+  "phase_gate": {
+    "can_move_next_phase": true,
+    "blocked_by": []
+  },
+  "idea_ids": [
+    "idea:form-owned-json",
+    "idea:kernel-native-api-front-door"
+  ],
+  "spec_ids": [
+    "spec:substrate-compiler",
+    "spec:native-kernel-http"
+  ],
+  "task_ids": [
+    "task:json-codec-callers"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "coder",
+        "validator"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/tests/i18n-extensions-band.fk",
+    "form/form-stdlib/tests/channel-query-json-band.fk",
+    "form/form-samples/cross-modal/36-channel-query-json/channel-query-json.fk",
+    "docs/coherence-substrate/form-stdlib-expression-audit.md"
+  ],
+  "change_files": [
+    "docs/coherence-substrate/form-stdlib-expression-audit.md",
+    "form/form-samples/cross-modal/36-channel-query-json/channel-query-json.fk",
+    "form/form-stdlib/cache.fk",
+    "form/form-stdlib/channel-query-json.fk",
+    "form/form-stdlib/form-ontology-loader.fk",
+    "form/form-stdlib/i18n.fk",
+    "form/form-stdlib/tests/channel-query-json-band.fk",
+    "form/form-stdlib/tests/concept-i18n-band.fk",
+    "form/form-stdlib/tests/i18n-extensions-band.fk",
+    "form/form-stdlib/tests/nl-emit-band.fk",
+    "form/form-stdlib/tests/self-witness-band.fk"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "i18n corpus loaders and channel-query JSON bridges now enter JSON through json_parse_body/json_response_body. Channel query values are projected into JSON cells before emission instead of constructing JSON strings by hand.",
+    "public_endpoints": [
+      "form://form-stdlib/tests/i18n-extensions-band.fk",
+      "form://form-stdlib/tests/channel-query-json-band.fk",
+      "form://form-samples/cross-modal/36-channel-query-json/channel-query-json.fk"
+    ],
+    "test_flows": [
+      "Clear generated i18n .fkb caches, then run source and binary sibling-kernel validation for i18n and channel-query JSON workloads."
+    ],
+    "gaps_found_and_closed": [
+      "i18n still used read_with_cache(..., parse-json); moved web, CLI, and presence-walk loaders to json_parse_body.",
+      "channel-query-json still had bespoke JSON quote/int/object string helpers; replaced query and response emission with JSON cell projection plus json_response_body.",
+      "json-to-query still parsed through parse-json; moved it to json_parse_body.",
+      "form-ontology-loader still needs the bootstrap parser while compiling codec/BML sections; named that as a compiler-pipeline cycle rather than hiding it."
+    ]
+  }
+}

--- a/form/form-samples/cross-modal/36-channel-query-json/channel-query-json.fk
+++ b/form/form-samples/cross-modal/36-channel-query-json/channel-query-json.fk
@@ -1,7 +1,7 @@
 ; channel-query-json.fk — encode a QUERY and a RESPONSE into JSON for
 ; a non-Form HTTP service (Slack webhook, Discord bot, generic REST).
 ;
-; preludes: form-stdlib/json.fk form-stdlib/channel-query.fk form-stdlib/sha256.fk form-stdlib/channel-query-json.fk
+; preludes: form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/channel-query.fk form-stdlib/sha256.fk form-stdlib/channel-query-json.fk
 ;
 ; The frame:
 ;   Form-native cells talk to each other through the channel-query

--- a/form/form-stdlib/cache.fk
+++ b/form/form-stdlib/cache.fk
@@ -44,8 +44,8 @@
 ;; path) or runs `parse-fn source-path source-text` and writes the
 ;; result back to the cache.
 ;;
-;; `parse-fn` is any (source-path text) → Recipe function. parse-json
-;; from form-stdlib/json.fk fits; future parse-yaml, parse-toml fit
+;; `parse-fn` is any (source-path text) → Recipe function. json_parse_body
+;; from form-stdlib/json-codec.fk fits; future parse-yaml, parse-toml fit
 ;; the same shape.
 
 (defn read_with_cache (source-path cache-path parse-fn)

--- a/form/form-stdlib/channel-query-json.fk
+++ b/form/form-stdlib/channel-query-json.fk
@@ -1,6 +1,6 @@
 ; channel-query-json.fk — JSON wire-bridge for the channel-query vocabulary.
 ;
-; preludes: form-stdlib/json.fk form-stdlib/channel-query.fk form-stdlib/sha256.fk
+; preludes: form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/channel-query.fk form-stdlib/sha256.fk
 ;
 ; The frame:
 ;   A QUERY/RESPONSE Recipe (channel-query.fk) is a substrate-resident
@@ -67,37 +67,17 @@
 ;   want substrate-refs and external-uris anyway — those round-trip
 ;   cleanly.
 
-;; --- low-level string helpers -------------------------------------
+;; --- JSON cell projection helpers ---------------------------------
 
-;; cqj-q — wrap a string as a JSON string literal. Escapes the two
-;; characters that MUST be escaped inside a JSON double-quoted string:
-;; backslash and quote. Other control characters are passed through
-;; (the verbs and statuses we emit are ASCII-safe by construction).
-(defn cqj-q-loop (s i n acc)
-    (if (eq i n) acc
-        (do
-            (let c (char_at s i))
-            (let cp (ord c))
-            (if (eq cp 92)
-                (cqj-q-loop s (add i 1) n (str_concat acc "\\\\"))
-                (if (eq cp 34)
-                    (cqj-q-loop s (add i 1) n (str_concat acc "\\\""))
-                    (cqj-q-loop s (add i 1) n (str_concat acc c)))))))
-
-(defn cqj-q (s)
-    (str_concat "\"" (str_concat (cqj-q-loop s 0 (str_len s) "") "\"")))
-
-;; cqj-int — render an integer as the JSON numeric form (no quotes).
-(defn cqj-int (i) (int_to_str i))
-
-;; cqj-nid-obj — emit a NodeID as a 4-key object.
-(defn cqj-nid-obj (nid)
-    (str_concat "{"
-    (str_concat "\"pkg\":"   (str_concat (cqj-int (node_pkg nid))
-    (str_concat ",\"level\":" (str_concat (cqj-int (node_level nid))
-    (str_concat ",\"type\":"  (str_concat (cqj-int (node_type nid))
-    (str_concat ",\"inst\":"  (str_concat (cqj-int (node_inst nid))
-                              "}"))))))))))
+;; cqj-nid-cell — project a NodeID into a JSON object cell. JsonCodec owns the
+;; text emission; this bridge only names the value shape.
+(defn cqj-nid-cell (nid)
+    (json-node-object
+        (list
+            (json-node-pair "pkg"   (json-node-int (node_pkg nid)))
+            (json-node-pair "level" (json-node-int (node_level nid)))
+            (json-node-pair "type"  (json-node-int (node_type nid)))
+            (json-node-pair "inst"  (json-node-int (node_inst nid))))))
 
 ;; cqj-nid-from-children — reconstruct a NodeID from 4 trivial-int
 ;; children (the on-wire form cq-nid-pack produces).
@@ -123,30 +103,33 @@
 (defn cqj-list-nth (xs i)
     (if (eq i 0) (head xs) (cqj-list-nth (tail xs) (sub i 1))))
 
-(defn cqj-body-to-json (body)
+(defn cqj-body-cell (body)
     (do
         (let kids (node_children body))
         (if (eq (len kids) 0)
-            ;; trivial leaf — render value
             (do
                 (let v (node_value body))
                 (if (str_eq (int_to_str v) "")
-                    "null"
-                    (cqj-q (int_to_str v))))
-            ;; composite — report arity-only stub
-            (str_concat "{\"recipe\":" (str_concat (cqj-int (len kids)) "}")))))
+                    (json-node-null)
+                    (json-node-string (int_to_str v))))
+            (json-node-object
+                (list (json-node-pair "recipe" (json-node-int (len kids))))))))
 
-(defn query-to-json (q)
+(defn query-to-json-cell (q)
     (do
         (let kids (node_children q))
         (let verb (node_value (cqj-list-nth kids 0)))
         (let addr-ref (cqj-list-nth kids 1))
         (let addr-nid (cq-nid-unpack-from-children (node_children addr-ref)))
         (let body (cqj-list-nth kids 2))
-        (str_concat "{\"verb\":"     (str_concat (cqj-q verb)
-        (str_concat ",\"address\":"  (str_concat (cqj-nid-obj addr-nid)
-        (str_concat ",\"body\":"     (str_concat (cqj-body-to-json body)
-                                     "}"))))))))
+        (json-node-object
+            (list
+                (json-node-pair "verb" (json-node-string verb))
+                (json-node-pair "address" (cqj-nid-cell addr-nid))
+                (json-node-pair "body" (cqj-body-cell body))))))
+
+(defn query-to-json (q)
+    (json_response_body (query-to-json-cell q)))
 
 ;; --- query decoder ------------------------------------------------
 ;;
@@ -167,7 +150,7 @@
 
 (defn json-to-query (s)
     (do
-        (let root (parse-json "channel-query-json" s))
+        (let root (json_parse_body "channel-query-json" s))
         (let cat (node_category root))
         (if (eq (node_inst cat) 10)            ; JSON-OBJECT
             (if (and (json-object-has? root "verb")
@@ -183,21 +166,22 @@
 
 ;; --- response encoder ---------------------------------------------
 
-;; cqj-item-to-json — render one mixed-content item by inspecting its
+;; cqj-item-to-json-cell — project one mixed-content item by inspecting its
 ;; Blueprint category. SUBSTRATE-REF and CELL-REF fully round-trip;
 ;; NOVEL-BLUEPRINT, RECIPE-CONTENT carry a shape stub; EXTERNAL-URI
 ;; carries url + the sha256 byte-count (the bytes themselves are not
 ;; safe to inline in JSON without further encoding — base64 would
 ;; pull form-stdlib/base64.fk in as a prelude; postponed).
 
-(defn cqj-item-substrate-or-cell (item type-label)
+(defn cqj-item-substrate-or-cell-cell (item type-label)
     (do
         (let nid (cq-nid-unpack-from-children (node_children item)))
-        (str_concat "{\"type\":\"" (str_concat type-label
-        (str_concat "\",\"value\":" (str_concat (cqj-nid-obj nid)
-                                    "}"))))))
+        (json-node-object
+            (list
+                (json-node-pair "type" (json-node-string type-label))
+                (json-node-pair "value" (cqj-nid-cell nid))))))
 
-(defn cqj-item-novel-or-recipe (item type-label)
+(defn cqj-item-novel-or-recipe-cell (item type-label)
     (do
         (let kids (node_children item))
         ;; novel-blueprint: first child is a SUBSTRATE-REF wrapping the
@@ -208,63 +192,80 @@
                 (let cat-ref (head kids))
                 (let cat-nid (cq-nid-unpack-from-children (node_children cat-ref)))
                 (let arity (sub (len kids) 1))
-                (str_concat "{\"type\":\"novel-blueprint\",\"value\":{\"category\":"
-                (str_concat (cqj-nid-obj cat-nid)
-                (str_concat ",\"arity\":" (str_concat (cqj-int arity) "}}")))))
+                (json-node-object
+                    (list
+                        (json-node-pair "type" (json-node-string "novel-blueprint"))
+                        (json-node-pair "value"
+                            (json-node-object
+                                (list
+                                    (json-node-pair "category" (cqj-nid-cell cat-nid))
+                                    (json-node-pair "arity" (json-node-int arity))))))))
             (do
                 (let inner (head kids))
                 (let cat-nid (node_category inner))
                 (let arity (len (node_children inner)))
-                (str_concat "{\"type\":\"recipe-content\",\"value\":{\"category\":"
-                (str_concat (cqj-nid-obj cat-nid)
-                (str_concat ",\"arity\":" (str_concat (cqj-int arity) "}}"))))))))
+                (json-node-object
+                    (list
+                        (json-node-pair "type" (json-node-string "recipe-content"))
+                        (json-node-pair "value"
+                            (json-node-object
+                                (list
+                                    (json-node-pair "category" (cqj-nid-cell cat-nid))
+                                    (json-node-pair "arity" (json-node-int arity)))))))))))
 
-(defn cqj-item-external (item)
+(defn cqj-item-external-cell (item)
     (do
         (let kids (node_children item))
         (let url (node_value (head kids))) ; first child is url string
         (let hash-len (sub (len kids) 1))
-        (str_concat "{\"type\":\"external-uri\",\"value\":{\"url\":"
-        (str_concat (cqj-q url)
-        (str_concat ",\"sha256_len\":" (str_concat (cqj-int hash-len) "}}"))))))
+        (json-node-object
+            (list
+                (json-node-pair "type" (json-node-string "external-uri"))
+                (json-node-pair "value"
+                    (json-node-object
+                        (list
+                            (json-node-pair "url" (json-node-string url))
+                            (json-node-pair "sha256_len" (json-node-int hash-len)))))))))
 
-(defn cqj-item-to-json (item)
+(defn cqj-item-to-json-cell (item)
     (do
         (let cat (node_category item))
         (let ci (node_inst cat))
-        (if (eq ci 1712) (cqj-item-substrate-or-cell item "substrate-ref")
-        (if (eq ci 1715) (cqj-item-substrate-or-cell item "cell-ref")
-        (if (eq ci 1713) (cqj-item-novel-or-recipe   item "novel-blueprint")
-        (if (eq ci 1714) (cqj-item-novel-or-recipe   item "recipe-content")
-        (if (eq ci 1716) (cqj-item-external item)
-            "{\"type\":\"unknown\"}")))))))
+        (if (eq ci 1712) (cqj-item-substrate-or-cell-cell item "substrate-ref")
+        (if (eq ci 1715) (cqj-item-substrate-or-cell-cell item "cell-ref")
+        (if (eq ci 1713) (cqj-item-novel-or-recipe-cell   item "novel-blueprint")
+        (if (eq ci 1714) (cqj-item-novel-or-recipe-cell   item "recipe-content")
+        (if (eq ci 1716) (cqj-item-external-cell item)
+            (json-node-object
+                (list (json-node-pair "type" (json-node-string "unknown")))))))))))
 
-(defn cqj-items-to-json-loop (items i n acc)
-    (if (eq i n) acc
+(defn cqj-items-to-cell-loop (items i n acc)
+    (if (eq i n) (json-reverse-acc acc)
         (do
             (let item (cqj-list-nth items i))
-            (let chunk (cqj-item-to-json item))
-            (let sep (if (eq i 0) "" ","))
-            (cqj-items-to-json-loop items (add i 1) n
-                (str_concat acc (str_concat sep chunk))))))
+            (cqj-items-to-cell-loop items (add i 1) n
+                (cons (cqj-item-to-json-cell item) acc)))))
 
-(defn cqj-items-to-json (items)
-    (str_concat "["
-        (str_concat (cqj-items-to-json-loop items 0 (len items) "") "]")))
+(defn cqj-items-to-cell (items)
+    (json-node-array (cqj-items-to-cell-loop items 0 (len items) (empty))))
 
 ;; A RESPONSE recipe's children, per channel-query.fk:
 ;;   [0] correlation (trivial-int)
 ;;   [1] status (trivial-string)
 ;;   [2] items wrapper (composite; its children are the items themselves)
-(defn response-to-json (r)
+(defn response-to-json-cell (r)
     (do
         (let kids (node_children r))
         (let corr (node_value (cqj-list-nth kids 0)))
         (let status (node_value (cqj-list-nth kids 1)))
         (let items (node_children (cqj-list-nth kids 2)))
-        (str_concat "{\"correlation\":"  (str_concat (cqj-int corr)
-        (str_concat ",\"status\":"       (str_concat (cqj-q status)
-        (str_concat ",\"items\":"        (str_concat (cqj-items-to-json items)
-                                         "}"))))))))
+        (json-node-object
+            (list
+                (json-node-pair "correlation" (json-node-int corr))
+                (json-node-pair "status" (json-node-string status))
+                (json-node-pair "items" (cqj-items-to-cell items))))))
+
+(defn response-to-json (r)
+    (json_response_body (response-to-json-cell r)))
 
 0

--- a/form/form-stdlib/form-ontology-loader.fk
+++ b/form/form-stdlib/form-ontology-loader.fk
@@ -16,11 +16,12 @@
 ; → gas (env bindings).
 ;
 ; Prelude requirement: form-stdlib/json.fk must load before this
-; file so parse-json and the json-* accessors are in scope.
+; file so the bootstrap parser and json-* accessors are in scope.
 
 ;; --- read + parse (with .fkb cache) ---------------------------------
 ;;
-;; First load: parse-json runs (~84 ms on form-ontology.json's 18 KB),
+;; First load: the bootstrap JSON parser runs (~84 ms on
+;; form-ontology.json's 18 KB),
 ;; writes the parsed Recipe to form-stdlib/.cache/form-ontology.fkb.
 ;; Subsequent loads: read_form_binary in microseconds. Cache invalidates
 ;; when form-ontology.json's mtime advances past the .fkb's. See
@@ -28,7 +29,10 @@
 ;;
 ;; Prelude requirement: form-stdlib/cache.fk must load before this
 ;; file so read_with_cache + cache-fresh? are in scope. Earlier deps
-;; (form-stdlib/json.fk for parse-json) still required.
+;; (form-stdlib/json.fk for the bootstrap parser) still required. This
+;; loader participates in compiling BML/codec sections, so moving it to
+;; JsonCodec belongs with the compiler-pipeline rewrite that removes that
+;; bootstrap cycle.
 
 (let ONTOLOGY-JSON
     (read_with_cache "form-stdlib/form-ontology.json"

--- a/form/form-stdlib/i18n.fk
+++ b/form/form-stdlib/i18n.fk
@@ -22,8 +22,9 @@
 ; each locale." Multiply across 4 locales × 2300 keys → ~9300 observed
 ; emission triples.
 ;
-; Prelude requirement: form-stdlib/json.fk and form-stdlib/cache.fk
-; must load before this file.
+; Prelude requirement: form-stdlib/json.fk, form-stdlib/cache.fk,
+; form-stdlib/codec.fk, form-stdlib/structured-codec.fk, and
+; form-stdlib/json-codec.fk must load before this file.
 
 ;; --- locale-file paths ----------------------------------------------
 ;;
@@ -50,7 +51,7 @@
     (read_with_cache
         (i18n-source-path locale-name)
         (i18n-cache-path locale-name)
-        parse-json))
+        json_parse_body))
 
 ;; --- key-path traversal --------------------------------------------
 ;;
@@ -112,7 +113,7 @@
 ;;
 ;; Use (i18n-string-by-path (cli-i18n-load "de") (list "help" "usage"))
 ;; to read a CLI surface in any locale, same shape as the web loader.
-;; The composition is bottom-up: same read_with_cache, same parse-json,
+;; The composition is bottom-up: same read_with_cache, same JsonCodec,
 ;; only the source/cache paths change.
 (defn cli-i18n-source-path (locale-name)
     (str_concat "../cli/lib/messages/"
@@ -126,7 +127,7 @@
     (read_with_cache
         (cli-i18n-source-path locale-name)
         (cli-i18n-cache-path locale-name)
-        parse-json))
+        json_parse_body))
 
 ;; --- sibling corpora: web/content/presence-walk --------------------
 ;;
@@ -146,6 +147,6 @@
     (read_with_cache
         (presence-walk-i18n-source-path locale-name)
         (presence-walk-i18n-cache-path locale-name)
-        parse-json))
+        json_parse_body))
 
 0

--- a/form/form-stdlib/tests/channel-query-json-band.fk
+++ b/form/form-stdlib/tests/channel-query-json-band.fk
@@ -1,6 +1,6 @@
 ; tests/channel-query-json-band.fk — channel-query JSON bridge sibling-witness band.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/sha256.fk form-stdlib/channel-query.fk form-stdlib/channel-query-json.fk
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/sha256.fk form-stdlib/channel-query.fk form-stdlib/channel-query-json.fk
 ;
 ; Exercises the bridge on:
 ;   - a QUERY (encode → match canonical string; decode → reconstruct verb+address)

--- a/form/form-stdlib/tests/concept-i18n-band.fk
+++ b/form/form-stdlib/tests/concept-i18n-band.fk
@@ -18,7 +18,7 @@
 ; end-to-end on real corpora, and we're naming the current state
 ; truthfully.
 ;
-; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/concept-corpus.fk form-stdlib/concept-i18n-bridge.fk
+; preludes: form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/concept-corpus.fk form-stdlib/concept-i18n-bridge.fk
 
 (do
     ;; --- load all four locales once --------------------------------

--- a/form/form-stdlib/tests/i18n-extensions-band.fk
+++ b/form/form-stdlib/tests/i18n-extensions-band.fk
@@ -5,7 +5,7 @@
 ; Three kernels must agree on every locale × key probe and the
 ; aggregate score.
 ;
-; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/i18n.fk
+; preludes: form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/cache.fk form-stdlib/i18n.fk
 
 (do
     ;; --- CLI corpus: help.usage across four locales ----------------

--- a/form/form-stdlib/tests/nl-emit-band.fk
+++ b/form/form-stdlib/tests/nl-emit-band.fk
@@ -11,7 +11,7 @@
 ; probes reuse those handles. Rust today runs Form without GC, so
 ; load-once-reuse-many is the discipline that keeps the band light.
 ;
-; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/nl-emit.fk
+; preludes: form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/nl-emit.fk
 
 (do
     (let en (i18n-load "en"))

--- a/form/form-stdlib/tests/self-witness-band.fk
+++ b/form/form-stdlib/tests/self-witness-band.fk
@@ -22,7 +22,7 @@
 ; delta drop toward zero on more corpora than just JSON. The witness
 ; this file embodies is the loss function the mutator will minimize.
 ;
-; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/self-witness.fk
+; preludes: form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/self-witness.fk
 
 (do
     ;; --- load en, narrow to the "common" section -------------------


### PR DESCRIPTION
## Summary
- move i18n loaders from direct parse-json to json_parse_body
- rebuild channel-query JSON emission as JSON cell projection plus json_response_body
- update the stdlib expression audit to name the remaining compiler/bootstrap parse-json cycle

## Proof
- make prompt-guide
- make wellness
- source and binary sibling validation for i18n extensions: 117
- source and binary sibling validation for channel-query JSON: 4
- channel-query cross-modal sample source/binary: query-json-match=1, response-json-match=1, verdict=2
- concept-i18n: 1710
- nl-emit: 550
- self-witness: 1120
- evidence validation: pass
- worktree PR guard: pass
- follow-through gate: pass after merging stale ready PR #2572 through the repo auto-merge path