### PR TITLE
Remove translation source hierarchy wording

### DIFF
--- a/api/app/routers/INDEX.md
+++ b/api/app/routers/INDEX.md
@@ -137,7 +137,7 @@
 | [substrate.py](substrate.py) | Coherence-substrate REST API. |
 | [task_activity_routes.py](task_activity_routes.py) | Task activity endpoints — live task visibility and SSE streaming. |
 | [traceability.py](traceability.py) | spec: full-code-traceability |
-| [translations.py](translations.py) | Translations router — POST human or machine translations for any entity. |
+| [translations.py](translations.py) | Translations router — POST submitted or generated translations for any entity. |
 | [treasury.py](treasury.py) | Implements: spec-122 (crypto treasury bridge) |
 | [ui_preferences.py](ui_preferences.py) | UI Preferences router — spec ux-tabs-mobile-friendly. |
 | [utils.py](utils.py) | Utility endpoints whose bodies live as Form recipes, not Python functions. |

--- a/api/app/routers/concepts.py
+++ b/api/app/routers/concepts.py
@@ -173,8 +173,8 @@ class ViewUpsert(BaseModel):
 
     author_type:
       - original_human: this view was authored directly in ``lang`` (no source)
-      - translation_human: this view was attuned from ``translated_from_lang``
-        by a human
+      - translation_human: this legacy label means an accepted submitted
+        rendering attuned from ``translated_from_lang``
       - translation_machine: this view was attuned by a machine backend
 
     ``translated_from_lang`` and ``translated_from_hash`` are required for the
@@ -580,7 +580,8 @@ async def update_story(concept_id: str, body: StoryPatch):
 async def upsert_concept_view(concept_id: str, body: ViewUpsert, request: Request):
     """Upsert a language view for a concept. Every language is equal — this
     endpoint accepts any installed locale on the same footing. The anchor
-    (freshest human-touched view) is discovered at read time, not hardcoded.
+    (freshest accepted anchor-eligible view) is discovered at read time, not
+    hardcoded.
 
     Called by the KB sync pass (reading ``docs/vision-kb/concepts/{id}.{lang}.md``)
     and by community contributors authoring or attuning directly. The new row
@@ -720,7 +721,7 @@ async def get_concept(
         default=None,
         description="Optional installed language view. When set, the concept is "
                     "rendered in that language view if one exists. A language_meta block "
-                    "declares which view is the anchor (freshest human-touched expression) "
+                    "declares which view is the anchor (freshest accepted expression) "
                     "and whether the returned view is stale relative to it. "
                     "If no view exists yet and an LLM backend is registered, a background "
                     "attunement is enqueued and the next request will be served from cache.",
@@ -733,7 +734,7 @@ async def get_concept(
     that view. ``language_meta`` exposes:
 
     - ``lang``: what was returned
-    - ``is_anchor``: true if this view is the most recently human-touched
+    - ``is_anchor``: true if this view is the most recently accepted anchor view
     - ``stale``: true if this view was translated from an earlier state of
       the anchor and needs re-attunement
     - ``anchor``: the anchor view's lang + updated_at, so UI can offer

--- a/api/app/routers/locales.py
+++ b/api/app/routers/locales.py
@@ -28,8 +28,9 @@ async def list_locales() -> dict:
     """List supported locales and how much of the concept space is reachable
     in each. Coverage is computed as: for every concept that has any view,
     how many have a canonical view in this lang, how many of those are
-    original authoring, how many are human-attuned, how many machine-attuned,
-    and how many are currently stale relative to the anchor.
+    original authoring, how many use the legacy contributor-submitted bucket,
+    how many are machine-attuned, and how many are currently stale relative to
+    the anchor.
     """
     from sqlalchemy import select
     from collections import defaultdict

--- a/api/app/routers/translations.py
+++ b/api/app/routers/translations.py
@@ -1,4 +1,4 @@
-"""Translations router — POST human or machine translations for any entity.
+"""Translations router — POST submitted or generated translations for any entity.
 
 Fills the spec gap in `multilingual-web` R8: anyone signed-in can
 submit a translation and it becomes canonical immediately; the prior
@@ -99,7 +99,7 @@ def _record_to_view(rec, source_contribution_id: str | None = None) -> Translati
     "",
     response_model=TranslationView,
     status_code=201,
-    summary="Submit a translation (human or machine); supersedes any prior canonical",
+    summary="Submit a translation rendering; supersedes any prior canonical",
 )
 async def submit_translation(body: TranslationSubmit) -> TranslationView:
     """Submit a translation for an entity. Becomes canonical immediately.

--- a/api/app/services/translation_cache_service.py
+++ b/api/app/services/translation_cache_service.py
@@ -1,20 +1,23 @@
 """Concept views — equal-status language renderings of a concept, idea, or
-contribution. No privileged source language. The anchor (freshest expression)
-is whichever view was most recently touched by a human. Stale views re-attune
-from the anchor.
+contribution. No privileged source language. The anchor (freshest accepted
+expression) is whichever anchor-eligible view was most recently accepted.
+Stale views re-attune from the anchor.
 
 Every view row carries:
   - content_hash: sha256 of its own current content (title + description + markdown)
   - translated_from_hash: the content_hash of the view this was rendered from
     (null when the view was authored directly in that language)
   - author_type: original_human | translation_human | translation_machine
+    (legacy provenance labels; not quality ranks)
 
 Anchor discovery at read time:
-  1. Consider all views whose author_type is original_human or translation_human
+  1. Consider all views whose author_type is anchor-eligible
   2. Pick the one with the latest updated_at
-  3. Ties broken by: original_human over translation_human
+  3. Ties broken by: direct original over submitted rendering
   The anchor is the living centre. Other views are stale if their
   translated_from_hash doesn't equal the anchor's current content_hash.
+  This is an acceptance/provenance policy, not a claim that one source type
+  translates better than another.
 
 History-preserving: every write creates a new row. Prior rows for the same
 (entity, lang) flip to status='superseded' but remain for the edit history.
@@ -102,7 +105,11 @@ AUTHOR_TYPE_ORIGINAL_HUMAN = "original_human"
 AUTHOR_TYPE_TRANSLATION_HUMAN = "translation_human"
 AUTHOR_TYPE_TRANSLATION_MACHINE = "translation_machine"
 
-HUMAN_AUTHOR_TYPES = {AUTHOR_TYPE_ORIGINAL_HUMAN, AUTHOR_TYPE_TRANSLATION_HUMAN}
+ANCHOR_ELIGIBLE_AUTHOR_TYPES = {
+    AUTHOR_TYPE_ORIGINAL_HUMAN,
+    AUTHOR_TYPE_TRANSLATION_HUMAN,
+}
+HUMAN_AUTHOR_TYPES = ANCHOR_ELIGIBLE_AUTHOR_TYPES  # Backward-compatible alias.
 
 STATUS_CANONICAL = "canonical"
 STATUS_SUPERSEDED = "superseded"
@@ -271,19 +278,19 @@ def all_canonical_views(entity_type: str, entity_id: str) -> list[EntityViewReco
 
 
 def find_anchor(views: list[EntityViewRecord]) -> EntityViewRecord | None:
-    """The anchor is the most recently human-touched view. Original authoring
-    wins ties with translation-human at the same updated_at.
-    """
-    humans = [v for v in views if v.author_type in HUMAN_AUTHOR_TYPES]
-    if not humans:
+    """The anchor is the most recently accepted anchor-eligible view."""
+    eligible = [
+        v for v in views if v.author_type in ANCHOR_ELIGIBLE_AUTHOR_TYPES
+    ]
+    if not eligible:
         return None
 
     def rank(v: EntityViewRecord) -> tuple:
         origin_rank = 1 if v.author_type == AUTHOR_TYPE_ORIGINAL_HUMAN else 0
         return (v.updated_at, origin_rank)
 
-    humans.sort(key=rank, reverse=True)
-    return humans[0]
+    eligible.sort(key=rank, reverse=True)
+    return eligible[0]
 
 
 def is_stale(view: EntityViewRecord, anchor: EntityViewRecord | None) -> bool:

--- a/cli/lib/commands/translate.mjs
+++ b/cli/lib/commands/translate.mjs
@@ -2,8 +2,8 @@
  * Translate commands — submit and inspect entity translations.
  *
  * Closes the spec gap in `multilingual-web` R8: any signed-in contributor
- * can submit a human translation; it becomes canonical immediately and
- * the prior canonical is preserved as superseded.
+ * can submit another rendering; it becomes canonical immediately and the
+ * prior canonical is preserved as superseded.
  *
  * Commands:
  *   coh translate submit <entity_type> <entity_id> --lang <lang> --file <path> [--title <t>] [--description <d>] [--from-lang <source>] [--by <author_id>] [--notes <notes>]

--- a/docs/system_audit/commit_evidence_2026-06-08_translation_mode_parity.json
+++ b/docs/system_audit/commit_evidence_2026-06-08_translation_mode_parity.json
@@ -1,0 +1,125 @@
+{
+  "date": "2026-06-08",
+  "thread_branch": "codex/translation-mode-parity-20260608",
+  "commit_scope": "Remove human-over-machine translation hierarchy wording and validate translation surfaces for provenance-based framing.",
+  "files_owned": [
+    "api/app/routers/INDEX.md",
+    "api/app/routers/concepts.py",
+    "api/app/routers/locales.py",
+    "api/app/routers/translations.py",
+    "api/app/services/translation_cache_service.py",
+    "cli/lib/commands/translate.mjs",
+    "docs/system_audit/commit_evidence_2026-06-08_translation_mode_parity.json",
+    "docs/vision-kb/INDEX.md",
+    "scripts/INDEX.md",
+    "scripts/validate_locale_surfaces.py",
+    "specs/multilingual-web.md",
+    "web/app/settings/translations/page.tsx",
+    "web/messages/de.json",
+    "web/messages/en.json",
+    "web/messages/es.json",
+    "web/messages/fr.json",
+    "web/messages/id.json",
+    "web/messages/pt-br.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make wellness",
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "python3 scripts/validate_locale_surfaces.py",
+      "cd api && python3 -m pytest -q tests/test_flow_multilingual.py tests/test_concept_views.py tests/test_translations_router.py",
+      "cd web && npm run build",
+      "cd web && NPM_CONFIG_CACHE=/tmp/coherence-npm-cache npm ci",
+      "cd web && npm run build",
+      "python3 scripts/generate_repo_indexes.py",
+      "python3 scripts/generate_repo_indexes.py --check"
+    ],
+    "notes": "Locale validation now checks message bundles plus translation-facing policy surfaces for targeted hierarchy phrases. API tests passed. The first web build failed because this fresh worktree lacked node_modules (next: command not found); npm ci installed dependencies and the web build then passed with existing Next/Turbopack warnings. After rebasing onto current origin/main, the index check reported stale scripts/INDEX.md and docs/vision-kb/INDEX.md; generating indexes repaired both."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Pending push, PR, and GitHub checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Pending merge, deploy, and public verification."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Translation UI and policy surfaces describe generated and contributor-submitted renderings as different provenance paths, not as a human-vs-machine quality hierarchy.",
+    "public_endpoints": [
+      "https://coherencycoin.com/settings/translations",
+      "https://coherencycoin.com/vision/lc-w-coherence?lang=fr",
+      "https://coherencycoin.com/vision/lc-w-coherence?lang=pt-br",
+      "https://api.coherencycoin.com/api/locales"
+    ],
+    "test_flows": [
+      "scripts/validate_locale_surfaces.py reports no English-anchor or translation-mode hierarchy wording.",
+      "/settings/translations labels coverage as original, contributor, machine, and stale without native-review or better-translation wording.",
+      "French and Brazilian Portuguese locale views still render with dynamic locale support while the API locales endpoint includes fr and pt-br."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof is complete. Public movement waits on PR checks, merge, deploy, and public verification."
+  },
+  "idea_ids": [
+    "multilingual-web",
+    "locale-as-data"
+  ],
+  "spec_ids": [
+    "multilingual-web"
+  ],
+  "task_ids": [
+    "translation-mode-parity-20260608"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "translation-mode-correction"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "scripts/validate_locale_surfaces.py now scans web messages and translation-facing API/CLI/spec/UI files for targeted hierarchy phrases.",
+    "web/app/settings/translations/page.tsx labels submitted renderings as contributor provenance and generated renderings as open to attunement.",
+    "specs/multilingual-web.md states translator_type is provenance, not a quality hierarchy.",
+    "api/app/services/translation_cache_service.py documents anchor eligibility as acceptance/provenance policy, not a claim that one source type translates better."
+  ],
+  "change_files": [
+    "api/app/routers/INDEX.md",
+    "api/app/routers/concepts.py",
+    "api/app/routers/locales.py",
+    "api/app/routers/translations.py",
+    "api/app/services/translation_cache_service.py",
+    "cli/lib/commands/translate.mjs",
+    "docs/vision-kb/INDEX.md",
+    "scripts/INDEX.md",
+    "scripts/validate_locale_surfaces.py",
+    "specs/multilingual-web.md",
+    "web/app/settings/translations/page.tsx",
+    "web/messages/de.json",
+    "web/messages/en.json",
+    "web/messages/es.json",
+    "web/messages/fr.json",
+    "web/messages/id.json",
+    "web/messages/pt-br.json"
+  ],
+  "change_intent": "runtime_fix"
+}

--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -1,7 +1,7 @@
 # The Living Collective — Knowledge Base
 
 > AI-maintained markdown wiki. Read this file first. Drill into linked files for detail.
-> **Last maintained**: 2026-06-08 | **Concepts**: 179 | **Status**: 4 expanding, 119 seed, 55 deepening, 1 living | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
+> **Last maintained**: 2026-06-08 | **Concepts**: 180 | **Status**: 4 expanding, 120 seed, 55 deepening, 1 living | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
 
 ## How to use this KB
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -137,7 +137,7 @@
 | [upgrade_specs_to_form_predicates.py](upgrade_specs_to_form_predicates.py) | Augment every spec's done_when with Form predicates derived from its |
 | [validate_commit_evidence.py](validate_commit_evidence.py) | Validate thread commit evidence artifacts for phase-gated process. |
 | [validate_local_api_matrix.py](validate_local_api_matrix.py) | Validate local API-backed page contracts and timing against a running API. |
-| [validate_locale_surfaces.py](validate_locale_surfaces.py) | Validate locale surfaces for default-locale parity and English-bias drift. |
+| [validate_locale_surfaces.py](validate_locale_surfaces.py) | Validate locale surfaces for default-locale parity and translation-mode drift. |
 | [validate_spec_idea_traceability.py](validate_spec_idea_traceability.py) | _no top-of-file purpose_ |
 | [validate_spec_prefix_canonicalization.py](validate_spec_prefix_canonicalization.py) | Validate canonical mapping for duplicated spec numeric prefixes. |
 | [validate_spec_quality.py](validate_spec_quality.py) | Validate spec quality so implementation does not need manual follow-up gap fixes. |

--- a/scripts/validate_locale_surfaces.py
+++ b/scripts/validate_locale_surfaces.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate locale surfaces for default-locale parity and English-bias drift."""
+"""Validate locale surfaces for default-locale parity and translation-mode drift."""
 
 from __future__ import annotations
 
@@ -17,13 +17,45 @@ WEB_MESSAGES_DIR = ROOT / "web" / "messages"
 CLI_MESSAGES_DIR = ROOT / "cli" / "lib" / "messages"
 WEB_MANIFEST = WEB_MESSAGES_DIR / "manifest.ts"
 API_MANIFEST = ROOT / "api" / "app" / "data" / "locale_manifest.json"
+TRANSLATION_POLICY_FILES = (
+    ROOT / "api" / "app" / "routers" / "concepts.py",
+    ROOT / "api" / "app" / "routers" / "locales.py",
+    ROOT / "api" / "app" / "routers" / "translations.py",
+    ROOT / "api" / "app" / "services" / "translation_cache_service.py",
+    ROOT / "api" / "app" / "routers" / "INDEX.md",
+    ROOT / "cli" / "lib" / "commands" / "translate.mjs",
+    ROOT / "specs" / "multilingual-web.md",
+    ROOT / "web" / "app" / "settings" / "translations" / "page.tsx",
+)
 
 NON_DEFAULT_BIASED_PHRASES = (
+    "ancla en inglés",
+    "berbahasa inggris",
     "english anchor",
     "english bundle",
+    "englische ankerfassung",
     "falls back to english",
     "fallback to english",
     "seeded from the english",
+)
+
+TRANSLATION_MODE_HIERARCHY_PHRASES = (
+    "author curated",
+    "author translated",
+    "better translation",
+    "human attunement",
+    "human attuned",
+    "human canonical",
+    "human first",
+    "human touched",
+    "human translated",
+    "human translation",
+    "human translations",
+    "human work",
+    "native review",
+    "native speaker",
+    "native voice",
+    "needs native voice",
 )
 
 
@@ -40,6 +72,11 @@ def _flatten(value: Any, prefix: str = "") -> dict[str, Any]:
     else:
         out[prefix] = value
     return out
+
+
+def _searchable_text(text: str) -> str:
+    spaced = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", text)
+    return re.sub(r"[\._\-]+", " ", spaced).lower()
 
 
 def _json_locale_codes(directory: Path) -> list[str]:
@@ -133,16 +170,35 @@ def validate() -> list[str]:
         )
 
     for code, bundle in web_bundles.items():
-        if code == DEFAULT_LOCALE:
-            continue
         for key, value in _flatten(bundle).items():
             if not isinstance(value, str):
                 continue
             lower_value = value.lower()
-            for phrase in NON_DEFAULT_BIASED_PHRASES:
-                if phrase in lower_value:
+            searchable_value = _searchable_text(value)
+            searchable_key = _searchable_text(key)
+            if code != DEFAULT_LOCALE:
+                for phrase in NON_DEFAULT_BIASED_PHRASES:
+                    if phrase in lower_value:
+                        errors.append(
+                            f"web/messages/{code}.json:{key} contains biased phrase {phrase!r}"
+                        )
+            for phrase in TRANSLATION_MODE_HIERARCHY_PHRASES:
+                if phrase in searchable_value or phrase in searchable_key:
                     errors.append(
-                        f"web/messages/{code}.json:{key} contains biased phrase {phrase!r}"
+                        f"web/messages/{code}.json:{key} contains translation hierarchy phrase "
+                        f"{phrase!r}"
+                    )
+
+    for path in TRANSLATION_POLICY_FILES:
+        if not path.exists():
+            continue
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            searchable_line = _searchable_text(line)
+            for phrase in TRANSLATION_MODE_HIERARCHY_PHRASES:
+                if phrase in searchable_line:
+                    rel = path.relative_to(ROOT)
+                    errors.append(
+                        f"{rel}:{line_no} contains translation hierarchy phrase {phrase!r}"
                     )
 
     return errors
@@ -164,7 +220,7 @@ def main() -> int:
     summary = (
         "locale surfaces aligned: "
         f"{len(_json_locale_codes(WEB_MESSAGES_DIR))} web/API/CLI locales, "
-        "message parity clean, non-default bundles free of English-anchor wording"
+        "message parity clean, bundles free of English-anchor and translation-mode hierarchy wording"
     )
     print(summary)
     return 0

--- a/specs/multilingual-web.md
+++ b/specs/multilingual-web.md
@@ -57,25 +57,25 @@ requirements:
   - "Middleware detects locale from URL → cookie → Accept-Language → default en"
   - "Every translatable entity (concept, idea, contribution, comment) carries a source_lang — English is not privileged; contributors write in the language they live in"
   - "Content translations cached in content_translations table keyed by (entity_type, entity_id, target_lang, source_lang, source_hash)"
-  - "Translations carry translator_type (machine | human) and translator_id; human translations supersede machine ones for the same (entity, target_lang)"
+  - "Translations carry translator_type (machine | human) and translator_id; provenance stays visible, and the newest accepted canonical row supersedes the prior canonical for the same (entity, target_lang)"
   - "Any contributor can submit a translation via POST /api/translations; it becomes canonical immediately and the prior canonical is preserved as superseded (history is the moderation surface, not a review queue)"
-  - "Source edits bump source_hash and invalidate stale translations automatically (both machine and human flagged as stale, not deleted)"
+  - "Source edits bump source_hash and invalidate stale translations automatically (all provenance buckets flagged as stale, not deleted)"
   - "Translator service injects a per-language glossary of frequency-anchor terms into the LLM prompt"
-  - "Every machine translation is flagged reviewed=false until a native speaker approves or replaces it"
+  - "Every generated translation carries review/provenance metadata until another contributor or agent accepts, updates, or replaces it"
   - "Contributions created in any supported language appear in any other supported language via cached translation on read"
   - "GET /api/concepts/{id}?lang=es returns canonical translation if present, else source language with pending_translation=true and enqueues translation"
-  - "POST /api/concepts/{id}/translate?lang=de force-regenerates the machine translation; never overwrites a human translation"
-  - "GET /api/locales returns supported locales with coverage stats (machine, human, reviewed) per locale"
+  - "POST /api/concepts/{id}/translate?lang=de force-regenerates a machine rendering; existing canonical/history rows are preserved unless an explicit override accepts the new row"
+  - "GET /api/locales returns supported locales with coverage stats per locale; legacy machine/human buckets are exposed as provenance labels"
   - "Glossary seeded for de, es, id with anchor terms: tending, ripening, wholeness, coherence, resonance, stewardship, kinship, belonging"
 done_when:
   - "Visiting /de/vision/lc-water-as-living-body shows German UI chrome and a German-translated story"
   - "Switching the picker from en to es on any page keeps the user on the equivalent /es/... path"
   - "A contributor can submit a contribution in Spanish; an English viewer sees it translated; a Bahasa viewer sees it in Bahasa"
-  - "Any signed-in contributor can submit a human translation via POST /api/translations; it replaces the machine version immediately"
-  - "Editing a source story flags every language row for that entity as stale (machine AND human preserved — never silently discarded)"
+  - "Any signed-in contributor can submit another rendering via POST /api/translations; it becomes canonical immediately and preserves the prior row as history"
+  - "Editing a source story flags every language row for that entity as stale (generated and submitted rows preserved — never silently discarded)"
   - "coh stories --lang de returns stories with translated titles and summaries"
-  - "coh translate submit {entity-id} --lang es --file translation.md posts a human translation"
-  - "Locale coverage visible on /settings/translations: per-locale counts of machine vs. human vs. stale"
+  - "coh translate submit {entity-id} --lang es --file translation.md posts a contributor rendering"
+  - "Locale coverage visible on /settings/translations: per-locale counts of generated vs. contributor-submitted vs. stale"
   - "All new and existing tests pass (api and web)"
   - 'file_exists("web/app/layout.tsx")'
   - 'symbol_in_file("web/app/layout.tsx", "RootLayout")'
@@ -136,8 +136,8 @@ test: "cd api && python -m pytest tests/test_translations_router.py tests/test_l
 constraints:
   - "Never mutate source markdown — translations are additive rows keyed by (target_lang, source_hash)"
   - "English is not privileged — source_lang is whatever the contributor wrote in; any locale can be source or target"
-  - "Human translations always outrank machine translations for the same (entity, target_lang)"
-  - "Stale translations (source_hash mismatch) are flagged, not deleted — prior human work is preserved for the translator to update"
+  - "Canonical selection is not a human-vs-machine quality ranking; provenance, acceptance, freshness, and history carry the decision"
+  - "Stale translations (source_hash mismatch) are flagged, not deleted — prior rendering work is preserved for the translator to update"
   - "Never silently fall back to another language in the UI chrome — missing message keys must fail loudly in dev"
   - "Source hash is sha256 of the source markdown; any change flags all language rows as stale"
   - "Glossary terms MUST be injected into the translation prompt for the target language every call"
@@ -148,7 +148,7 @@ constraints:
 
 ## Purpose
 
-The platform's mission names "every idea tracked, for humanity" — but a single-language surface excludes most of humanity. Communities in Peru, Puerto Rico, Guatemala, and Bali already carry stewardship practices the vision describes; they deserve to meet the work in their own tongue AND to contribute in their own voice. This spec makes every translatable surface multilingual in both directions: read and write. Machine translation provides coverage from day one; human translations from community members replace them on arrival, and history is preserved so anything can be revisited.
+The platform's mission names "every idea tracked, for humanity" — but a single-language surface excludes most of humanity. Communities in Peru, Puerto Rico, Guatemala, and Bali already carry stewardship practices the vision describes; they deserve to meet the work in their own tongue AND to contribute in their own voice. This spec makes every translatable surface multilingual in both directions: read and write. Machine translation can provide coverage from day one; contributor or agent renderings can replace it on arrival, and history is preserved so anything can be revisited.
 
 ## Requirements
 
@@ -157,13 +157,13 @@ The platform's mission names "every idea tracked, for humanity" — but a single
 - [ ] **R3**: `LocaleSwitcher` component in the header shows the current language, offers the others, persists choice via `NEXT_LOCALE` cookie, and rewrites the current URL to the new locale.
 - [ ] **R4**: `content_translations` Postgres table stores per-entity translated markdown keyed by `(entity_type, entity_id, target_lang, source_hash)`. Supports entities `concept`, `idea`, `contribution`, `comment`. Each row carries `source_lang`, `translator_type` (`machine | human`), and `translator_id`.
 - [ ] **R5**: `translator` service calls the configured LLM with a prompt that always includes the per-language glossary. Returns translated markdown. No auto-regeneration in the request path — translations are enqueued and served from cache on the next request.
-- [ ] **R6**: Source-hash invalidation: on any source edit, compute sha256 of the new source; cached rows with different hashes are flagged `stale=true`. Nothing is deleted — prior human work is preserved for the translator to update.
+- [ ] **R6**: Source-hash invalidation: on any source edit, compute sha256 of the new source; cached rows with different hashes are flagged `stale=true`. Nothing is deleted — prior rendering work is preserved for the translator to update.
 - [ ] **R7**: Glossary table stores anchor terms per language. Seed with: tending, ripening, wholeness, coherence, resonance, stewardship, kinship, belonging — with their felt-sense equivalents in de, es, id. Admins can edit via `PATCH /api/glossary/{lang}`.
-- [ ] **R8**: Canonical selection: for a given (entity, target_lang), the canonical row is the newest non-stale human translation if any exists, else the newest machine translation. Readers always see the canonical.
-- [ ] **R9**: Human translation submission: any signed-in contributor can `POST /api/translations` with `{entity_type, entity_id, target_lang, translated_markdown}`. It becomes canonical immediately. The prior canonical is preserved as `superseded` so history is visible on the edit page.
+- [ ] **R8**: Canonical selection: for a given (entity, target_lang), the canonical row is the newest non-stale accepted rendering. `translator_type` remains visible as provenance, not a quality hierarchy. Readers always see the canonical.
+- [ ] **R9**: Rendering submission: any signed-in contributor can `POST /api/translations` with `{entity_type, entity_id, target_lang, translated_markdown}`. It becomes canonical immediately. The prior canonical is preserved as `superseded` so history is visible on the edit page.
 - [ ] **R10**: Multi-directional source languages: contributions and comments store `source_lang` from contributor input. `GET /api/contributions/{id}?lang=es` returns the canonical Spanish view regardless of whether the source was English, German, or Balinese. If no translation exists, returns source with `pending_translation=true`.
-- [ ] **R11**: "Needs native review" banner appears on any machine-translated surface for users whose profile locale matches. A "Propose a better translation" action opens an inline editor that submits via R9. No approval gate.
-- [ ] **R12**: `GET /api/locales` returns supported locales with coverage stats per locale: total entities, machine-translated, human-translated, stale.
+- [ ] **R11**: "Open for attunement" banner appears on generated surfaces for users whose profile locale matches. A "Propose another rendering" action opens an inline editor that submits via R9. No approval gate.
+- [ ] **R12**: `GET /api/locales` returns supported locales with coverage stats per locale: total entities, generated renderings, contributor-submitted renderings, stale.
 - [ ] **R13**: Per-entity translation history: `GET /api/translations?entity_type=concept&entity_id=lc-xxx&lang=es` lists every translation row for that entity+lang, newest first. The edit page shows this so a new translator sees prior attempts.
 - [ ] **R14**: CLI additions: `coh stories --lang de`, `coh translate show {id} --lang es`, `coh translate submit {id} --lang es --file t.md`, `coh glossary --lang id`.
 
@@ -194,10 +194,10 @@ The platform's mission names "every idea tracked, for humanity" — but a single
 Extended existing endpoint. Returns `{concept_id, source_lang, lang, translation_status, translator_type, reviewed, stale, translated_markdown}` where `translation_status` is `native | canonical | pending | stale_fallback`. If `pending`, enqueues translation and returns source markdown with `pending_translation: true`.
 
 ### `POST /api/concepts/{id}/translate?lang=de`
-Force regenerate the machine translation. Refuses (409) if a human-canonical translation exists unless `force_override=true` by admin. Response: `{concept_id, lang, translator_type: "machine", source_hash, translated_at}`.
+Force regenerate a machine rendering. Existing canonical/history rows stay preserved; the new row becomes canonical only when the request explicitly accepts that replacement. Response: `{concept_id, lang, translator_type: "machine", source_hash, translated_at}`.
 
 ### `POST /api/translations`
-Submit a human translation. Body: `{entity_type, entity_id, target_lang, translated_markdown, notes?}`. Any signed-in contributor can submit. Becomes canonical immediately. The prior canonical row is preserved with `status: "superseded"` so the history is visible on the edit page.
+Submit a rendering. Body: `{entity_type, entity_id, target_lang, translated_markdown, notes?}`. Any signed-in contributor can submit. Becomes canonical immediately. The prior canonical row is preserved with `status: "superseded"` so the history is visible on the edit page.
 
 ### `GET /api/translations?entity_type=&entity_id=&lang=&status=`
 List translation rows for an entity, newest first. `status` filter: `canonical | stale | superseded`. Backs the history view on the edit page.
@@ -220,14 +220,14 @@ ContentTranslation:
   source_hash: string        # sha256 of source markdown at translation time
   translated_markdown: text
   translator_type: enum [machine, human]
-  translator_id: string | null  # contributor id if human, else null
+  translator_id: string | null  # contributor id when available
   translator_model: string | null  # e.g. "claude-opus-4-7" for machine
   status: enum [canonical, stale, superseded]
   notes: text | null         # translator's note on word choices and felt-sense
   created_at: timestamp
   updated_at: timestamp
   index: [entity_type, entity_id, target_lang, status]
-  # No unique constraint on (entity, lang) — history is preserved. Canonical selection is by status + translator_type + recency.
+  # No unique constraint on (entity, lang) — history is preserved. Canonical selection is by accepted status + recency; translator_type is provenance.
 
 GlossaryEntry:
   id: uuid
@@ -252,13 +252,13 @@ Contribution (existing — extend):
 
 **Canonical selection rule** (in `select_canonical()`):
 1. Prefer rows with `status=canonical` for the target_lang.
-2. Among those, prefer `translator_type=human` over `machine`.
+2. Among those, prefer rows accepted explicitly for this locale surface.
 3. Among ties, prefer the most recent by `updated_at`.
 4. If no canonical row exists, return source with `pending_translation=true` and enqueue machine translation.
 
-**When a human translation arrives** (in `POST /api/translations`):
+**When another rendering arrives** (in `POST /api/translations`):
 1. The prior canonical row (if any) is flipped to `status=superseded`.
-2. The new row is inserted with `status=canonical`, `translator_type=human`, current source_hash.
+2. The new row is inserted with `status=canonical`, its visible `translator_type`, and current source_hash.
 3. No approval gate — trust is the default. History is the moderation surface: if something feels off, anyone can submit another translation, and the lineage is visible on the edit page.
 
 ## Files to Create/Modify
@@ -268,7 +268,7 @@ Contribution (existing — extend):
 - `api/app/services/translation_cache.py` — `get_or_translate()`, `select_canonical()`, `invalidate_for_entity()`, `source_hash_of()`
 - `api/app/services/translator.py` — `translate_markdown(text, source_lang, target_lang, glossary)`, `build_glossary_prompt(lang)`
 - `api/app/routers/locale.py` — `/api/locales`, `/api/glossary/{lang}` handlers
-- `api/app/routers/translations.py` — `POST /api/translations` (submit human translation), `GET /api/translations` (history)
+- `api/app/routers/translations.py` — `POST /api/translations` (submit rendering), `GET /api/translations` (history)
 - `api/app/routers/concepts.py` — extend `GET /api/concepts/{id}` with `lang` query param; add `POST /api/concepts/{id}/translate`
 - `api/app/routers/contributions.py` — accept `source_lang` on create; honor `lang` on read
 - `api/migrations/XXXX_content_translations.sql` — create `content_translations`, `glossary_entries`, `supported_locales`; add `source_lang` to `contributions`, `comments`
@@ -284,20 +284,20 @@ Contribution (existing — extend):
 - `web/app/[locale]/...` — move all existing routes under `[locale]`
 - `web/messages/en.json`, `web/messages/de.json`, `web/messages/es.json`, `web/messages/id.json` — UI chrome strings
 - `web/components/LocaleSwitcher.tsx` — header language picker
-- `web/components/StoryContent.tsx` — accept `lang` prop, show "Needs native review" + "Propose better translation" banners when machine-translated
-- `web/components/TranslationEditor.tsx` — inline markdown editor for submitting a human translation (posts to `/api/translations`)
+- `web/components/StoryContent.tsx` — accept `lang` prop, show "Open for attunement" + "Propose another rendering" banners when generated
+- `web/components/TranslationEditor.tsx` — inline markdown editor for submitting another rendering (posts to `/api/translations`)
 - `web/components/ContributionForm.tsx` — language selector defaulting to profile locale; submits `source_lang`
-- `web/app/[locale]/settings/translations/page.tsx` — coverage dashboard (counts per locale, links into concepts needing native voice)
+- `web/app/[locale]/settings/translations/page.tsx` — coverage dashboard (counts per locale, links into concepts open for attunement)
 - `web/app/[locale]/translate/[entity_type]/[entity_id]/page.tsx` — full-page translation editor with history and glossary reference
 
 ### Tests
 - `api/tests/test_locale.py` — locale list, glossary CRUD
-- `api/tests/test_translation_cache.py` — cache hit, miss, invalidation on source edit, human-beats-machine canonical selection
-- `api/tests/test_translations_api.py` — submit human translation, it becomes canonical immediately, prior canonical becomes superseded, history lists both
+- `api/tests/test_translation_cache.py` — cache hit, miss, invalidation on source edit, accepted-canonical selection
+- `api/tests/test_translations_api.py` — submit another rendering, it becomes canonical immediately, prior canonical becomes superseded, history lists both
 - `api/tests/test_contributions_i18n.py` — contribution in es readable in en, id, de
 - `web/tests/locale-switcher.test.ts` — URL rewrite on switch
 - `web/tests/e2e/de-vision.spec.ts` — Playwright: visit /de/vision, assert German chrome
-- `web/tests/e2e/submit-translation.spec.ts` — Playwright: submit human translation, see it replace machine version on refresh
+- `web/tests/e2e/submit-translation.spec.ts` — Playwright: submit another rendering, see it replace prior generated version on refresh
 
 ## Acceptance Tests
 
@@ -305,10 +305,10 @@ Contribution (existing — extend):
 - `api/tests/test_locale.py::test_glossary_seeded_for_all_locales`
 - `api/tests/test_translation_cache.py::test_source_edit_flags_translations_stale`
 - `api/tests/test_translation_cache.py::test_pending_returns_source_enqueues_translation`
-- `api/tests/test_translation_cache.py::test_human_translation_beats_machine_in_canonical_selection`
-- `api/tests/test_translations_api.py::test_human_submission_becomes_canonical_immediately`
-- `api/tests/test_translations_api.py::test_prior_canonical_becomes_superseded_on_new_human_translation`
-- `api/tests/test_translations_api.py::test_machine_translate_never_overwrites_human_canonical`
+- `api/tests/test_translation_cache.py::test_accepted_rendering_wins_canonical_selection`
+- `api/tests/test_translations_api.py::test_submission_becomes_canonical_immediately`
+- `api/tests/test_translations_api.py::test_prior_canonical_becomes_superseded_on_new_rendering`
+- `api/tests/test_translations_api.py::test_generated_rendering_preserves_history_on_override`
 - `api/tests/test_translations_api.py::test_history_lists_superseded_rows_newest_first`
 - `api/tests/test_contributions_i18n.py::test_spanish_contribution_readable_in_english`
 - `api/tests/test_concepts.py::test_get_concept_with_lang_returns_translated`
@@ -338,12 +338,12 @@ Manual: visit `/de/vision/lc-water-as-living-body`, confirm German chrome and tr
 - No detected language-of-origin for existing contributions — they'll be assumed `en` on migration. A one-off reclassification pass may be needed if non-English contributions already exist in the DB.
 - No offline translation mode — translator service requires the configured LLM provider to be reachable. A queue-and-retry on provider failure is left to a follow-up.
 - No per-user "preferred locale" in contributor profiles yet — falls back to browser Accept-Language. Profile locale field is a small follow-up migration.
-- History pruning is unspecified — every human translation adds a superseded row. If volume grows, a "keep last N per (entity, lang)" pass is a straightforward follow-up.
-- Regional Spanish variants (es-PE, es-PR, es-GT) will layer in as community translations on top of neutral `es` once native speakers want to contribute them. No schema change needed.
+- History pruning is unspecified — every submitted rendering adds a superseded row. If volume grows, a "keep last N per (entity, lang)" pass is a straightforward follow-up.
+- Regional Spanish variants (es-PE, es-PR, es-GT) will layer in as community renderings on top of neutral `es` once contributors want to tend them. No schema change needed.
 
 ## Risks and Assumptions
 
-- **LLM translation flattens frequency** — mitigated by per-language glossary injection, the "Needs native voice" banner, and the "Propose a better translation" inline editor. Human translations supersede machine ones the moment they land. Worst case before community engagement: translations read as policy-speak until a native speaker drops a better version. The glossary and the human-first canonical rule are the living correction surface.
+- **Translation can flatten frequency** — mitigated by per-language glossary injection, the "Open for attunement" banner, and the "Propose another rendering" inline editor. Generated and contributor renderings stay visible through provenance and history; the newest accepted rendering becomes canonical without claiming any source type is inherently better. Worst case before deeper attunement: translations read as policy-speak until another contributor or agent offers a version that carries the meaning more clearly.
 - **Translation cost at scale** — 56 concepts × ~5KB × 3 languages ≈ 840KB output tokens per full rebuild. Cached aggressively; regenerated only on source edit. Config-driven model choice lets Haiku handle bulk and Opus handle care-work.
 - **URL breakage** — moving routes under `[locale]` changes every path. Middleware redirects `/vision/xxx` → `/en/vision/xxx` to preserve existing links.
 - **Assumption — trust by default**: anyone signed in can replace a translation, and history is the correction surface rather than an approval gate. If a bad translation lands, the next contributor to notice can replace it, and the superseded row remains visible. This is aligned with the vision: tending comes from relationship, not from moderation.
@@ -361,10 +361,10 @@ Manual: visit `/de/vision/lc-water-as-living-body`, confirm German chrome and tr
 - Integration tests — `api/tests/test_flow_multilingual.py`, `test_on_demand_attunement.py`
 
 **Confirmed during this session** (each a discrete commit in the trail):
-- `POST /api/translations` endpoint + `GET` history — human/machine supersede semantics exposed
+- `POST /api/translations` endpoint + `GET` history — submitted/generated supersede semantics exposed
 - `coh translate submit <entity_type> <entity_id> --lang <l> --file <path>` and `coh translate history` CLI
 - Anchor glossary seeded for `es` and `id` (matching the existing `de` pattern); 15 anchor terms per language
-- `/settings/translations` coverage dashboard — per-locale `original/human/machine/stale` tallies from `GET /api/locales`, linked from `/settings`
+- `/settings/translations` coverage dashboard — per-locale original/contributor/machine/stale tallies from `GET /api/locales`, linked from `/settings`
 - Language picker in site header — `LocaleSwitcherCompact` wired at `web/components/site_header.tsx` (desktop and mobile menu); cookie-backed, ?lang= override, Accept-Language auto-detection all in `web/middleware.ts`
 
 **Deferred to its own restructure PR**:

--- a/web/app/settings/translations/page.tsx
+++ b/web/app/settings/translations/page.tsx
@@ -7,7 +7,7 @@ export const dynamic = "force-dynamic";
 export const metadata = {
   title: "Translations coverage — Coherence Network",
   description:
-    "Per-locale counts of original, machine-attuned, human-attuned, and stale translations across the concept space.",
+    "Per-locale counts of original, machine-attuned, contributor-attuned, and stale renderings across the concept space.",
 };
 
 type Coverage = {
@@ -52,7 +52,7 @@ function CoverageBar({ coverage }: { coverage: Coverage }) {
   return (
     <div
       className="h-2 w-full rounded overflow-hidden flex"
-      title={`${coverage.original} original · ${coverage.human} human · ${coverage.machine} machine · ${coverage.stale} stale`}
+      title={`${coverage.original} original · ${coverage.human} contributor · ${coverage.machine} machine · ${coverage.stale} stale`}
     >
       <div
         className="bg-amber-500/80"
@@ -77,8 +77,8 @@ function CoverageBar({ coverage }: { coverage: Coverage }) {
 function Legend() {
   const items = [
     { color: "bg-amber-500/80", label: "original — written in this language" },
-    { color: "bg-violet-500/80", label: "human — translation from a contributor" },
-    { color: "bg-teal-500/60", label: "machine — machine translation, awaiting native voice" },
+    { color: "bg-violet-500/80", label: "contributor — submitted rendering" },
+    { color: "bg-teal-500/60", label: "machine — generated rendering, open to attunement" },
     { color: "bg-rose-500/40", label: "stale — source has changed since translation" },
   ];
   return (
@@ -113,9 +113,9 @@ export default async function TranslationsCoveragePage() {
       <h1 className="text-3xl font-extralight text-white mb-2">Translations</h1>
       <p className="text-stone-400 mb-8 text-sm leading-relaxed">
         Per-locale coverage across concepts and other translatable entities.
-        Original authoring in a language sits alongside human and machine
-        translations; stale markers rise as source content changes and
-        translations age out.
+        Original authoring in a language sits alongside contributor and machine
+        renderings; stale markers rise as source content changes and
+        renderings age out.
       </p>
 
       {!data && (

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -153,7 +153,7 @@
     "lang": "de",
     "name": "German",
     "nativeName": "Deutsch",
-    "notes": "First-pass attunement from the current default anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
+    "notes": "First-pass attunement from the current default anchor on 2026-05-09. These keys render today and invite re-attunement from any contributor or agent carrying the meaning differently. Re-attuning a key means: feel the meaning, render it in that voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
     "role": "anchor"
   },
   "common": {
@@ -295,10 +295,10 @@
     "levelLivingExpression": "Lebendiger Ausdruck",
     "visualExpressionsHeading": "Bildhafte Ausdrücke",
     "resonantAssetsIntro": "Jeder Ausdruck ist ein einzigartiger Beitrag. Der resonanteste steigt an die Oberfläche.",
-    "needsNativeVoice": "Braucht eine muttersprachliche Stimme – schlage eine bessere Übersetzung vor",
+    "needsAttunement": "Offen für Neuabstimmung - schlage eine andere Fassung vor",
     "pendingTranslation": "Noch keine Sicht in dieser Sprache – zeige die Anker-Sicht",
     "translationPendingTitle": "Übersetzung wird vorbereitet",
-    "translationPendingBody": "Für dieses Konzept gibt es noch keine vollständige Sicht in dieser Sprache. Die englische Ankerfassung bleibt hier verborgen, damit die Seite keine Sprachen mischt, während die Einstimmung läuft.",
+    "translationPendingBody": "Für dieses Konzept gibt es noch keine vollständige Sicht in dieser Sprache. Die aktuelle Anker-Sicht bleibt hier verborgen, damit die Seite keine Sprachen mischt, während die Einstimmung läuft.",
     "staleAwaitingReattunement": "Die Anker-Sicht hat sich bewegt – diese Sicht wartet auf Nachstimmung",
     "voicesHeading": "Stimmen aus dem Feld",
     "voicesLede": "Wie dieses Konzept im Leben klingt, erzählt von denen, die es leben.",
@@ -2462,7 +2462,7 @@
     },
     "noteEyebrow": "Eine Notiz aus diesem Körper",
     "editProfileCta": "Wie du dieses Profil beanspruchst, bearbeitest oder entfernst →",
-    "sourceLanguageDisclosure": "Hinweis: Der kuratierte Inhalt dieser Seite ist derzeit auf Englisch. Die Seitennavigation und Überschriften und der Datenbereich darunter (Werktitel, Beschreibungen, Evidenzkörper) werden automatisch in deine Sprache übersetzt; eine vom Autor kuratierte Übersetzung der längeren Prosa auf dieser Seite folgt. In der Zwischenzeit zeigt dir die eingebaute Funktion deines Browsers „Diese Seite übersetzen“ den Rest in deiner Sprache."
+    "sourceLanguageDisclosure": "Hinweis: Die längere kuratierte Prosa dieser Seite ist noch nicht für jede Sprache gerendert. Die Seitennavigation, Überschriften und der Datenbereich darunter (Werktitel, Beschreibungen, Evidenzkörper) werden automatisch in deine Sprache übersetzt; eine kuratierte Fassung der längeren Prosa auf dieser Seite folgt. In der Zwischenzeit zeigt dir die eingebaute Funktion deines Browsers „Diese Seite übersetzen“ den Rest in deiner Sprache."
   },
   "presence": {
     "location": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -154,7 +154,7 @@
     "name": "English",
     "nativeName": "English",
     "role": "anchor",
-    "notes": "This bundle is the current anchor — keys land here as they're lifted out of components into the data layer. Other locales attune from the freshest anchor view. See feedback_i18n_architecture.md (no privileged source language: any locale can become anchor when human-touched fresher than this one)."
+    "notes": "This bundle is the current anchor — keys land here as they're lifted out of components into the data layer. Other locales attune from the freshest anchor view. See feedback_i18n_architecture.md (no privileged source language: any locale can become anchor when its accepted rendering is fresher than this one)."
   },
   "common": {
     "skipToContent": "Skip to main content",
@@ -295,7 +295,7 @@
     "levelLivingExpression": "Living Expression",
     "visualExpressionsHeading": "Visual expressions",
     "resonantAssetsIntro": "Each expression is a unique contribution. The most resonant rises to the surface.",
-    "needsNativeVoice": "Needs a native voice — propose a better translation",
+    "needsAttunement": "Open for attunement - propose another rendering",
     "pendingTranslation": "No view in this language yet — showing the anchor view",
     "translationPendingTitle": "Translation is being prepared",
     "translationPendingBody": "This concept does not have a complete view in this language yet. The current anchor view is held back here so the page does not mix languages while attunement runs.",
@@ -2552,7 +2552,7 @@
     },
     "noteEyebrow": "A note from this body",
     "editProfileCta": "How to claim, edit, or remove this profile →",
-    "sourceLanguageDisclosure": "Note: this page's longer curated prose has not yet been author-translated for every locale. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; an author-curated translation of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature can carry the rest."
+    "sourceLanguageDisclosure": "Note: this page's longer curated prose has not yet been rendered for every locale. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; a curated rendering of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature can carry the rest."
   },
   "presence": {
     "location": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -153,7 +153,7 @@
     "lang": "es",
     "name": "Spanish",
     "nativeName": "Español",
-    "notes": "First-pass attunement from the current default anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
+    "notes": "First-pass attunement from the current default anchor on 2026-05-09. These keys render today and invite re-attunement from any contributor or agent carrying the meaning differently. Re-attuning a key means: feel the meaning, render it in that voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
     "role": "anchor"
   },
   "common": {
@@ -295,10 +295,10 @@
     "levelLivingExpression": "Expresión Viva",
     "visualExpressionsHeading": "Expresiones visuales",
     "resonantAssetsIntro": "Cada expresión es una contribución única. La más resonante emerge a la superficie.",
-    "needsNativeVoice": "Necesita una voz nativa — propón una mejor traducción",
+    "needsAttunement": "Abierto a nueva sintonía - propón otra versión",
     "pendingTranslation": "Aún no hay vista en este idioma — mostrando la vista ancla",
     "translationPendingTitle": "La traducción se está preparando",
-    "translationPendingBody": "Este concepto aún no tiene una vista completa en este idioma. La versión ancla en inglés queda oculta aquí para que la página no mezcle idiomas mientras se realiza la sintonización.",
+    "translationPendingBody": "Este concepto aún no tiene una vista completa en este idioma. La vista ancla actual queda oculta aquí para que la página no mezcle idiomas mientras se realiza la sintonización.",
     "staleAwaitingReattunement": "La vista ancla ha cambiado — esta vista espera una nueva sintonización",
     "voicesHeading": "Voces desde el campo",
     "voicesLede": "Cómo vive este concepto en la práctica, contado por quienes lo viven.",
@@ -2462,7 +2462,7 @@
     },
     "noteEyebrow": "Una nota desde este cuerpo",
     "editProfileCta": "Cómo reclamar, editar o eliminar este perfil →",
-    "sourceLanguageDisclosure": "Nota: el contenido curado de esta página está actualmente en inglés. La navegación, los encabezados y la capa de datos a continuación (títulos de obras, descripciones, cuerpo de evidencia) se traducen automáticamente a tu idioma; una traducción curada por el autor de la prosa más larga en esta página vendrá después. Mientras tanto, la función incorporada de tu navegador „traducir esta página“ mostrará el resto en tu idioma."
+    "sourceLanguageDisclosure": "Nota: la prosa curada más larga de esta página aún no está renderizada para todos los idiomas. La navegación, los encabezados y la capa de datos a continuación (títulos de obras, descripciones, cuerpo de evidencia) se traducen automáticamente a tu idioma; una versión curada de esa prosa vendrá después. Mientras tanto, la función incorporada de tu navegador „traducir esta página“ mostrará el resto en tu idioma."
   },
   "presence": {
     "location": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -154,7 +154,7 @@
     "name": "French",
     "nativeName": "Français",
     "role": "seed",
-    "notes": "French is supported as a locale; this bundle is seeded from the current default anchor so the key shape is complete while human attunement continues."
+    "notes": "French is supported as a locale; this bundle is seeded from the current default anchor so the key shape is complete while further human and AI attunement continues."
   },
   "common": {
     "skipToContent": "Skip to main content",
@@ -295,11 +295,11 @@
     "levelLivingExpression": "Living Expression",
     "visualExpressionsHeading": "Visual expressions",
     "resonantAssetsIntro": "Each expression is a unique contribution. The most resonant rises to the surface.",
-    "needsNativeVoice": "Needs a native voice — propose a better translation",
-    "pendingTranslation": "No view in this language yet — showing the anchor view",
-    "translationPendingTitle": "Translation is being prepared",
-    "translationPendingBody": "This concept does not have a complete view in this language yet. The current anchor view is held back here so the page does not mix languages while attunement runs.",
-    "staleAwaitingReattunement": "Anchor view has moved — this view awaits re-attunement",
+    "needsAttunement": "Ouvert à l'accordage - proposez un autre rendu",
+    "pendingTranslation": "Pas encore de vue dans cette langue - affichage de la vue ancre",
+    "translationPendingTitle": "La traduction est en préparation",
+    "translationPendingBody": "Ce concept n'a pas encore de vue complète dans cette langue. La vue ancre actuelle est retenue ici afin que la page ne mélange pas les langues pendant l'accordage.",
+    "staleAwaitingReattunement": "La vue ancre a changé - cette vue attend un nouvel accordage",
     "voicesHeading": "Voices from the field",
     "voicesLede": "How this concept lives in practice, told by those living it.",
     "voicesEmpty": "No voice has spoken yet. Yours would be the first — a gift to whoever reads next.",
@@ -2552,7 +2552,7 @@
     },
     "noteEyebrow": "A note from this body",
     "editProfileCta": "How to claim, edit, or remove this profile →",
-    "sourceLanguageDisclosure": "Note: this page's longer curated prose has not yet been author-translated for every locale. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; an author-curated translation of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature can carry the rest."
+    "sourceLanguageDisclosure": "Note : la prose curée plus longue de cette page n'a pas encore été rendue pour chaque langue. L'interface du site (navigation, titres, libellés) et la couche de données ci-dessous (titres des œuvres, descriptions, corps de preuves) se traduisent automatiquement dans votre langue ; un rendu curé de cette prose suivra. En attendant, la fonction intégrée de votre navigateur pour traduire cette page peut porter le reste."
   },
   "presence": {
     "location": {

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -153,7 +153,7 @@
     "lang": "id",
     "name": "Indonesian",
     "nativeName": "Bahasa Indonesia",
-    "notes": "First-pass attunement from the current default anchor on 2026-05-09. These keys render today and invite re-attunement from a native voice when one passes through. Re-attuning a key means: feel the meaning, speak it in your own voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
+    "notes": "First-pass attunement from the current default anchor on 2026-05-09. These keys render today and invite re-attunement from any contributor or agent carrying the meaning differently. Re-attuning a key means: feel the meaning, render it in that voice, then remove the key path from `first_pass_keys` (it becomes settled). See feedback_i18n_architecture.md for the five linked practices that hold this body's voice.",
     "role": "anchor"
   },
   "common": {
@@ -295,10 +295,10 @@
     "levelLivingExpression": "Ekspresi Hidup",
     "visualExpressionsHeading": "Ekspresi visual",
     "resonantAssetsIntro": "Setiap ekspresi adalah sumbangan unik. Yang paling beresonansi naik ke permukaan.",
-    "needsNativeVoice": "Butuh suara penutur asli — usulkan terjemahan yang lebih baik",
+    "needsAttunement": "Terbuka untuk penyelarasan - usulkan versi lain",
     "pendingTranslation": "Belum ada pandangan dalam bahasa ini — menampilkan pandangan jangkar",
     "translationPendingTitle": "Terjemahan sedang disiapkan",
-    "translationPendingBody": "Konsep ini belum memiliki tampilan lengkap dalam bahasa ini. Versi jangkar berbahasa Inggris disembunyikan di sini agar halaman tidak mencampur bahasa saat penyelarasan berjalan.",
+    "translationPendingBody": "Konsep ini belum memiliki tampilan lengkap dalam bahasa ini. Pandangan jangkar saat ini disembunyikan di sini agar halaman tidak mencampur bahasa saat penyelarasan berjalan.",
     "staleAwaitingReattunement": "Pandangan jangkar telah berpindah — pandangan ini menunggu penyelarasan ulang",
     "voicesHeading": "Suara dari lapangan",
     "voicesLede": "Bagaimana konsep ini hidup dalam praktik, diceritakan oleh yang menjalaninya.",
@@ -2462,7 +2462,7 @@
     },
     "noteEyebrow": "Catatan dari tubuh ini",
     "editProfileCta": "Cara mengklaim, mengedit, atau menghapus profil ini →",
-    "sourceLanguageDisclosure": "Catatan: konten kuratorial halaman ini saat ini dalam bahasa Inggris. Navigasi situs (judul, label) dan lapisan data di bawah (judul karya, deskripsi, kumpulan bukti) diterjemahkan secara otomatis ke dalam bahasa Anda; terjemahan kuratorial penulis dari prosa yang lebih panjang di halaman ini akan menyusul. Sementara itu, fitur „terjemahkan halaman ini“ bawaan browser Anda akan menampilkan sisanya dalam bahasa Anda."
+    "sourceLanguageDisclosure": "Catatan: prosa kuratorial yang lebih panjang di halaman ini belum dirender untuk setiap bahasa. Navigasi situs (judul, label) dan lapisan data di bawah (judul karya, deskripsi, kumpulan bukti) diterjemahkan secara otomatis ke dalam bahasa Anda; render kuratorial untuk prosa yang lebih panjang di halaman ini akan menyusul. Sementara itu, fitur „terjemahkan halaman ini“ bawaan browser Anda akan menampilkan sisanya dalam bahasa Anda."
   },
   "presence": {
     "location": {

--- a/web/messages/pt-br.json
+++ b/web/messages/pt-br.json
@@ -154,7 +154,7 @@
     "name": "Brazilian Portuguese",
     "nativeName": "Português (Brasil)",
     "role": "seed",
-    "notes": "Brazilian Portuguese is supported as a locale; this bundle is seeded from the current default anchor so the key shape is complete while human attunement continues."
+    "notes": "Brazilian Portuguese is supported as a locale; this bundle is seeded from the current default anchor so the key shape is complete while further human and AI attunement continues."
   },
   "common": {
     "skipToContent": "Skip to main content",
@@ -295,11 +295,11 @@
     "levelLivingExpression": "Living Expression",
     "visualExpressionsHeading": "Visual expressions",
     "resonantAssetsIntro": "Each expression is a unique contribution. The most resonant rises to the surface.",
-    "needsNativeVoice": "Needs a native voice — propose a better translation",
-    "pendingTranslation": "No view in this language yet — showing the anchor view",
-    "translationPendingTitle": "Translation is being prepared",
-    "translationPendingBody": "This concept does not have a complete view in this language yet. The current anchor view is held back here so the page does not mix languages while attunement runs.",
-    "staleAwaitingReattunement": "Anchor view has moved — this view awaits re-attunement",
+    "needsAttunement": "Aberto à sintonia - proponha outra versão",
+    "pendingTranslation": "Ainda não há visão neste idioma - mostrando a visão âncora",
+    "translationPendingTitle": "A tradução está sendo preparada",
+    "translationPendingBody": "Este conceito ainda não tem uma visão completa neste idioma. A visão âncora atual fica retida aqui para que a página não misture idiomas enquanto a sintonia roda.",
+    "staleAwaitingReattunement": "A visão âncora mudou - esta visão aguarda nova sintonia",
     "voicesHeading": "Voices from the field",
     "voicesLede": "How this concept lives in practice, told by those living it.",
     "voicesEmpty": "No voice has spoken yet. Yours would be the first — a gift to whoever reads next.",
@@ -2552,7 +2552,7 @@
     },
     "noteEyebrow": "A note from this body",
     "editProfileCta": "How to claim, edit, or remove this profile →",
-    "sourceLanguageDisclosure": "Note: this page's longer curated prose has not yet been author-translated for every locale. The site chrome (navigation, headings, labels) and the data layer below (work titles, descriptions, body of evidence) translate automatically into your language; an author-curated translation of the longer prose on this page will follow. In the meantime, your browser's built-in translate-this-page feature can carry the rest."
+    "sourceLanguageDisclosure": "Nota: a prosa curada mais longa desta página ainda não foi renderizada para todos os idiomas. A interface do site (navegação, títulos, rótulos) e a camada de dados abaixo (títulos das obras, descrições, corpo de evidências) são traduzidas automaticamente para o seu idioma; uma versão curada dessa prosa virá depois. Enquanto isso, o recurso integrado do navegador para traduzir esta página pode carregar o restante."
   },
   "presence": {
     "location": {


### PR DESCRIPTION
## Summary
- removes human-over-machine translation hierarchy wording from locale message bundles, /settings/translations, API/CLI docs, and specs/multilingual-web.md
- reframes translator_type as provenance/accepted-rendering metadata rather than a quality rank
- extends scripts/validate_locale_surfaces.py to catch English-anchor and translation-mode hierarchy wording across translation-facing surfaces
- regenerates stale indexes required by the current main gate

## Validation
- make wellness
- python3 scripts/validate_locale_surfaces.py
- python3 -m pytest -q tests/test_flow_multilingual.py tests/test_concept_views.py tests/test_translations_router.py (from api/)
- npm run build (from web/)
- python3 scripts/generate_repo_indexes.py --check
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- python3 scripts/validate_spec_quality.py --base origin/main --head HEAD
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD

## Notes
- npm ci was needed in this fresh worktree before the web build because next was not installed locally.
