### PR TITLE
tend: warm api caches in the background so health comes up in ~1-2s, not ~22s

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -312,7 +313,17 @@ async def _setup_service_registry(app: FastAPI) -> None:
 async def lifespan(app: FastAPI):
     _warn_on_suspect_cors_config()
     _ensure_db_tables()
-    _warm_startup_caches()
+    # Warm read caches in the BACKGROUND so the app reports healthy in ~1-2s
+    # rather than blocking startup for the full warm (~22s). The warm is pure
+    # pre-population — every cache it fills also fills lazily on first request —
+    # so until it finishes the first requests just take the cold path and still
+    # return 200. Blocking here kept each freshly recreated container unhealthy
+    # for the whole warm, so every `api` deploy opened a Traefik-404 / CF-502
+    # window with no healthy backend; that gap is what surfaced as the reported
+    # POST /api/ideas "404 page not found".
+    threading.Thread(
+        target=_warm_startup_caches, name="startup-cache-warm", daemon=True
+    ).start()
     await _setup_service_registry(app)
 
     # Register the on-demand translator backend. Because the app uses a


### PR DESCRIPTION
## Why

Follow-up to the `/api/ideas` 404 investigation ([#2582](https://github.com/seeker71/Coherence-Network/pull/2582)): the reported intermittent `404 page not found` / 502 was **not** a kernel routing bug — it was the **api container recreate window**. This closes that window.

## The window

- `Dockerfile.api` `HEALTHCHECK` curls `/api/health`, which only returns 200 once `lifespan` startup completes.
- `_warm_startup_caches()` ran **synchronously** inside `lifespan`, blocking ~22s on full cache pre-population.
- `auto-deploy.sh` does `docker compose up -d --wait --force-recreate`: the old container is replaced and the new one stays **unhealthy for the whole warm**, so Traefik has no backend → clients get Traefik's lowercase `404 page not found` / Cloudflare 502 for ~22s every api deploy.

## The fix

Move the warm to a **background daemon thread**. It's pure read-cache pre-population (every cache it fills also fills lazily on first request) and already non-fatal (`try/except`), so:

- `lifespan` completes immediately → container reports healthy in **~1–2s**.
- Until the warm finishes, the first requests take the cold path and **still return 200** (just slightly slower), instead of failing.
- Recreate window shrinks from **~22s of 404/502** → **~1–2s**.

## Safety

- Tests are unaffected — they **bypass `lifespan`** (`conftest.py:362` mirrors only the default-workspace ensure), so the background thread never starts under test.
- `py_compile` clean. No behavior change to any endpoint; only *when* the cache fills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)