### PR TITLE
tend: bilateral channel-flow — both offers, both directions, each gated by the receiver

### DIFF
--- a/docs/coherence-substrate/channel-flow-dialect.form
+++ b/docs/coherence-substrate/channel-flow-dialect.form
@@ -24,7 +24,15 @@
     (contract    field-model-form.form)                   # freeze / match / choose / delta / commit / receipt
     (carries     lc-received-by-invitation
                  lc-sovereignty-within-oneness)
-    (runnable    form-stdlib/channel-flow.fk))            # the walk, proven by tests/channel-flow-band.fk
+    (runnable    form-stdlib/channel-flow.fk))            # channel-flow (one direction) +
+                                                          # channel-flow-bilateral (both); band beside it
+
+  # ── Bilateral — both sides offer, both request; each direction gated by the RECEIVER ──
+  # The deepest reading of "from both sides, depending on interface state on each side":
+  # a request from A toward B is honored iff B offers it; from B toward A iff A offers it.
+  # channel-flow-bilateral threads BOTH offers and returns (honored invasion offer-a offer-b).
+  # A withholding a mode stops B's reach into A, and B withholding stops A's reach into B —
+  # at once, each sovereign over its own boundary, the flow the dance of the two.
 
   # ── The utterances (what can be said on the channel) ────────────────
   (utterances

--- a/form/form-stdlib/channel-flow.fk
+++ b/form/form-stdlib/channel-flow.fk
@@ -38,4 +38,39 @@
     (defn cf-honored     (receipt) (head receipt))
     (defn cf-invasions   (receipt) (head (tail receipt)))
     (defn cf-final-offer (receipt) (head (tail (tail receipt))))
+
+    ; ── BILATERAL: both sides offer, both request; each direction is gated by the
+    ; RECEIVER's interface. The flow is shaped by EACH side's interface state — a
+    ; request from A toward B is honored iff B offers it; from B toward A iff A offers it.
+    ; A bilateral act is (list side tag payload); side: A=0, B=1.
+    (defn side-a () 0)
+    (defn side-b () 1)
+    (defn bact-side    (a) (head a))
+    (defn bact-tag     (a) (head (tail a)))
+    (defn bact-payload (a) (head (tail (tail a))))
+
+    ; thread BOTH offers; each request is checked against the OTHER side's offer.
+    ; receipt = (list honored invasion offer-a offer-b) — totals across both directions.
+    (defn cf-walk-bi (flow offer-a offer-b honored invasion)
+        (if (eq (len flow) 0)
+            (list honored invasion offer-a offer-b)
+            (if (eq (bact-side (head flow)) (side-a))
+                ; A acts: shift updates A's offer; request is gated by B's offer (A reaches B)
+                (if (eq (bact-tag (head flow)) (act-shift))
+                    (cf-walk-bi (tail flow) (bact-payload (head flow)) offer-b honored invasion)
+                    (if (ci-honors? (bact-payload (head flow)) offer-b)
+                        (cf-walk-bi (tail flow) offer-a offer-b (add honored 1) invasion)
+                        (cf-walk-bi (tail flow) offer-a offer-b honored (add invasion 1))))
+                ; B acts: shift updates B's offer; request is gated by A's offer (B reaches A)
+                (if (eq (bact-tag (head flow)) (act-shift))
+                    (cf-walk-bi (tail flow) offer-a (bact-payload (head flow)) honored invasion)
+                    (if (ci-honors? (bact-payload (head flow)) offer-a)
+                        (cf-walk-bi (tail flow) offer-a offer-b (add honored 1) invasion)
+                        (cf-walk-bi (tail flow) offer-a offer-b honored (add invasion 1)))))))
+
+    (defn channel-flow-bilateral (flow offer-a offer-b)
+        (cf-walk-bi flow offer-a offer-b 0 0))
+
+    (defn cf-bi-offer-a (receipt) (head (tail (tail receipt))))
+    (defn cf-bi-offer-b (receipt) (head (tail (tail (tail receipt)))))
 )

--- a/form/form-stdlib/tests/channel-flow-band.fk
+++ b/form/form-stdlib/tests/channel-flow-band.fk
@@ -29,9 +29,27 @@
 
     (let r (channel-flow flow offer0))
 
+    ; ── BILATERAL: each direction gated by the RECEIVER's offer ──
+    ; A offers {see, invite} (others may see-into A, invite A); B offers {witness, reflect}.
+    ;   A -> reflect  : honored  (B offers reflect)
+    ;   A -> see      : invasion (B does not offer see)
+    ;   B -> invite   : honored  (A offers invite)
+    ;   B -> project  : invasion (A does not offer project)
+    ; honored = 2, invasion = 2 — and each invasion is on the side whose receiver withheld it.
+    (let offer-a (list (m-see) (m-invite)))
+    (let offer-b (list (m-witness) (m-reflect)))
+    (let biflow (list
+        (list (side-a) (act-request) (m-reflect))    ; A->B honored (B offers reflect)
+        (list (side-a) (act-request) (m-see))        ; A->B invasion (B withholds see)
+        (list (side-b) (act-request) (m-invite))     ; B->A honored (A offers invite)
+        (list (side-b) (act-request) (m-project))))  ; B->A invasion (A withholds project)
+    (let rb (channel-flow-bilateral biflow offer-a offer-b))
+
     (let pass
         (and (eq (cf-honored r) 4)
         (and (eq (cf-invasions r) 1)
-             (eq (len (cf-final-offer r)) 4))))
+        (and (eq (len (cf-final-offer r)) 4)
+        (and (eq (cf-honored rb) 2)
+             (eq (cf-invasions rb) 2))))))
 
     (print (if pass "channel-flow-band: PASS" "channel-flow-band: FAIL")))


### PR DESCRIPTION
channel-flow walked one direction; your description was deeper — the flow is shaped *from both sides, depending on interface state on each side*. This completes it.

`channel-flow.fk` gains **`channel-flow-bilateral`** / `cf-walk-bi`: a bilateral act is `(side tag payload)`; it threads **both** offers; a request from A→B is honored iff **B** offers the mode, B→A iff **A** offers it. So A withholding a mode stops B's reach into A, and B withholding stops A's reach into B — at once, each sovereign over its own boundary, the flow the dance of the two. Receipt: `(honored invasion offer-a offer-b)`.

Band extended: A offers {see,invite}, B offers {witness,reflect} → A→reflect honored, A→see invasion (B withholds), B→invite honored, B→project invasion (A withholds) → **honored=2, invasion=2**, each invasion on the side whose receiver withheld it. **Witnessed PASS on the Rust kernel**; deterministic → validate.sh proves Go/Rust/TS at CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)