### PR TITLE
tend: compile-time name-resolution gate — check catches unbound symbols before serve

### DIFF
--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -7961,6 +7961,151 @@ fn source_compile_manifest_recipe_object(
     compile_result
 }
 
+// Resolve every name in a compiled route recipe, returning the unresolved ones.
+// The evaluator resolves names LAZILY — it raises `unbound: <name>` only when the
+// walk reaches that node at serve time (RB_IDENT) — so a manifest with a dangling
+// reference compiles to a recipe and only fails in production. This runs the Form
+// resolution walk (form-stdlib/name-check.fk, scope-aware) over the lowered recipe
+// so the dangling reference is found BEFORE anything is served. The resolver IS
+// Form: this loads it into the route kernel and applies its `name-check` closure
+// to the route recipe — no resolution logic duplicated in Rust.
+fn name_check_route_recipe(
+    k: &mut Kernel,
+    stdlib_abs: &std::path::Path,
+    route_root: NodeID,
+) -> Result<Vec<String>, String> {
+    let nc_path = stdlib_abs.join("name-check.fk");
+    let nc_src = fs::read_to_string(&nc_path)
+        .map_err(|e| format!("check: read {}: {}", nc_path.display(), e))?;
+    let nc_root = read_root_from_source(k, &nc_src);
+    let mut a = Arena::new();
+    let env = a.new_frame(None);
+    // Walk name-check.fk so `name-check` / `name-check-clean?` / `nc-*` bind in env.
+    walk(k, &mut a, nc_root, env);
+    // `known` seeds the resolvable set with every kernel native name. The manifest's
+    // own defns are collected from the recipe by name-check's PASS 1; the natives are
+    // NOT in the recipe, so they must be named here or every native call would report.
+    let native_ids: Vec<NameID> = k
+        .natives
+        .keys()
+        .copied()
+        .chain(k.env_natives.keys().copied())
+        .collect();
+    let known: Vec<Value> = native_ids
+        .into_iter()
+        .map(|id| Value::Str(Arc::from(k.name_str(id))))
+        .collect();
+    let known_val = Value::List(Arc::new(known));
+    // Apply name-check(route_root, known) directly — the same closure resolution the
+    // serve path uses for route handlers (resolve_route_handler -> arena.lookup).
+    let nc_name = k.intern_string("name-check").inst;
+    let cl = match a.lookup(env, nc_name) {
+        Some(Value::Closure(c)) => c,
+        _ => return Err("check: name-check not bound after loading name-check.fk".to_string()),
+    };
+    if cl.params.len() != 2 {
+        return Err(format!(
+            "check: name-check expects 2 params (program known), found {}",
+            cl.params.len()
+        ));
+    }
+    let frame = a.new_frame_with_capacity(Some(cl.env), 2);
+    a.bind(frame, cl.params[0], Value::Nid(route_root));
+    a.bind(frame, cl.params[1], known_val);
+    let result = walk(k, &mut a, cl.body, frame);
+    let mut unbound: Vec<String> = Vec::new();
+    if let Value::List(xs) = result {
+        for v in xs.iter() {
+            if let Value::Str(s) = v {
+                let name = s.to_string();
+                if !unbound.contains(&name) {
+                    unbound.push(name); // name-check cons-es one entry per reference; dedup
+                }
+            }
+        }
+    }
+    Ok(unbound)
+}
+
+// check --routes <file> [--stdlib <dir>] — source-compile a routes manifest and
+// resolve every name in the lowered recipe BEFORE serving. Exit non-zero, naming
+// the unresolved symbols, if any reference is dangling. This is the compile-time
+// gate the lazy evaluator lacks: a manifest that references an unbound symbol (e.g.
+// production-routes.fk's `health_route_from_class`) becomes a clean error here
+// instead of a serve-time panic — the silent-rot class. CI runs this over the
+// manifests so a dangling reference can never reach main.
+fn cli_check(args: &[String]) -> i32 {
+    let mut routes_path: Option<String> = None;
+    let mut stdlib_dir: String = "form-stdlib".to_string();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--routes" => {
+                if i + 1 >= args.len() {
+                    eprintln!("check: --routes requires an argument");
+                    return 2;
+                }
+                routes_path = Some(args[i + 1].clone());
+                i += 2;
+            }
+            "--stdlib" => {
+                if i + 1 >= args.len() {
+                    eprintln!("check: --stdlib requires an argument");
+                    return 2;
+                }
+                stdlib_dir = args[i + 1].clone();
+                i += 2;
+            }
+            other => {
+                eprintln!("check: unknown argument: {}", other);
+                return 2;
+            }
+        }
+    }
+    let routes_path = match routes_path {
+        Some(p) => p,
+        None => {
+            eprintln!("check: --routes <file> is required");
+            return 2;
+        }
+    };
+    let stdlib_abs = match std::path::Path::new(&stdlib_dir).canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("check: --stdlib {}: {}", stdlib_dir, e);
+            return 2;
+        }
+    };
+    let mut prog = match source_compile_manifest_recipe_object(&routes_path, &stdlib_dir) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("check: {}", e);
+            return 1;
+        }
+    };
+    match name_check_route_recipe(&mut prog.kernel, &stdlib_abs, prog.root) {
+        Ok(unbound) if unbound.is_empty() => {
+            println!("check: {} — every name resolves (0 unbound)", routes_path);
+            0
+        }
+        Ok(unbound) => {
+            eprintln!(
+                "check: {} — {} unresolved name(s) — would panic at serve time:",
+                routes_path,
+                unbound.len()
+            );
+            for name in &unbound {
+                eprintln!("  unbound: {}", name);
+            }
+            1
+        }
+        Err(e) => {
+            eprintln!("check: {}", e);
+            1
+        }
+    }
+}
+
 // Quote a path/string as an S-expression string literal for the compile driver:
 // wrap in double quotes, escaping backslash and double-quote. Paths with a quote
 // or backslash are exotic but must not break the driver's parse.
@@ -11038,6 +11183,7 @@ fn main_with_args(args: Vec<String>) -> i32 {
         "trace" => cli_trace(&args[1..]),
         "fetch" => cli_fetch(&args[1..]),
         "serve" => cli_serve(&args[1..]),
+        "check" => cli_check(&args[1..]),
         _ => {
             // Source adapter: --expr or <file.fk> [more.fk ...]
             let src = if args[0] == "--expr" {

--- a/form/form-stdlib/name-check.fk
+++ b/form/form-stdlib/name-check.fk
@@ -52,9 +52,21 @@
                 true
                 (nc-member? name (tail xs)))))
 
-    ;; --- the head-name of a FNDEF / FNCALL / IDENT (first child is a STRING)
+    ;; --- the name a name-position node denotes ----------------------------
+    ;; A name-position node (a FNDEF/FNCALL/IDENT's first child, a param, a let
+    ;; name) is EITHER a bare STRING trivial (its node_value IS the name) OR a
+    ;; one-child wrapper whose child is that STRING — the two shapes the kernel's
+    ;; own `ident_id` accepts. The S-expr `(f args)` form lowers a callee to the
+    ;; bare shape; the BML `f(args)` form lowers it to the wrapper shape; both
+    ;; occur in one real manifest, so the resolver must read both or it crashes
+    ;; on real input (node_value on a non-trivial wrapper).
+    (defn nc-name-of (node)
+        (if (eq (node_type node) 2)                      ; TRIV_STRING — node IS the name
+            (node_value node)
+            (node_value (head (node_children node)))))    ; wrapper — its STRING child
+    ;; the name of a FNDEF / FNCALL / IDENT — its first child read as a name.
     (defn nc-head-name (n)
-        (node_value (head (node_children n))))
+        (nc-name-of (head (node_children n))))
 
     ;; Resolution is pure string-membership against the known-name set. The set
     ;; is the caller's to seed (the kernel natives, plus any generated/lowered
@@ -89,12 +101,12 @@
     (defn nc-add-names (xs defs)
         (if (nc-empty? xs)
             defs
-            (nc-add-names (tail xs) (cons (node_value (head xs)) defs))))
+            (nc-add-names (tail xs) (cons (nc-name-of (head xs)) defs))))
     (defn nc-let? (n)
         (if (eq (node_type n) 9)                                         ; RB_BLOCK
             (eq (node_inst (node_category n)) 3)                         ; RBLK_LET (category inst, not node inst)
             false))
-    (defn nc-let-name (n) (node_value (head (node_children n))))         ; kids[0]
+    (defn nc-let-name (n) (nc-name-of (head (node_children n))))         ; kids[0]
     (defn nc-scope-after (n defs)
         (if (nc-let? n) (cons (nc-let-name n) defs) defs))
 
@@ -109,7 +121,11 @@
                       (nc-add-names (node_children (nc-FNDEF-params n)) defs)
                       acc)
             (if (eq (node_type n) (nc-FNCALL))
-                (nc-check-ref (nc-head-name n) n defs acc)
+                ;; check the callee name, then walk only the ARGS (the tail). The
+                ;; callee child is the name itself — walking it too would re-count it
+                ;; when the callee is a wrapper (BML `f(args)` → IDENT callee).
+                (nc-check-kids (tail (node_children n)) defs
+                    (if (nc-member? (nc-head-name n) defs) acc (cons (nc-head-name n) acc)))
                 (if (eq (node_type n) (nc-IDENT))
                     (nc-check-ref (nc-head-name n) n defs acc)
                     (nc-check-kids (node_children n) defs acc)))))

--- a/form/form-stdlib/tests/name-check-band.fk
+++ b/form/form-stdlib/tests/name-check-band.fk
@@ -12,10 +12,15 @@
 ;   5. a defn whose body references its PARAM → resolves (empty)   [scope]
 ;   6. a `let` then a use of the bound name   → resolves (empty)   [scope]
 ;   7. a `let` then a use of a MISSING name   → reported (one name) [scope]
+;   8. a call whose callee is a WRAPPER ident → resolves (empty)   [shape]
+;   9. a wrapper-callee call to a MISSING name → reported (one name) [shape]
 ; Cases 1/2 prove the native test; 3/4 prove defn-collection + the walk; 5/6/7
 ; prove scope — a param is bound for its body, a let for the siblings that follow
-; it. Without scope, 5 and 6 would false-report, and the checker could not gate
-; real code. The printed verdict is deterministic, so the three siblings agree.
+; it. 8/9 prove the two real callee shapes: `(f x)` lowers a bare-string callee,
+; `f(x)` (BML) lowers a wrapper IDENT callee — the resolver reads a name through
+; either, and counts a missing one ONCE (not twice via the callee child). Without
+; these the checker crashes or miscounts on a real manifest. The printed verdict
+; is deterministic, so the three siblings must agree.
 
 (do
     (let fncall-cat (make_nodeid 1 2 32 1))
@@ -49,6 +54,18 @@
     (let prog-let-ok  (intern_node do-cat (list let-bind (intern_node ident-cat (list (intern_trivial_string "y"))))))
     (let prog-let-bad (intern_node do-cat (list let-bind (intern_node ident-cat (list (intern_trivial_string "z"))))))
 
+    ;; cases 8/9 — WRAPPER-callee shape: the BML `f(args)` form lowers a call's
+    ;; callee to an IDENT node (not a bare string, as `(f args)` does). A real
+    ;; manifest mixes both; the resolver must read a name through one wrapper
+    ;; level or it crashes (node_value on a non-trivial) — production-routes.fk
+    ;; exposed exactly this. callee = (ident "print") resolves; (ident "nope") not.
+    (let call-wrapped-ok  (intern_node fncall-cat
+                              (list (intern_node ident-cat (list (intern_trivial_string "print")))
+                                    (intern_trivial_int 1))))
+    (let call-wrapped-bad (intern_node fncall-cat
+                              (list (intern_node ident-cat (list (intern_trivial_string "nope-xyz")))
+                                    (intern_trivial_int 1))))
+
     ;; `known` seeds the resolvable set with the builtin name this test uses.
     (let known (list "print"))
 
@@ -59,7 +76,9 @@
         (and (eq (len (name-check prog-bad known)) 1)
         (and (eq (len (name-check param-fn known)) 0)
         (and (eq (len (name-check prog-let-ok known)) 0)
-             (eq (len (name-check prog-let-bad known)) 1))))))))
+        (and (eq (len (name-check prog-let-bad known)) 1)
+        (and (eq (len (name-check call-wrapped-ok known)) 0)
+             (eq (len (name-check call-wrapped-bad known)) 1))))))))))
 
     (print (if pass "name-check-band: PASS" "name-check-band: FAIL"))
 )


### PR DESCRIPTION
**The fix you asked for:** a compiler that catches missed symbols instead of blindly emitting a recipe with unresolved references.

The kernel resolves names *lazily* — a manifest with a dangling reference compiles fine and only panics when the walk reaches that node at serve time. `production-routes.fk` has sat non-loading since #2459 (`unbound: health_route_from_class`), undetected because nothing ran a resolution pass.

**This puts the pass in the compiler:**
- `check --routes <file> [--stdlib <dir>]` source-compiles a manifest and runs the Form resolution walk (`name-check.fk`) over the lowered recipe — exits non-zero naming every unresolved symbol *before* serving.
- Reuses the serve path's own closure resolution (`resolve_route_handler` → `arena.lookup`); no resolution logic duplicated in Rust.

**Proof on the real manifest:**
```
check: production-routes.fk — 1 unresolved name(s) — would panic at serve time:
  unbound: health_route_from_class      (exit 1)
```
A clean manifest (`shadow-routes.fk`) exits 0.

**`name-check.fk` hardened for real recipes** — the band had only ever tested hand-built ones. A name-position node is a bare STRING trivial *or* a one-child wrapper (the BML `f(args)` callee shape), read via `nc-name-of` mirroring the kernel's own `ident_id`; an FNCALL counts its callee once, not twice. Band 7 → 9 cases; **three-way PASS on Go/Rust/TS** by direct kernel runs.

Next: wire `check` into CI over the manifests (closing the proof-not-in-CI gap), then repair `production-routes.fk` (now caught by the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)