### PR TITLE
Restore form.route source lowering

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json
+++ b/docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json
@@ -1,0 +1,100 @@
+{
+  "date": "2026-06-08",
+  "thread_branch": "codex/route-language-lowering-20260608",
+  "commit_scope": "Restore form.route BML route-class lowering so route templates/classes compile into language-model cells while generic form.bml continues through the broad BML grammar.",
+  "files_owned": [
+    "form/form-stdlib/source-compiler.fk",
+    "docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "make wellness",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/kernel-http.fk form-stdlib/language-model.fk form-stdlib/tests/source-language-route-class-template-band.fk",
+      "cd form && form-source-compile-file ../deploy/kernel-router/production-routes.fk and verify emitted HealthRoute/kh-route-data-ref cells",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/tests/json-codec-bml-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-multi-dialect-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/tests/form-bml-maintenance-dialect.fk",
+      "git diff --check"
+    ],
+    "results": {
+      "source_language_route_class_template_band": "525377",
+      "production_routes_source_compile": "emitted RouteCell, HealthRoute_handle, language-class HealthRoute, kh-route-data-ref \"health\", and health_route_from_class",
+      "json_codec_bml_band": "8191",
+      "source_compiler_multi_dialect_band": "0",
+      "form_bml_maintenance_dialect": "77",
+      "diff_check": "pass"
+    }
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote CI is pending until this branch is pushed and a PR is opened."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Production deployment is pending until PR checks pass, the stack merges, and deploy verification runs."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_by": [
+      "remote CI pending",
+      "deploy verification pending"
+    ]
+  },
+  "idea_ids": [
+    "kernel-first-router",
+    "source-language-native-recipes"
+  ],
+  "spec_ids": [
+    "kernel-router-source-language-classes"
+  ],
+  "task_ids": [
+    "route-language-lowering-20260608"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/tests/source-language-route-class-template-band.fk",
+    "deploy/kernel-router/production-routes.fk",
+    "form/form-stdlib/tests/json-codec-bml-band.fk",
+    "form/form-stdlib/tests/source-compiler-multi-dialect-band.fk",
+    "form/form-stdlib/tests/form-bml-maintenance-dialect.fk"
+  ],
+  "change_files": [
+    "form/form-stdlib/source-compiler.fk"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "section [form.route] template/class route source now compiles back into executable LanguageTemplate, LanguageClass, KernelHTTPRoute, and KernelHTTPRouteDataRef cells instead of collapsing to an empty do block.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com"
+    ],
+    "test_flows": [
+      "source-language-route-class-template-band returns 525377 across Go/Rust/TypeScript kernels",
+      "production-routes.fk source compilation emits HealthRoute and kh-route-data-ref cells for the native router manifest",
+      "adjacent JSON codec BML and source-compiler multi-dialect bands remain green"
+    ]
+  }
+}

--- a/docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json
+++ b/docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json
@@ -22,6 +22,7 @@
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/bml-source.fk form-stdlib/source-compiler.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/tests/json-codec-bml-band.fk",
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/bml-source.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-multi-dialect-band.fk",
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/bml-source.fk form-stdlib/source-compiler.fk form-stdlib/tests/form-bml-maintenance-dialect.fk",
+      "cd form/form-kernel-rust && cargo fmt --check",
       "cd form/form-kernel-rust && cargo build --quiet",
       "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json",
       "git diff --check"
@@ -33,12 +34,13 @@
       "json_codec_bml_band": "8191",
       "source_compiler_multi_dialect_band": "0",
       "form_bml_maintenance_dialect": "77",
+      "rust_fmt_check": "pass",
       "rust_cargo_build": "pass",
       "commit_evidence_validation": "pass",
       "diff_check": "pass"
     },
-    "non_blocking_observations": [
-      "cd form/form-kernel-rust && cargo fmt --check failed on existing rustfmt drift across form/form-kernel-rust/src/main.rs, far beyond the source prelude constant touched here; this slice did not reformat the whole kernel."
+    "resolved_observations": [
+      "cargo fmt released the existing rustfmt drift in form/form-kernel-rust/src/main.rs; cargo fmt --check now passes."
     ]
   },
   "ci_validation": {

--- a/docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json
+++ b/docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json
@@ -1,9 +1,10 @@
 {
   "date": "2026-06-08",
   "thread_branch": "codex/route-language-lowering-20260608",
-  "commit_scope": "Restore form.route BML route-class lowering so route templates/classes compile into language-model cells while generic form.bml continues through the broad BML grammar.",
+  "commit_scope": "Restore form.route BML route-class lowering and split typed-template/route-call parsing into named BML source objects before route-domain lowering.",
   "files_owned": [
     "form/form-stdlib/source-compiler.fk",
+    "form/form-stdlib/tests/bml-route-source-object-band.fk",
     "docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json"
   ],
   "local_validation": {
@@ -11,6 +12,7 @@
     "commands": [
       "make prompt-guide",
       "make wellness",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/tests/bml-route-source-object-band.fk",
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/kernel-http.fk form-stdlib/language-model.fk form-stdlib/tests/source-language-route-class-template-band.fk",
       "cd form && form-source-compile-file ../deploy/kernel-router/production-routes.fk and verify emitted HealthRoute/kh-route-data-ref cells",
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/tests/json-codec-bml-band.fk",
@@ -19,6 +21,7 @@
       "git diff --check"
     ],
     "results": {
+      "bml_route_source_object_band": "2047",
       "source_language_route_class_template_band": "525377",
       "production_routes_source_compile": "emitted RouteCell, HealthRoute_handle, language-class HealthRoute, kh-route-data-ref \"health\", and health_route_from_class",
       "json_codec_bml_band": "8191",
@@ -76,22 +79,25 @@
   },
   "evidence_refs": [
     "form/form-stdlib/tests/source-language-route-class-template-band.fk",
+    "form/form-stdlib/tests/bml-route-source-object-band.fk",
     "deploy/kernel-router/production-routes.fk",
     "form/form-stdlib/tests/json-codec-bml-band.fk",
     "form/form-stdlib/tests/source-compiler-multi-dialect-band.fk",
     "form/form-stdlib/tests/form-bml-maintenance-dialect.fk"
   ],
   "change_files": [
-    "form/form-stdlib/source-compiler.fk"
+    "form/form-stdlib/source-compiler.fk",
+    "form/form-stdlib/tests/bml-route-source-object-band.fk"
   ],
   "change_intent": "runtime_fix",
   "e2e_validation": {
     "status": "pass",
-    "expected_behavior_delta": "section [form.route] template/class route source now compiles back into executable LanguageTemplate, LanguageClass, KernelHTTPRoute, and KernelHTTPRouteDataRef cells instead of collapsing to an empty do block.",
+    "expected_behavior_delta": "section [form.route] template/class route source now compiles back into executable LanguageTemplate, LanguageClass, KernelHTTPRoute, and KernelHTTPRouteDataRef cells, with BML typed-template and route-call syntax visible as reusable source objects before route semantics are chosen.",
     "public_endpoints": [
       "https://api.coherencycoin.com"
     ],
     "test_flows": [
+      "bml-route-source-object-band returns 2047 across Go/Rust/TypeScript kernels",
       "source-language-route-class-template-band returns 525377 across Go/Rust/TypeScript kernels",
       "production-routes.fk source compilation emits HealthRoute and kh-route-data-ref cells for the native router manifest",
       "adjacent JSON codec BML and source-compiler multi-dialect bands remain green"

--- a/docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json
+++ b/docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json
@@ -1,10 +1,14 @@
 {
   "date": "2026-06-08",
   "thread_branch": "codex/route-language-lowering-20260608",
-  "commit_scope": "Restore form.route BML route-class lowering and split typed-template/route-call parsing into named BML source objects before route-domain lowering.",
+  "commit_scope": "Extract reusable BML source cells into bml-source.fk and wire full form.bml/form.route section lowering through the BML line/block compiler.",
   "files_owned": [
+    "form/form-stdlib/bml-source.fk",
     "form/form-stdlib/source-compiler.fk",
     "form/form-stdlib/tests/bml-route-source-object-band.fk",
+    "form/validate.sh",
+    "form/form-kernel-rust/src/main.rs",
+    "kernels/SOURCE_LANGUAGE_KERNEL_ROUTER_ARCHITECTURE.md",
     "docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json"
   ],
   "local_validation": {
@@ -12,23 +16,30 @@
     "commands": [
       "make prompt-guide",
       "make wellness",
-      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/tests/bml-route-source-object-band.fk",
-      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/kernel-http.fk form-stdlib/language-model.fk form-stdlib/tests/source-language-route-class-template-band.fk",
-      "cd form && form-source-compile-file ../deploy/kernel-router/production-routes.fk and verify emitted HealthRoute/kh-route-data-ref cells",
-      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/tests/json-codec-bml-band.fk",
-      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-multi-dialect-band.fk",
-      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/tests/form-bml-maintenance-dialect.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/bml-source.fk form-stdlib/tests/bml-route-source-object-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/bml-source.fk form-stdlib/source-compiler.fk form-stdlib/kernel-http.fk form-stdlib/language-model.fk form-stdlib/tests/source-language-route-class-template-band.fk",
+      "cd form && form-source-compile-file ../deploy/kernel-router/production-routes.fk with bml-source.fk in the source-compile prelude, then verify emitted HealthRoute/kh-route-data-ref cells",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/bml-source.fk form-stdlib/source-compiler.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/tests/json-codec-bml-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/bml-source.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-multi-dialect-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/bml-source.fk form-stdlib/source-compiler.fk form-stdlib/tests/form-bml-maintenance-dialect.fk",
+      "cd form/form-kernel-rust && cargo build --quiet",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json",
       "git diff --check"
     ],
     "results": {
       "bml_route_source_object_band": "2047",
       "source_language_route_class_template_band": "525377",
-      "production_routes_source_compile": "emitted RouteCell, HealthRoute_handle, language-class HealthRoute, kh-route-data-ref \"health\", and health_route_from_class",
+      "production_routes_source_compile": "emitted RouteCell, HealthRoute_handle, language-class HealthRoute, kh-route-data-ref \"health\", and health_route_from_class with bml-source.fk in the source-compile prelude",
       "json_codec_bml_band": "8191",
       "source_compiler_multi_dialect_band": "0",
       "form_bml_maintenance_dialect": "77",
+      "rust_cargo_build": "pass",
+      "commit_evidence_validation": "pass",
       "diff_check": "pass"
-    }
+    },
+    "non_blocking_observations": [
+      "cd form/form-kernel-rust && cargo fmt --check failed on existing rustfmt drift across form/form-kernel-rust/src/main.rs, far beyond the source prelude constant touched here; this slice did not reformat the whole kernel."
+    ]
   },
   "ci_validation": {
     "status": "pending",
@@ -78,6 +89,7 @@
     "version": "gpt-5"
   },
   "evidence_refs": [
+    "form/form-stdlib/bml-source.fk",
     "form/form-stdlib/tests/source-language-route-class-template-band.fk",
     "form/form-stdlib/tests/bml-route-source-object-band.fk",
     "deploy/kernel-router/production-routes.fk",
@@ -86,13 +98,17 @@
     "form/form-stdlib/tests/form-bml-maintenance-dialect.fk"
   ],
   "change_files": [
+    "form/form-stdlib/bml-source.fk",
     "form/form-stdlib/source-compiler.fk",
-    "form/form-stdlib/tests/bml-route-source-object-band.fk"
+    "form/form-stdlib/tests/bml-route-source-object-band.fk",
+    "form/validate.sh",
+    "form/form-kernel-rust/src/main.rs",
+    "kernels/SOURCE_LANGUAGE_KERNEL_ROUTER_ARCHITECTURE.md"
   ],
   "change_intent": "runtime_fix",
   "e2e_validation": {
     "status": "pass",
-    "expected_behavior_delta": "section [form.route] template/class route source now compiles back into executable LanguageTemplate, LanguageClass, KernelHTTPRoute, and KernelHTTPRouteDataRef cells, with BML typed-template and route-call syntax visible as reusable source objects before route semantics are chosen.",
+    "expected_behavior_delta": "section [form.bml] and section [form.route] bodies compile all top-level let/class/def/expression forms through the BML line/block compiler; route source compiles back into executable LanguageTemplate, LanguageClass, KernelHTTPRoute, and KernelHTTPRouteDataRef cells while reusable BML typed-template and route-call source cells live outside the route compiler in bml-source.fk.",
     "public_endpoints": [
       "https://api.coherencycoin.com"
     ],

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -7657,16 +7657,18 @@ fn worker_loop(
 
 // The form-stdlib preludes a source manifest is source-compiled through, in load
 // order: the ontology loader asks the kernel-native bp table for coordinates,
-// then source-compiler.fk lowers a `section [...]` against those bindings.
+// then bml-source.fk names reusable BML source cells, and source-compiler.fk
+// lowers a `section [...]` against those bindings.
 // This is the SAME prelude set + lowering `form/validate.sh prepare_sources`
 // runs to source-compile a `section [...]` file — the router reuses the body's
 // own compiler, not a Rust reimplementation of a source-language parser.
-const SOURCE_COMPILE_PRELUDES: [&str; 6] = [
+const SOURCE_COMPILE_PRELUDES: [&str; 7] = [
     "form-ontology-loader.fk",
     "line-grammar.fk",
     "bmf-core.fk",
     "bmf-grammar.fk",
     "bml.fk",
+    "bml-source.fk",
     "source-compiler.fk",
 ];
 

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -1457,13 +1457,16 @@ fn source_native_empty_list() -> Value {
 }
 
 fn source_native_atom(kind: &str, value: &str) -> Value {
-    Value::List(vec![
-        source_native_str("cell"),
-        source_native_str(kind),
-        source_native_str(value),
-        source_native_empty_list(),
-        Value::Null,
-    ].into())
+    Value::List(
+        vec![
+            source_native_str("cell"),
+            source_native_str(kind),
+            source_native_str(value),
+            source_native_empty_list(),
+            Value::Null,
+        ]
+        .into(),
+    )
 }
 
 fn source_native_string_set(value: &Value, field: &str) -> HashSet<String> {
@@ -2579,7 +2582,9 @@ impl Kernel {
             }
             Value::Null
         });
-        self.register_native("empty", cat_list_nat(), |_, _, _| Value::List(vec![].into()));
+        self.register_native("empty", cat_list_nat(), |_, _, _| {
+            Value::List(vec![].into())
+        });
         // _list_append — functional list extension: `(_list_append xs x)` →
         // a NEW list = xs ++ [x]. The Python adapter lowers the accumulator
         // idiom `result.append(x)` to `(let result (_list_append result x))`,
@@ -3343,9 +3348,9 @@ impl Kernel {
         // Byte-level host file read — returns a list of ints (0-255), one per byte.
         self.register_native("read_file_bytes", cat_call(), |_, _, args| {
             match fs::read(args[0].as_str()) {
-                Ok(bytes) => {
-                    Value::List(Arc::new(bytes.into_iter().map(|b| Value::Int(b as i64)).collect()))
-                }
+                Ok(bytes) => Value::List(Arc::new(
+                    bytes.into_iter().map(|b| Value::Int(b as i64)).collect(),
+                )),
                 Err(_) => Value::Null,
             }
         });
@@ -4271,11 +4276,14 @@ impl Kernel {
             match k.source_attr.get(&nid).copied() {
                 Some((file_id, line, col)) => {
                     let file = k.strs[file_id as usize].clone();
-                    Value::List(vec![
-                        Value::Str(file.into()),
-                        Value::Int(line as i64),
-                        Value::Int(col as i64),
-                    ].into())
+                    Value::List(
+                        vec![
+                            Value::Str(file.into()),
+                            Value::Int(line as i64),
+                            Value::Int(col as i64),
+                        ]
+                        .into(),
+                    )
                 }
                 None => Value::List(vec![].into()),
             }
@@ -4439,11 +4447,14 @@ impl Kernel {
             Value::Int(k.walk_cache.len() as i64)
         });
         self.register_native("walk-cache-stats", cat_witness(), |k, _, _| {
-            Value::List(vec![
-                Value::Int(k.walk_cache_hits as i64),
-                Value::Int(k.walk_cache_misses as i64),
-                Value::Int(k.walk_cache.len() as i64),
-            ].into())
+            Value::List(
+                vec![
+                    Value::Int(k.walk_cache_hits as i64),
+                    Value::Int(k.walk_cache_misses as i64),
+                    Value::Int(k.walk_cache.len() as i64),
+                ]
+                .into(),
+            )
         });
 
         // native_blueprint — read a native's Form category from inside Form.
@@ -7821,7 +7832,8 @@ fn compile_source_section_to_recipe_node(
         sexp_string_literal(dialect_name),
         sexp_string_literal(body)
     );
-    let (kernel, value) = run_source_with_bootstrap("route-section-compile", bootstrap, driver_body)?;
+    let (kernel, value) =
+        run_source_with_bootstrap("route-section-compile", bootstrap, driver_body)?;
     match value {
         Value::Nid(root) => Ok((kernel, root)),
         _ => Err("source-compile: fsc-compile-section-recipe did not return a recipe".to_string()),
@@ -8256,7 +8268,10 @@ mod gate_known_set_tests {
             .chain(["not", "let", "if", "defn"])
             .collect();
         for v in BUILD_VERBS {
-            assert!(covered.contains(v), "BUILD_VERBS has {v} but this test doesn't cover it");
+            assert!(
+                covered.contains(v),
+                "BUILD_VERBS has {v} but this test doesn't cover it"
+            );
         }
         // and a verb build_verb does NOT know must hit the FNCALL fallback, so the
         // gate still flags genuinely-unbound names (e.g. health_route_from_class).
@@ -9199,82 +9214,100 @@ fn router_bml_candidate_value(candidate: &RouterBmlCandidate) -> Value {
 }
 
 fn router_http_header_value(name: &str, value: &str) -> Value {
-    Value::List(vec![
-        Value::Int(KH_TAG_HEADER),
-        Value::Str(name.to_string().into()),
-        Value::Str(value.to_string().into()),
-    ].into())
+    Value::List(
+        vec![
+            Value::Int(KH_TAG_HEADER),
+            Value::Str(name.to_string().into()),
+            Value::Str(value.to_string().into()),
+        ]
+        .into(),
+    )
 }
 
 fn router_http_field_value(name: &str, value: &str) -> Value {
-    Value::List(vec![
-        Value::Int(KH_TAG_FIELD),
-        Value::Str(name.to_string().into()),
-        Value::Str(value.to_string().into()),
-    ].into())
+    Value::List(
+        vec![
+            Value::Int(KH_TAG_FIELD),
+            Value::Str(name.to_string().into()),
+            Value::Str(value.to_string().into()),
+        ]
+        .into(),
+    )
 }
 
 fn router_http_route_value(candidate: &RouteCandidateValue) -> Value {
-    Value::List(vec![
-        Value::Int(KH_TAG_ROUTE),
-        Value::Str(candidate.route_name.clone().into()),
-        Value::Str(candidate.route_method.clone().into()),
-        Value::Str(candidate.route_pattern.clone().into()),
-        Value::Int(candidate.route_priority),
-        Value::Str(candidate.route_handler_name.clone().into()),
-        Value::Str(candidate.route_required_header.clone().into()),
-        Value::Int(candidate.route_pressure_budget),
-    ].into())
+    Value::List(
+        vec![
+            Value::Int(KH_TAG_ROUTE),
+            Value::Str(candidate.route_name.clone().into()),
+            Value::Str(candidate.route_method.clone().into()),
+            Value::Str(candidate.route_pattern.clone().into()),
+            Value::Int(candidate.route_priority),
+            Value::Str(candidate.route_handler_name.clone().into()),
+            Value::Str(candidate.route_required_header.clone().into()),
+            Value::Int(candidate.route_pressure_budget),
+        ]
+        .into(),
+    )
 }
 
 fn router_http_request_value(candidate: &RouteCandidateValue) -> Value {
-    Value::List(vec![
-        Value::Int(KH_TAG_REQUEST),
-        Value::Str(candidate.request_method.clone().into()),
-        Value::Str(candidate.request_path.clone().into()),
-        Value::List(Arc::new(
-            candidate
-                .request_headers
-                .iter()
-                .map(|(name, value)| router_http_header_value(name, value))
-                .collect(),
-        )),
-        Value::List(Arc::new(
-            candidate
-                .request_query
-                .iter()
-                .map(|(name, value)| router_http_field_value(name, value))
-                .collect(),
-        )),
-        Value::Str(candidate.request_body.clone().into()),
-    ].into())
+    Value::List(
+        vec![
+            Value::Int(KH_TAG_REQUEST),
+            Value::Str(candidate.request_method.clone().into()),
+            Value::Str(candidate.request_path.clone().into()),
+            Value::List(Arc::new(
+                candidate
+                    .request_headers
+                    .iter()
+                    .map(|(name, value)| router_http_header_value(name, value))
+                    .collect(),
+            )),
+            Value::List(Arc::new(
+                candidate
+                    .request_query
+                    .iter()
+                    .map(|(name, value)| router_http_field_value(name, value))
+                    .collect(),
+            )),
+            Value::Str(candidate.request_body.clone().into()),
+        ]
+        .into(),
+    )
 }
 
 fn router_pressure_row_value(row: &RoutePressureRow) -> Value {
-    Value::List(vec![
-        Value::Int(KH_TAG_PRESSURE_ROW),
-        Value::Str(row.axis.clone().into()),
-        row.observed.clone(),
-        row.expected.clone(),
-        Value::Int(row.pressure),
-    ].into())
+    Value::List(
+        vec![
+            Value::Int(KH_TAG_PRESSURE_ROW),
+            Value::Str(row.axis.clone().into()),
+            row.observed.clone(),
+            row.expected.clone(),
+            Value::Int(row.pressure),
+        ]
+        .into(),
+    )
 }
 
 fn router_route_candidate_value(candidate: &RouteCandidateValue) -> Value {
-    Value::List(vec![
-        Value::Int(KH_TAG_ROUTE_CANDIDATE),
-        router_http_route_value(candidate),
-        router_http_request_value(candidate),
-        Value::List(Arc::new(
-            candidate
-                .pressure_matrix
-                .iter()
-                .map(router_pressure_row_value)
-                .collect(),
-        )),
-        Value::Int(candidate.pressure),
-        Value::Int(candidate.score),
-    ].into())
+    Value::List(
+        vec![
+            Value::Int(KH_TAG_ROUTE_CANDIDATE),
+            router_http_route_value(candidate),
+            router_http_request_value(candidate),
+            Value::List(Arc::new(
+                candidate
+                    .pressure_matrix
+                    .iter()
+                    .map(router_pressure_row_value)
+                    .collect(),
+            )),
+            Value::Int(candidate.pressure),
+            Value::Int(candidate.score),
+        ]
+        .into(),
+    )
 }
 
 fn router_route_candidate_matrix_value(candidate: &RouteCandidateValue) -> Value {
@@ -9326,7 +9359,10 @@ fn router_context_data(
             "__request_target__".to_string(),
             Value::Str(target.to_string().into()),
         ),
-        ("__request_path__".to_string(), Value::Str(path.to_string().into())),
+        (
+            "__request_path__".to_string(),
+            Value::Str(path.to_string().into()),
+        ),
         (
             "__router_native_route_count__".to_string(),
             Value::Str(metrics.native_route_count.to_string().into()),
@@ -9401,7 +9437,10 @@ fn router_context_data(
         ));
         match parse_http_upstream(upstream_base) {
             Ok((host, port, base_path)) => {
-                pairs.push(("__router_upstream_host__".to_string(), Value::Str(host.into())));
+                pairs.push((
+                    "__router_upstream_host__".to_string(),
+                    Value::Str(host.into()),
+                ));
                 pairs.push((
                     "__router_upstream_port__".to_string(),
                     Value::Str(port.to_string().into()),
@@ -9412,7 +9451,10 @@ fn router_context_data(
                 ));
             }
             Err(e) => {
-                pairs.push(("__router_upstream_parse_error__".to_string(), Value::Str(e.into())));
+                pairs.push((
+                    "__router_upstream_parse_error__".to_string(),
+                    Value::Str(e.into()),
+                ));
             }
         }
     }
@@ -9673,7 +9715,9 @@ mod router_context_tests {
             _ => panic!("kernel request must be a Form list value"),
         };
         assert!(matches!(&request_rows[1], Value::Str(method) if method.as_ref() == "GET"));
-        assert!(matches!(&request_rows[2], Value::Str(path) if path.as_ref() == "/api/runtime/health"));
+        assert!(
+            matches!(&request_rows[2], Value::Str(path) if path.as_ref() == "/api/runtime/health")
+        );
         let request_headers = match &request_rows[3] {
             Value::List(xs) => xs,
             _ => panic!("kernel request headers must be a Form list value"),
@@ -9684,7 +9728,9 @@ mod router_context_tests {
             _ => panic!("kernel request query must be a Form list value"),
         };
         assert_eq!(list_tag(&request_query[0]), KH_TAG_FIELD);
-        assert!(matches!(&request_rows[5], Value::Str(body) if body.as_ref() == "{\"alive\":true}"));
+        assert!(
+            matches!(&request_rows[5], Value::Str(body) if body.as_ref() == "{\"alive\":true}")
+        );
         let rows = match candidate_value {
             Value::List(xs) => xs,
             _ => panic!("route candidate must be a Form list value"),
@@ -9910,8 +9956,9 @@ mod route_spec_tests {
                 },
             )]),
         };
-        let (_, _, routes, _) = build_worker_kernel_with_route_data(&program, &path_str, &route_data)
-            .expect("recipe-object route program loads");
+        let (_, _, routes, _) =
+            build_worker_kernel_with_route_data(&program, &path_str, &route_data)
+                .expect("recipe-object route program loads");
         let spec = &routes[0];
         assert_eq!(spec.name, "health");
         assert_eq!(spec.method, "ANY");

--- a/form/form-stdlib/bml-source.fk
+++ b/form/form-stdlib/bml-source.fk
@@ -1,0 +1,114 @@
+; bml-source.fk - shared BML source cells.
+;
+; preludes: form-stdlib/core.fk
+;
+; This module names BML-shaped source forms before any dialect chooses what
+; they mean. A route lowerer can map these cells to KernelHTTPRoute values;
+; another domain lowerer can reuse the same source shape differently.
+
+(do
+    (defn bml-source-sub (s a b) (substring s a b))
+    (defn bml-source-find (s needle i) (str_find s needle i))
+
+    (defn bml-source-rev-into (xs acc)
+        (if (eq (len xs) 0) acc
+            (bml-source-rev-into (tail xs) (cons (head xs) acc))))
+
+    (defn bml-source-rev (xs)
+        (bml-source-rev-into xs (empty)))
+
+    (defn bml-source-space? (ch)
+        (or (str_eq ch " ") (or (str_eq ch "\n") (or (str_eq ch "\t") (str_eq ch "\r")))))
+
+    (defn bml-source-skip-spaces (s i)
+        (if (ge i (str_len s)) i
+            (if (bml-source-space? (char_at s i))
+                (bml-source-skip-spaces s (add i 1))
+                i)))
+
+    (defn bml-source-rtrim-index (s i)
+        (if (le i 0) 0
+            (if (bml-source-space? (char_at s (sub i 1)))
+                (bml-source-rtrim-index s (sub i 1))
+                i)))
+
+    (defn bml-source-trim (s)
+        (do
+            (let start (bml-source-skip-spaces s 0))
+            (let end (bml-source-rtrim-index s (str_len s)))
+            (if (ge start end) "" (bml-source-sub s start end))))
+
+    (defn bml-source-last-char-index (s)
+        (sub (str_len s) 1))
+
+    (defn bml-source-strip-semi (s)
+        (do
+            (let value (bml-source-trim s))
+            (if (eq (str_len value) 0) value
+                (if (str_eq (char_at value (bml-source-last-char-index value)) ";")
+                    (bml-source-trim (bml-source-sub value 0 (bml-source-last-char-index value)))
+                    value))))
+
+    (defn bml-source-name-list-loop (args i acc)
+        (do
+            (let p (bml-source-skip-spaces args i))
+            (if (ge p (str_len args)) (bml-source-rev acc)
+                (do
+                    (let comma (bml-source-find args "," p))
+                    (let end (if (lt comma 0) (str_len args) comma))
+                    (let name (bml-source-trim (bml-source-sub args p end)))
+                    (let rest-start (if (lt comma 0) (str_len args) (add comma 1)))
+                    (bml-source-name-list-loop args rest-start (cons name acc))))))
+
+    (defn bml-source-name-list (args)
+        (bml-source-name-list-loop args 0 (empty)))
+
+    (defn bml-source-template-use (class-name template-name type-arguments)
+        (list "bml-source-template-use" class-name template-name type-arguments))
+
+    (defn bml-source-template-use? (source)
+        (if (eq (len source) 4)
+            (str_eq (nth source 0) "bml-source-template-use")
+            false))
+
+    (defn bml-source-template-use-class-name (source) (nth source 1))
+    (defn bml-source-template-use-template-name (source) (nth source 2))
+    (defn bml-source-template-use-type-arguments (source) (nth source 3))
+
+    (defn bml-source-parse-template-use (class-name typed-template)
+        (do
+            (let type-open (bml-source-find typed-template "<" 0))
+            (let type-close (bml-source-find typed-template ">" type-open))
+            (let template-name (bml-source-trim (bml-source-sub typed-template 0 type-open)))
+            (let type-args-text (bml-source-sub typed-template (add type-open 1) type-close))
+            (let type-args (bml-source-name-list type-args-text))
+            (bml-source-template-use class-name template-name type-args)))
+
+    (defn bml-source-route-call (name args)
+        (list "bml-source-route-call" name args))
+
+    (defn bml-source-route-call? (source)
+        (if (eq (len source) 3)
+            (str_eq (nth source 0) "bml-source-route-call")
+            false))
+
+    (defn bml-source-route-call-name (source) (nth source 1))
+    (defn bml-source-route-call-args (source) (nth source 2))
+
+    (defn bml-source-route-call-from-expr (expr)
+        (do
+            (let value (bml-source-strip-semi (bml-source-trim expr)))
+            (let route-open (bml-source-find value "(" 0))
+            (let route-close (bml-source-last-char-index value))
+            (let route-call-name (bml-source-trim (bml-source-sub value 0 route-open)))
+            (let route-args (bml-source-sub value (add route-open 1) route-close))
+            (bml-source-route-call route-call-name route-args)))
+
+    (defn bml-source-route-call-from-assignment (line)
+        (do
+            (let value (bml-source-strip-semi line))
+            (let eq-pos (bml-source-find value "=" 0))
+            (bml-source-route-call-from-expr
+                (bml-source-sub value (add eq-pos 1) (str_len value)))))
+
+    0)

--- a/form/form-stdlib/source-compiler.fk
+++ b/form/form-stdlib/source-compiler.fk
@@ -617,11 +617,11 @@
         (if (fsc-empty? xs) ys
             (cons (head xs) (fsc-list-append (tail xs) ys))))
 
-    ;; --- route-domain BML lowering -----------------------------------
+    ;; --- BML source objects + route-domain lowering -------------------
     ;;
-    ;; `form.route` is a BML-shaped domain surface. It lowers template/class
-    ;; route declarations into the shared language-model cells instead of the
-    ;; generic UE-* nodes used by the broad BML grammar.
+    ;; `form.route` is a BML-shaped domain surface. BML mechanics become
+    ;; source objects first; the route dialect then lowers those objects into
+    ;; shared language-model cells instead of generic UE-* nodes.
 
     ;; Comma-separated names → list of trimmed name strings.
     (defn fsc-bml-name-list-strings-loop (args i acc)
@@ -662,6 +662,54 @@
     (defn fsc-bml-class-member-name (class-name member-name)
         (str_concat class-name (str_concat "_" member-name)))
 
+    (defn fsc-bml-template-use-source (class-name template-name type-arguments)
+        (list "fsc-bml-template-use" class-name template-name type-arguments))
+
+    (defn fsc-bml-template-use-source? (source)
+        (if (eq (len source) 4)
+            (str_eq (nth source 0) "fsc-bml-template-use")
+            false))
+
+    (defn fsc-bml-template-use-class-name (source) (nth source 1))
+    (defn fsc-bml-template-use-template-name (source) (nth source 2))
+    (defn fsc-bml-template-use-type-arguments (source) (nth source 3))
+
+    (defn fsc-bml-parse-template-use-source (class-name typed-template)
+        (do
+            (let type-open (fsc-find-char-from typed-template "<" 0))
+            (let type-close (fsc-find-char-from typed-template ">" type-open))
+            (let template-name (fsc-trim (fsc-sub typed-template 0 type-open)))
+            (let type-args-text (fsc-sub typed-template (add type-open 1) type-close))
+            (let type-args (fsc-bml-name-list-strings-loop type-args-text 0 (empty)))
+            (fsc-bml-template-use-source class-name template-name type-args)))
+
+    (defn fsc-bml-route-call-source (name args)
+        (list "fsc-bml-route-call" name args))
+
+    (defn fsc-bml-route-call-source? (source)
+        (if (eq (len source) 3)
+            (str_eq (nth source 0) "fsc-bml-route-call")
+            false))
+
+    (defn fsc-bml-route-call-name (source) (nth source 1))
+    (defn fsc-bml-route-call-args (source) (nth source 2))
+
+    (defn fsc-bml-route-call-source-from-expr (expr)
+        (do
+            (let value (fsc-strip-semi (fsc-trim expr)))
+            (let route-open (fsc-find-char-from value "(" 0))
+            (let route-close (fsc-last-char-index value))
+            (let route-call-name (fsc-trim (fsc-sub value 0 route-open)))
+            (let route-args (fsc-sub value (add route-open 1) route-close))
+            (fsc-bml-route-call-source route-call-name route-args)))
+
+    (defn fsc-bml-route-call-source-from-assignment (line)
+        (do
+            (let value (fsc-strip-semi line))
+            (let eq-pos (fsc-find-char-from value "=" 0))
+            (fsc-bml-route-call-source-from-expr
+                (fsc-sub value (add eq-pos 1) (str_len value)))))
+
     (defn fsc-bml-route-data-arg-recipes-for-class (args class-name)
         (do
             (let p (fsc-skip-spaces args 0))
@@ -675,6 +723,28 @@
                     (fsc-compile-form-bml-expr-recipe
                         (fsc-bml-class-member-name class-name handler-text))
                     (empty)))))
+
+    (defn fsc-bml-route-call-arg-recipes (route-call)
+        (if (str_eq (fsc-bml-route-call-name route-call) "route_data")
+            (fsc-bml-route-data-arg-recipes (fsc-bml-route-call-args route-call))
+            (fsc-bml-args-recipes-loop (fsc-bml-route-call-args route-call) 0 (empty))))
+
+    (defn fsc-bml-route-call-arg-recipes-for-class (route-call class-name)
+        (if (str_eq (fsc-bml-route-call-name route-call) "route_data")
+            (fsc-bml-route-data-arg-recipes-for-class
+                (fsc-bml-route-call-args route-call)
+                class-name)
+            (fsc-bml-args-recipes-loop (fsc-bml-route-call-args route-call) 0 (empty))))
+
+    (defn fsc-bml-route-call-language-class-fn (route-call)
+        (if (str_eq (fsc-bml-route-call-name route-call) "route_data")
+            "language-route-class-route-data"
+            "language-route-class"))
+
+    (defn fsc-bml-route-call-kernel-route-fn (route-call)
+        (if (str_eq (fsc-bml-route-call-name route-call) "route_data")
+            "kh-route-data-ref"
+            "kh-route"))
 
     ;; String literal escape interpretation. Mirrors the kernel parser so
     ;; Recipe-path source sections carry the same string cells as parsed Form.
@@ -891,49 +961,30 @@
             (let eq-pos (fsc-find-char-from line "=" colon))
             (let class-name (fsc-trim (fsc-sub line 6 colon)))
             (let typed-template (fsc-trim (fsc-sub line (add colon 1) eq-pos)))
-            (let type-open (fsc-find-char-from typed-template "<" 0))
-            (let type-close (fsc-find-char-from typed-template ">" type-open))
-            (let template-name (fsc-trim (fsc-sub typed-template 0 type-open)))
-            (let type-args-text (fsc-sub typed-template (add type-open 1) type-close))
-            (let type-args (fsc-bml-name-list-strings-loop type-args-text 0 (empty)))
-            (let route-open (fsc-find-char-from line "(" eq-pos))
-            (let route-close (fsc-last-char-index line))
-            (let route-call-name (fsc-trim (fsc-sub line (add eq-pos 1) route-open)))
-            (let route-args (fsc-sub line (add route-open 1) route-close))
-            (let route-arg-recipes
-                (if (str_eq route-call-name "route_data")
-                    (fsc-bml-route-data-arg-recipes route-args)
-                    (fsc-bml-args-recipes-loop route-args 0 (empty))))
+            (let template-use (fsc-bml-parse-template-use-source class-name typed-template))
+            (let route-call
+                (fsc-bml-route-call-source-from-expr
+                    (fsc-sub line (add eq-pos 1) (str_len line))))
+            (let route-arg-recipes (fsc-bml-route-call-arg-recipes route-call))
             (fsc-rec-let class-name
                 (fsc-rec-call
-                    (if (str_eq route-call-name "route_data")
-                        "language-route-class-route-data"
-                        "language-route-class")
-                    (cons (fsc-rec-string class-name)
-                    (cons (fsc-rec-ident template-name)
-                    (cons (fsc-rec-string-list type-args)
+                    (fsc-bml-route-call-language-class-fn route-call)
+                    (cons (fsc-rec-string (fsc-bml-template-use-class-name template-use))
+                    (cons (fsc-rec-ident (fsc-bml-template-use-template-name template-use))
+                    (cons (fsc-rec-string-list (fsc-bml-template-use-type-arguments template-use))
                           route-arg-recipes)))))))
 
     (defn fsc-compile-form-bml-language-class-block-route-recipe
         (line class-name template-name type-args)
         (do
-            (let value (fsc-strip-semi line))
-            (let eq-pos (fsc-find-char-from value "=" 0))
-            (let route-open (fsc-find-char-from value "(" eq-pos))
-            (let route-close (fsc-last-char-index value))
-            (let route-call-name (fsc-trim (fsc-sub value (add eq-pos 1) route-open)))
-            (let route-args (fsc-sub value (add route-open 1) route-close))
+            (let route-call (fsc-bml-route-call-source-from-assignment line))
             (let route-arg-recipes
-                (if (str_eq route-call-name "route_data")
-                    (fsc-bml-route-data-arg-recipes-for-class route-args class-name)
-                    (fsc-bml-args-recipes-loop route-args 0 (empty))))
+                (fsc-bml-route-call-arg-recipes-for-class route-call class-name))
             (fsc-rec-call "language-class-member-route"
                 (list
                     (fsc-rec-string "route")
                     (fsc-rec-call
-                        (if (str_eq route-call-name "route_data")
-                            "kh-route-data-ref"
-                            "kh-route")
+                        (fsc-bml-route-call-kernel-route-fn route-call)
                         route-arg-recipes)))))
 
     (defn fsc-compile-form-bml-class-def-block-recipe (body line body-start class-name)
@@ -1022,25 +1073,27 @@
             (let brace (fsc-find-char-from line "{" colon))
             (let class-name (fsc-trim (fsc-sub line 6 colon)))
             (let typed-template (fsc-trim (fsc-sub line (add colon 1) brace)))
-            (let type-open (fsc-find-char-from typed-template "<" 0))
-            (let type-close (fsc-find-char-from typed-template ">" type-open))
-            (let template-name (fsc-trim (fsc-sub typed-template 0 type-open)))
-            (let type-args-text (fsc-sub typed-template (add type-open 1) type-close))
-            (let type-args (fsc-bml-name-list-strings-loop type-args-text 0 (empty)))
+            (let template-use (fsc-bml-parse-template-use-source class-name typed-template))
             (let body-end (fsc-bml-block-end body body-start 0))
             (let method-defs
                 (fsc-bml-class-method-defs-loop body body-start body-end class-name (empty)))
             (let members
                 (fsc-bml-class-member-recipes-loop
-                    body body-start body-end class-name template-name type-args (empty)))
+                    body
+                    body-start
+                    body-end
+                    class-name
+                    (fsc-bml-template-use-template-name template-use)
+                    (fsc-bml-template-use-type-arguments template-use)
+                    (empty)))
             (fsc-list-append method-defs
                 (list
                     (fsc-rec-let class-name
                         (fsc-rec-call "language-class"
                             (list
-                                (fsc-rec-string class-name)
-                                (fsc-rec-ident template-name)
-                                (fsc-rec-string-list type-args)
+                                (fsc-rec-string (fsc-bml-template-use-class-name template-use))
+                                (fsc-rec-ident (fsc-bml-template-use-template-name template-use))
+                                (fsc-rec-string-list (fsc-bml-template-use-type-arguments template-use))
                                 (fsc-rec-list-of members))))))))
 
     ;; A block-line returns a (possibly empty) list of recipes. Empty for

--- a/form/form-stdlib/source-compiler.fk
+++ b/form/form-stdlib/source-compiler.fk
@@ -287,7 +287,91 @@
                 (fsc-float-body? (fsc-sub value 1 (str_len value)))
                 (fsc-float-body? value)))))
 
-    
+    (defn fsc-bml-find-comma-loop (s i depth quoted)
+        (if (ge i (str_len s)) (sub 0 1)
+            (do
+                (let ch (char_at s i))
+                (if quoted
+                    (if (and (str_eq ch "\\") (lt (add i 1) (str_len s)))
+                        (fsc-bml-find-comma-loop s (add i 2) depth quoted)
+                        (if (str_eq ch "\"")
+                            (fsc-bml-find-comma-loop s (add i 1) depth false)
+                            (fsc-bml-find-comma-loop s (add i 1) depth quoted)))
+                    (if (str_eq ch "\"")
+                        (fsc-bml-find-comma-loop s (add i 1) depth true)
+                        (if (str_eq ch "(")
+                            (fsc-bml-find-comma-loop s (add i 1) (add depth 1) quoted)
+                            (if (str_eq ch ")")
+                                (fsc-bml-find-comma-loop s (add i 1) (sub depth 1) quoted)
+                                (if (and (eq depth 0) (str_eq ch ","))
+                                    i
+                                    (fsc-bml-find-comma-loop s (add i 1) depth quoted)))))))))
+
+    (defn fsc-bml-find-comma (s i)
+        (fsc-bml-find-comma-loop s i 0 false))
+
+    (defn fsc-bml-block-end (body i depth)
+        (do
+            (let e (fsc-line-end body i))
+            (let line (fsc-trim (fsc-sub body i e)))
+            (if (str_eq line "}")
+                (if (eq depth 0) i
+                    (fsc-bml-block-end body (fsc-line-next body i) (sub depth 1)))
+                (if (fsc-line-opens-block? line)
+                    (fsc-bml-block-end body (fsc-line-next body i) (add depth 1))
+                    (fsc-bml-block-end body (fsc-line-next body i) depth)))))
+
+    (defn fsc-bml-comment-line? (line)
+        (if (fsc-skip-rule-line? line) true
+            (fsc-prefix? line "//")))
+
+    (defn fsc-bml-normalize-ws-loop (s i quoted saw-space)
+        (if (ge i (str_len s)) ""
+            (do
+                (let ch (char_at s i))
+                (if quoted
+                    (if (and (str_eq ch "\\") (lt (add i 1) (str_len s)))
+                        (str_concat ch
+                            (str_concat
+                                (char_at s (add i 1))
+                                (fsc-bml-normalize-ws-loop s (add i 2) quoted false)))
+                        (str_concat ch
+                            (fsc-bml-normalize-ws-loop s (add i 1) (if (str_eq ch "\"") false true) false)))
+                    (if (str_eq ch "\"")
+                        (str_concat ch
+                            (fsc-bml-normalize-ws-loop s (add i 1) true false))
+                        (if (fsc-space? ch)
+                            (if saw-space
+                                (fsc-bml-normalize-ws-loop s (add i 1) quoted saw-space)
+                                (str_concat " " (fsc-bml-normalize-ws-loop s (add i 1) quoted true)))
+                            (str_concat ch
+                                (fsc-bml-normalize-ws-loop s (add i 1) quoted false))))))))
+
+    (defn fsc-bml-normalize-ws (s)
+        (fsc-trim (fsc-bml-normalize-ws-loop s 0 false false)))
+
+    (defn fsc-bml-stmt-end-loop (body i end depth quoted)
+        (if (ge i end) end
+            (do
+                (let ch (char_at body i))
+                (if quoted
+                    (if (and (str_eq ch "\\") (lt (add i 1) end))
+                        (fsc-bml-stmt-end-loop body (add i 2) end depth quoted)
+                        (if (str_eq ch "\"")
+                            (fsc-bml-stmt-end-loop body (add i 1) end depth false)
+                            (fsc-bml-stmt-end-loop body (add i 1) end depth quoted)))
+                    (if (str_eq ch "\"")
+                        (fsc-bml-stmt-end-loop body (add i 1) end depth true)
+                        (if (str_eq ch "(")
+                            (fsc-bml-stmt-end-loop body (add i 1) end (add depth 1) quoted)
+                            (if (str_eq ch ")")
+                                (fsc-bml-stmt-end-loop body (add i 1) end (sub depth 1) quoted)
+                                (if (and (eq depth 0) (str_eq ch ";"))
+                                    (add i 1)
+                                    (fsc-bml-stmt-end-loop body (add i 1) end depth quoted)))))))))
+
+    (defn fsc-bml-stmt-end (body i end)
+        (fsc-bml-stmt-end-loop body i end 0 false))
 
     (defn fsc-high-level-form-dialect? (dialect-name)
         (or (str_eq dialect-name "form.bml")
@@ -533,7 +617,85 @@
         (if (fsc-empty? xs) ys
             (cons (head xs) (fsc-list-append (tail xs) ys))))
 
-    
+    ;; --- route-domain BML lowering -----------------------------------
+    ;;
+    ;; `form.route` is a BML-shaped domain surface. It lowers template/class
+    ;; route declarations into the shared language-model cells instead of the
+    ;; generic UE-* nodes used by the broad BML grammar.
+
+    ;; Comma-separated names → list of trimmed name strings.
+    (defn fsc-bml-name-list-strings-loop (args i acc)
+        (do
+            (let p (fsc-skip-spaces args i))
+            (if (ge p (str_len args)) (fsc-rev acc)
+                (do
+                    (let comma (fsc-find-char-from args "," p))
+                    (let end (if (lt comma 0) (str_len args) comma))
+                    (let name (fsc-trim (fsc-sub args p end)))
+                    (let rest-start (if (lt comma 0) (str_len args) (add comma 1)))
+                    (fsc-bml-name-list-strings-loop args rest-start (cons name acc))))))
+
+    ;; Comma-separated arg exprs → list of arg Recipes (in order).
+    (defn fsc-bml-args-recipes-loop (args i acc)
+        (do
+            (let p (fsc-skip-spaces args i))
+            (if (ge p (str_len args)) (fsc-rev acc)
+                (do
+                    (let comma (fsc-bml-find-comma args p))
+                    (let end (if (lt comma 0) (str_len args) comma))
+                    (let part (fsc-trim (fsc-sub args p end)))
+                    (let rest-start (if (lt comma 0) (str_len args) (add comma 1)))
+                    (fsc-bml-args-recipes-loop args rest-start
+                        (cons (fsc-compile-form-bml-expr-recipe part) acc))))))
+
+    (defn fsc-bml-route-data-arg-recipes (args)
+        (do
+            (let p (fsc-skip-spaces args 0))
+            (let comma (fsc-bml-find-comma args p))
+            (let route-id-end (if (lt comma 0) (str_len args) comma))
+            (let handler-start (if (lt comma 0) (str_len args) (add comma 1)))
+            (let route-id (fsc-trim (fsc-sub args p route-id-end)))
+            (let handler-text (fsc-trim (fsc-sub args handler-start (str_len args))))
+            (cons (fsc-rec-string route-id)
+                  (cons (fsc-compile-form-bml-expr-recipe handler-text) (empty)))))
+
+    (defn fsc-bml-class-member-name (class-name member-name)
+        (str_concat class-name (str_concat "_" member-name)))
+
+    (defn fsc-bml-route-data-arg-recipes-for-class (args class-name)
+        (do
+            (let p (fsc-skip-spaces args 0))
+            (let comma (fsc-bml-find-comma args p))
+            (let route-id-end (if (lt comma 0) (str_len args) comma))
+            (let handler-start (if (lt comma 0) (str_len args) (add comma 1)))
+            (let route-id (fsc-trim (fsc-sub args p route-id-end)))
+            (let handler-text (fsc-trim (fsc-sub args handler-start (str_len args))))
+            (cons (fsc-rec-string route-id)
+                  (cons
+                    (fsc-compile-form-bml-expr-recipe
+                        (fsc-bml-class-member-name class-name handler-text))
+                    (empty)))))
+
+    ;; String literal escape interpretation. Mirrors the kernel parser so
+    ;; Recipe-path source sections carry the same string cells as parsed Form.
+    (defn fsc-unescape-str-loop (s i acc)
+        (if (ge i (str_len s)) acc
+            (do
+                (let ch (char_at s i))
+                (if (and (str_eq ch "\\") (lt (add i 1) (str_len s)))
+                    (do
+                        (let nx (char_at s (add i 1)))
+                        (let lit
+                            (if (str_eq nx "n") "\n"
+                            (if (str_eq nx "t") "\t"
+                            (if (str_eq nx "r") "\r"
+                            (if (str_eq nx "\\") "\\"
+                            (if (str_eq nx "\"") "\""
+                                nx))))))
+                        (fsc-unescape-str-loop s (add i 2) (str_concat acc lit)))
+                    (fsc-unescape-str-loop s (add i 1) (str_concat acc ch))))))
+
+    (defn fsc-unescape-str (s) (fsc-unescape-str-loop s 0 ""))
 
     ;; Math/compare/logic primitives are parser SPECIAL FORMS in the
     ;; kernel — there's no env binding for `gt`, `add`, etc. Look the
@@ -546,6 +708,438 @@
                 (fsc-rec-call name args)
                 (intern_node (form-prim-node prim-row) args))))
 
+    (defn fsc-compile-form-bml-call-recipe (expr open)
+        (do
+            (let close (fsc-last-char-index expr))
+            (let name (fsc-trim (fsc-sub expr 0 open)))
+            (let args (fsc-sub expr (add open 1) close))
+            (let arg-recipes (if (eq (str_len (fsc-trim args)) 0) (empty)
+                                 (fsc-bml-args-recipes-loop args 0 (empty))))
+            (fsc-rec-form-call name arg-recipes)))
+
+    ;; Match inline `if ... then ... else ...` at the top level. The scanner
+    ;; respects strings, call parentheses, and nested top-level if branches.
+    (defn fsc-bml-prev-token-boundary? (s i)
+        (if (le i 0) true
+            (do
+                (let prev (char_at s (sub i 1)))
+                (or (fsc-space? prev)
+                    (or (str_eq prev "(") (str_eq prev ","))))))
+
+    (defn fsc-bml-if-token-at? (s i)
+        (and (fsc-bml-prev-token-boundary? s i)
+             (fsc-find-string-at? s "if " i 0)))
+
+    (defn fsc-bml-find-top-then-loop (s i depth quoted)
+        (if (ge i (str_len s)) (sub 0 1)
+            (do
+                (let ch (char_at s i))
+                (if quoted
+                    (if (and (str_eq ch "\\") (lt (add i 1) (str_len s)))
+                        (fsc-bml-find-top-then-loop s (add i 2) depth quoted)
+                        (if (str_eq ch "\"")
+                            (fsc-bml-find-top-then-loop s (add i 1) depth false)
+                            (fsc-bml-find-top-then-loop s (add i 1) depth quoted)))
+                    (if (str_eq ch "\"")
+                        (fsc-bml-find-top-then-loop s (add i 1) depth true)
+                        (if (str_eq ch "(")
+                            (fsc-bml-find-top-then-loop s (add i 1) (add depth 1) quoted)
+                            (if (str_eq ch ")")
+                                (fsc-bml-find-top-then-loop s (add i 1) (sub depth 1) quoted)
+                                (if (and (eq depth 0) (fsc-find-string-at? s " then " i 0))
+                                    i
+                                    (fsc-bml-find-top-then-loop s (add i 1) depth quoted)))))))))
+
+    (defn fsc-bml-find-top-then (s)
+        (fsc-bml-find-top-then-loop s 0 0 false))
+
+    (defn fsc-bml-find-matching-else-loop (s i depth quoted nested)
+        (if (ge i (str_len s)) (sub 0 1)
+            (do
+                (let ch (char_at s i))
+                (if quoted
+                    (if (and (str_eq ch "\\") (lt (add i 1) (str_len s)))
+                        (fsc-bml-find-matching-else-loop s (add i 2) depth quoted nested)
+                        (if (str_eq ch "\"")
+                            (fsc-bml-find-matching-else-loop s (add i 1) depth false nested)
+                            (fsc-bml-find-matching-else-loop s (add i 1) depth quoted nested)))
+                    (if (str_eq ch "\"")
+                        (fsc-bml-find-matching-else-loop s (add i 1) depth true nested)
+                        (if (str_eq ch "(")
+                            (fsc-bml-find-matching-else-loop s (add i 1) (add depth 1) quoted nested)
+                            (if (str_eq ch ")")
+                                (fsc-bml-find-matching-else-loop s (add i 1) (sub depth 1) quoted nested)
+                                (if (and (eq depth 0) (fsc-bml-if-token-at? s i))
+                                    (fsc-bml-find-matching-else-loop s (add i 3) depth quoted (add nested 1))
+                                    (if (and (eq depth 0) (fsc-find-string-at? s " else " i 0))
+                                        (if (eq nested 0)
+                                            i
+                                            (fsc-bml-find-matching-else-loop s (add i 6) depth quoted (sub nested 1)))
+                                        (fsc-bml-find-matching-else-loop s (add i 1) depth quoted nested))))))))))
+
+    (defn fsc-bml-find-matching-else (s then-pos)
+        (fsc-bml-find-matching-else-loop s (add then-pos 6) 0 false 0))
+
+    (defn fsc-compile-form-bml-if-recipe (expr)
+        (do
+            (let then-pos (fsc-bml-find-top-then expr))
+            (let else-pos (fsc-bml-find-matching-else expr then-pos))
+            (let cond-text (fsc-trim (fsc-sub expr 3 then-pos)))
+            (let yes-text (fsc-trim (fsc-sub expr (add then-pos 6) else-pos)))
+            (let no-text (fsc-trim (fsc-sub expr (add else-pos 6) (str_len expr))))
+            (fsc-rec-if3 (fsc-compile-form-bml-expr-recipe cond-text)
+                         (fsc-compile-form-bml-expr-recipe yes-text)
+                         (fsc-compile-form-bml-expr-recipe no-text))))
+
+    (defn fsc-compile-form-bml-expr-recipe (raw)
+        (do
+            (let expr (fsc-bml-normalize-ws (fsc-strip-semi raw)))
+            (let open (fsc-find-char-from expr "(" 0))
+            (if (eq (str_len expr) 0) (fsc-rec-call "empty" (empty))
+            (if (fsc-prefix? expr "if ")
+                (fsc-compile-form-bml-if-recipe expr)
+            (if (and (ge open 0) (str_eq (char_at expr (fsc-last-char-index expr)) ")"))
+                (fsc-compile-form-bml-call-recipe expr open)
+            (if (str_eq expr "empty") (fsc-rec-call "empty" (empty))
+            (if (str_eq expr "true")  (fsc-rec-true)
+            (if (str_eq expr "false") (fsc-rec-false)
+            (if (str_eq expr "null")  (fsc-rec-ident "null")
+            (if (fsc-float? expr) (intern_trivial_float expr)
+            (if (fsc-int? expr) (intern_trivial_int (str_to_int expr))
+            (if (str_eq (char_at expr 0) "\"")
+                (intern_trivial_string
+                    (fsc-unescape-str (fsc-sub expr 1 (fsc-last-char-index expr))))
+                (fsc-rec-ident expr)))))))))))))
+
+    (defn fsc-compile-form-bml-def-recipe (line)
+        (do
+            (let open (fsc-find-char-from line "(" 4))
+            (let close (fsc-find-char-from line ")" open))
+            (let eq-pos (fsc-find-char-from line "=" close))
+            (let name (fsc-trim (fsc-sub line 4 open)))
+            (let args (fsc-sub line (add open 1) close))
+            (let body (fsc-sub line (add eq-pos 1) (str_len line)))
+            (let param-names (fsc-bml-name-list-strings-loop args 0 (empty)))
+            (fsc-rec-fndef name param-names
+                           (fsc-compile-form-bml-expr-recipe body))))
+
+    (defn fsc-compile-form-bml-let-recipe (line)
+        (do
+            (let eq-pos (fsc-find-char-from line "=" 4))
+            (let name (fsc-trim (fsc-sub line 4 eq-pos)))
+            (let body (fsc-sub line (add eq-pos 1) (str_len line)))
+            (fsc-rec-let name (fsc-compile-form-bml-expr-recipe body))))
+
+    (defn fsc-compile-form-bml-template-recipe (line)
+        (do
+            (let open (fsc-find-char-from line "<" 9))
+            (let close (fsc-find-char-from line ">" open))
+            (let name (fsc-trim (fsc-sub line 9 open)))
+            (let params (fsc-sub line (add open 1) close))
+            (let param-names (fsc-bml-name-list-strings-loop params 0 (empty)))
+            (fsc-rec-let name
+                (fsc-rec-call "language-template"
+                    (list
+                        (fsc-rec-string name)
+                        (fsc-rec-string-list param-names))))))
+
+    (defn fsc-compile-form-bml-template-member-recipe (line)
+        (do
+            (let value (fsc-strip-semi line))
+            (let colon (fsc-find-char-from value ":" 7))
+            (let name (fsc-trim (fsc-sub value 7 colon)))
+            (let value-type (fsc-trim (fsc-sub value (add colon 1) (str_len value))))
+            (fsc-rec-call "language-template-member"
+                (list (fsc-rec-string name) (fsc-rec-string value-type)))))
+
+    (defn fsc-bml-template-members-loop (body i end acc)
+        (do
+            (let p (fsc-skip-spaces body i))
+            (if (ge p end) (fsc-rev acc)
+                (do
+                    (let line-end (fsc-line-end body p))
+                    (let line (fsc-trim (fsc-sub body p line-end)))
+                    (if (fsc-bml-comment-line? line)
+                        (fsc-bml-template-members-loop body
+                            (fsc-line-next body p) end acc)
+                    (if (fsc-prefix? line "member ")
+                        (fsc-bml-template-members-loop body
+                            (fsc-line-next body p) end
+                            (cons (fsc-compile-form-bml-template-member-recipe line) acc))
+                        (fsc-bml-template-members-loop body
+                            (fsc-line-next body p) end acc)))))))
+
+    (defn fsc-compile-form-bml-template-block-recipe (body line body-start)
+        (do
+            (let open (fsc-find-char-from line "<" 9))
+            (let close (fsc-find-char-from line ">" open))
+            (let name (fsc-trim (fsc-sub line 9 open)))
+            (let params (fsc-sub line (add open 1) close))
+            (let param-names (fsc-bml-name-list-strings-loop params 0 (empty)))
+            (let body-end (fsc-bml-block-end body body-start 0))
+            (let members (fsc-bml-template-members-loop body body-start body-end (empty)))
+            (fsc-rec-let name
+                (fsc-rec-call "language-template-with-members"
+                    (list
+                        (fsc-rec-string name)
+                        (fsc-rec-string-list param-names)
+                        (fsc-rec-list-of members))))))
+
+    (defn fsc-compile-form-bml-language-class-recipe (line)
+        (do
+            (let colon (fsc-find-char-from line ":" 6))
+            (let eq-pos (fsc-find-char-from line "=" colon))
+            (let class-name (fsc-trim (fsc-sub line 6 colon)))
+            (let typed-template (fsc-trim (fsc-sub line (add colon 1) eq-pos)))
+            (let type-open (fsc-find-char-from typed-template "<" 0))
+            (let type-close (fsc-find-char-from typed-template ">" type-open))
+            (let template-name (fsc-trim (fsc-sub typed-template 0 type-open)))
+            (let type-args-text (fsc-sub typed-template (add type-open 1) type-close))
+            (let type-args (fsc-bml-name-list-strings-loop type-args-text 0 (empty)))
+            (let route-open (fsc-find-char-from line "(" eq-pos))
+            (let route-close (fsc-last-char-index line))
+            (let route-call-name (fsc-trim (fsc-sub line (add eq-pos 1) route-open)))
+            (let route-args (fsc-sub line (add route-open 1) route-close))
+            (let route-arg-recipes
+                (if (str_eq route-call-name "route_data")
+                    (fsc-bml-route-data-arg-recipes route-args)
+                    (fsc-bml-args-recipes-loop route-args 0 (empty))))
+            (fsc-rec-let class-name
+                (fsc-rec-call
+                    (if (str_eq route-call-name "route_data")
+                        "language-route-class-route-data"
+                        "language-route-class")
+                    (cons (fsc-rec-string class-name)
+                    (cons (fsc-rec-ident template-name)
+                    (cons (fsc-rec-string-list type-args)
+                          route-arg-recipes)))))))
+
+    (defn fsc-compile-form-bml-language-class-block-route-recipe
+        (line class-name template-name type-args)
+        (do
+            (let value (fsc-strip-semi line))
+            (let eq-pos (fsc-find-char-from value "=" 0))
+            (let route-open (fsc-find-char-from value "(" eq-pos))
+            (let route-close (fsc-last-char-index value))
+            (let route-call-name (fsc-trim (fsc-sub value (add eq-pos 1) route-open)))
+            (let route-args (fsc-sub value (add route-open 1) route-close))
+            (let route-arg-recipes
+                (if (str_eq route-call-name "route_data")
+                    (fsc-bml-route-data-arg-recipes-for-class route-args class-name)
+                    (fsc-bml-args-recipes-loop route-args 0 (empty))))
+            (fsc-rec-call "language-class-member-route"
+                (list
+                    (fsc-rec-string "route")
+                    (fsc-rec-call
+                        (if (str_eq route-call-name "route_data")
+                            "kh-route-data-ref"
+                            "kh-route")
+                        route-arg-recipes)))))
+
+    (defn fsc-compile-form-bml-class-def-block-recipe (body line body-start class-name)
+        (do
+            (let open (fsc-find-char-from line "(" 4))
+            (let close (fsc-find-char-from line ")" open))
+            (let method-name (fsc-trim (fsc-sub line 4 open)))
+            (let args (fsc-sub line (add open 1) close))
+            (let param-names (fsc-bml-name-list-strings-loop args 0 (empty)))
+            (let body-end (fsc-bml-block-end body body-start 0))
+            (let stmt-recipes
+                (fsc-bml-block-stmts-recipes-loop body body-start body-end (empty)))
+            (fsc-rec-fndef
+                (fsc-bml-class-member-name class-name method-name)
+                param-names
+                (fsc-rec-do stmt-recipes))))
+
+    (defn fsc-compile-form-bml-class-method-member-recipe (line class-name)
+        (do
+            (let open (fsc-find-char-from line "(" 4))
+            (let method-name (fsc-trim (fsc-sub line 4 open)))
+            (fsc-rec-call "language-class-member-method"
+                (list
+                    (fsc-rec-string method-name)
+                    (fsc-rec-ident (fsc-bml-class-member-name class-name method-name))))))
+
+    (defn fsc-bml-class-method-defs-loop
+        (body i end class-name acc)
+        (do
+            (let p (fsc-skip-spaces body i))
+            (if (ge p end) (fsc-rev acc)
+                (do
+                    (let line-end (fsc-line-end body p))
+                    (let line (fsc-trim (fsc-sub body p line-end)))
+                    (if (fsc-bml-comment-line? line)
+                        (fsc-bml-class-method-defs-loop body
+                            (fsc-line-next body p) end class-name acc)
+                    (if (and (fsc-prefix? line "def ") (fsc-line-opens-block? line))
+                        (do
+                            (let method-start (fsc-line-next body p))
+                            (let method-end (fsc-bml-block-end body method-start 0))
+                            (fsc-bml-class-method-defs-loop body
+                                (fsc-line-next body method-end) end class-name
+                                (cons
+                                    (fsc-compile-form-bml-class-def-block-recipe
+                                        body line method-start class-name)
+                                    acc)))
+                        (fsc-bml-class-method-defs-loop body
+                            (fsc-line-next body p) end class-name acc)))))))
+
+    (defn fsc-bml-class-member-recipes-loop
+        (body i end class-name template-name type-args acc)
+        (do
+            (let p (fsc-skip-spaces body i))
+            (if (ge p end) (fsc-rev acc)
+                (do
+                    (let line-end (fsc-line-end body p))
+                    (let line (fsc-trim (fsc-sub body p line-end)))
+                    (if (fsc-bml-comment-line? line)
+                        (fsc-bml-class-member-recipes-loop body
+                            (fsc-line-next body p) end class-name template-name type-args acc)
+                    (if (and (fsc-prefix? line "def ") (fsc-line-opens-block? line))
+                        (do
+                            (let method-start (fsc-line-next body p))
+                            (let method-end (fsc-bml-block-end body method-start 0))
+                            (fsc-bml-class-member-recipes-loop body
+                                (fsc-line-next body method-end) end class-name template-name type-args
+                                (cons
+                                    (fsc-compile-form-bml-class-method-member-recipe line class-name)
+                                    acc)))
+                    (do
+                        (let stmt-end (fsc-bml-stmt-end body p end))
+                        (let stmt (fsc-trim (fsc-sub body p stmt-end)))
+                        (let member-recipes
+                            (if (fsc-prefix? (fsc-strip-semi stmt) "route ")
+                                (list
+                                    (fsc-compile-form-bml-language-class-block-route-recipe
+                                        stmt class-name template-name type-args))
+                                (empty)))
+                        (fsc-bml-class-member-recipes-loop body stmt-end end class-name template-name type-args
+                            (fsc-rec-append-rev member-recipes acc)))))))))
+
+    (defn fsc-compile-form-bml-language-class-block-recipes (body line body-start)
+        (do
+            (let colon (fsc-find-char-from line ":" 6))
+            (let brace (fsc-find-char-from line "{" colon))
+            (let class-name (fsc-trim (fsc-sub line 6 colon)))
+            (let typed-template (fsc-trim (fsc-sub line (add colon 1) brace)))
+            (let type-open (fsc-find-char-from typed-template "<" 0))
+            (let type-close (fsc-find-char-from typed-template ">" type-open))
+            (let template-name (fsc-trim (fsc-sub typed-template 0 type-open)))
+            (let type-args-text (fsc-sub typed-template (add type-open 1) type-close))
+            (let type-args (fsc-bml-name-list-strings-loop type-args-text 0 (empty)))
+            (let body-end (fsc-bml-block-end body body-start 0))
+            (let method-defs
+                (fsc-bml-class-method-defs-loop body body-start body-end class-name (empty)))
+            (let members
+                (fsc-bml-class-member-recipes-loop
+                    body body-start body-end class-name template-name type-args (empty)))
+            (fsc-list-append method-defs
+                (list
+                    (fsc-rec-let class-name
+                        (fsc-rec-call "language-class"
+                            (list
+                                (fsc-rec-string class-name)
+                                (fsc-rec-ident template-name)
+                                (fsc-rec-string-list type-args)
+                                (fsc-rec-list-of members))))))))
+
+    ;; A block-line returns a (possibly empty) list of recipes. Empty for
+    ;; comments; one recipe for let or bare expr.
+    (defn fsc-compile-form-bml-block-line-recipe (line)
+        (do
+            (let value (fsc-strip-semi line))
+            (if (fsc-bml-comment-line? value) (empty)
+                (if (fsc-prefix? value "let ")
+                    (do
+                    (let eq-pos (fsc-find-char-from value "=" 4))
+                    (let name (fsc-trim (fsc-sub value 4 eq-pos)))
+                    (let body (fsc-sub value (add eq-pos 1) (str_len value)))
+                    (list (fsc-rec-let name (fsc-compile-form-bml-expr-recipe body))))
+                (list (fsc-compile-form-bml-expr-recipe value))))))
+
+    (defn fsc-bml-block-stmts-recipes-loop (body i end acc)
+        (do
+            (let p (fsc-skip-spaces body i))
+            (if (ge p end) (fsc-rev acc)
+                (do
+                    (let line-end (fsc-line-end body p))
+                    (let line (fsc-trim (fsc-sub body p line-end)))
+                    (if (fsc-bml-comment-line? line)
+                        (fsc-bml-block-stmts-recipes-loop body
+                            (fsc-line-next body p) end acc)
+                    (do
+                    (let stmt-end (fsc-bml-stmt-end body p end))
+                    (let stmt (fsc-trim (fsc-sub body p stmt-end)))
+                    (let line-recipes (fsc-compile-form-bml-block-line-recipe stmt))
+                    (fsc-bml-block-stmts-recipes-loop body stmt-end end
+                        (fsc-rec-append-rev line-recipes acc))))))))
+
+    (defn fsc-compile-form-bml-def-block-recipe (body line body-start)
+        (do
+            (let open (fsc-find-char-from line "(" 4))
+            (let close (fsc-find-char-from line ")" open))
+            (let name (fsc-trim (fsc-sub line 4 open)))
+            (let args (fsc-sub line (add open 1) close))
+            (let param-names (fsc-bml-name-list-strings-loop args 0 (empty)))
+            (let body-end (fsc-bml-block-end body body-start 0))
+            (let stmt-recipes
+                (fsc-bml-block-stmts-recipes-loop body body-start body-end (empty)))
+            (fsc-rec-fndef name param-names (fsc-rec-do stmt-recipes))))
+
+    (defn fsc-compile-form-bml-line-recipe (line)
+        (do
+            (let value (fsc-strip-semi line))
+            (if (fsc-bml-comment-line? value) (empty)
+            (if (fsc-prefix? value "template ")
+                (list (fsc-compile-form-bml-template-recipe value))
+            (if (fsc-prefix? value "class ")
+                (list (fsc-compile-form-bml-language-class-recipe value))
+            (if (fsc-prefix? value "def ")
+                (list (fsc-compile-form-bml-def-recipe value))
+            (if (fsc-prefix? value "let ")
+                (list (fsc-compile-form-bml-let-recipe value))
+                (list (fsc-compile-form-bml-expr-recipe value)))))))))
+
+    (defn fsc-form-bml-lines-recipes-loop (body i acc)
+        (do
+            (let p (fsc-skip-spaces body i))
+            (if (ge p (str_len body)) (fsc-rev acc)
+            (do
+                (let e (fsc-line-end body p))
+                (let line (fsc-trim (fsc-sub body p e)))
+                (if (and (fsc-prefix? line "template ") (fsc-line-opens-block? line))
+                    (do
+                        (let body-start (fsc-line-next body p))
+                        (let body-end (fsc-bml-block-end body body-start 0))
+                        (fsc-form-bml-lines-recipes-loop body
+                            (fsc-line-next body body-end)
+                            (cons (fsc-compile-form-bml-template-block-recipe body line body-start)
+                                  acc)))
+                (if (and (fsc-prefix? line "class ") (fsc-line-opens-block? line))
+                    (do
+                        (let body-start (fsc-line-next body p))
+                        (let body-end (fsc-bml-block-end body body-start 0))
+                        (let class-recipes
+                            (fsc-compile-form-bml-language-class-block-recipes body line body-start))
+                        (fsc-form-bml-lines-recipes-loop body
+                            (fsc-line-next body body-end)
+                            (fsc-rec-append-rev class-recipes acc)))
+                (if (and (fsc-prefix? line "def ") (fsc-line-opens-block? line))
+                    (do
+                        (let body-start (fsc-line-next body p))
+                        (let body-end (fsc-bml-block-end body body-start 0))
+                        (fsc-form-bml-lines-recipes-loop body
+                            (fsc-line-next body body-end)
+                            (cons (fsc-compile-form-bml-def-block-recipe body line body-start)
+                                  acc)))
+                    (do
+                        (let line-recipes (fsc-compile-form-bml-line-recipe line))
+                        (fsc-form-bml-lines-recipes-loop body
+                            (fsc-line-next body p)
+                            (fsc-rec-append-rev line-recipes acc))))))))))
+
+    (defn fsc-compile-form-route-section-recipe (body)
+        (fsc-rec-do (fsc-form-bml-lines-recipes-loop body 0 (empty))))
 
 
     ;; --- Recipe source emitter --------------------------------------
@@ -640,9 +1234,11 @@
     ;; --- compile section as executable Form source -------------------
 
     (defn fsc-compile-section-recipe (dialect-name body)
+        (if (str_eq dialect-name "form.route")
+            (fsc-compile-form-route-section-recipe body)
         (if (fsc-high-level-form-dialect? dialect-name)
             (g-parse (bml-grammar) body)
-            (fsc-bmf-section-recipe dialect-name body)))
+            (fsc-bmf-section-recipe dialect-name body))))
 
     (defn fsc-compile-section (dialect-name body)
         (do

--- a/form/form-stdlib/source-compiler.fk
+++ b/form/form-stdlib/source-compiler.fk
@@ -617,11 +617,11 @@
         (if (fsc-empty? xs) ys
             (cons (head xs) (fsc-list-append (tail xs) ys))))
 
-    ;; --- BML source objects + route-domain lowering -------------------
+    ;; --- BML route-domain lowering ------------------------------------
     ;;
-    ;; `form.route` is a BML-shaped domain surface. BML mechanics become
-    ;; source objects first; the route dialect then lowers those objects into
-    ;; shared language-model cells instead of generic UE-* nodes.
+    ;; `form.route` is a BML-shaped domain surface. Shared source cells live in
+    ;; bml-source.fk; this compiler consumes them and lowers route-domain
+    ;; objects into shared language-model cells instead of generic UE-* nodes.
 
     ;; Comma-separated names → list of trimmed name strings.
     (defn fsc-bml-name-list-strings-loop (args i acc)
@@ -662,54 +662,6 @@
     (defn fsc-bml-class-member-name (class-name member-name)
         (str_concat class-name (str_concat "_" member-name)))
 
-    (defn fsc-bml-template-use-source (class-name template-name type-arguments)
-        (list "fsc-bml-template-use" class-name template-name type-arguments))
-
-    (defn fsc-bml-template-use-source? (source)
-        (if (eq (len source) 4)
-            (str_eq (nth source 0) "fsc-bml-template-use")
-            false))
-
-    (defn fsc-bml-template-use-class-name (source) (nth source 1))
-    (defn fsc-bml-template-use-template-name (source) (nth source 2))
-    (defn fsc-bml-template-use-type-arguments (source) (nth source 3))
-
-    (defn fsc-bml-parse-template-use-source (class-name typed-template)
-        (do
-            (let type-open (fsc-find-char-from typed-template "<" 0))
-            (let type-close (fsc-find-char-from typed-template ">" type-open))
-            (let template-name (fsc-trim (fsc-sub typed-template 0 type-open)))
-            (let type-args-text (fsc-sub typed-template (add type-open 1) type-close))
-            (let type-args (fsc-bml-name-list-strings-loop type-args-text 0 (empty)))
-            (fsc-bml-template-use-source class-name template-name type-args)))
-
-    (defn fsc-bml-route-call-source (name args)
-        (list "fsc-bml-route-call" name args))
-
-    (defn fsc-bml-route-call-source? (source)
-        (if (eq (len source) 3)
-            (str_eq (nth source 0) "fsc-bml-route-call")
-            false))
-
-    (defn fsc-bml-route-call-name (source) (nth source 1))
-    (defn fsc-bml-route-call-args (source) (nth source 2))
-
-    (defn fsc-bml-route-call-source-from-expr (expr)
-        (do
-            (let value (fsc-strip-semi (fsc-trim expr)))
-            (let route-open (fsc-find-char-from value "(" 0))
-            (let route-close (fsc-last-char-index value))
-            (let route-call-name (fsc-trim (fsc-sub value 0 route-open)))
-            (let route-args (fsc-sub value (add route-open 1) route-close))
-            (fsc-bml-route-call-source route-call-name route-args)))
-
-    (defn fsc-bml-route-call-source-from-assignment (line)
-        (do
-            (let value (fsc-strip-semi line))
-            (let eq-pos (fsc-find-char-from value "=" 0))
-            (fsc-bml-route-call-source-from-expr
-                (fsc-sub value (add eq-pos 1) (str_len value)))))
-
     (defn fsc-bml-route-data-arg-recipes-for-class (args class-name)
         (do
             (let p (fsc-skip-spaces args 0))
@@ -725,24 +677,24 @@
                     (empty)))))
 
     (defn fsc-bml-route-call-arg-recipes (route-call)
-        (if (str_eq (fsc-bml-route-call-name route-call) "route_data")
-            (fsc-bml-route-data-arg-recipes (fsc-bml-route-call-args route-call))
-            (fsc-bml-args-recipes-loop (fsc-bml-route-call-args route-call) 0 (empty))))
+        (if (str_eq (bml-source-route-call-name route-call) "route_data")
+            (fsc-bml-route-data-arg-recipes (bml-source-route-call-args route-call))
+            (fsc-bml-args-recipes-loop (bml-source-route-call-args route-call) 0 (empty))))
 
     (defn fsc-bml-route-call-arg-recipes-for-class (route-call class-name)
-        (if (str_eq (fsc-bml-route-call-name route-call) "route_data")
+        (if (str_eq (bml-source-route-call-name route-call) "route_data")
             (fsc-bml-route-data-arg-recipes-for-class
-                (fsc-bml-route-call-args route-call)
+                (bml-source-route-call-args route-call)
                 class-name)
-            (fsc-bml-args-recipes-loop (fsc-bml-route-call-args route-call) 0 (empty))))
+            (fsc-bml-args-recipes-loop (bml-source-route-call-args route-call) 0 (empty))))
 
     (defn fsc-bml-route-call-language-class-fn (route-call)
-        (if (str_eq (fsc-bml-route-call-name route-call) "route_data")
+        (if (str_eq (bml-source-route-call-name route-call) "route_data")
             "language-route-class-route-data"
             "language-route-class"))
 
     (defn fsc-bml-route-call-kernel-route-fn (route-call)
-        (if (str_eq (fsc-bml-route-call-name route-call) "route_data")
+        (if (str_eq (bml-source-route-call-name route-call) "route_data")
             "kh-route-data-ref"
             "kh-route"))
 
@@ -961,23 +913,23 @@
             (let eq-pos (fsc-find-char-from line "=" colon))
             (let class-name (fsc-trim (fsc-sub line 6 colon)))
             (let typed-template (fsc-trim (fsc-sub line (add colon 1) eq-pos)))
-            (let template-use (fsc-bml-parse-template-use-source class-name typed-template))
+            (let template-use (bml-source-parse-template-use class-name typed-template))
             (let route-call
-                (fsc-bml-route-call-source-from-expr
+                (bml-source-route-call-from-expr
                     (fsc-sub line (add eq-pos 1) (str_len line))))
             (let route-arg-recipes (fsc-bml-route-call-arg-recipes route-call))
             (fsc-rec-let class-name
                 (fsc-rec-call
                     (fsc-bml-route-call-language-class-fn route-call)
-                    (cons (fsc-rec-string (fsc-bml-template-use-class-name template-use))
-                    (cons (fsc-rec-ident (fsc-bml-template-use-template-name template-use))
-                    (cons (fsc-rec-string-list (fsc-bml-template-use-type-arguments template-use))
+                    (cons (fsc-rec-string (bml-source-template-use-class-name template-use))
+                    (cons (fsc-rec-ident (bml-source-template-use-template-name template-use))
+                    (cons (fsc-rec-string-list (bml-source-template-use-type-arguments template-use))
                           route-arg-recipes)))))))
 
     (defn fsc-compile-form-bml-language-class-block-route-recipe
         (line class-name template-name type-args)
         (do
-            (let route-call (fsc-bml-route-call-source-from-assignment line))
+            (let route-call (bml-source-route-call-from-assignment line))
             (let route-arg-recipes
                 (fsc-bml-route-call-arg-recipes-for-class route-call class-name))
             (fsc-rec-call "language-class-member-route"
@@ -1073,7 +1025,7 @@
             (let brace (fsc-find-char-from line "{" colon))
             (let class-name (fsc-trim (fsc-sub line 6 colon)))
             (let typed-template (fsc-trim (fsc-sub line (add colon 1) brace)))
-            (let template-use (fsc-bml-parse-template-use-source class-name typed-template))
+            (let template-use (bml-source-parse-template-use class-name typed-template))
             (let body-end (fsc-bml-block-end body body-start 0))
             (let method-defs
                 (fsc-bml-class-method-defs-loop body body-start body-end class-name (empty)))
@@ -1083,17 +1035,17 @@
                     body-start
                     body-end
                     class-name
-                    (fsc-bml-template-use-template-name template-use)
-                    (fsc-bml-template-use-type-arguments template-use)
+                    (bml-source-template-use-template-name template-use)
+                    (bml-source-template-use-type-arguments template-use)
                     (empty)))
             (fsc-list-append method-defs
                 (list
                     (fsc-rec-let class-name
                         (fsc-rec-call "language-class"
                             (list
-                                (fsc-rec-string (fsc-bml-template-use-class-name template-use))
-                                (fsc-rec-ident (fsc-bml-template-use-template-name template-use))
-                                (fsc-rec-string-list (fsc-bml-template-use-type-arguments template-use))
+                                (fsc-rec-string (bml-source-template-use-class-name template-use))
+                                (fsc-rec-ident (bml-source-template-use-template-name template-use))
+                                (fsc-rec-string-list (bml-source-template-use-type-arguments template-use))
                                 (fsc-rec-list-of members))))))))
 
     ;; A block-line returns a (possibly empty) list of recipes. Empty for
@@ -1191,8 +1143,11 @@
                             (fsc-line-next body p)
                             (fsc-rec-append-rev line-recipes acc))))))))))
 
-    (defn fsc-compile-form-route-section-recipe (body)
+    (defn fsc-compile-form-bml-section-recipe (body)
         (fsc-rec-do (fsc-form-bml-lines-recipes-loop body 0 (empty))))
+
+    (defn fsc-compile-form-route-section-recipe (body)
+        (fsc-compile-form-bml-section-recipe body))
 
 
     ;; --- Recipe source emitter --------------------------------------
@@ -1289,9 +1244,11 @@
     (defn fsc-compile-section-recipe (dialect-name body)
         (if (str_eq dialect-name "form.route")
             (fsc-compile-form-route-section-recipe body)
+        (if (str_eq dialect-name "form.bml")
+            (fsc-compile-form-bml-section-recipe body)
         (if (fsc-high-level-form-dialect? dialect-name)
             (g-parse (bml-grammar) body)
-            (fsc-bmf-section-recipe dialect-name body))))
+            (fsc-bmf-section-recipe dialect-name body)))))
 
     (defn fsc-compile-section (dialect-name body)
         (do

--- a/form/form-stdlib/tests/bml-route-source-object-band.fk
+++ b/form/form-stdlib/tests/bml-route-source-object-band.fk
@@ -1,0 +1,32 @@
+; bml-route-source-object-band.fk - shared BML route source object proof.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk
+;
+; Band verdict: 2047 when BML typed-template and route-call syntax is visible
+; as reusable source objects before a domain lowerer decides route semantics.
+
+(do
+    (let template_use
+        (fsc-bml-parse-template-use-source
+            "RuntimeDataRoute"
+            "RouteCell<KernelHTTPRequest, KernelHTTPResponse>"))
+    (let route_call
+        (fsc-bml-route-call-source-from-assignment
+            "route = route_data(runtime-data, handle);"))
+    (let direct_call
+        (fsc-bml-route-call-source-from-expr
+            "route(\"runtime-health\", \"GET\", \"/api/runtime/health\", 9, \"route_runtime_health\", \"Accept\", 0)"))
+
+    (sum
+        (list
+            (if (fsc-bml-template-use-source? template_use) 1 0)
+            (if (str_eq (fsc-bml-template-use-class-name template_use) "RuntimeDataRoute") 2 0)
+            (if (str_eq (fsc-bml-template-use-template-name template_use) "RouteCell") 4 0)
+            (if (eq (len (fsc-bml-template-use-type-arguments template_use)) 2) 8 0)
+            (if (str_eq (nth (fsc-bml-template-use-type-arguments template_use) 0) "KernelHTTPRequest") 16 0)
+            (if (str_eq (nth (fsc-bml-template-use-type-arguments template_use) 1) "KernelHTTPResponse") 32 0)
+            (if (fsc-bml-route-call-source? route_call) 64 0)
+            (if (str_eq (fsc-bml-route-call-name route_call) "route_data") 128 0)
+            (if (str_eq (fsc-bml-route-call-args route_call) "runtime-data, handle") 256 0)
+            (if (str_eq (fsc-bml-route-call-name direct_call) "route") 512 0)
+            (if (fsc-contains? (fsc-bml-route-call-args direct_call) "/api/runtime/health") 1024 0))))

--- a/form/form-stdlib/tests/bml-route-source-object-band.fk
+++ b/form/form-stdlib/tests/bml-route-source-object-band.fk
@@ -1,32 +1,32 @@
 ; bml-route-source-object-band.fk - shared BML route source object proof.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk
+; preludes: form-stdlib/core.fk form-stdlib/bml-source.fk
 ;
 ; Band verdict: 2047 when BML typed-template and route-call syntax is visible
 ; as reusable source objects before a domain lowerer decides route semantics.
 
 (do
     (let template_use
-        (fsc-bml-parse-template-use-source
+        (bml-source-parse-template-use
             "RuntimeDataRoute"
             "RouteCell<KernelHTTPRequest, KernelHTTPResponse>"))
     (let route_call
-        (fsc-bml-route-call-source-from-assignment
+        (bml-source-route-call-from-assignment
             "route = route_data(runtime-data, handle);"))
     (let direct_call
-        (fsc-bml-route-call-source-from-expr
+        (bml-source-route-call-from-expr
             "route(\"runtime-health\", \"GET\", \"/api/runtime/health\", 9, \"route_runtime_health\", \"Accept\", 0)"))
 
     (sum
         (list
-            (if (fsc-bml-template-use-source? template_use) 1 0)
-            (if (str_eq (fsc-bml-template-use-class-name template_use) "RuntimeDataRoute") 2 0)
-            (if (str_eq (fsc-bml-template-use-template-name template_use) "RouteCell") 4 0)
-            (if (eq (len (fsc-bml-template-use-type-arguments template_use)) 2) 8 0)
-            (if (str_eq (nth (fsc-bml-template-use-type-arguments template_use) 0) "KernelHTTPRequest") 16 0)
-            (if (str_eq (nth (fsc-bml-template-use-type-arguments template_use) 1) "KernelHTTPResponse") 32 0)
-            (if (fsc-bml-route-call-source? route_call) 64 0)
-            (if (str_eq (fsc-bml-route-call-name route_call) "route_data") 128 0)
-            (if (str_eq (fsc-bml-route-call-args route_call) "runtime-data, handle") 256 0)
-            (if (str_eq (fsc-bml-route-call-name direct_call) "route") 512 0)
-            (if (fsc-contains? (fsc-bml-route-call-args direct_call) "/api/runtime/health") 1024 0))))
+            (if (bml-source-template-use? template_use) 1 0)
+            (if (str_eq (bml-source-template-use-class-name template_use) "RuntimeDataRoute") 2 0)
+            (if (str_eq (bml-source-template-use-template-name template_use) "RouteCell") 4 0)
+            (if (eq (len (bml-source-template-use-type-arguments template_use)) 2) 8 0)
+            (if (str_eq (nth (bml-source-template-use-type-arguments template_use) 0) "KernelHTTPRequest") 16 0)
+            (if (str_eq (nth (bml-source-template-use-type-arguments template_use) 1) "KernelHTTPResponse") 32 0)
+            (if (bml-source-route-call? route_call) 64 0)
+            (if (str_eq (bml-source-route-call-name route_call) "route_data") 128 0)
+            (if (str_eq (bml-source-route-call-args route_call) "runtime-data, handle") 256 0)
+            (if (str_eq (bml-source-route-call-name direct_call) "route") 512 0)
+            (if (ge (str_find (bml-source-route-call-args direct_call) "/api/runtime/health" 0) 0) 1024 0))))

--- a/form/validate.sh
+++ b/form/validate.sh
@@ -77,7 +77,7 @@ prepare_sources() {
             out="$source_compile_dir/$safe"
             driver="$source_compile_dir/compile-${safe}.fk"
             printf '(do (form-source-compile-file "%s" "%s"))\n' "$src" "$out" > "$driver"
-            "$GO_BIN" "form-stdlib/form-ontology-loader.fk" "form-stdlib/line-grammar.fk" "form-stdlib/bmf-core.fk" "form-stdlib/bmf-grammar.fk" "form-stdlib/bml.fk" "form-stdlib/source-compiler.fk" "$driver" >/dev/null
+            "$GO_BIN" "form-stdlib/form-ontology-loader.fk" "form-stdlib/line-grammar.fk" "form-stdlib/bmf-core.fk" "form-stdlib/bmf-grammar.fk" "form-stdlib/bml.fk" "form-stdlib/bml-source.fk" "form-stdlib/source-compiler.fk" "$driver" >/dev/null
             prepared_args+=("$out")
         else
             prepared_args+=("$src")

--- a/kernels/SOURCE_LANGUAGE_KERNEL_ROUTER_ARCHITECTURE.md
+++ b/kernels/SOURCE_LANGUAGE_KERNEL_ROUTER_ARCHITECTURE.md
@@ -230,8 +230,12 @@ classDiagram
 
 Current implementation anchors:
 
-- `form/form-stdlib/source-compiler.fk` parses `template` and `class` lines in
-  `section [form.route]` and returns Recipe objects through
+- `form/form-stdlib/bml-source.fk` names reusable BML source cells such as
+  typed template use and route call source objects before any dialect chooses
+  what they mean.
+- `form/form-stdlib/source-compiler.fk` walks full `section [form.bml]` and
+  `section [form.route]` bodies through the BML line/block compiler, consumes
+  those source cells for route-domain lowering, and returns Recipe objects through
   `fsc-compile-section-recipe`.
 - `form/form-stdlib/language-model.fk` defines `LanguageTemplate`,
   `LanguageClass`, and `language-route-class-kernel-route`. Their runtime type


### PR DESCRIPTION
## Summary
- restore route-domain BML lowering for `section [form.route]`
- extract reusable BML typed-template and route-call source cells into `form/form-stdlib/bml-source.fk`
- route full `section [form.bml]` and `section [form.route]` bodies through the BML line/block compiler so top-level `let`, `class`, `def`, and expression forms all emit
- keep route semantics as a domain lowering consumer: `RouteCell` templates, `LanguageClass`, `KernelHTTPRoute`, and `KernelHTTPRouteDataRef` cells are emitted from high grammar source
- format the Rust kernel source so `cargo fmt --check` is clean
- rebase and push the full JSON/native HTTP stack onto `origin/main` `5f34f9d7`

## Proof
- `make prompt-guide`
- `make wellness`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/bml-source.fk form-stdlib/tests/bml-route-source-object-band.fk` -> `2047`
- `cd form && ./validate.sh ... source-language-route-class-template-band.fk` -> `525377`
- `cd form && ./validate.sh ... json-codec-bml-band.fk` -> `8191`
- `cd form && ./validate.sh ... source-compiler-multi-dialect-band.fk` -> `0`
- `cd form && ./validate.sh ... form-bml-maintenance-dialect.fk` -> `77`
- `production-routes.fk` source compilation emits `RouteCell`, `HealthRoute_handle`, `kh-route-data-ref "health"`, and `health_route_from_class`
- `cd form/form-kernel-rust && cargo fmt --check`
- `cd form/form-kernel-rust && cargo build --quiet` passes with existing warnings
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-08_route_language_lowering.json`
- `git diff --check`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/worktree_pr_guard.py --mode all --branch codex/route-language-lowering-20260608` passes local preflight; remote tracking is `skipped_no_token`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
