### PR TITLE
tend: index BMF choice dispatch for BML source parsing

### DIFF
--- a/docs/system_audit/commit_evidence_20260608_bmf_object_choice_direct_dispatch.json
+++ b/docs/system_audit/commit_evidence_20260608_bmf_object_choice_direct_dispatch.json
@@ -1,0 +1,148 @@
+{
+  "date": "2026-06-08",
+  "thread_branch": "codex/choice-pool-research-20260608",
+  "commit_scope": "Add one-pass guarded direct dispatch for BMF object-pattern choices and bucketed first-literal rule-set dispatch for BMF/BML compiler and BML source-parser rule selection, expose BML source dispatch telemetry, preserve ordered matching for mixed/cut-aware alternatives, repair full-suite validation drift, and measure before/after impact.",
+  "files_owned": [
+    "form/form-stdlib/engine.fk",
+    "form/form-stdlib/compiler.fk",
+    "form/form-stdlib/grammars/bml.fk",
+    "form/form-stdlib/tests/bmf-compiler-runtime.fk",
+    "form/form-stdlib/tests/bmf-form-object-runtime-band.fk",
+    "form/form-stdlib/tests/bml-compiler-runtime.fk",
+    "form/form-stdlib/tests/source-compiler-multi-dialect-band.fk",
+    "form/form-stdlib/tests/source-corpus-roundtrip-band.fk",
+    "form/form-stdlib/tests/task-runtime.fk",
+    "docs/system_audit/commit_evidence_20260608_bmf_object_choice_direct_dispatch.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "make prompt-guide",
+      "make wellness",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/engine.fk form-stdlib/tests/bmf-form-object-runtime-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tests/task-runtime.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/tests/bmf-compiler-runtime.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-compiler-runtime.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/tests/bmf-bml-compiler-picture-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-numeric-literals-source-proof.fk form-stdlib/tests/bml-thesis-char-escapes-source-proof.fk form-stdlib/tests/bml-thesis-float-literals-source-proof.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-exit-proof.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk form-stdlib/tests/source-compiler-multi-dialect-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/go-bmf.fk form-stdlib/grammars/typescript-bmf.fk form-stdlib/tests/source-corpus-roundtrip-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/grammar-chars.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/tests/bmf-component-runtime-exec-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-thesis-rule-body-execution-proof.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/engine.fk form-stdlib/tests/bmf-object-runtime.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/grammar-chars.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/tests/bmf-source-rule-to-runtime-band.fk",
+      "cd form && ./validate.sh",
+      "gh pr merge 2615 --repo seeker71/Coherence-Network --merge --delete-branch",
+      "git fetch origin main && git rebase origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "cd form && ./validate.sh",
+      "benchmark: /tmp/coherence_choice_bench_20260608.fk against /tmp/coh-choice-baseline-20260608 origin/main and patched worktree, 7 warmed aggregate samples per tree",
+      "benchmark: bmf-compiler-runtime, bml-compiler-runtime, and bml-thesis-exit against origin/main and patched worktree, 5 warmed samples per workload/tree",
+      "benchmark: /tmp/coherence_rule_set_linear_20260608.fk versus /tmp/coherence_rule_set_direct_20260608.fk on the patched worktree, 7 warmed aggregate samples per path",
+      "benchmark: /tmp/coherence_rule_dispatch_linear_20260608.fk versus /tmp/coherence_rule_dispatch_entry_index_20260608.fk versus /tmp/coherence_rule_dispatch_bucketed_20260608.fk on the patched worktree, 7 warmed aggregate samples per path",
+      "benchmark: /tmp/coherence_bml_source_parse_linear_20260608.fk versus /tmp/coherence_bml_source_parse_indexed_20260608.fk on the patched worktree with prepared source-section preludes, 7 warmed Go-kernel samples per path"
+    ],
+    "notes": "A normal make prompt-guide reading now passes on this dirty continuation branch. An earlier normal make prompt-guide reading reported a sibling continuity blocker outside this worktree: /Users/ursmuff/.claude-worktrees/Coherence-Network/bml-capability-ledger-slice-20260607 branch=codex/bml-capability-ledger-slice-20260607 ahead=2 behind=25 upstream=no; that earlier in-flight turn used the gate-provided continuation bypass. make wellness passes; its current reading shows deploy aligned and witness-trace within budget. The followthrough gate initially found stale PR #2615; it was mergeable with passing checks, so it was merged before this branch was rebased onto updated origin/main. Focused BMF/BML engine, compiler, source-parser, dispatch-telemetry, and compiler-picture bands pass across Go, Rust, and TypeScript kernels. Final full validate on the rebased branch passes with 309 ok, 0 divergent. The previous full-suite drift was repaired by declaring the BML grammar preludes needed by source compiler bands and converting task-runtime.fk to native S-expression Form so it directly proves core task runtime behavior. Isolated 32-arm object-choice aggregate benchmark improved from 10.064884s mean / 10.008265s median on origin/main to 9.034380s mean / 9.027495s median on the patched worktree: 10.239% faster by mean and 9.800% faster by median. Real validation workloads were startup-heavy and effectively flat to slightly slower: bmf-compiler-runtime mean 5.257903s baseline vs 5.286527s patched (-0.544%), bml-compiler-runtime mean 5.490179s baseline vs 5.506224s patched (-0.292%), bml-thesis-exit mean 5.559805s baseline vs 5.567491s patched (-0.138%). The next slice added indexed first-literal rule-set dispatch: an on-the-fly FIRST scan was slightly slower than linear, so the carried implementation precomputes rule indexes once. The first 32-rule rule-set benchmark improved from 12.379231s mean / 12.337638s median for linear rule scan to 10.068999s mean / 10.016387s median for indexed dispatch: 18.662% faster by mean and 18.814% faster by median. The latest rule-set slice moves that index to ordered bucket segments: linear rule scan was 12.336970s mean / 12.308525s median, entry-index scan was 10.141437s mean / 10.123488s median, and bucketed dispatch was 9.947811s mean / 9.965323s median. Bucketed dispatch is 19.366% faster than linear by mean and 1.909% faster than entry-index scan by mean on a 32-rule exact-value workload. The BML source executable/declaration parser now routes through precomputed rule indexes. On the same 48-return-token stream parsed 12 times, the preserved ordered source-step loop took 5.011512s mean / 5.028754s median, while the indexed source parser took 1.333789s mean / 1.325145s median: 73.385% faster by mean and 73.649% faster by median. The BML source index counters are now named at the grammar level and proven in bml-compiler-runtime.fk: known, skipped, buckets, and segments are visible for executable and declaration parser indexes. This proves the rule-selection path wants precomputed bucket dispatch data and gives the next adaptive ordering/thread-pool work an observable surface."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote CI is pending until this branch is pushed and a PR is opened."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "No deploy attempted for this local Form runtime optimization."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Scoped runtime proof is complete. Commit, PR, CI, and any deployment validation remain pending."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "BMF object choices scan bare object-literal alternatives directly because every such alternative returns the same empty-captures/tail result shape. The first non-literal alternative falls back to the ordered linear matcher over the whole choice, so mixed alternatives and cut-aware choices retain ordered semantics. Rule-set selection can precompute ordered first-literal bucket segments and skip rules whose first object cannot match while preserving ordered matching for unknown or ambiguous FIRST sets. BML source executable and declaration parsing now uses the same indexed object-rule dispatch over preselected rule subsets.",
+    "public_endpoints": [
+      "internal Form sibling kernels"
+    ],
+    "test_flows": [
+      "bmf-form-object-runtime-band proves direct-safe literal-only choices, wildcard and duplicate literal choices, unsafe mixed literal/non-literal choices, and unchanged match behavior",
+      "bmf-form-object-runtime-band proves bucketed rule-set skip counters, ordered unknown-FIRST fallback, and no-match failure",
+      "bml-compiler-runtime and bml-thesis-exit-proof prove BML choose/choice lowering still executes correctly",
+      "BML numeric, char escape, float literal, and exit source proofs pass with executable/declaration parsing routed through precomputed rule indexes",
+      "bml-compiler-runtime proves source dispatch telemetry counters for executable and declaration indexes",
+      "bmf-compiler-runtime and bml-compiler-runtime prove whole-rule-set first-rule helpers select BMF and BML rules correctly",
+      "bmf-object-runtime, bmf-component-runtime-exec, and bmf-source-rule-to-runtime cover shared BMF compiler/object paths"
+    ]
+  },
+  "idea_ids": [
+    "parallel-choice-kernel",
+    "bmf-bml-compiler-choice-dispatch"
+  ],
+  "spec_ids": [
+    "bmf-object-runtime",
+    "bml-compiler-runtime"
+  ],
+  "task_ids": [
+    "choice-pool-research-20260608"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "architecture-review",
+        "performance-priority"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "evidence-recording"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "engine.fk now classifies object-pattern choice alternatives and uses a one-pass direct scan for bare object-literal prefixes.",
+    "engine.fk now exposes object-rule-set-index and apply-indexed-object-rule-set for precomputed ordered first-literal bucket dispatch.",
+    "engine.fk now exposes dispatch counters for known rules, candidate rules, skipped rules, buckets, and segments.",
+    "compiler.fk exposes apply-bmf-compiler-first-rule over a precomputed BMF compiler rule index.",
+    "grammars/bml.fk exposes apply-bml-compiler-first-rule and apply-bml-bmf-first-rule over precomputed BML rule indexes.",
+    "grammars/bml.fk routes BML source executable and declaration parser steps through precomputed BMF rule indexes for their exact source-rule subsets.",
+    "grammars/bml.fk exposes BML source executable/declaration dispatch telemetry counters for known rules, candidates, skipped rules, buckets, and segments.",
+    "compiler.fk compiler-picture metadata now points at apply-bmf-compiler-first-rule and apply-bml-bmf-first-rule plus the indexed source parser.",
+    "Literal-only choices, including wildcard and duplicate literals, are direct-safe because bare object-literal matches are result-equivalent.",
+    "Mixed literal/non-literal choices fall back to ordered matching as soon as the direct scan reaches the first non-literal alternative.",
+    "Existing cut-aware ordered semantics remain in match-object-choice-linear and are used for all unsafe choices.",
+    "bmf-form-object-runtime-band score increased to 67108863 with direct-choice classifier, fallback, bucketed rule-set, and dispatch-counter proofs.",
+    "bmf-compiler-runtime score increased to 2097279 with BMF whole-rule-set first-rule proof.",
+    "bml-compiler-runtime score increased to 131012 with BML whole-rule-set first-rule and BML source dispatch telemetry proofs.",
+    "Focused BMF/BML compiler and runtime proof bands pass across Go, Rust, and TypeScript kernels.",
+    "Full form validation now passes on the rebased branch: 309 ok, 0 divergent.",
+    "Before/after isolated aggregate benchmark improved 10.064884s mean to 9.034380s mean across 7 warmed validate-wrapper runs.",
+    "Indexed rule-set benchmark improved 12.379231s mean linear scan to 10.068999s mean indexed dispatch across 7 warmed validate-wrapper runs.",
+    "Bucketed rule-set benchmark improved 12.336970s mean linear scan to 9.947811s mean bucketed dispatch and 10.141437s mean entry-index scan to 9.947811s mean bucketed dispatch across 7 warmed validate-wrapper runs.",
+    "BML source parse benchmark improved 5.011512s mean linear source-step loop to 1.333789s mean indexed source parser, with median improvement from 5.028754s to 1.325145s across 7 warmed Go-kernel runs using prepared source-section preludes.",
+    "Real BMF/BML proof workload timings were effectively flat to slightly slower under startup-heavy validate-wrapper measurement until the real BML source parser was routed through indexes; the source-parser path now shows an isolated end-to-end parser win."
+  ],
+  "change_files": [
+    "form/form-stdlib/engine.fk",
+    "form/form-stdlib/compiler.fk",
+    "form/form-stdlib/grammars/bml.fk",
+    "form/form-stdlib/tests/bmf-compiler-runtime.fk",
+    "form/form-stdlib/tests/bmf-form-object-runtime-band.fk",
+    "form/form-stdlib/tests/bml-compiler-runtime.fk",
+    "form/form-stdlib/tests/source-compiler-multi-dialect-band.fk",
+    "form/form-stdlib/tests/source-corpus-roundtrip-band.fk",
+    "form/form-stdlib/tests/task-runtime.fk"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/compiler.fk
+++ b/form/form-stdlib/compiler.fk
@@ -157,7 +157,7 @@
             (list
                 (compiler-stage "grammar-source" "A grammar is source, not metadata." "BMF or BNF or Form grammar text" "source grammar objects" "BMF-grammar.bml and compiler.fk")
                 (compiler-stage "grammar-parse" "The grammar parses itself into objects." "BMF object runtime" "Rule or Branch or Sequence or Repeat objects" "bmf-compiler-runtime.fk")
-                (compiler-stage "grammar-compile" "Source grammar objects lower into reusable compiler objects." "compiler-object" "compiler-rule and comp-bmf-* cells" "apply-bmf-compiler-rule")
+                (compiler-stage "grammar-compile" "Source grammar objects lower into reusable compiler objects." "compiler-object" "compiler-rule and comp-bmf-* cells" "apply-bmf-compiler-first-rule")
                 (compiler-stage "dialect-capsule" "A grammar becomes a runtime port by selector." "runtime-grammar registry" "parse and emit capsule" "runtime-real-grammar-capsules-band.fk")
                 (compiler-stage "sibling-proof" "The same grammar carrier walks on each kernel." "Go/Rust/TypeScript kernels" "identical result" "form/validate.sh"))))
 
@@ -173,7 +173,7 @@
     (defn bmf-bml-language-ports (_x)
         (list
             (compiler-language-port "BMF" "BMF grammar text" "compiler.fk bmf second" "bmf-compiler-rules" "comp-bmf-runtime" "form-kernel" "compiler-object" "proven" "full original source body semantic lowering remains growing" "bmf-compiler-runtime.fk")
-            (compiler-language-port "BML" "BML object/runtime source" "grammars/bml.fk" "apply-bml-bmf-rule" "bml-compile-program" "form-kernel" "compiler-object" "proven" "complete thesis corpus execution remains growing" "bml-compiler-runtime.fk")
+            (compiler-language-port "BML" "BML object/runtime source" "grammars/bml.fk" "apply-bml-bmf-first-rule and indexed source parser" "bml-compile-program" "form-kernel" "compiler-object" "proven" "complete thesis corpus execution remains growing" "bml-compiler-runtime.fk")
             (compiler-language-port "Python" "Python source" "grammars/python-bmf.fk" "python-bmf-lift.fk" "python-bmf-eval.fk" "form-kernel" "compiler-object" "in-motion" "f-strings, decorators, try/catch, modules, ORM runtime" "PYTHON_BMF_CONTRACT.md")
             (compiler-language-port "TypeScript" "TypeScript source" "grammars/typescript-bmf.fk" "shared BMF object lift" "emit-engine or Form recipe" "form-kernel" "compiler-object" "seed" "full TS grammar and semantic lift" "source-compiler-multi-dialect-band.fk")
             (compiler-language-port "Go" "Go source" "grammars/go-bmf.fk" "shared BMF object lift" "emit-engine or Form recipe" "form-kernel" "compiler-object" "seed" "full Go grammar and semantic lift" "source-compiler-multi-dialect-band.fk")
@@ -953,6 +953,9 @@
                   bmf-compile-bmf-rule-full
                   bmf-identity-inverse)))
 
+    (let bmf-compiler-rule-index
+        (object-rule-set-index bmf-compiler-rules))
+
     (defn bmf-compiler-rule-name (r) (head r))
 
     (defn bmf-compiler-find-rule (rule-name rules)
@@ -985,6 +988,9 @@
 
     (defn apply-bmf-compiler-rule (rule-name objects)
         (apply-object-rule (bmf-compiler-find-rule rule-name bmf-compiler-rules) objects))
+
+    (defn apply-bmf-compiler-first-rule (objects)
+        (apply-indexed-object-rule-set bmf-compiler-rule-index objects))
 
     section [bmf.bmf] {
       rule-reversible ::= $name:name "::=" $pattern:pattern "=>" $action:name "<=" $reverse:name ";" => bmf-emit-reversible-rule-source;

--- a/form/form-stdlib/engine.fk
+++ b/form/form-stdlib/engine.fk
@@ -1834,6 +1834,27 @@
 
     (defn object-pattern-tag (p) (head p))
 
+    (defn object-literal-pattern? (p)
+        (and (gt (len p) 0) (str_eq (object-pattern-tag p) "object")))
+
+    (defn object-literal-kind (p) (nth p 1))
+    (defn object-literal-value (p) (nth p 2))
+
+    ;; Bare object-literal alternatives all produce the same result shape:
+    ;; empty captures plus the stream tail. That makes `choose_any` safe for
+    ;; literal-only choices even when two literals overlap; mixed choices still
+    ;; use the ordered matcher.
+    (defn object-choice-direct-safe? (alternatives)
+        (if (nil? alternatives) true
+            (if (object-literal-pattern? (head alternatives))
+                (object-choice-direct-safe? (tail alternatives))
+                false)))
+
+    (defn object-literal-matches-object? (p obj)
+        (and (str_eq (object-literal-kind p) (bmf-object-kind obj))
+             (or (str_eq (object-literal-value p) "")
+                 (str_eq (object-literal-value p) (bmf-object-value obj)))))
+
     (defn match-object-pattern (p object-stream)
         (do
             (let tag (object-pattern-tag p))
@@ -1884,7 +1905,7 @@
                                            (match-rest m)
                                            (cap-merge acc-caps (match-caps m))))))))
 
-    (defn match-object-choice (alternatives object-stream)
+    (defn match-object-choice-linear (alternatives object-stream)
         (if (nil? alternatives)
             (mk-fail "no object alternative matched")
             (do
@@ -1894,7 +1915,236 @@
                 ;; cut's scope stays this choice, not its caller.
                 (if (match? m) m
                 (if (fail-cut? m) (mk-fail (fail-reason m))
-                    (match-object-choice (tail alternatives) object-stream))))))
+                    (match-object-choice-linear (tail alternatives) object-stream))))))
+
+    (defn match-object-choice-direct-or-linear (alternatives object-stream all-alternatives)
+        (if (nil? alternatives)
+            (mk-fail "no object alternative matched")
+            (if (object-literal-pattern? (head alternatives))
+                (if (nil? object-stream)
+                    (match-object-choice-direct-or-linear (tail alternatives) object-stream all-alternatives)
+                    (if (object-literal-matches-object? (head alternatives) (head object-stream))
+                        (match-object-literal (head alternatives) object-stream)
+                        (match-object-choice-direct-or-linear (tail alternatives) object-stream all-alternatives)))
+                (match-object-choice-linear all-alternatives object-stream))))
+
+    (defn match-object-choice (alternatives object-stream)
+        (match-object-choice-direct-or-linear alternatives object-stream alternatives))
+
+    (defn object-pattern-first-literal (p)
+        (if (nil? p) (empty)
+            (do
+                (let tag (object-pattern-tag p))
+                (if (str_eq tag "object") p
+                (if (str_eq tag "capture")
+                    (object-pattern-first-literal (nth p 2))
+                (if (str_eq tag "sequence")
+                    (if (nil? (tail p))
+                        (empty)
+                        (object-pattern-first-literal (head (tail p))))
+                    (empty)))))))
+
+    (defn object-rule-first-literal (rule)
+        (object-pattern-first-literal (rule-pattern rule)))
+
+    (defn object-rule-candidate? (rule object-stream)
+        (do
+            (let first (object-rule-first-literal rule))
+            (if (nil? first) true
+            (if (nil? object-stream) false
+                (object-literal-matches-object? first (head object-stream))))))
+
+    (defn object-rule-index-entry (rule)
+        (list (object-rule-first-literal rule) rule))
+
+    (defn object-rule-index-entry-first (entry) (head entry))
+    (defn object-rule-index-entry-rule (entry) (nth entry 1))
+
+    (defn object-dispatch-key (first)
+        (list (object-literal-kind first) (object-literal-value first)))
+
+    (defn object-dispatch-key-kind (key) (head key))
+    (defn object-dispatch-key-value (key) (nth key 1))
+
+    (defn object-dispatch-key-wild? (key)
+        (str_eq (object-dispatch-key-value key) ""))
+
+    (defn object-dispatch-key-eq? (a b)
+        (and (str_eq (object-dispatch-key-kind a) (object-dispatch-key-kind b))
+             (str_eq (object-dispatch-key-value a) (object-dispatch-key-value b))))
+
+    (defn object-dispatch-key-matches-object? (key obj)
+        (and (str_eq (object-dispatch-key-kind key) (bmf-object-kind obj))
+             (or (object-dispatch-key-wild? key)
+                 (str_eq (object-dispatch-key-value key) (bmf-object-value obj)))))
+
+    (defn object-rule-index-entry-key (entry)
+        (object-dispatch-key (object-rule-index-entry-first entry)))
+
+    (defn object-rule-index-entry-kind (entry)
+        (object-dispatch-key-kind (object-rule-index-entry-key entry)))
+
+    (defn object-rule-index-entry-wild? (entry)
+        (object-dispatch-key-wild? (object-rule-index-entry-key entry)))
+
+    (defn object-rule-entries-has-exact-kind? (entries kind)
+        (if (nil? entries) false
+            (if (and (str_eq (object-rule-index-entry-kind (head entries)) kind)
+                     (not (object-rule-index-entry-wild? (head entries))))
+                true
+                (object-rule-entries-has-exact-kind? (tail entries) kind))))
+
+    (defn object-rule-entries-ambiguous? (entries)
+        (if (nil? entries) false
+            (if (and (object-rule-index-entry-wild? (head entries))
+                     (object-rule-entries-has-exact-kind?
+                        entries
+                        (object-rule-index-entry-kind (head entries))))
+                true
+                (object-rule-entries-ambiguous? (tail entries)))))
+
+    (defn object-rule-bucket (key entries)
+        (list "object-rule-bucket" key entries))
+
+    (defn object-rule-bucket-key (bucket) (nth bucket 1))
+    (defn object-rule-bucket-entries (bucket) (nth bucket 2))
+
+    (defn object-rule-bucket-add-entry (bucket entry)
+        (object-rule-bucket
+            (object-rule-bucket-key bucket)
+            (append (object-rule-bucket-entries bucket) (list entry))))
+
+    (defn object-rule-buckets-add-entry (buckets entry)
+        (if (nil? buckets)
+            (list (object-rule-bucket (object-rule-index-entry-key entry) (list entry)))
+            (if (object-dispatch-key-eq?
+                    (object-rule-bucket-key (head buckets))
+                    (object-rule-index-entry-key entry))
+                (cons (object-rule-bucket-add-entry (head buckets) entry) (tail buckets))
+                (cons (head buckets)
+                      (object-rule-buckets-add-entry (tail buckets) entry)))))
+
+    (defn object-rule-exact-buckets (entries buckets)
+        (if (nil? entries) buckets
+            (if (object-rule-index-entry-wild? (head entries))
+                (object-rule-exact-buckets (tail entries) buckets)
+                (object-rule-exact-buckets
+                    (tail entries)
+                    (object-rule-buckets-add-entry buckets (head entries))))))
+
+    (defn object-rule-wild-buckets (entries buckets)
+        (if (nil? entries) buckets
+            (if (object-rule-index-entry-wild? (head entries))
+                (object-rule-wild-buckets
+                    (tail entries)
+                    (object-rule-buckets-add-entry buckets (head entries)))
+                (object-rule-wild-buckets (tail entries) buckets))))
+
+    (defn object-rule-segment (mode exact-buckets wild-buckets ordered-entries unknown-entry)
+        (list "object-rule-segment" mode exact-buckets wild-buckets ordered-entries unknown-entry))
+
+    (defn object-rule-segment-mode (segment) (nth segment 1))
+    (defn object-rule-segment-exact-buckets (segment) (nth segment 2))
+    (defn object-rule-segment-wild-buckets (segment) (nth segment 3))
+    (defn object-rule-segment-ordered-entries (segment) (nth segment 4))
+    (defn object-rule-segment-unknown-entry (segment) (nth segment 5))
+
+    (defn object-rule-build-segment (entries unknown-entry)
+        (if (object-rule-entries-ambiguous? entries)
+            (object-rule-segment "ordered" (empty) (empty) entries unknown-entry)
+            (object-rule-segment "bucketed"
+                                 (object-rule-exact-buckets entries (empty))
+                                 (object-rule-wild-buckets entries (empty))
+                                 entries
+                                 unknown-entry)))
+
+    (defn object-rule-index-known-run (rules entries)
+        (if (nil? rules)
+            (list entries (empty) (empty))
+            (do
+                (let entry (object-rule-index-entry (head rules)))
+                (if (nil? (object-rule-index-entry-first entry))
+                    (list entries entry (tail rules))
+                    (object-rule-index-known-run
+                        (tail rules)
+                        (append entries (list entry)))))))
+
+    (defn object-rule-set-index (rules)
+        (if (nil? rules) (empty)
+            (do
+                (let run (object-rule-index-known-run rules (empty)))
+                (cons (object-rule-build-segment (head run) (nth run 1))
+                      (object-rule-set-index (nth run 2))))))
+
+    (defn object-rule-index-entry-candidate? (entry object-stream)
+        (do
+            (let first (object-rule-index-entry-first entry))
+            (if (nil? first) true
+            (if (nil? object-stream) false
+                (object-literal-matches-object? first (head object-stream))))))
+
+    (defn object-rule-index-entry-count (entries)
+        (if (nil? entries) 0
+            (add 1 (object-rule-index-entry-count (tail entries)))))
+
+    (defn object-rule-bucket-count (buckets)
+        (if (nil? buckets) 0
+            (add 1 (object-rule-bucket-count (tail buckets)))))
+
+    (defn object-rule-buckets-entry-count (buckets)
+        (if (nil? buckets) 0
+            (add (object-rule-index-entry-count (object-rule-bucket-entries (head buckets)))
+                 (object-rule-buckets-entry-count (tail buckets)))))
+
+    (defn object-rule-buckets-candidate-count (buckets object-stream)
+        (if (nil? buckets) 0
+            (if (nil? object-stream) 0
+                (if (object-dispatch-key-matches-object?
+                        (object-rule-bucket-key (head buckets))
+                        (head object-stream))
+                    (add (object-rule-index-entry-count (object-rule-bucket-entries (head buckets)))
+                         (object-rule-buckets-candidate-count (tail buckets) object-stream))
+                    (object-rule-buckets-candidate-count (tail buckets) object-stream)))))
+
+    (defn object-rule-segment-known-count (segment)
+        (object-rule-index-entry-count (object-rule-segment-ordered-entries segment)))
+
+    (defn object-rule-segment-bucket-count (segment)
+        (add (object-rule-bucket-count (object-rule-segment-exact-buckets segment))
+             (object-rule-bucket-count (object-rule-segment-wild-buckets segment))))
+
+    (defn object-rule-segment-candidate-count (segment object-stream)
+        (if (str_eq (object-rule-segment-mode segment) "bucketed")
+            (add (object-rule-buckets-candidate-count
+                    (object-rule-segment-exact-buckets segment)
+                    object-stream)
+                 (object-rule-buckets-candidate-count
+                    (object-rule-segment-wild-buckets segment)
+                    object-stream))
+            (object-rule-segment-known-count segment)))
+
+    (defn object-rule-dispatch-index-known-count (segments)
+        (if (nil? segments) 0
+            (add (object-rule-segment-known-count (head segments))
+                 (object-rule-dispatch-index-known-count (tail segments)))))
+
+    (defn object-rule-dispatch-index-candidate-count (segments object-stream)
+        (if (nil? segments) 0
+            (add (object-rule-segment-candidate-count (head segments) object-stream)
+                 (object-rule-dispatch-index-candidate-count (tail segments) object-stream))))
+
+    (defn object-rule-dispatch-index-skip-count (segments object-stream)
+        (sub (object-rule-dispatch-index-known-count segments)
+             (object-rule-dispatch-index-candidate-count segments object-stream)))
+
+    (defn object-rule-dispatch-index-bucket-count (segments)
+        (if (nil? segments) 0
+            (add (object-rule-segment-bucket-count (head segments))
+                 (object-rule-dispatch-index-bucket-count (tail segments)))))
+
+    (defn object-rule-dispatch-index-segment-count (segments)
+        (if (nil? segments) 0
+            (add 1 (object-rule-dispatch-index-segment-count (tail segments)))))
 
     (defn capture-object-value (m original-stream)
         (if (nil? (match-caps m))
@@ -1943,6 +2193,83 @@
                                 "result"
                                 object)
                               (match-rest m))))))
+
+    (defn apply-object-rule-index-entry (entry object-stream)
+        (apply-object-rule (object-rule-index-entry-rule entry) object-stream))
+
+    (defn apply-object-rule-index-entries (entries object-stream)
+        (if (nil? entries)
+            (mk-fail "no object rule matched")
+            (if (object-rule-index-entry-candidate? (head entries) object-stream)
+                (do
+                    (let m (apply-object-rule-index-entry (head entries) object-stream))
+                    (if (match? m) m
+                    (if (fail-cut? m) (mk-fail (fail-reason m))
+                        (apply-object-rule-index-entries (tail entries) object-stream))))
+                (apply-object-rule-index-entries (tail entries) object-stream))))
+
+    (defn apply-object-rule-buckets (buckets object-stream)
+        (if (nil? buckets)
+            (mk-fail "no object rule matched")
+            (if (and (not (nil? object-stream))
+                     (object-dispatch-key-matches-object?
+                        (object-rule-bucket-key (head buckets))
+                        (head object-stream)))
+                (apply-object-rule-index-entries
+                    (object-rule-bucket-entries (head buckets))
+                    object-stream)
+                (apply-object-rule-buckets (tail buckets) object-stream))))
+
+    (defn apply-object-rule-segment-unknown (segment object-stream)
+        (if (nil? (object-rule-segment-unknown-entry segment))
+            (mk-fail "no object rule matched")
+            (apply-object-rule-index-entry
+                (object-rule-segment-unknown-entry segment)
+                object-stream)))
+
+    (defn apply-bucketed-object-rule-segment (segment object-stream)
+        (do
+            (let exact-match
+                (apply-object-rule-buckets
+                    (object-rule-segment-exact-buckets segment)
+                    object-stream))
+            (if (match? exact-match) exact-match
+            (if (fail-cut? exact-match) (mk-fail (fail-reason exact-match))
+                (do
+                    (let wild-match
+                        (apply-object-rule-buckets
+                            (object-rule-segment-wild-buckets segment)
+                            object-stream))
+                    (if (match? wild-match) wild-match
+                    (if (fail-cut? wild-match) (mk-fail (fail-reason wild-match))
+                        (apply-object-rule-segment-unknown segment object-stream))))))))
+
+    (defn apply-ordered-object-rule-segment (segment object-stream)
+        (do
+            (let ordered-match
+                (apply-object-rule-index-entries
+                    (object-rule-segment-ordered-entries segment)
+                    object-stream))
+            (if (match? ordered-match) ordered-match
+            (if (fail-cut? ordered-match) (mk-fail (fail-reason ordered-match))
+                (apply-object-rule-segment-unknown segment object-stream)))))
+
+    (defn apply-object-rule-segment (segment object-stream)
+        (if (str_eq (object-rule-segment-mode segment) "bucketed")
+            (apply-bucketed-object-rule-segment segment object-stream)
+            (apply-ordered-object-rule-segment segment object-stream)))
+
+    (defn apply-indexed-object-rule-set (segments object-stream)
+        (if (nil? segments)
+            (mk-fail "no object rule matched")
+            (do
+                (let m (apply-object-rule-segment (head segments) object-stream))
+                (if (match? m) m
+                (if (fail-cut? m) (mk-fail (fail-reason m))
+                    (apply-indexed-object-rule-set (tail segments) object-stream))))))
+
+    (defn apply-object-rule-set (rules object-stream)
+        (apply-indexed-object-rule-set (object-rule-set-index rules) object-stream))
 
     (defn apply-object-rule-reverse (rule object)
         (do

--- a/form/form-stdlib/grammars/bml.fk
+++ b/form/form-stdlib/grammars/bml.fk
@@ -3225,6 +3225,9 @@
                   bml-compile-file
                   bmf-identity-inverse)))
 
+    (let bml-compiler-rule-index
+        (object-rule-set-index bml-compiler-rules))
+
     (defn bml-compiler-rule-name (r) (head r))
 
     (defn bml-compiler-find-rule (rule-name rules)
@@ -3251,6 +3254,9 @@
 
     (defn apply-bml-compiler-rule (rule-name objects)
         (apply-object-rule (bml-compiler-find-rule rule-name bml-compiler-rules) objects))
+
+    (defn apply-bml-compiler-first-rule (objects)
+        (apply-indexed-object-rule-set bml-compiler-rule-index objects))
 
     ;; --- BMF rule emitters ------------------------------------------
 
@@ -3724,6 +3730,9 @@
       state-int ::= "save" ";" $value:int ";" "discard" ";" => bml-emit-state-int;
     }
 
+    (let bml-bmf-rule-index
+        (object-rule-set-index bml-bmf-rules))
+
     (defn bml-bmf-rule-name (r) (head r))
 
     (defn bml-bmf-find-rule (rule-name rules)
@@ -3734,6 +3743,9 @@
 
     (defn apply-bml-bmf-rule (rule-name objects)
         (apply-object-rule (bml-bmf-find-rule rule-name bml-bmf-rules) objects))
+
+    (defn apply-bml-bmf-first-rule (objects)
+        (apply-indexed-object-rule-set bml-bmf-rule-index objects))
 
     (defn bml-bmf-match-node (match)
         (bmf-object-value (cap-get (match-caps match) "result")))
@@ -3767,6 +3779,57 @@
               "file-import-two-star"
               "file-import-one-star"))
 
+    (defn bml-bmf-rules-by-names (rule-names)
+        (if (nil? rule-names) (empty)
+            (cons (bml-bmf-find-rule (head rule-names) bml-bmf-rules)
+                  (bml-bmf-rules-by-names (tail rule-names)))))
+
+    (let bml-source-executable-rule-index
+        (object-rule-set-index
+            (bml-bmf-rules-by-names (bml-source-executable-rules 0))))
+
+    (let bml-source-declaration-rule-index
+        (object-rule-set-index
+            (bml-bmf-rules-by-names (bml-source-declaration-rules 0))))
+
+    (defn bml-source-executable-rule-index-known-count (_x)
+        (object-rule-dispatch-index-known-count bml-source-executable-rule-index))
+
+    (defn bml-source-executable-rule-index-candidate-count (objects)
+        (object-rule-dispatch-index-candidate-count
+            bml-source-executable-rule-index
+            objects))
+
+    (defn bml-source-executable-rule-index-skip-count (objects)
+        (object-rule-dispatch-index-skip-count
+            bml-source-executable-rule-index
+            objects))
+
+    (defn bml-source-executable-rule-index-bucket-count (_x)
+        (object-rule-dispatch-index-bucket-count bml-source-executable-rule-index))
+
+    (defn bml-source-executable-rule-index-segment-count (_x)
+        (object-rule-dispatch-index-segment-count bml-source-executable-rule-index))
+
+    (defn bml-source-declaration-rule-index-known-count (_x)
+        (object-rule-dispatch-index-known-count bml-source-declaration-rule-index))
+
+    (defn bml-source-declaration-rule-index-candidate-count (objects)
+        (object-rule-dispatch-index-candidate-count
+            bml-source-declaration-rule-index
+            objects))
+
+    (defn bml-source-declaration-rule-index-skip-count (objects)
+        (object-rule-dispatch-index-skip-count
+            bml-source-declaration-rule-index
+            objects))
+
+    (defn bml-source-declaration-rule-index-bucket-count (_x)
+        (object-rule-dispatch-index-bucket-count bml-source-declaration-rule-index))
+
+    (defn bml-source-declaration-rule-index-segment-count (_x)
+        (object-rule-dispatch-index-segment-count bml-source-declaration-rule-index))
+
     (defn bml-source-parse-step (ok rule node rest)
         (list "bml-source-parse-step" ok rule node rest))
 
@@ -3790,6 +3853,19 @@
                     (bml-source-parse-executable-step-loop
                         objects
                         (tail rule-names))))))
+
+    (defn bml-source-parse-indexed-step (objects rule-index)
+        (do
+            (let m (apply-indexed-object-rule-set rule-index objects))
+            (if (match? m)
+                (do
+                    (let result (cap-get (match-caps m) "result"))
+                    (bml-source-parse-step
+                        true
+                        (bmf-object-kind result)
+                        (bmf-object-value result)
+                        (match-rest m)))
+                (bml-source-parse-step false "" (empty) objects))))
 
     (defn bml-source-token-value? (object value)
         (if (nil? object) false
@@ -4692,9 +4768,9 @@
             (bml-source-parse-step false "" (empty) objects)))
 
     (defn bml-source-parse-executable-step (objects)
-        (bml-source-parse-executable-step-loop
+        (bml-source-parse-indexed-step
             objects
-            (bml-source-executable-rules 0)))
+            bml-source-executable-rule-index))
 
     (defn bml-source-exec-parse-result (ok nodes rest rules)
         (list "bml-source-exec-parse-result" ok nodes rest rules))
@@ -4747,9 +4823,9 @@
             (bml-source-parse-balanced-class-shell objects)
             (do
                 (let step
-                    (bml-source-parse-executable-step-loop
+                    (bml-source-parse-indexed-step
                         objects
-                        (bml-source-declaration-rules 0)))
+                        bml-source-declaration-rule-index))
                 (if (bml-source-parse-step-ok? step)
                     step
                     (do

--- a/form/form-stdlib/tests/bmf-compiler-runtime.fk
+++ b/form/form-stdlib/tests/bmf-compiler-runtime.fk
@@ -23,6 +23,9 @@
         (apply-bmf-compiler-rule "BMFChar-int"
             (list (bmf-src-op "\\") (bmf-src-int "65"))))
     (let char-int-object (result-object char-int-match))
+    (let first-rule-match
+        (apply-bmf-compiler-first-rule
+            (list (bmf-src-op "\\") (bmf-src-int "66"))))
 
     (let char-a-match
         (apply-bmf-compiler-rule "BMFChar-quoted"
@@ -243,5 +246,10 @@
         (add (if (eq (kind-score (result-value attr-match) "comp-bmf-attribute") 1) 262144 0)
              (if (eq (kind-score (result-value rule-match) "comp-bmf-rule") 1) 524288 0)))))))))))))))))))))
 
-    (add shape-code (add coverage-score value-score))
+    (let first-rule-score
+        (if (str_eq (bmf-object-kind (result-object first-rule-match)) "BMFChar-int")
+            1048576
+            0))
+
+    (add shape-code (add coverage-score (add value-score first-rule-score)))
 )

--- a/form/form-stdlib/tests/bmf-form-object-runtime-band.fk
+++ b/form/form-stdlib/tests/bmf-form-object-runtime-band.fk
@@ -79,6 +79,71 @@
     (let cut-match (apply-object-rule cut-rule opt-absent-stream))
     (let stop-match (match-object-pattern (list "stop") object-stream))
 
+    (let direct-choice-pattern
+        (list "choice"
+              (object-lit "kw" "return")
+              (object-lit "kw" "break")
+              (object-lit "op" "{")))
+    (let direct-choice-match
+        (match-object-pattern
+            direct-choice-pattern
+            (list (bmf-atom "kw" "break") (bmf-atom "end" "."))))
+    (let wildcard-choice-pattern
+        (list "choice"
+              (object-lit "kw" "")
+              (object-lit "kw" "break")))
+    (let duplicate-choice-pattern
+        (list "choice"
+              (object-lit "kw" "return")
+              (object-lit "kw" "return")))
+    (let mixed-choice-pattern
+        (list "choice"
+              (object-lit "kw" "return")
+              (list "sequence" (object-lit "kw" "break"))))
+    (let mixed-choice-match
+        (match-object-pattern
+            mixed-choice-pattern
+            (list (bmf-atom "kw" "return") (bmf-atom "end" "."))))
+
+    (let rule-set-stream
+        (list
+            (bmf-atom "kw" "break")
+            (bmf-atom "int" "9")
+            (bmf-atom "end" ".")))
+    (let return-rule
+        (list "kw-return"
+              (list "sequence"
+                    (object-lit "kw" "return")
+                    (list "capture" "n" (object-lit "int" "")))
+              emit-captures
+              emit-source-span))
+    (let break-rule
+        (list "kw-break"
+              (list "sequence"
+                    (object-lit "kw" "break")
+                    (list "capture" "n" (object-lit "int" "")))
+              emit-captures
+              emit-source-span))
+    (let unknown-first-rule
+        (list "empty-first"
+              (list "opt" (object-lit "ws" " "))
+              emit-captures
+              emit-source-span))
+    (let rule-set-known-match
+        (apply-object-rule-set
+            (list return-rule break-rule)
+            rule-set-stream))
+    (let rule-set-known-index
+        (object-rule-set-index (list return-rule break-rule)))
+    (let rule-set-ordered-match
+        (apply-object-rule-set
+            (list return-rule unknown-first-rule break-rule)
+            rule-set-stream))
+    (let rule-set-no-match
+        (apply-object-rule-set
+            (list return-rule break-rule)
+            (list (bmf-atom "kw" "continue") (bmf-atom "end" "."))))
+
     (sum
         (list
             (bool-score (match? match) 1)
@@ -91,4 +156,19 @@
             (bool-score (match? star-match) 128)
             (int-score (len (cap-get (match-caps star-match) "items")) 2 256)
             (bool-score (fail? cut-match) 512)
-            (bool-score (fail? stop-match) 1024))))
+            (bool-score (fail? stop-match) 1024)
+            (bool-score (object-choice-direct-safe? (tail direct-choice-pattern)) 2048)
+            (bool-score (object-choice-direct-safe? (tail wildcard-choice-pattern)) 4096)
+            (bool-score (object-choice-direct-safe? (tail duplicate-choice-pattern)) 8192)
+            (bool-score (match? direct-choice-match) 16384)
+            (int-score (len (match-rest direct-choice-match)) 1 32768)
+            (bool-score (not (object-choice-direct-safe? (tail mixed-choice-pattern))) 65536)
+            (bool-score (match? mixed-choice-match) 131072)
+            (str-score (bmf-object-kind (cap-get (match-caps rule-set-known-match) "result")) "kw-break" 262144)
+            (str-score (bmf-object-kind (cap-get (match-caps rule-set-ordered-match) "result")) "empty-first" 524288)
+            (bool-score (fail? rule-set-no-match) 1048576)
+            (int-score (object-rule-dispatch-index-known-count rule-set-known-index) 2 2097152)
+            (int-score (object-rule-dispatch-index-candidate-count rule-set-known-index rule-set-stream) 1 4194304)
+            (int-score (object-rule-dispatch-index-skip-count rule-set-known-index rule-set-stream) 1 8388608)
+            (int-score (object-rule-dispatch-index-bucket-count rule-set-known-index) 2 16777216)
+            (int-score (object-rule-dispatch-index-segment-count rule-set-known-index) 1 33554432))))

--- a/form/form-stdlib/tests/bml-compiler-runtime.fk
+++ b/form/form-stdlib/tests/bml-compiler-runtime.fk
@@ -16,10 +16,18 @@
         (apply-bml-bmf-rule "class-header"
             (list (bml-src-keyword "class") (bml-src-name "Demo")
                   (bml-src-op ":") (bml-src-name "Application"))))
+    (let class-first-rule-match
+        (apply-bml-bmf-first-rule
+            (list (bml-src-keyword "class") (bml-src-name "Direct")
+                  (bml-src-op ":") (bml-src-name "Application"))))
     (let class-kids (node_children (result-value class-match)))
     (let class-score
         (add (str_len (node_value (head class-kids)))
              (str_len (node_value (head (tail class-kids)))))) ; Demo + Application = 15
+    (let class-first-rule-score
+        (if (str_eq (bmf-object-kind (result-object class-first-rule-match)) "class-header")
+            128
+            0))
 
     (let method-match
         (apply-bml-bmf-rule "method-return-add"
@@ -76,6 +84,32 @@
     (let source-score
         (add (str_to_int (source-value method-match "left"))
              (str_to_int (source-value method-match "right")))) ; undo source 1 + 2 = 3
+    (let return-stream
+        (list (bml-src-keyword "return")
+              (bml-src-int "9")
+              (bml-src-op ";")))
+    (let return-step (bml-source-parse-executable-step return-stream))
+    (let executable-dispatch-score
+        (add
+            (if (str_eq (bml-source-parse-step-rule return-step) "return-int") 256 0)
+            (add
+                (if (gt (bml-source-executable-rule-index-known-count 0) 0) 512 0)
+                (add
+                    (if (gt (bml-source-executable-rule-index-skip-count return-stream) 0) 1024 0)
+                    (add
+                        (if (gt (bml-source-executable-rule-index-bucket-count 0) 0) 2048 0)
+                        (if (gt (bml-source-executable-rule-index-segment-count 0) 0) 4096 0))))))
+    (let class-stream
+        (list (bml-src-keyword "class")
+              (bml-src-name "Telemetry")))
+    (let declaration-dispatch-score
+        (add
+            (if (gt (bml-source-declaration-rule-index-known-count 0) 0) 8192 0)
+            (add
+                (if (gt (bml-source-declaration-rule-index-skip-count class-stream) 0) 16384 0)
+                (add
+                    (if (gt (bml-source-declaration-rule-index-bucket-count 0) 0) 32768 0)
+                    (if (gt (bml-source-declaration-rule-index-segment-count 0) 0) 65536 0)))))
 
     (add class-score
     (add method-score
@@ -84,5 +118,8 @@
     (add section-score
     (add field-score
     (add const-score
-    (add reference-score source-score))))))))
+    (add reference-score
+    (add source-score
+    (add class-first-rule-score
+    (add executable-dispatch-score declaration-dispatch-score)))))))))))
 )

--- a/form/form-stdlib/tests/source-compiler-multi-dialect-band.fk
+++ b/form/form-stdlib/tests/source-compiler-multi-dialect-band.fk
@@ -8,7 +8,7 @@
 ; one driver line per section and wrote the corresponding sidecar to
 ; disk with non-zero size.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/source-compiler.fk
 
 (do
     (let source

--- a/form/form-stdlib/tests/source-corpus-roundtrip-band.fk
+++ b/form/form-stdlib/tests/source-corpus-roundtrip-band.fk
@@ -1,6 +1,6 @@
 ; source-corpus-roundtrip-band.fk - active source sections through target lenses
 ;
-; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/go-bmf.fk form-stdlib/grammars/typescript-bmf.fk
+; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/bml.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/go-bmf.fk form-stdlib/grammars/typescript-bmf.fk
 
 (do
     (let ACTIVE-CORPUS-ADD (make_nodeid 8 44 2 1))

--- a/form/form-stdlib/tests/task-runtime.fk
+++ b/form/form-stdlib/tests/task-runtime.fk
@@ -2,18 +2,25 @@
 ; Returns 91 when pending/resolved/failed task cells, await, resume, and
 ; undo all behave the same across supported kernels.
 
-section [form.action] {
-    def inc(x) = add(x, 1);
-    def b->i(b) = if b then 1 else 0;
+(do
+    (defn task-runtime-inc (x) (add x 1))
+    (defn task-runtime-bool-int (b) (if b 1 0))
 
-    let origin = list("py-await", "suspend");
-    let pending = task-pending(origin, inc);
-    let ready = task-resolve(pending, 41);
-    let rejected = task-reject(pending, list("error", "cancelled"));
-    let pending-await = task-await(pending);
+    (let origin (list "py-await" "suspend"))
+    (let pending (task-pending origin task-runtime-inc))
+    (let ready (task-resolve pending 41))
+    (let rejected (task-reject pending (list "error" "cancelled")))
+    (let pending-await (task-await pending))
 
-    let ready-score = add(task-await(ready), add(task-step(ready), len(cell-undo(ready))));
-    let state-score = add(b->i(task-ready?(ready)), add(b->i(task?(pending)), b->i(task-failed?(rejected))));
-    let undo-score = add(b->i(task?(pending-await)), len(cell-undo(rejected)));
-    add(ready-score, add(state-score, undo-score));
-}
+    (let ready-score
+        (add (task-await ready)
+             (add (task-step ready)
+                  (len (cell-undo ready)))))
+    (let state-score
+        (add (task-runtime-bool-int (task-ready? ready))
+             (add (task-runtime-bool-int (task? pending))
+                  (task-runtime-bool-int (task-failed? rejected)))))
+    (let undo-score
+        (add (task-runtime-bool-int (task? pending-await))
+             (len (cell-undo rejected))))
+    (add ready-score (add state-score undo-score)))


### PR DESCRIPTION
## Summary
- add direct-safe BMF object choice dispatch and indexed/bucketed object-rule dispatch
- route BMF/BML compiler first-rule and BML source executable/declaration parsing through precomputed rule indexes
- expose BML source dispatch telemetry counters for known, candidate, skipped, bucket, and segment counts

## Proof
- make prompt-guide
- make wellness
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- cd form && ./validate.sh -> 309 ok, 0 divergent
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260608_bmf_object_choice_direct_dispatch.json

## Measurement
- BML source parser benchmark: mean 5.011512s -> 1.333789s, about 73.4% faster
- bucketed rule dispatch benchmark: mean 12.336970s -> 9.947811s, about 19.4% faster
