### PR TITLE
tend: reachability walk — measure the BMF bootstrap's minimum closure vs releasable tissue

### DIFF
--- a/docs/system_audit/bmf-bootstrap-floor-audit.md
+++ b/docs/system_audit/bmf-bootstrap-floor-audit.md
@@ -1,0 +1,149 @@
+# BMF bootstrap floor — minimum closure vs releasable tissue
+
+What the BMF/BML source-compile **actually reaches**, measured over the pinned,
+self-contained bootstrap `.fkb` (the 8 source-compile preludes bundled into one
+artifact). The instrument is [`form/form-stdlib/reachability.fk`](../../form/form-stdlib/reachability.fk)
+— a Form-native transitive-closure walk, sibling to `name-check.fk`. Regenerate
+this manifest any time with `scripts/bmf_bootstrap_audit.sh --names`.
+
+## Tiers (snapshot 2026-06-08)
+
+| tier | count | meaning |
+|------|-------|---------|
+| **FLOOR** | 146 | reached from the compile entry (`fsc-compile-section-recipe`) — the **minimum to compile any BMF/BML section**: parse (`g-parse` + the grammar) + emit (`fsc-rec-*` + ontology category mapping). Covers both the high-level and BMF paths. |
+| **STORE** | 65 | reached from setup/runtime entries but not the compile entry — the ontology load + the runtime the emitted recipe needs. **FLOOR + STORE = 211 = must-store** for a working, self-contained bootstrap. |
+| **RELEASABLE** | 291 | reached from **no** entry — candidate old bootstrap tissue to compost. |
+| total | 502 | every defn the bootstrap currently bundles. |
+
+**Caveat — the honest bound.** The walk is *static* (it follows `FNCALL` callees
+and `IDENT` references). A defn reached only through a *constructed* name (a string
+built at runtime and resolved indirectly) appears RELEASABLE but is not. So the 291
+are **candidates**: verify dynamic references per-defn before composting. (Example:
+the entire `json-*` parser appears RELEASABLE — likely because the ontology is
+loaded from cache rather than re-parsed; confirm the live load path before release.)
+
+## Toward the north-star compiler
+
+The minimum is small — ~146 recipes for parse + emit. That is the core to rewrite
+as the streaming, cursor-based, recipe-emitting compiler: generic (data-driven over
+the grammar), blazing fast, and leaning on the kernel's **content-addressing** so
+that multiple parse branches are an order of magnitude cheaper — shared sub-recipes
+intern once, discarded branches cost nothing (GC'd, never copied), overlapping
+branches memoize for free. Releasing the 291 clears the field; the pinned bootstrap
+(#2587) lets the core be swapped under a stable artifact without stdlib-drift.
+
+## FLOOR — the minimum to compile any section (146)
+
+  append bmf-unescape-str bmf-unescape-str-loop bml-grammar bp chain-incdec? cp-in-class? 
+  cur-advance cur-eof? cur-peek cur-pos cur-slice cur-surface cur-win2 cursor-of cursor-str 
+  fol-row5->nodeid fol-table-lookup fsc-bmf-section-recipe fsc-capture-fn 
+  fsc-compile-section-recipe fsc-dialect-fn fsc-empty? fsc-find-char-from 
+  fsc-find-string-from fsc-high-level-form-dialect? fsc-line-end fsc-line-next fsc-lit-fn 
+  fsc-pattern-item-recipe fsc-pattern-items-recipes fsc-read-part-end fsc-read-quoted-end 
+  fsc-rec-call fsc-rec-do fsc-rec-ident fsc-rec-let fsc-rec-list-of fsc-rec-string fsc-rev 
+  fsc-rev-into fsc-rtrim-index fsc-rule-line-recipe fsc-rules-recipes-loop 
+  fsc-skip-rule-line? fsc-skip-spaces fsc-space? fsc-sub fsc-trim fsc-word-char? 
+  fsc-word-loop? fsc-word-start-char? fsc-word? g-build g-caps g-cur g-kids g-match 
+  g-match-rule g-no g-ok g-ok? g-parse g-rule g-rule-find g-rules g-start g-val gc-empty 
+  gc-get gc-put gen-scan gm-alt gm-args gm-args-loop gm-call-suffix gm-cap gm-chain 
+  gm-chain-loop gm-char gm-cls gm-infix gm-infix-climb gm-infix-loop gm-lit gm-num 
+  gm-num-frac gm-num-int gm-opt gm-q-scan gm-ref gm-rep gm-rep-loop gm-run gm-run-loop gm-sep 
+  gm-sep-loop gm-seq gm-str gm-ternary grammar infix-peek-op is-alpha-cp is-digit-cp 
+  is-ident-cont-cp is-ws-cp nil? nlist nlist-items nth p-cap p-chain p-char p-infix p-lit 
+  p-num p-opt p-ref p-rep p-run p-sep p-str p-ternary r3-pat r3-tpl reverse-acc 
+  reverse-acc-loop rok-cur rok-node rok? rule3 skip-block-comment skip-line-comment skip-ws 
+  surf-kind surf-len surf-payload surface-string t-const t-const-bool t-const-int t-emit 
+  t-splice t-splice-int t-splices unit 
+
+## STORE — ontology load + emitted-recipe runtime (65)
+
+  cache-fresh? fol-3to5-loop fol-all-dialect-lets fol-all-dialect-lets-loop 
+  fol-all-engine-defns fol-all-engine-defns-loop fol-append fol-build-row fol-build-rows 
+  fol-build-rows-loop fol-cat fol-concat-acc fol-dialect-cat-let fol-dialect-cat-lets-loop 
+  fol-dialect-lets fol-engine-entries-loop fol-engine-entry-body-factory 
+  fol-engine-entry-body-string fol-engine-entry-defn fol-engine-family-defns fol-rec-call 
+  fol-rec-fndef-0 fol-rec-let fol-rec-make-nodeid fol-user-alias-rows fol-user-rows-for 
+  fol-user-rows-loop form-cat-node form-prim-node form-row-inst form-row-type 
+  form-source-compile-file form-source-compile-loop form-source-compile-text 
+  form-table-lookup fsc-compile-section fsc-last-char-index fsc-line-opens-block? fsc-q 
+  fsc-quote-loop fsc-section-end fsc-section-end-depth fsc-source-dialect 
+  fsc-source-emit-call fsc-source-emit-join fsc-source-emit-list fsc-source-emit-list-loop 
+  fsc-source-emit-params fsc-source-emit-params-loop fsc-source-emit-recipe 
+  fsc-source-primitive-name fsc-source-primitive-name-loop json-array-elements json-int-value 
+  json-object-get json-object-get-loop json-object-has-loop json-object-has? 
+  json-object-pairs json-pair-key json-pair-value json-reverse-acc json-reverse-acc-loop 
+  json-string-value read_with_cache 
+
+## RELEASABLE — candidate old bootstrap tissue (291) — verify dynamic refs before composting
+
+  apply-form-action-bmf-rule build-emit build-kids build-tpl caps-add caps-empty caps-get 
+  cur-checkpoint cur-peek-char cur-restore cursor-file find-from find-loop 
+  form-action-bmf-call form-action-bmf-call0 form-action-bmf-call1 form-action-bmf-call2 
+  form-action-bmf-call3 form-action-bmf-call4 form-action-bmf-call5 form-action-bmf-def 
+  form-action-bmf-do-roundtrip form-action-bmf-do-source form-action-bmf-find-rule 
+  form-action-bmf-ident form-action-bmf-if form-action-bmf-int form-action-bmf-let 
+  form-action-bmf-program form-action-bmf-proof-score form-action-bmf-roundtrip-program 
+  form-action-bmf-rules form-action-bmf-string form-action-bmf-value form-prim-or-empty 
+  fsc-action-args fsc-action-call-node fsc-action-cap fsc-action-do-node fsc-action-emit-call 
+  fsc-action-emit-def fsc-action-emit-do fsc-action-emit-ident fsc-action-emit-if 
+  fsc-action-emit-int fsc-action-emit-let fsc-action-emit-string fsc-action-expr 
+  fsc-action-ident-node fsc-action-if-node fsc-action-int fsc-action-items 
+  fsc-action-keyword? fsc-action-kw fsc-action-let-node fsc-action-name fsc-action-name-char? 
+  fsc-action-name-kind fsc-action-op fsc-action-param-block fsc-action-param-nodes 
+  fsc-action-params fsc-action-scan-int fsc-action-scan-int-loop fsc-action-scan-name 
+  fsc-action-scan-name-loop fsc-action-scan-next fsc-action-scan-op fsc-action-scan-skip 
+  fsc-action-scan-string fsc-action-scan-string-loop fsc-action-source-span 
+  fsc-action-src-args fsc-action-src-expr fsc-action-src-int fsc-action-src-items 
+  fsc-action-src-kw fsc-action-src-name fsc-action-src-op fsc-action-src-params 
+  fsc-action-src-string fsc-action-string fsc-bmf-lower-node fsc-bmf-roundtrip-node-eq? 
+  fsc-bmf-source-node-eq? fsc-capture-expr fsc-contains? fsc-digit? fsc-file-source-cursor 
+  fsc-file-source-cursor-window fsc-find-char-from-len fsc-find-string-at-len? 
+  fsc-find-string-at? fsc-find-string-from-len fsc-float-body? fsc-float-dot-loop? fsc-float? 
+  fsc-int-loop? fsc-int? fsc-lens-roundtrip-anchor-eq? fsc-lens-roundtrip-node-eq? 
+  fsc-list-append fsc-literal-expr fsc-prefix? fsc-rec-append-rev fsc-rec-false fsc-rec-fndef 
+  fsc-rec-form-call fsc-rec-if3 fsc-rec-param-trivials fsc-rec-string-list 
+  fsc-rec-string-list-items fsc-rec-true fsc-repo-binary-document 
+  fsc-repo-binary-document-byte-count fsc-repo-binary-document-structure fsc-repo-corpus 
+  fsc-repo-corpus-files fsc-repo-corpus-name fsc-repo-corpus-total-bytes fsc-repo-document 
+  fsc-repo-document-kind fsc-repo-document-size fsc-repo-document-spans 
+  fsc-repo-document-structure fsc-repo-empty-spans fsc-repo-field-int fsc-repo-field-key 
+  fsc-repo-field-node fsc-repo-field-string fsc-repo-field-value fsc-repo-field-value-int 
+  fsc-repo-field-value-string fsc-repo-file fsc-repo-file-byte-count fsc-repo-file-from-bytes 
+  fsc-repo-file-from-text fsc-repo-file-kind fsc-repo-file-media-type fsc-repo-file-path 
+  fsc-repo-file-sensed fsc-repo-meaning fsc-repo-meaning-decoder fsc-repo-meaning-fields 
+  fsc-repo-text-document fsc-repo-text-document-line-count fsc-repo-text-document-lines 
+  fsc-repo-text-document-structure fsc-repo-text-line fsc-repo-text-line-end 
+  fsc-repo-text-line-end-col fsc-repo-text-line-end-line fsc-repo-text-line-length 
+  fsc-repo-text-line-number fsc-repo-text-line-start fsc-repo-text-line-start-col 
+  fsc-repo-text-lines fsc-repo-text-lines-loop fsc-rule-ref-expr fsc-scan-result 
+  fsc-scan-result-cursor fsc-scan-result-object fsc-source-advance-n fsc-source-corpus 
+  fsc-source-corpus-files fsc-source-corpus-name fsc-source-cursor fsc-source-cursor-advance 
+  fsc-source-cursor-char fsc-source-cursor-col fsc-source-cursor-end? 
+  fsc-source-cursor-file-prefix? fsc-source-cursor-file-window? fsc-source-cursor-file? 
+  fsc-source-cursor-line fsc-source-cursor-next fsc-source-cursor-offset 
+  fsc-source-cursor-prefix? fsc-source-cursor-range fsc-source-cursor-slice 
+  fsc-source-cursor-source fsc-source-cursor-source-len fsc-source-cursor-window 
+  fsc-source-cursor-window-contains? fsc-source-cursor-window-start 
+  fsc-source-cursor-windowed fsc-source-cursor-with-len fsc-source-dialect-eof-kind 
+  fsc-source-dialect-int-kind fsc-source-dialect-keyword-kind fsc-source-dialect-keywords 
+  fsc-source-dialect-name-kind fsc-source-dialect-op-kind fsc-source-dialect-ops 
+  fsc-source-dialect-string-kind fsc-source-file fsc-source-file-kind fsc-source-file-path 
+  fsc-source-file-sections fsc-source-match-op fsc-source-name-char? fsc-source-name-kind 
+  fsc-source-name-start-char? fsc-source-object fsc-source-scan-int fsc-source-scan-int-loop 
+  fsc-source-scan-name fsc-source-scan-name-loop fsc-source-scan-next 
+  fsc-source-scan-next-dialect fsc-source-scan-op fsc-source-scan-skip fsc-source-scan-string 
+  fsc-source-scan-string-loop fsc-source-section-binary fsc-source-section-binary-node 
+  fsc-source-section-dialect fsc-source-section-node-eq? fsc-source-section-rule-name 
+  fsc-source-section-source fsc-source-window-size fsc-string-list-contains? 
+  fsc-string-to-bytes fsc-string-to-bytes-len-loop fsc-strip-semi is-blank? json-array-length 
+  json-count-line json-is-digit-cp json-is-digit-or-minus-cp json-is-ws-cp json-mk-pair-r 
+  json-mk-tok json-next-token json-object-keys json-object-keys-loop json-pair-pos 
+  json-pair-r json-parse-array json-parse-array-elements json-parse-object 
+  json-parse-object-pairs json-parse-value json-scan-literal json-scan-number 
+  json-scan-number-end json-scan-string json-scan-string-end-loop json-scan-string-end-pos 
+  json-scan-string-loop json-skip-ws json-substr json-tok-kind json-tok-start json-tok-val 
+  json-token-end line-num line-text lines-from-source lines-loop m-caps m-cur m-no m-ok m-ok? 
+  match-alt match-cap match-cls match-lit match-opt match-pat match-run match-run-loop 
+  match-seq parse-json pick-min rule-of rule-pat rule-tpl run-cur run-node run-ok? run-rule 
+  split-on split-on-loop starts-with-keyword? starts-with? surface-file trim trim-leading-ws 
+  trim-trailing-ws 

--- a/form/form-stdlib/reachability.fk
+++ b/form/form-stdlib/reachability.fk
@@ -1,0 +1,100 @@
+; reachability.fk — the minimum-closure walk, in Form's own voice.
+;
+; A sibling of name-check.fk: the SAME recipe-tree walk (dispatch on node_type,
+; the bare-string / one-child-wrapper name shapes), but it accumulates the set of
+; names TRANSITIVELY REACHED from an entry, instead of the set that fails to
+; resolve. Where name-check answers "what is broken?", this answers "what is
+; actually used?" — and therefore "what can be released?".
+;
+; Why it earns its place: a self-contained bootstrap (a loaded module or a
+; read_form_binary artifact) bundles every defn it COULD need. Only some are
+; reached from the real entry points. The reached set is the minimum a bootstrap
+; must store; the rest is releasable tissue. This walk measures that split over
+; the post-lowering recipe, so the answer is grounded in what the kernel runs,
+; not in a guess.
+;
+; Caveat (the honest bound): the walk is STATIC — it follows FNCALL callees and
+; IDENT references. A defn reached only through a CONSTRUCTED name (a string built
+; at runtime and resolved indirectly) looks unreached but is not. So the unreached
+; set is a list of CANDIDATES for release; a dynamic reference is verified per-defn
+; before composting. The walk narrows the field; judgment closes the gap.
+;
+; Companion: name-check.fk (the resolution walk this mirrors), form-engine.form
+; (the evaluator both are siblings of).
+
+(do
+    (defn rc-empty? (xs) (eq (len xs) 0))
+    (defn rc-member? (name xs)
+        (if (rc-empty? xs) false
+            (if (str_eq name (head xs)) true (rc-member? name (tail xs)))))
+    (defn rc-append (a b) (if (rc-empty? a) b (cons (head a) (rc-append (tail a) b))))
+
+    ;; a name-position node: a bare STRING trivial (type 2), or a one-child wrapper
+    ;; whose child is that STRING — the two shapes the kernel's own ident_id accepts.
+    (defn rc-name-of (node)
+        (if (eq (node_type node) 2)
+            (node_value node)
+            (node_value (head (node_children node)))))
+
+    ;; --- (name . body) for every FNDEF (kids = [name params body]) ---
+    (defn rc-pairs (n acc)
+        (if (eq (node_type n) 31)
+            (rc-pairs-kids (node_children n)
+                (cons (list (rc-name-of (head (node_children n)))
+                            (head (tail (tail (node_children n))))) acc))
+            (rc-pairs-kids (node_children n) acc)))
+    (defn rc-pairs-kids (xs acc)
+        (if (rc-empty? xs) acc (rc-pairs-kids (tail xs) (rc-pairs (head xs) acc))))
+    (defn rc-names (pairs acc)
+        (if (rc-empty? pairs) acc (rc-names (tail pairs) (cons (head (head pairs)) acc))))
+    ;; (list body) if name has a defn body, else (empty) — an empty-list sentinel
+    ;; (a native name has no body; the kernel has no `null` literal in this reader).
+    (defn rc-body-of (name pairs)
+        (if (rc-empty? pairs) (empty)
+            (if (str_eq name (head (head pairs))) (list (head (tail (head pairs))))
+                (rc-body-of name (tail pairs)))))
+
+    ;; --- references (FNCALL callee + IDENT name) inside a body ---
+    (defn rc-refs (n acc)
+        (if (eq (node_type n) 32)
+            (rc-refs-kids (tail (node_children n)) (cons (rc-name-of (head (node_children n))) acc))
+            (if (eq (node_type n) 33)
+                (cons (rc-name-of n) acc)
+                (rc-refs-kids (node_children n) acc))))
+    (defn rc-refs-kids (xs acc)
+        (if (rc-empty? xs) acc (rc-refs-kids (tail xs) (rc-refs (head xs) acc))))
+    (defn rc-refs-or-empty (wrapped)
+        (if (rc-empty? wrapped) (empty) (rc-refs (head wrapped) (empty))))
+    (defn rc-body-refs (name pairs) (rc-refs-or-empty (rc-body-of name pairs)))
+
+    ;; --- BFS: the transitive reachable name set from a worklist ---
+    (defn rc-reach (worklist pairs visited)
+        (if (rc-empty? worklist) visited
+            (rc-reach-1 (head worklist) (tail worklist) pairs visited)))
+    (defn rc-reach-1 (name rest pairs visited)
+        (if (rc-member? name visited)
+            (rc-reach rest pairs visited)
+            (rc-reach (rc-append rest (rc-body-refs name pairs)) pairs (cons name visited))))
+
+    ;; --- top-level CALLS (the executed setup), skipping FNDEF definitions ---
+    ;; The real roots are not just an API entry — a bootstrap's top-level forms run
+    ;; (e.g. loading the ontology). These are the names CALLED at the top level.
+    (defn rc-toplevel (n acc)
+        (if (eq (node_type n) 31) acc
+            (if (eq (node_type n) 32)
+                (rc-toplevel-kids (tail (node_children n)) (cons (rc-name-of (head (node_children n))) acc))
+                (if (eq (node_type n) 33) acc
+                    (rc-toplevel-kids (node_children n) acc)))))
+    (defn rc-toplevel-kids (xs acc)
+        (if (rc-empty? xs) acc (rc-toplevel-kids (tail xs) (rc-toplevel (head xs) acc))))
+
+    ;; --- count reached names that are DEFNS (natives are reached but have no body) ---
+    (defn rc-count-in (names set acc)
+        (if (rc-empty? names) acc
+            (rc-count-in (tail names) set
+                (if (rc-member? (head names) set) (add acc 1) acc))))
+
+    ;; the surface: the transitive reachable set from a single entry name.
+    (defn reachable-from (program entry)
+        (rc-reach (list entry) (rc-pairs program (empty)) (empty)))
+)

--- a/form/form-stdlib/tests/reachability-band.fk
+++ b/form/form-stdlib/tests/reachability-band.fk
@@ -1,0 +1,43 @@
+; reachability-band.fk — proof that the closure walk keeps what is reached and
+; drops what is not.
+;
+; preludes: form-stdlib/reachability.fk
+;
+; Builds a 5-defn program with intern_node (no source->recipe reflection needed):
+;   a -> b -> c   (a chain reached from entry "a")
+;   dead -> gone  (an island, unreachable from "a")
+; and asserts reachable-from(program, "a") reaches exactly {a, b, c}: the three
+; chain defns are members, and the reached-defn count is 3 (so dead + gone, the
+; other two defns, are NOT reached). The verdict is deterministic, so the three
+; sibling kernels must agree.
+
+(do
+    (let fndef-cat  (make_nodeid 1 2 31 1))
+    (let fncall-cat (make_nodeid 1 2 32 1))
+    (let seq-cat    (make_nodeid 1 2 9 2))
+    (let do-cat     (make_nodeid 1 2 9 1))
+
+    (defn mkfn (name body)
+        (intern_node fndef-cat
+            (list (intern_trivial_string name) (intern_node seq-cat (empty)) body)))
+    (defn call (name) (intern_node fncall-cat (list (intern_trivial_string name))))
+
+    (let a    (mkfn "a"    (call "b")))
+    (let b    (mkfn "b"    (call "c")))
+    (let c    (mkfn "c"    (intern_trivial_int 0)))
+    (let dead (mkfn "dead" (call "gone")))
+    (let gone (mkfn "gone" (intern_trivial_int 0)))
+    (let program (intern_node do-cat (list a b c dead gone)))
+
+    (let reached   (reachable-from program "a"))
+    (let all-defns (rc-names (rc-pairs program (empty)) (empty)))
+
+    ;; a/b/c reached; the reached-DEFN count is exactly 3 (so dead+gone are not).
+    (let pass
+        (and (rc-member? "a" reached)
+        (and (rc-member? "b" reached)
+        (and (rc-member? "c" reached)
+             (eq (rc-count-in all-defns reached 0) 3)))))
+
+    (print (if pass "reachability-band: PASS" "reachability-band: FAIL"))
+)

--- a/scripts/bmf_bootstrap_audit.sh
+++ b/scripts/bmf_bootstrap_audit.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# bmf_bootstrap_audit.sh — measure the BMF bootstrap's minimum closure vs releasable tissue.
+#
+# Emits the self-contained bootstrap .fkb (the 8 source-compile preludes bundled), then
+# walks it with form-stdlib/reachability.fk from the REAL entry points and tiers every
+# defn:
+#   FLOOR      — reached from the compile entry (fsc-compile-section-recipe): the minimum
+#                to compile ANY BMF/BML section (parse + emit).
+#   STORE      — reached from setup/runtime entries but not the compile entry (the ontology
+#                load, the runtime the emitted recipe needs). FLOOR + STORE = must-store.
+#   RELEASABLE — reached from NO entry: candidate old bootstrap tissue to compost.
+#
+# This is the instrument for releasing old tissue toward a north-star streaming compiler:
+# it turns "release some of that" into an exact, regenerable list. The walk is STATIC
+# (FNCALL/IDENT refs); a defn reached only via a CONSTRUCTED name looks RELEASABLE but is
+# not — verify dynamic refs per-defn before composting.
+#
+# Run:  scripts/bmf_bootstrap_audit.sh            # summary + tier counts
+#       scripts/bmf_bootstrap_audit.sh --names    # also print every defn, tagged by tier
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMDIR="$ROOT/form"
+RS_BIN="$FORMDIR/form-kernel-rust/target/release/form-kernel-rust"
+RC="$FORMDIR/form-stdlib/reachability.fk"
+PRELUDES=(json cache form-ontology-loader line-grammar bmf-core bmf-grammar bml source-compiler)
+WANT_NAMES=0
+[[ "${1:-}" == "--names" ]] && WANT_NAMES=1
+
+if [[ ! -x "$RS_BIN" || "$FORMDIR/form-kernel-rust/src/main.rs" -nt "$RS_BIN" ]]; then
+    echo "  building rust kernel..." >&2
+    (cd "$FORMDIR/form-kernel-rust" && cargo build --release --quiet)
+fi
+
+cd "$FORMDIR"
+prelude_args=()
+for p in "${PRELUDES[@]}"; do prelude_args+=("form-stdlib/$p.fk"); done
+
+fkb="$(mktemp "${TMPDIR:-/tmp}/bmf-bootstrap.XXXXXX.fkb")"
+trap 'rm -f "$fkb" "$drv"' EXIT
+"$RS_BIN" --emit-binary "$fkb" "${prelude_args[@]}" >/dev/null
+
+drv="$(mktemp "${TMPDIR:-/tmp}/bmf-audit-drv.XXXXXX.fk")"
+cat > "$drv" <<EOF
+(do
+  (let program (read_form_binary "$fkb"))
+  (let pairs (rc-pairs program (empty)))
+  (let all-defns (rc-names pairs (empty)))
+  (let floor (reachable-from program "fsc-compile-section-recipe"))
+  (let entries (rc-append (rc-toplevel program (empty))
+                  (list "fsc-compile-section-recipe" "form-bmf-second" "bmf-section" "form-source-compile-file")))
+  (let store (rc-reach entries pairs (empty)))
+  (defn tag (name) (if (rc-member? name store) (if (rc-member? name floor) "FLOOR" "STORE") "RELEASABLE"))
+  (defn dump (names) (if (rc-empty? names) 0 (do (print (str_concat (str_concat (tag (head names)) "\t") (head names))) (dump (tail names)))))
+  (dump all-defns))
+EOF
+
+tsv="$("$RS_BIN" "$RC" "$drv" 2>/dev/null | grep -E '^(FLOOR|STORE|RELEASABLE)	')"
+floor=$(printf '%s\n' "$tsv" | grep -c '^FLOOR')
+store=$(printf '%s\n' "$tsv" | grep -c '^STORE')
+rel=$(printf '%s\n' "$tsv" | grep -c '^RELEASABLE')
+total=$((floor + store + rel))
+
+echo "BMF bootstrap closure audit"
+echo "  total defns:        $total"
+echo "  FLOOR (compile min): $floor"
+echo "  STORE (setup+runtime): $store   -> must-store: $((floor + store))"
+echo "  RELEASABLE (candidate compost): $rel"
+
+if [[ "$WANT_NAMES" -eq 1 ]]; then
+    echo; printf '%s\n' "$tsv" | sort
+fi


### PR DESCRIPTION
Answers *"what is the minimum BMF recipe to compile any section, and what must a self-contained bootstrap store"* by **measuring** it.

- **`form-stdlib/reachability.fk`** — a Form-native transitive-closure walk, sibling to `name-check.fk` (same node walk; accumulates the *reached* set instead of the *unresolved* one). name-check answers "what is broken?"; this answers "what is actually used?" — and so "what can be released?".
- **`tests/reachability-band.fk`** — three-way proof (**PASS Go/Rust/TS**): a reached chain is kept, an unreachable island dropped.
- **`scripts/bmf_bootstrap_audit.sh`** — emits the pinned bootstrap `.fkb` and tiers every defn FLOOR/STORE/RELEASABLE. Regenerable.
- **`docs/system_audit/bmf-bootstrap-floor-audit.md`** — the manifest.

Measured over the pinned bootstrap (#2587), **502 defns**:
| tier | count | meaning |
|------|-------|---------|
| FLOOR | 146 | minimum to compile any section (parse + emit, both paths) |
| STORE | 65 | ontology load + emitted-recipe runtime — **FLOOR+STORE = 211 must-store** |
| RELEASABLE | 291 | reached from no entry — candidate old bootstrap tissue |

Static analysis caveat: the 291 are **candidates** — a defn reached only via a constructed name looks releasable but isn't; verify dynamic refs before composting. The instrument for releasing old tissue toward the north-star streaming compiler, whose small core is the FLOOR 146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)