### PR TITLE
tend: narrow presence image path to heal web tsc error

### DIFF
--- a/web/tests/homepage-presence-lineage.test.ts
+++ b/web/tests/homepage-presence-lineage.test.ts
@@ -85,6 +85,8 @@ describe("homepage presence lineage", () => {
     ]);
 
     for (const image of imageMatches) {
+      expect(image, "presence image path is defined").toBeTruthy();
+      if (!image) continue;
       expect(existsSync(join(root, "public", image))).toBe(true);
     }
   });


### PR DESCRIPTION
## What

Heals the single TypeScript error in the `web/` tree, getting `tsc --noEmit` back to fully green.

`web/tests/homepage-presence-lineage.test.ts` iterated `imageMatches` — typed `(string | undefined)[]` because it maps the optional `image?: string` trace field — and passed each entry into `join(root, "public", image)`, which requires `string`. That was `TS2345`.

## Fix

A local guard inside the loop:

```ts
for (const image of imageMatches) {
  expect(image, "presence image path is defined").toBeTruthy();
  if (!image) continue;
  expect(existsSync(join(root, "public", image))).toBe(true);
}
```

- `expect(image).toBeTruthy()` fails loudly with a named message if any presence ever resolves to an undefined image path.
- `if (!image) continue` narrows `image` to `string` for the compiler.

Chosen over a bare `image!` non-null assertion: the definedness guarantee (the `toEqual` against five exact strings on line 79) lives eight lines up, so a local guard stays honest even if that distant assertion is later edited — a missing image becomes a clear test failure rather than a silent crash inside `join`.

No `@ts-ignore`, no suppression. Scoped to exactly the line the error named.

## Proof

`cd web && tsc --noEmit` exits 0 with no output — this was the only error in the web tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)