### PR TITLE
Attune locale surfaces beyond default language

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -38,7 +38,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 161 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 143 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 144 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/cli/lib/i18n.mjs
+++ b/cli/lib/i18n.mjs
@@ -6,11 +6,11 @@
  *   2. COHERENCE_LOCALE environment variable
  *   3. locale field in ~/.coherence-network/config.json
  *   4. LANG / LC_ALL / LC_MESSAGES env vars (parsed for a supported locale)
- *   5. Default locale (en)
+ *   5. Default locale
  *
  * Messages live as JSON bundles in cli/lib/messages/{lang}.json so the same
  * text file can travel with the npm package. A missing key falls back to the
- * English bundle; a missing bundle falls back to English. Unknown keys
+ * default bundle; a missing bundle falls back to the default locale. Unknown keys
  * render as the key string itself — gaps stay visible rather than silent.
  */
 
@@ -135,7 +135,7 @@ function interpolate(template, params) {
 
 /**
  * Create a translator bound to a locale.
- * Returns t(key, params?) that does message lookup with English fallback.
+ * Returns t(key, params?) that does message lookup with default-locale fallback.
  */
 export function createT(lang) {
   const target = loadBundle(lang);

--- a/docs/system_audit/commit_evidence_2026-06-08_locale_surface_bias_validation.json
+++ b/docs/system_audit/commit_evidence_2026-06-08_locale_surface_bias_validation.json
@@ -1,0 +1,121 @@
+{
+  "date": "2026-06-08",
+  "thread_branch": "codex/locale-bias-validation-20260608",
+  "commit_scope": "Add a cross-surface locale validation pass and remove English-anchor wording from user-facing and tooling surfaces.",
+  "files_owned": [
+    "MANIFEST.md",
+    "cli/lib/i18n.mjs",
+    "docs/system_audit/commit_evidence_2026-06-08_locale_surface_bias_validation.json",
+    "scripts/INDEX.md",
+    "scripts/sync_kb_to_db.py",
+    "scripts/validate_locale_surfaces.py",
+    "scripts/wellness_check.py",
+    "web/lib/locale-fetch.ts",
+    "web/messages/de.json",
+    "web/messages/en.json",
+    "web/messages/es.json",
+    "web/messages/fr.json",
+    "web/messages/id.json",
+    "web/messages/pt-br.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make wellness",
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "python3 scripts/validate_locale_surfaces.py",
+      "python3 -m json.tool web/messages/fr.json",
+      "python3 -m json.tool web/messages/pt-br.json",
+      "python3 -m json.tool web/messages/en.json",
+      "rg -n 'English anchor|English bundle|falls back to English|fallback to English|seeded from the English|currently in English|en anchor' web/messages cli/lib scripts/sync_kb_to_db.py scripts/wellness_check.py web/lib/locale-fetch.ts api/app/services/localized_errors.py -g '*.json' -g '*.mjs' -g '*.py' -g '*.ts'",
+      "python3 scripts/generate_repo_indexes.py",
+      "cd api && python3 -m pytest -q tests/test_flow_multilingual.py tests/test_concept_views.py",
+      "cd web && NPM_CONFIG_CACHE=/tmp/coherence-npm-cache npm ci && npm run build",
+      "python3 scripts/validate_locale_surfaces.py --summary",
+      "make wellness | sed -n '/## Locale parity/,/## Chain/p'",
+      "git diff --check"
+    ],
+    "notes": "Initial wellness reported fr and pt-br each missing begin.receiveTitle and begin.receiveHelp. The pass adds those keys, neutralizes user-facing English-anchor phrasing to current/default anchor phrasing, adds scripts/validate_locale_surfaces.py, and wires its concise result into wellness. The first web build attempt failed because this fresh worktree lacked node_modules (next: command not found); npm ci installed dependencies and the build then passed with existing Next/Turbopack warnings."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Pending push, PR, and GitHub checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Pending merge, Hostinger deploy, and public verification if this branch is shipped."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Locale support remains data-driven across web, API, and CLI. Future language additions are validated by installed bundle parity and manifest alignment rather than manual English-centered grep. French and Brazilian Portuguese no longer lag the current default message key set.",
+    "public_endpoints": [
+      "https://coherencycoin.com/begin?lang=fr",
+      "https://coherencycoin.com/begin?lang=pt-br",
+      "https://api.coherencycoin.com/api/locales"
+    ],
+    "test_flows": [
+      "scripts/validate_locale_surfaces.py reports web/API/CLI locale alignment.",
+      "make wellness reports every locale aligned and locale surfaces aligned.",
+      "The non-default web message bundles do not carry English-anchor wording."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof is complete. Public movement waits on PR checks, merge, deploy, and verification."
+  },
+  "idea_ids": [
+    "multilingual-web",
+    "locale-as-data"
+  ],
+  "spec_ids": [
+    "multilingual-web"
+  ],
+  "task_ids": [
+    "locale-surface-bias-validation-20260608"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "bias-validation-request"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "scripts/validate_locale_surfaces.py compares web message bundles, web/messages/manifest.ts, api/app/data/locale_manifest.json, and cli/lib/messages/*.json.",
+    "make wellness now includes a Locale surfaces section with the validator's concise result.",
+    "web/messages/fr.json and web/messages/pt-br.json include begin.receiveTitle and begin.receiveHelp.",
+    "User-facing pending-translation copy names the current anchor view instead of an English anchor."
+  ],
+  "change_files": [
+    "MANIFEST.md",
+    "cli/lib/i18n.mjs",
+    "docs/system_audit/commit_evidence_2026-06-08_locale_surface_bias_validation.json",
+    "scripts/INDEX.md",
+    "scripts/sync_kb_to_db.py",
+    "scripts/validate_locale_surfaces.py",
+    "scripts/wellness_check.py",
+    "web/lib/locale-fetch.ts",
+    "web/messages/de.json",
+    "web/messages/en.json",
+    "web/messages/es.json",
+    "web/messages/fr.json",
+    "web/messages/id.json",
+    "web/messages/pt-br.json"
+  ],
+  "change_intent": "runtime_fix"
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 143
+**Total files**: 144
 
 | File | Purpose |
 |---|---|
@@ -137,6 +137,7 @@
 | [upgrade_specs_to_form_predicates.py](upgrade_specs_to_form_predicates.py) | Augment every spec's done_when with Form predicates derived from its |
 | [validate_commit_evidence.py](validate_commit_evidence.py) | Validate thread commit evidence artifacts for phase-gated process. |
 | [validate_local_api_matrix.py](validate_local_api_matrix.py) | Validate local API-backed page contracts and timing against a running API. |
+| [validate_locale_surfaces.py](validate_locale_surfaces.py) | Validate locale surfaces for default-locale parity and English-bias drift. |
 | [validate_spec_idea_traceability.py](validate_spec_idea_traceability.py) | _no top-of-file purpose_ |
 | [validate_spec_prefix_canonicalization.py](validate_spec_prefix_canonicalization.py) | Validate canonical mapping for duplicated spec numeric prefixes. |
 | [validate_spec_quality.py](validate_spec_quality.py) | Validate spec quality so implementation does not need manual follow-up gap fixes. |

--- a/scripts/sync_kb_to_db.py
+++ b/scripts/sync_kb_to_db.py
@@ -224,7 +224,7 @@ def content_hash(markdown: str, title: str, description: str) -> str:
 
 
 def parse_view_file(filepath: Path) -> dict:
-    """Parse a view file: English original (lc-xxx.md) or a non-English view
+    """Parse a view file: default-locale root view (lc-xxx.md) or a locale view
     (lc-xxx.<lang>.md). Returns lang, title, description, markdown, and any
     translation metadata declared in frontmatter.
     """
@@ -246,9 +246,9 @@ def parse_view_file(filepath: Path) -> dict:
     story = extract_story_content(text) or ""
 
     # Default author_type:
-    #   - English view -> original_human (unless frontmatter says otherwise)
-    #   - non-English with translated_from -> translation_human
-    #   - non-English with no translated_from -> original_human (authored directly in that lang)
+    #   - default-locale view -> original_human (unless frontmatter says otherwise)
+    #   - locale view with translated_from -> translation_human
+    #   - locale view with no translated_from -> original_human (authored directly in that lang)
     declared_author = fm.get("author_type")
     if declared_author:
         author_type = declared_author
@@ -273,7 +273,7 @@ def parse_view_file(filepath: Path) -> dict:
 
 
 def view_files_for_concept(concept_id: str) -> list[Path]:
-    """All view files for a concept: the English original plus any <lang>.md siblings."""
+    """All view files for a concept: the root view plus any <lang>.md siblings."""
     files = []
     en = KB_DIR / f"{concept_id}.md"
     if en.exists():
@@ -291,10 +291,10 @@ def sync_views_for_concept(
     """Project every language view file for a concept into the DB.
 
     Order matters: sync the anchor-eligible (non-translated) view first so its
-    content_hash is available to the translated views for linkage. For now the
-    English file acts as the starting point if no other lang file is marked as
-    the anchor; when a non-English view is edited to become the anchor, a
-    subsequent sync pass will re-read the files and update accordingly.
+    content_hash is available to the translated views for linkage. The root
+    file acts as the starting point if no other lang file is marked as the
+    anchor; when another locale view is edited to become the anchor, a
+    subsequent sync pass re-reads the files and updates accordingly.
     """
     files = view_files_for_concept(concept_id)
     if not files:
@@ -350,7 +350,7 @@ def sync_views_for_concept(
 def parse_idea_view_file(filepath: Path) -> dict:
     """Parse ideas/<slug>.<lang>.md into a view payload.
 
-    The non-language file (ideas/agent-pipeline.md) is the English view.
+    The non-language file (ideas/agent-pipeline.md) is the default-locale view.
     Files with a .<lang>.md suffix (agent-pipeline.de.md) are translations.
     """
     text = filepath.read_text(encoding="utf-8")

--- a/scripts/validate_locale_surfaces.py
+++ b/scripts/validate_locale_surfaces.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Validate locale surfaces for default-locale parity and English-bias drift."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_LOCALE = "en"
+WEB_MESSAGES_DIR = ROOT / "web" / "messages"
+CLI_MESSAGES_DIR = ROOT / "cli" / "lib" / "messages"
+WEB_MANIFEST = WEB_MESSAGES_DIR / "manifest.ts"
+API_MANIFEST = ROOT / "api" / "app" / "data" / "locale_manifest.json"
+
+NON_DEFAULT_BIASED_PHRASES = (
+    "english anchor",
+    "english bundle",
+    "falls back to english",
+    "fallback to english",
+    "seeded from the english",
+)
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _flatten(value: Any, prefix: str = "") -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    if isinstance(value, dict):
+        for key, child in value.items():
+            path = f"{prefix}.{key}" if prefix else key
+            out.update(_flatten(child, path))
+    else:
+        out[prefix] = value
+    return out
+
+
+def _json_locale_codes(directory: Path) -> list[str]:
+    if not directory.is_dir():
+        return []
+    return sorted(
+        path.stem
+        for path in directory.glob("*.json")
+        if re.fullmatch(r"[A-Za-z][A-Za-z0-9-]*", path.stem)
+    )
+
+
+def _web_manifest_codes() -> list[str]:
+    if not WEB_MANIFEST.exists():
+        return []
+    text = WEB_MANIFEST.read_text(encoding="utf-8")
+    match = re.search(r"export const LOCALES = (\[.*?\]) as const;", text, re.S)
+    if not match:
+        return []
+    return sorted(entry["code"] for entry in json.loads(match.group(1)))
+
+
+def _api_manifest_entries() -> list[dict[str, str]]:
+    if not API_MANIFEST.exists():
+        return []
+    manifest = _read_json(API_MANIFEST)
+    entries = manifest.get("locales", []) if isinstance(manifest, dict) else []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _attunement_meta(bundle: dict[str, Any], code: str) -> dict[str, str]:
+    raw = bundle.get("_attunement", {}) if isinstance(bundle, dict) else {}
+    attunement = raw if isinstance(raw, dict) else {}
+    name = attunement.get("name") or attunement.get("languageName") or code
+    native_name = attunement.get("nativeName") or attunement.get("native_name") or name
+    return {"name": str(name), "native_name": str(native_name)}
+
+
+def validate() -> list[str]:
+    errors: list[str] = []
+    web_codes = _json_locale_codes(WEB_MESSAGES_DIR)
+    cli_codes = _json_locale_codes(CLI_MESSAGES_DIR)
+
+    if DEFAULT_LOCALE not in web_codes:
+        return [f"web/messages/{DEFAULT_LOCALE}.json is required"]
+
+    default_bundle = _read_json(WEB_MESSAGES_DIR / f"{DEFAULT_LOCALE}.json")
+    default_keys = set(_flatten(default_bundle))
+    web_bundles = {
+        code: _read_json(WEB_MESSAGES_DIR / f"{code}.json")
+        for code in web_codes
+    }
+
+    for code, bundle in web_bundles.items():
+        keys = set(_flatten(bundle))
+        missing = sorted(default_keys - keys)
+        extra = sorted(keys - default_keys)
+        if missing:
+            errors.append(f"web/messages/{code}.json missing keys: {', '.join(missing[:8])}")
+        if extra:
+            errors.append(f"web/messages/{code}.json extra keys: {', '.join(extra[:8])}")
+
+    manifest_codes = _web_manifest_codes()
+    if manifest_codes != web_codes:
+        errors.append(
+            f"web/messages/manifest.ts locales {manifest_codes or 'unreadable'} "
+            f"do not match installed web bundles {web_codes}"
+        )
+
+    api_entries = _api_manifest_entries()
+    api_codes = sorted(str(entry.get("code")) for entry in api_entries if entry.get("code"))
+    if api_codes != web_codes:
+        errors.append(
+            f"api/app/data/locale_manifest.json locales {api_codes or 'unreadable'} "
+            f"do not match installed web bundles {web_codes}"
+        )
+    else:
+        api_by_code = {entry["code"]: entry for entry in api_entries if entry.get("code")}
+        for code, bundle in web_bundles.items():
+            expected = _attunement_meta(bundle, code)
+            actual = api_by_code.get(code, {})
+            if actual.get("name") != expected["name"] or actual.get("native_name") != expected["native_name"]:
+                errors.append(
+                    f"api locale metadata for {code} does not match web _attunement metadata"
+                )
+
+    if cli_codes != web_codes:
+        errors.append(
+            f"cli/lib/messages locales {cli_codes or 'unreadable'} "
+            f"do not match installed web bundles {web_codes}"
+        )
+
+    for code, bundle in web_bundles.items():
+        if code == DEFAULT_LOCALE:
+            continue
+        for key, value in _flatten(bundle).items():
+            if not isinstance(value, str):
+                continue
+            lower_value = value.lower()
+            for phrase in NON_DEFAULT_BIASED_PHRASES:
+                if phrase in lower_value:
+                    errors.append(
+                        f"web/messages/{code}.json:{key} contains biased phrase {phrase!r}"
+                    )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--summary", action="store_true", help="Print a one-line reading.")
+    args = parser.parse_args()
+
+    errors = validate()
+    if errors:
+        if args.summary:
+            print(f"locale surface drift: {len(errors)} issue(s)")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    summary = (
+        "locale surfaces aligned: "
+        f"{len(_json_locale_codes(WEB_MESSAGES_DIR))} web/API/CLI locales, "
+        "message parity clean, non-default bundles free of English-anchor wording"
+    )
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -394,15 +394,16 @@ def sense_locale_parity() -> list[str]:
     """Do the body's voice speak the same body in every tongue?
 
     The web body speaks through every ``web/messages/{lang}.json``
-    translation file. English is the canonical source — new chrome strings,
-    copy refinements, and new sections land there first and are mirrored into
-    the installed locale bundles. When that mirroring lags, a visitor sees
-    half the page in their language and half falling back to English
-    mid-sentence.
+    translation file. The current default bundle is the canonical source —
+    new chrome strings, copy refinements, and new sections land there first
+    and are mirrored into the installed locale bundles. When that mirroring
+    lags, a visitor sees half the page in their language and half falling back
+    to the default locale mid-sentence.
 
-    This lens compares the key set of each locale to en's, surfacing:
-      · missing keys (en has strings the locale doesn't)
-      · extra keys (locale carries strings en no longer has)
+    This lens compares the key set of each locale to the default bundle,
+    surfacing:
+      · missing keys (the default bundle has strings the locale doesn't)
+      · extra keys (locale carries strings the default bundle no longer has)
 
     Drift is signal, not failure. A locale at 99% parity with three
     extras is a body recently moving; a locale at 70% is a body
@@ -472,6 +473,29 @@ def sense_locale_parity() -> list[str]:
     if all_aligned:
         return [f"  every locale aligned with en ({len(en_keys)} keys, {len(locales)} tongues)"]
 
+    return lines
+
+
+def sense_locale_surfaces() -> list[str]:
+    """Check that web, API, and CLI locale doors carry the same installed tongues."""
+    script = ROOT / "scripts" / "validate_locale_surfaces.py"
+    if not script.exists():
+        return ["  scripts/validate_locale_surfaces.py not found"]
+    result = subprocess.run(
+        [sys.executable, str(script), "--summary"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = [line for line in result.stdout.splitlines() if line.strip()]
+    if result.returncode == 0 and output:
+        return [f"  {output[0]}"]
+    lines = ["  locale surface validation wants attention"]
+    for line in output[:6]:
+        lines.append(f"    {line}")
+    if result.stderr.strip():
+        lines.append(f"    stderr: {result.stderr.strip().splitlines()[0]}")
     return lines
 
 
@@ -1844,6 +1868,7 @@ def main() -> int:
         ("Source maps — do specs point at files that exist?", sense_spec_sources()),
         ("Symbol resolution — do the named symbols still live in those files?", sense_spec_symbols()),
         ("Locale parity — does the body speak the same body in every tongue?", sense_locale_parity()),
+        ("Locale surfaces — do web, API, and CLI carry the same tongues?", sense_locale_surfaces()),
         ("Chain — does idea→spec→code→test reach end to end?", sense_chain()),
         ("Form engine — does the meta-circular evaluator cover Python dispatch?", sense_form_engine()),
         ("Form ontology — does the form-side table agree with each kernel parser?", sense_form_ontology()),

--- a/web/lib/locale-fetch.ts
+++ b/web/lib/locale-fetch.ts
@@ -6,8 +6,8 @@
  *   - fetchWithLocale(path, init?): a fetch that automatically appends ?lang=
  *     to every request (unless the path already has one, or lang is the default)
  *
- * Use in server components and async pages. For the DEFAULT_LOCALE (en) the
- * helper still appends the lang so the API returns the English view when one
+ * Use in server components and async pages. For the DEFAULT_LOCALE, the
+ * helper still appends the lang so the API returns that locale's view when one
  * exists (the caller can always override by passing an explicit lang in path).
  */
 

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -153,7 +153,7 @@
     "lang": "de",
     "name": "German",
     "nativeName": "Deutsch",
-    "notes": "First-pass attunement from the en anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
+    "notes": "First-pass attunement from the current default anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
     "role": "anchor"
   },
   "common": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -298,7 +298,7 @@
     "needsNativeVoice": "Needs a native voice — propose a better translation",
     "pendingTranslation": "No view in this language yet — showing the anchor view",
     "translationPendingTitle": "Translation is being prepared",
-    "translationPendingBody": "This concept does not have a complete view in this language yet. The English anchor is held back here so the page does not mix languages while attunement runs.",
+    "translationPendingBody": "This concept does not have a complete view in this language yet. The current anchor view is held back here so the page does not mix languages while attunement runs.",
     "staleAwaitingReattunement": "Anchor view has moved — this view awaits re-attunement",
     "voicesHeading": "Voices from the field",
     "voicesLede": "How this concept lives in practice, told by those living it.",
@@ -2552,7 +2552,7 @@
     },
     "noteEyebrow": "A note from this body",
     "editProfileCta": "How to claim, edit, or remove this profile →",
-    "sourceLanguageDisclosure": "Note: this page's curated content is currently in English. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; an author-curated translation of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature will render the rest in your language too."
+    "sourceLanguageDisclosure": "Note: this page's longer curated prose has not yet been author-translated for every locale. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; an author-curated translation of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature can carry the rest."
   },
   "presence": {
     "location": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -153,7 +153,7 @@
     "lang": "es",
     "name": "Spanish",
     "nativeName": "Español",
-    "notes": "First-pass attunement from the en anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
+    "notes": "First-pass attunement from the current default anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
     "role": "anchor"
   },
   "common": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -154,7 +154,7 @@
     "name": "French",
     "nativeName": "Français",
     "role": "seed",
-    "notes": "French is supported as a locale; this bundle is seeded from the English anchor so the key shape is complete while human attunement continues."
+    "notes": "French is supported as a locale; this bundle is seeded from the current default anchor so the key shape is complete while human attunement continues."
   },
   "common": {
     "skipToContent": "Skip to main content",
@@ -298,7 +298,7 @@
     "needsNativeVoice": "Needs a native voice — propose a better translation",
     "pendingTranslation": "No view in this language yet — showing the anchor view",
     "translationPendingTitle": "Translation is being prepared",
-    "translationPendingBody": "This concept does not have a complete view in this language yet. The English anchor is held back here so the page does not mix languages while attunement runs.",
+    "translationPendingBody": "This concept does not have a complete view in this language yet. The current anchor view is held back here so the page does not mix languages while attunement runs.",
     "staleAwaitingReattunement": "Anchor view has moved — this view awaits re-attunement",
     "voicesHeading": "Voices from the field",
     "voicesLede": "How this concept lives in practice, told by those living it.",
@@ -1969,6 +1969,8 @@
     "errorGeneric": "Something didn't connect. You can also write directly to urs at umuff71@gmail.com.",
     "submitBtn": "Weave in",
     "submitBtnSubmitting": "Weaving in…",
+    "receiveTitle": "Comment voulez-vous être accueilli ?",
+    "receiveHelp": "Vous choisissez les termes — vous pourrez les modifier plus tard, ou vous retirer à tout moment.",
     "readFirst": "← Read first",
     "finePrint": "By weaving in you're saying yes to being part of [the body](/vision/lc-network). The network reaches back with care, not noise. You keep sovereignty over what you share, and you can ask to be removed at any time. After landing you'll see your [body of weaving](/me/work) page — empty at first, filling as you contribute. For full crypto-key sovereignty (ed25519 keypair, advanced), use [/join](/join) instead. To register specific offerings, services, or spaces right away, [/share](/share) is the dedicated surface.",
     "roles": {
@@ -2550,7 +2552,7 @@
     },
     "noteEyebrow": "A note from this body",
     "editProfileCta": "How to claim, edit, or remove this profile →",
-    "sourceLanguageDisclosure": "Note: this page's curated content is currently in English. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; an author-curated translation of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature will render the rest in your language too."
+    "sourceLanguageDisclosure": "Note: this page's longer curated prose has not yet been author-translated for every locale. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; an author-curated translation of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature can carry the rest."
   },
   "presence": {
     "location": {

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -153,7 +153,7 @@
     "lang": "id",
     "name": "Indonesian",
     "nativeName": "Bahasa Indonesia",
-    "notes": "First-pass attunement from the en anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
+    "notes": "First-pass attunement from the current default anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
     "role": "anchor"
   },
   "common": {

--- a/web/messages/pt-br.json
+++ b/web/messages/pt-br.json
@@ -154,7 +154,7 @@
     "name": "Brazilian Portuguese",
     "nativeName": "Português (Brasil)",
     "role": "seed",
-    "notes": "Brazilian Portuguese is supported as a locale; this bundle is seeded from the English anchor so the key shape is complete while human attunement continues."
+    "notes": "Brazilian Portuguese is supported as a locale; this bundle is seeded from the current default anchor so the key shape is complete while human attunement continues."
   },
   "common": {
     "skipToContent": "Skip to main content",
@@ -298,7 +298,7 @@
     "needsNativeVoice": "Needs a native voice — propose a better translation",
     "pendingTranslation": "No view in this language yet — showing the anchor view",
     "translationPendingTitle": "Translation is being prepared",
-    "translationPendingBody": "This concept does not have a complete view in this language yet. The English anchor is held back here so the page does not mix languages while attunement runs.",
+    "translationPendingBody": "This concept does not have a complete view in this language yet. The current anchor view is held back here so the page does not mix languages while attunement runs.",
     "staleAwaitingReattunement": "Anchor view has moved — this view awaits re-attunement",
     "voicesHeading": "Voices from the field",
     "voicesLede": "How this concept lives in practice, told by those living it.",
@@ -1969,6 +1969,8 @@
     "errorGeneric": "Something didn't connect. You can also write directly to urs at umuff71@gmail.com.",
     "submitBtn": "Weave in",
     "submitBtnSubmitting": "Weaving in…",
+    "receiveTitle": "Como você quer ser recebido?",
+    "receiveHelp": "Você escolhe os termos — pode mudar qualquer um deles depois, ou se afastar a qualquer momento.",
     "readFirst": "← Read first",
     "finePrint": "By weaving in you're saying yes to being part of [the body](/vision/lc-network). The network reaches back with care, not noise. You keep sovereignty over what you share, and you can ask to be removed at any time. After landing you'll see your [body of weaving](/me/work) page — empty at first, filling as you contribute. For full crypto-key sovereignty (ed25519 keypair, advanced), use [/join](/join) instead. To register specific offerings, services, or spaces right away, [/share](/share) is the dedicated surface.",
     "roles": {
@@ -2550,7 +2552,7 @@
     },
     "noteEyebrow": "A note from this body",
     "editProfileCta": "How to claim, edit, or remove this profile →",
-    "sourceLanguageDisclosure": "Note: this page's curated content is currently in English. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; an author-curated translation of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature will render the rest in your language too."
+    "sourceLanguageDisclosure": "Note: this page's longer curated prose has not yet been author-translated for every locale. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; an author-curated translation of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature can carry the rest."
   },
   "presence": {
     "location": {


### PR DESCRIPTION
## Summary\n- add a locale-surface validator covering web message bundles, generated web manifest, API locale manifest, and CLI message bundles\n- wire the validator into wellness as a concise Locale surfaces readout\n- fill the French and Brazilian Portuguese /begin keys that drifted after the latest copy change\n- replace English-anchor wording with current/default-anchor wording across user-facing locale copy and tooling comments\n\n## Validation\n- make wellness\n- python3 scripts/validate_locale_surfaces.py\n- python3 scripts/generate_repo_indexes.py --check\n- cd api && python3 -m pytest -q tests/test_flow_multilingual.py tests/test_concept_views.py\n- cd web && NPM_CONFIG_CACHE=/tmp/coherence-npm-cache npm ci && npm run build\n- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main\n- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict\n- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence