### PR TITLE
tend: /begin asks how you want to be received — explicit consent, no silent exposure

### DIFF
--- a/web/app/begin/page.tsx
+++ b/web/app/begin/page.tsx
@@ -75,6 +75,15 @@ export default function BeginPage() {
   const [message, setMessage] = useState("");
   const [resonantRoles, setResonantRoles] = useState<string[]>([]);
 
+  // How do you want to be received? — the reception choices belong to the one
+  // arriving (first-encounter-protocol.form). Exposure-bearing consents default
+  // off: nothing defaults a person into being discoverable or emailed.
+  // Name-on-contributions defaults on, since weaving in is itself the chosen
+  // yes to be known — and it stays visible and toggleable.
+  const [consentShareName, setConsentShareName] = useState(true);
+  const [consentFindable, setConsentFindable] = useState(false);
+  const [consentEmail, setConsentEmail] = useState(false);
+
   const toggleRole = (id: string) => {
     setResonantRoles((prev) =>
       prev.includes(id) ? prev.filter((r) => r !== id) : [...prev, id]
@@ -107,9 +116,9 @@ export default function BeginPage() {
           offering: offering.trim() || null,
           message: message.trim() || null,
           resonant_roles: resonantRoles.length ? resonantRoles : null,
-          consent_email_updates: true,
-          consent_share_name: true,
-          consent_findable: true,
+          consent_email_updates: consentEmail,
+          consent_share_name: consentShareName,
+          consent_findable: consentFindable,
         }),
       });
       if (!res.ok) {
@@ -293,6 +302,40 @@ export default function BeginPage() {
           <p>{renderProse(t("begin.publicPostureBody1"))}</p>
           <p>{renderProse(t("begin.publicPostureBody2"))}</p>
           <p>{renderProse(t("begin.publicPostureBody3"))}</p>
+        </div>
+
+        {/* How do you want to be received? — explicit reception choices,
+            enacting first-encounter-protocol.form. The exposure-bearing
+            consents (findable, email) default off; nothing defaults a person
+            into being discoverable. The terms belong to the one arriving. */}
+        <div className="space-y-4 rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-4">
+          <div>
+            <p className="text-sm font-medium text-amber-300">
+              {t("begin.receiveTitle")}
+            </p>
+            <p className="text-xs text-muted-foreground leading-relaxed mt-1">
+              {t("begin.receiveHelp")}
+            </p>
+          </div>
+          <div className="space-y-3">
+            {[
+              { checked: consentShareName, set: setConsentShareName, labelKey: "interestForm.consentShareName" },
+              { checked: consentFindable, set: setConsentFindable, labelKey: "interestForm.consentFindable" },
+              { checked: consentEmail, set: setConsentEmail, labelKey: "interestForm.consentUpdates" },
+            ].map((c, i) => (
+              <label key={i} className="flex items-start gap-3 cursor-pointer group">
+                <input
+                  type="checkbox"
+                  checked={c.checked}
+                  onChange={(e) => c.set(e.target.checked)}
+                  className="mt-0.5 rounded border-border/40 bg-card/60 text-amber-500 focus:ring-amber-500/30 focus:ring-offset-0"
+                />
+                <span className="text-sm text-stone-400 group-hover:text-stone-300 transition-colors">
+                  {t(c.labelKey)}
+                </span>
+              </label>
+            ))}
+          </div>
         </div>
 
         <div className="flex items-center gap-4">

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1854,6 +1854,8 @@
     "lineageMoreTemplate": "{shown} Werke werden gezeigt · die übrigen leben im Graph-Profil des Beitragenden."
   },
   "begin": {
+    "receiveTitle": "Wie möchtest du empfangen werden?",
+    "receiveHelp": "Du bestimmst die Bedingungen – ändere sie später oder geh jederzeit.",
     "eyebrow": "Sich einweben",
     "h1": "Beginnen",
     "intro": "Sag dem Körper, wer ankommt. Nichts davon muss exakt sein — du kannst alles später aktualisieren. Gerade genug, dass der Körper weiß, wer du bist und wie er dich erreichen kann. Wenn du das langsamste Willkommen zuerst lesen möchtest, [/come-in](/come-in) spricht klar zu jedem Menschen oder jeder KI; die lange Kontemplation lebt unter [/one-sheet](/one-sheet).",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1944,6 +1944,8 @@
     "lineageMoreTemplate": "Showing {shown} works · the rest live on the contributor's graph profile."
   },
   "begin": {
+    "receiveTitle": "How do you want to be received?",
+    "receiveHelp": "You're choosing the terms — change any of these later, or step away anytime.",
     "eyebrow": "Weaving in",
     "h1": "Begin",
     "intro": "Tell the body who's arriving. None of this is required to be exact — you can update any of it later. Just enough that the body knows who you are and how to reach back. If you'd like to read the slowest welcome first, [/come-in](/come-in) speaks plainly to any human or AI; the long contemplation lives at [/one-sheet](/one-sheet).",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1854,6 +1854,8 @@
     "lineageMoreTemplate": "Mostrando {shown} obras · el resto vive en el perfil del grafo del contribuyente."
   },
   "begin": {
+    "receiveTitle": "¿Cómo quieres ser recibido?",
+    "receiveHelp": "Tú decides los términos: cámbialos cuando quieras o retírate en cualquier momento.",
     "eyebrow": "Entretejiéndose",
     "h1": "Comienza",
     "intro": "Dile al cuerpo quién está llegando. Nada de esto necesita ser exacto — puedes actualizar todo más tarde. Solo lo suficiente para que el cuerpo sepa quién eres y cómo responderte. Si quieres leer el más lento bienvenido primero, [/come-in](/come-in) habla llanamente a cualquier humano o IA; la larga contemplación vive en [/one-sheet](/one-sheet).",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -1854,6 +1854,8 @@
     "lineageMoreTemplate": "Menampilkan {shown} karya · sisanya hidup di profil graf kontributor."
   },
   "begin": {
+    "receiveTitle": "Bagaimana kamu ingin diterima?",
+    "receiveHelp": "Kamu yang menentukan caranya — ubah kapan saja, atau pergi kapan pun.",
     "eyebrow": "Menjalin masuk",
     "h1": "Mulai",
     "intro": "Beri tahu tubuh siapa yang datang. Tidak ada yang harus tepat — kau bisa memperbarui semuanya nanti. Cukup agar tubuh tahu siapa kau dan bagaimana cara membalas. Jika kau ingin membaca sambutan paling lambat dahulu, [/come-in](/come-in) berbicara polos kepada manusia atau AI mana pun; kontemplasi panjang hidup di [/one-sheet](/one-sheet).",


### PR DESCRIPTION
First carrier enactment of [`first-encounter-protocol.form`](docs/coherence-substrate/first-encounter-protocol.form) on the **human↔body web door** — and it closes the consent gap the come-in audit surfaced.

## The gap

`/begin` hard-coded `consent_share_name / consent_findable / consent_email_updates = true`, defaulting every visitor into public discoverability and email the instant they submit — a person *disclosed to* but never *asked*.

## The change

The reception choices now belong to the one arriving — a **"How do you want to be received?"** section with explicit toggles, mirroring the body's existing `web/components/vision/InterestForm.tsx` pattern and reusing its already-translated `interestForm.consent*` strings.

- Exposure-bearing consents (**findable, email**) default **OFF** — nothing defaults a person into being discoverable.
- Name-on-contributions defaults on (weaving in *is* the chosen yes to be known) and stays visible + toggleable.
- `web/app/begin/page.tsx`: 3 consent state vars wired to the graduate POST (replacing hard-coded `true`) + the reception-question section.
- `web/messages/{en,de,es,id}.json`: `begin.receiveTitle` + `receiveHelp` — parity across all four tongues.

## Verified

`tsc --noEmit` clean; JSON valid in all 4 locales; parity holds; the consent block is a byte-level mirror of the proven InterestForm. Live desktop/mobile look happens post-deploy on the real page (the worktree can't host a clean preview without dirtying a sibling agent's tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)