### PR TITLE
Package API locale manifest fallback

### DIFF
--- a/api/app/data/locale_manifest.json
+++ b/api/app/data/locale_manifest.json
@@ -1,0 +1,35 @@
+{
+  "default": "en",
+  "locales": [
+    {
+      "code": "en",
+      "name": "English",
+      "native_name": "English"
+    },
+    {
+      "code": "de",
+      "name": "German",
+      "native_name": "Deutsch"
+    },
+    {
+      "code": "es",
+      "name": "Spanish",
+      "native_name": "Español"
+    },
+    {
+      "code": "fr",
+      "name": "French",
+      "native_name": "Français"
+    },
+    {
+      "code": "id",
+      "name": "Indonesian",
+      "native_name": "Bahasa Indonesia"
+    },
+    {
+      "code": "pt-br",
+      "name": "Brazilian Portuguese",
+      "native_name": "Português (Brasil)"
+    }
+  ]
+}

--- a/api/app/services/translator_service.py
+++ b/api/app/services/translator_service.py
@@ -26,6 +26,7 @@ from app.services import translation_cache_service as _cache
 DEFAULT_LOCALE = "en"
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WEB_MESSAGES_DIR = _REPO_ROOT / "web" / "messages"
+_API_LOCALE_MANIFEST = Path(__file__).resolve().parents[1] / "data" / "locale_manifest.json"
 
 
 def _locale_meta(path: Path) -> dict[str, str]:
@@ -52,6 +53,9 @@ def _discover_supported_locales() -> dict[str, dict[str, str]]:
         for path in sorted(_WEB_MESSAGES_DIR.glob("*.json")):
             locales[path.stem] = _locale_meta(path)
 
+    if not locales:
+        locales = _manifest_locale_meta(_API_LOCALE_MANIFEST)
+
     if DEFAULT_LOCALE not in locales:
         return {DEFAULT_LOCALE: {"name": "English", "native_name": "English"}}
 
@@ -59,6 +63,27 @@ def _discover_supported_locales() -> dict[str, dict[str, str]]:
     for code in sorted(c for c in locales if c != DEFAULT_LOCALE):
         ordered[code] = locales[code]
     return ordered
+
+
+def _manifest_locale_meta(path: Path) -> dict[str, dict[str, str]]:
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    raw_locales = manifest.get("locales", []) if isinstance(manifest, dict) else []
+    if not isinstance(raw_locales, list):
+        return {}
+    locales: dict[str, dict[str, str]] = {}
+    for entry in raw_locales:
+        if not isinstance(entry, dict):
+            continue
+        code = entry.get("code")
+        if not isinstance(code, str) or not code:
+            continue
+        name = entry.get("name") or code
+        native_name = entry.get("native_name") or entry.get("nativeName") or name
+        locales[code] = {"name": str(name), "native_name": str(native_name)}
+    return locales
 
 
 SUPPORTED_LOCALES: dict[str, dict[str, str]] = _discover_supported_locales()

--- a/api/tests/test_concept_views.py
+++ b/api/tests/test_concept_views.py
@@ -15,6 +15,7 @@ Covers:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from uuid import uuid4
 
@@ -22,6 +23,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app
+from app.services import translator_service
 
 BASE = "http://test"
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -71,6 +73,42 @@ async def test_list_locales_matches_installed_message_bundles():
         codes = {loc["code"] for loc in r.json()["locales"]}
         assert _installed_locale_codes().issubset(codes)
         assert r.json()["default"] == "en"
+
+
+def test_api_locale_manifest_matches_installed_message_bundles():
+    manifest_path = REPO_ROOT / "api" / "app" / "data" / "locale_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    codes = {entry["code"] for entry in manifest["locales"]}
+    assert _installed_locale_codes().issubset(codes)
+    assert manifest["default"] == "en"
+
+
+def test_api_locale_manifest_supports_production_image_fallback(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "locale_manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "default": "en",
+                "locales": [
+                    {"code": "en", "name": "English", "native_name": "English"},
+                    {"code": "fr", "name": "French", "native_name": "Français"},
+                    {
+                        "code": "pt-br",
+                        "name": "Brazilian Portuguese",
+                        "native_name": "Português (Brasil)",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(translator_service, "_WEB_MESSAGES_DIR", tmp_path / "missing")
+    monkeypatch.setattr(translator_service, "_API_LOCALE_MANIFEST", manifest_path)
+
+    locales = translator_service._discover_supported_locales()
+
+    assert list(locales) == ["en", "fr", "pt-br"]
+    assert locales["pt-br"]["native_name"] == "Português (Brasil)"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/system_audit/commit_evidence_2026-06-08_api_locale_manifest.json
+++ b/docs/system_audit/commit_evidence_2026-06-08_api_locale_manifest.json
@@ -1,0 +1,101 @@
+{
+  "date": "2026-06-08",
+  "thread_branch": "codex/api-locale-manifest-20260608",
+  "commit_scope": "Package the bundle-discovered locale manifest inside the API image so public agent/API surfaces expose French and Brazilian Portuguese without hardcoded language selection.",
+  "files_owned": [
+    "api/app/data/locale_manifest.json",
+    "api/app/services/translator_service.py",
+    "api/tests/test_concept_views.py",
+    "web/scripts/generate-locale-manifest.mjs",
+    "docs/system_audit/commit_evidence_2026-06-08_api_locale_manifest.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "node web/scripts/generate-locale-manifest.mjs",
+      "cd api && python3 -m pytest -q tests/test_concept_views.py::test_api_locale_manifest_matches_installed_message_bundles tests/test_concept_views.py::test_api_locale_manifest_supports_production_image_fallback tests/test_flow_multilingual.py::test_list_locales_matches_installed_message_bundles",
+      "cd api && python3 - <<'PY' ... translator_service normal and manifest fallback discovery ... PY",
+      "make wellness",
+      "cd web && npm run build",
+      "cd api && python3 -m pytest -q tests/test_flow_multilingual.py tests/test_concept_views.py",
+      "git diff --check"
+    ],
+    "notes": "The web locale manifest generator now writes api/app/data/locale_manifest.json from installed web/messages/*.json bundles. translator_service reads that API-local manifest only when web/messages is unavailable, matching the production API image shape. Focused regression confirms fallback discovery includes en, fr, and pt-br; local smoke confirms fallback discovery includes all installed locales: en, de, es, fr, id, pt-br."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Pending push, pull request, and GitHub checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Pending merge, Hostinger deploy, and public verification that https://api.coherencycoin.com/api/locales includes fr and pt-br."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Public API and agent-adjacent locale discovery surfaces report the same installed locale set as the web interface, including French and Brazilian Portuguese, even when the deployed API container does not include web/messages.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/locales",
+      "https://coherencycoin.com/hati-suci?lang=fr",
+      "https://coherencycoin.com/hati-suci?lang=pt-br",
+      "https://api.coherencycoin.com/api/agent/tasks"
+    ],
+    "test_flows": [
+      "Public API /api/locales includes fr and pt-br after deploy.",
+      "Public web request with ?lang=fr renders with html lang=\"fr\".",
+      "Public web request with ?lang=pt-br renders with html lang=\"pt-br\".",
+      "Human-through-agent public interaction can create/read a verification task carrying locale context."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof is complete. Public proof waits on PR checks, merge, deploy, and verification."
+  },
+  "idea_ids": [
+    "multilingual-web",
+    "locale-as-data"
+  ],
+  "spec_ids": [
+    "multilingual-web"
+  ],
+  "task_ids": [
+    "api-locale-manifest-20260608"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "public-deploy-request"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "deployment"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "api/app/data/locale_manifest.json is generated from installed web message bundles and copied by Dockerfile.api through COPY api/ ./.",
+    "api/app/services/translator_service.py falls back to the API-local manifest when web/messages is absent.",
+    "api/tests/test_concept_views.py simulates the production image fallback and verifies Brazilian Portuguese metadata.",
+    "make wellness reports locale parity aligned with en across five non-English tongues."
+  ],
+  "change_files": [
+    "api/app/data/locale_manifest.json",
+    "api/app/services/translator_service.py",
+    "api/tests/test_concept_views.py",
+    "web/scripts/generate-locale-manifest.mjs",
+    "docs/system_audit/commit_evidence_2026-06-08_api_locale_manifest.json"
+  ],
+  "change_intent": "runtime_fix"
+}

--- a/web/scripts/generate-locale-manifest.mjs
+++ b/web/scripts/generate-locale-manifest.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,6 +8,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const webRoot = join(__dirname, "..");
 const messagesDir = join(webRoot, "messages");
 const outputPath = join(messagesDir, "manifest.ts");
+const apiManifestPath = join(webRoot, "..", "api", "app", "data", "locale_manifest.json");
 
 function safeIdent(code) {
   return `bundle_${code.replace(/[^A-Za-z0-9_]/g, "_")}`;
@@ -62,4 +63,18 @@ ${bundles.join("\n")}
 `;
 
 writeFileSync(outputPath, source);
-console.log(`generated messages/manifest.ts for ${codes.join(", ")}`);
+
+mkdirSync(dirname(apiManifestPath), { recursive: true });
+writeFileSync(
+  apiManifestPath,
+  `${JSON.stringify({
+    default: DEFAULT_LOCALE,
+    locales: locales.map(({ code, name, nativeName }) => ({
+      code,
+      name,
+      native_name: nativeName,
+    })),
+  }, null, 2)}\n`,
+);
+
+console.log(`generated locale manifests for ${codes.join(", ")}`);


### PR DESCRIPTION
## Summary\n- generate an API-packaged locale manifest from installed web message bundles\n- make translator_service fall back to that manifest when web/messages is absent in the API image\n- add regression coverage for manifest parity and production-image fallback\n\n## Validation\n- make wellness\n- cd api && python3 -m pytest -q tests/test_flow_multilingual.py tests/test_concept_views.py\n- cd web && npm run build\n- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main\n- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict\n- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence\n\nPublic deploy note: this follows PR #2603 because production /api/locales exposed only en from the API container while web locales already served fr and pt-br.