### PR TITLE
Deploy kernel-router as API front door

### DIFF
--- a/.github/workflows/hostinger-api-native-deploy.yml
+++ b/.github/workflows/hostinger-api-native-deploy.yml
@@ -37,4 +37,5 @@ jobs:
         run: |
           VERIFY_REQUIRE_API_HEALTH_SHA=1 \
           VERIFY_REQUIRE_WEB_HEALTH_PROXY_SHA=1 \
+          VERIFY_REQUIRE_KERNEL_FRONT_DOOR=1 \
             scripts/verify_web_api_deploy.sh "$PUBLIC_API_BASE_URL" "$PUBLIC_DEPLOY_WEB_BASE"

--- a/Dockerfile.kernel-router
+++ b/Dockerfile.kernel-router
@@ -18,19 +18,19 @@
 #      because this image serves, it is not imported by Python).
 #   2. runtime — a lean debian-slim with ONLY the stripped binary, the form-stdlib
 #      (so a BML-authored manifest can be source-compiled at load via --stdlib),
-#      and the shadow routes manifest. No Rust toolchain in the final image.
+#      and both route manifests. No Rust toolchain in the final image.
 #
-# SHADOW MODE BY DEFAULT: the baked manifest (deploy/kernel-router/shadow-routes.fk)
+# SHADOW MODE BY DEFAULT: the default manifest (deploy/kernel-router/shadow-routes.fk)
 # binds an EMPTY routes list, so EVERY request fans out to ${UPSTREAM_URL}
 # (default http://api:8000) — byte-identical to today's behavior, one proxy hop,
 # with the X-Form-Router: fanout-python header as live evidence the router carries
 # the traffic. Promoting a route to native = adding a (path handler) line to the
 # manifest; nothing else in the topology changes.
 #
-# THIS IMAGE DOES NOT FLIP PRODUCTION. Building and even running this container
-# changes nothing about what fronts api.coherencycoin.com — that is a Traefik
-# re-point (one label), Urs's intent, a SEPARATE step. See
-# deploy/kernel-router/docker-compose.kernel-router.yml and KERNEL_AS_ROUTER.md.
+# PRODUCTION FLIP: the image also carries production-routes.fk and its route data.
+# The deploy layer chooses ROUTES_FILE=/routes/production-routes.fk when Traefik
+# points api.coherencycoin.com at kernel-router. Rollback is the same topology
+# with ROUTES_FILE=/routes/shadow-routes.fk, or Traefik pointed back at api.
 
 # -----------------------------------------------------------------------------
 # Stage 1 — build form-kernel-rust: the native binary (the front-door server)
@@ -56,7 +56,7 @@ RUN cargo build --release --bin form-kernel-rust \
 
 
 # -----------------------------------------------------------------------------
-# Stage 2 — lean runtime: just the binary + form-stdlib + the shadow manifest
+# Stage 2 — lean runtime: just the binary + form-stdlib + route manifests
 # -----------------------------------------------------------------------------
 FROM debian:bookworm-slim AS runtime
 
@@ -92,10 +92,13 @@ RUN chmod +x /app/bin/form-kernel-rust \
 # stdlib in lets a BML manifest work later without rebuilding the image.
 COPY form/form-stdlib/ /app/form/form-stdlib/
 
-# The shadow routes manifest: an EMPTY routes list -> every path fans out to the
-# upstream. This is the deployable shadow-mode default; mount/replace
-# /routes/shadow-routes.fk to promote native routes.
+# Route manifests:
+#   shadow-routes.fk      empty routes -> every path fans out to the upstream
+#   production-routes.fk  native route cells plus fan-out tail
+# production-routes-data.json carries route metadata addressed by route-data ref.
 COPY deploy/kernel-router/shadow-routes.fk /routes/shadow-routes.fk
+COPY deploy/kernel-router/production-routes.fk /routes/production-routes.fk
+COPY deploy/kernel-router/production-routes-data.json /routes/production-routes-data.json
 
 # The entrypoint resolves env at RUN time so PORT / UPSTREAM_URL / ROUTES_FILE
 # are container-configurable (compose env, -e flags) without rebuilding.

--- a/deploy/kernel-router/docker-compose.kernel-router.yml
+++ b/deploy/kernel-router/docker-compose.kernel-router.yml
@@ -1,27 +1,12 @@
-# docker-compose.kernel-router.yml — the kernel-router as a DEFINED-BUT-INACTIVE
-# service. An OVERLAY, intentionally NOT the production docker-compose.yml.
+# docker-compose.kernel-router.yml — production front-door overlay.
 #
-# The production deploy runs `docker compose -f docker-compose.yml ...` (see
-# deploy/hostinger/auto-deploy.sh). This file is a SEPARATE overlay the deploy
-# never includes, so defining the service here changes NOTHING about production
-# routing until someone explicitly composes with this file AND uncomments the
-# Traefik labels below. The service is buildable and runnable on demand; it does
-# not front api.coherencycoin.com.
-#
-# WHAT THIS IS: the deployable shadow step of the flip in
-# kernels/KERNEL_AS_ROUTER.md. The kernel-router (form-kernel-rust serve) sits in
-# front of the api service and, in shadow mode (empty routes manifest), fans
-# EVERYTHING out to api:8000 — byte-identical to today, one proxy hop, with
-# X-Form-Router: fanout-python as live evidence.
-#
-# WHAT THIS IS NOT: the flip. The flip is pointing Traefik at this service
-# instead of at the api service. That is one label change (uncommented below),
-# and it is Urs's INTENT — a stakes-and-vision decision, not something this file
-# performs. Today's front door (Traefik -> coherence-api -> api:8000) is
-# untouched by merging this overlay.
+# This overlay expresses the flip: Traefik routes api.coherencycoin.com to the
+# kernel-router service on port 8080, and the api service remains the private
+# fan-out upstream on api:8000. Routes in production-routes.fk run Form-native;
+# unmatched routes fan out to CPython with X-Form-Router: fanout-python.
 #
 # ---------------------------------------------------------------------------
-# HOW TO RUN IT IN SHADOW (local / staging, NO production routing change):
+# HOW TO RUN IT LOCALLY / IN STAGING:
 #
 #   # from the compose root, layering this overlay on top of the base compose
 #   docker compose \
@@ -29,24 +14,19 @@
 #     -f repo/deploy/kernel-router/docker-compose.kernel-router.yml \
 #     up -d --build kernel-router
 #
-#   # the router is now reachable on :8088 (host) and proxies to api:8000.
-#   # PROVE it carries traffic, byte-identically:
-#   curl -i http://localhost:8088/api/health   # 200 + X-Form-Router: fanout-python
-#   curl -s http://localhost:8088/api/health | diff - <(curl -s http://localhost:8000/api/health)
-#   #   ^ identical body; the only difference is the X-Form-Router header
-#
-# ---------------------------------------------------------------------------
-# THE FLIP (Urs's intent — a SEPARATE step, do NOT do this as part of building):
-#
-#   To make the kernel-router the REAL front door for api.coherencycoin.com,
-#   uncomment the `traefik.*` labels on the kernel-router service below AND
-#   remove (or override to a non-web entrypoint) the Traefik router rule on the
-#   api service in the base docker-compose.yml, so Traefik routes
-#   Host(api.coherencycoin.com) -> kernel-router -> (fan-out) api:8000.
-#   Rollback = re-comment these labels / restore the api rule. Instant, no data
-#   migration. THIS IS THE FLIP. Building this overlay is not.
+#   curl -i http://localhost:8088/api/attention/kernel-runtime
+#   # X-Form-Router: native-kernel
+#   curl -i http://localhost:8088/api/health
+#   # X-Form-Router: fanout-python unless /api/health is promoted
 
 services:
+  api:
+    # Keep api on the compose network as the private upstream, but remove it as
+    # a public Traefik target. The kernel-router owns the public coherence-api
+    # router and fans out to api:8000 for not-yet-native routes.
+    labels:
+      traefik.enable: "false"
+
   kernel-router:
     build:
       # Build context is the repo root (where Dockerfile.kernel-router lives).
@@ -57,39 +37,22 @@ services:
     image: coherence-network-kernel-router:latest
     restart: unless-stopped
     environment:
-      # The fan-out target: the api service on the shared compose network. In
-      # shadow mode EVERY request goes here (empty routes manifest).
+      # The fan-out target: the api service on the shared compose network.
       UPSTREAM_URL: "http://api:8000"
       KERNEL_ROUTER_PORT: "8080"
-      ROUTES_FILE: "/routes/shadow-routes.fk"
+      ROUTES_FILE: "/routes/production-routes.fk"
+      STDLIB_DIR: "/app/form/form-stdlib"
       # KERNEL_ROUTER_WORKERS: "4"   # optional pool size; default = host parallelism
     depends_on:
       # The fan-out upstream must exist; the router proxies to it.
       - api
-    # Host port mapping for LOCAL/STAGING shadow proof only. This exposes the
-    # router on the host so you can curl it directly WITHOUT touching Traefik or
-    # production routing. In the real flip Traefik talks to it over the compose
-    # network (port 8080) and this host mapping is unnecessary.
+    # Host port mapping for local/staging proof only. In production Traefik talks
+    # to the service over the compose network on port 8080.
     ports:
       - "8088:8080"
-
-    # ----------------------------------------------------------------------
-    # TRAEFIK LABELS — PRESENT BUT INACTIVE (commented). Uncommenting these is
-    # THE FLIP (Urs's intent). They mirror the api service's production rule
-    # (Host(api.coherencycoin.com) -> port 8000) but point at the kernel-router
-    # on port 8080. Activating them WITHOUT also removing the api service's own
-    # Traefik rule would create two routers for the same Host — so the flip is:
-    # uncomment here, AND drop/redirect the api rule in the base compose.
-    #
-    # labels:
-    #   - "traefik.enable=true"
-    #   - "traefik.http.routers.coherence-api.rule=Host(`api.coherencycoin.com`)"
-    #   - "traefik.http.routers.coherence-api.entrypoints=websecure"
-    #   - "traefik.http.routers.coherence-api.tls.certresolver=letsencrypt"
-    #   - "traefik.http.services.coherence-api.loadbalancer.server.port=8080"
-    # ----------------------------------------------------------------------
-
-# The api service is defined in the base docker-compose.yml. This overlay only
-# ADDS the kernel-router; it does not redefine api, and it does NOT touch the
-# api service's Traefik labels. Merging this file leaves production routing
-# exactly as it is.
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.coherence-api.rule=Host(`api.coherencycoin.com`)"
+      - "traefik.http.routers.coherence-api.entrypoints=websecure"
+      - "traefik.http.routers.coherence-api.tls.certresolver=letsencrypt"
+      - "traefik.http.services.coherence-api.loadbalancer.server.port=8080"

--- a/deploy/kernel-router/entrypoint.sh
+++ b/deploy/kernel-router/entrypoint.sh
@@ -44,5 +44,10 @@ if [ -n "${KERNEL_ROUTER_WORKERS:-}" ]; then
   set -- "$@" --workers "$KERNEL_ROUTER_WORKERS"
 fi
 
-echo "kernel-router: serve --host $HOST --port $PORT --routes $ROUTES --upstream $UPSTREAM (shadow mode: empty routes -> all fan-out)"
+MODE="production/native routes with fan-out tail"
+case "$ROUTES" in
+  *shadow-routes.fk) MODE="shadow mode: empty routes -> all fan-out" ;;
+esac
+
+echo "kernel-router: serve --host $HOST --port $PORT --routes $ROUTES --upstream $UPSTREAM ($MODE)"
 exec /app/bin/form-kernel-rust "$@"

--- a/docs/system_audit/commit_evidence_2026-06-08_kernel_front_door_flip.json
+++ b/docs/system_audit/commit_evidence_2026-06-08_kernel_front_door_flip.json
@@ -1,0 +1,119 @@
+{
+  "date": "2026-06-08",
+  "thread_branch": "codex/native-front-door-flip-20260608",
+  "commit_scope": "Flip the Hostinger API native deploy path so api.coherencycoin.com is fronted by kernel-router with production-routes.fk, while keeping api as the private CPython fan-out upstream.",
+  "files_owned": [
+    ".github/workflows/hostinger-api-native-deploy.yml",
+    "Dockerfile.kernel-router",
+    "deploy/kernel-router/docker-compose.kernel-router.yml",
+    "deploy/kernel-router/entrypoint.sh",
+    "docs/system_audit/commit_evidence_2026-06-08_kernel_front_door_flip.json",
+    "scripts/hostinger_api_native_deploy.sh",
+    "scripts/runtime_surface_report.py",
+    "scripts/test_hostinger_api_native_deploy.sh",
+    "scripts/verify_web_api_deploy.sh",
+    "scripts/wellness_check.py"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && make prompt-guide",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && make wellness",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && scripts/test_hostinger_api_native_deploy.sh",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && bash -n scripts/hostinger_api_native_deploy.sh",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && bash -n scripts/test_hostinger_api_native_deploy.sh",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && bash -n scripts/verify_web_api_deploy.sh",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && sh -n deploy/kernel-router/entrypoint.sh",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && VERIFY_WEB_API_DEPLOY_SOURCE_ONLY=1 scripts/verify_web_api_deploy.sh http://127.0.0.1:9 http://127.0.0.1:9",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && python3 -m py_compile scripts/runtime_surface_report.py scripts/wellness_check.py",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && python3 scripts/runtime_surface_report.py --json",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && scripts/check_route_manifests.sh",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && python3 form/form-kernel-rust/production_routes_harness.py",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/native-front-door-flip-20260608 && git diff --check"
+    ],
+    "notes": "The Hostinger deploy transform test passed and proved provider environment preservation plus front-door flip composition: kernel-router service present, Dockerfile.kernel-router selected, ROUTES_FILE=/routes/production-routes.fk, STDLIB_DIR=/app/form/form-stdlib, UPSTREAM_URL=http://api:8000, api Traefik disabled, and coherence-api Traefik service port set to 8080. Runtime-surface JSON currently reports public /api/attention/kernel-runtime reachable as 404 with no X-Form-Router before deploy, so kernel_first_served_routes remains 0 by measurement, not by hard-coded assumption. Manifest name checks passed for production-routes.fk and shadow-routes.fk. The production-route harness passed: all 109 promoted-route checks matched the local CPython oracle, /api/attention/kernel-runtime returned 200 with X-Form-Router=native-kernel, /api/health fanned out with X-Form-Router=fanout-python, native p50 was 0.619ms, CPython p50 was 13.295ms, and native was 21.5x faster in that run. A local Docker image build was attempted but could not run because the Docker daemon socket was unavailable in this desktop session."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote CI is pending until this branch is pushed and a PR is opened."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Production flip is pending until this branch is merged and the Hostinger API Native Deploy workflow runs with VERIFY_REQUIRE_KERNEL_FRONT_DOOR=1."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "The Hostinger API native deployment composes kernel-router as the public coherence-api Traefik target, loads production-routes.fk with the stdlib available, and keeps CPython api private behind UPSTREAM_URL=http://api:8000 for fan-out routes.",
+    "public_endpoints": [
+      "/api/attention/kernel-runtime",
+      "/api/health",
+      "/api/gates/main-head"
+    ],
+    "test_flows": [
+      "scripts/test_hostinger_api_native_deploy.sh",
+      "scripts/verify_web_api_deploy.sh with VERIFY_REQUIRE_KERNEL_FRONT_DOOR=1",
+      "python3 form/form-kernel-rust/production_routes_harness.py"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Local deploy-transform, syntax, manifest, runtime-surface, and production-route harness proofs pass. CI, PR review, merge, Hostinger workflow deploy, and public X-Form-Router verification remain pending."
+  },
+  "idea_ids": [
+    "native-kernel-front-door",
+    "kernel-router-production-flip",
+    "form-bml-native-substrate-surfaces"
+  ],
+  "spec_ids": [
+    "native-route-goal-front-door",
+    "kernel-as-router"
+  ],
+  "task_ids": [
+    "kernel-front-door-flip-2026-06-08"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "review"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Dockerfile.kernel-router now bakes production-routes.fk and production-routes-data.json alongside shadow-routes.fk, so ROUTES_FILE can select production-native handlers without an external mount.",
+    "deploy/kernel-router/entrypoint.sh reports shadow vs production/native mode based on ROUTES_FILE rather than always announcing shadow mode.",
+    "deploy/kernel-router/docker-compose.kernel-router.yml now expresses the actual front-door overlay: api Traefik disabled, kernel-router Traefik enabled for Host(api.coherencycoin.com), production-routes.fk loaded, stdlib available, and api retained as private fan-out upstream.",
+    "scripts/hostinger_api_native_deploy.sh now generates a Docker Compose overlay, merges it with the Hostinger project payload using docker compose config --no-interpolate, and posts the single composed payload Hostinger expects.",
+    "scripts/verify_web_api_deploy.sh has VERIFY_REQUIRE_KERNEL_FRONT_DOOR=1, which curls /api/attention/kernel-runtime and requires X-Form-Router: native-kernel.",
+    ".github/workflows/hostinger-api-native-deploy.yml enables VERIFY_REQUIRE_KERNEL_FRONT_DOOR=1 for the Hostinger native deploy verification step.",
+    "scripts/runtime_surface_report.py no longer hard-codes kernel-first served routes as zero; it reads the public X-Form-Router probe and infers served count from the production manifest when the probe is native-kernel.",
+    "scripts/wellness_check.py now reports kernel-first served/capable runtime-share from runtime_surface_report instead of repeating the pre-flip assumption."
+  ],
+  "change_files": [
+    ".github/workflows/hostinger-api-native-deploy.yml",
+    "Dockerfile.kernel-router",
+    "deploy/kernel-router/docker-compose.kernel-router.yml",
+    "deploy/kernel-router/entrypoint.sh",
+    "scripts/hostinger_api_native_deploy.sh",
+    "scripts/runtime_surface_report.py",
+    "scripts/test_hostinger_api_native_deploy.sh",
+    "scripts/verify_web_api_deploy.sh",
+    "scripts/wellness_check.py"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/hostinger_api_native_deploy.sh
+++ b/scripts/hostinger_api_native_deploy.sh
@@ -22,6 +22,12 @@ need curl
 need jq
 need perl
 need gh
+need docker
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "docker compose is required" >&2
+  exit 2
+fi
 
 if [[ -z "${HOSTINGER_API_TOKEN:-}" ]]; then
   echo "HOSTINGER_API_TOKEN is required" >&2
@@ -47,6 +53,8 @@ trap 'rm -rf "$tmp_dir"' EXIT
 
 project_json="$tmp_dir/project.json"
 compose_in="$tmp_dir/docker-compose.yml"
+compose_rebased="$tmp_dir/docker-compose.rebased.yml"
+compose_overlay="$tmp_dir/docker-compose.kernel-front-door.yml"
 compose_out="$tmp_dir/docker-compose.api-native.yml"
 env_in="$tmp_dir/project.env"
 env_out="$tmp_dir/project.updated.env"
@@ -78,7 +86,58 @@ GIT_CONTEXT="$git_context" PULSE_CONTEXT="$pulse_context" perl -0pe '
   if ($_ !~ /DEPLOYED_SHA:\s*\$\{DEPLOYED_SHA\}/) {
     s{(NEXT_PUBLIC_API_URL:\s*\$\{NEXT_PUBLIC_API_URL\}\n)}{$1        DEPLOYED_SHA: \${DEPLOYED_SHA}\n};
   }
-' "$compose_in" > "$compose_out"
+' "$compose_in" > "$compose_rebased"
+
+cat > "$compose_overlay" <<YAML
+services:
+  api:
+    labels:
+      traefik.enable: "false"
+
+  kernel-router:
+    build:
+      context: ${git_context}
+      dockerfile: Dockerfile.kernel-router
+    image: coherence-network-kernel-router:\${DEPLOYED_SHA}
+    restart: unless-stopped
+    environment:
+      UPSTREAM_URL: http://api:8000
+      KERNEL_ROUTER_PORT: "8080"
+      ROUTES_FILE: /routes/production-routes.fk
+      STDLIB_DIR: /app/form/form-stdlib
+    depends_on:
+      - api
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.coherence-api.rule=Host(\`api.coherencycoin.com\`)"
+      - "traefik.http.routers.coherence-api.entrypoints=websecure"
+      - "traefik.http.routers.coherence-api.tls.certresolver=letsencrypt"
+      - "traefik.http.services.coherence-api.loadbalancer.server.port=8080"
+YAML
+
+docker compose \
+  --project-name "$PROJECT_NAME" \
+  -f "$compose_rebased" \
+  -f "$compose_overlay" \
+  config --no-interpolate \
+  > "$compose_out"
+
+if ! grep -q 'kernel-router:' "$compose_out"; then
+  echo "hostinger-api-native: kernel-router service missing after compose merge" >&2
+  exit 1
+fi
+if ! grep -q 'ROUTES_FILE: /routes/production-routes.fk' "$compose_out"; then
+  echo "hostinger-api-native: production routes manifest missing after compose merge" >&2
+  exit 1
+fi
+if ! grep -q 'traefik.enable=false' "$compose_out"; then
+  echo "hostinger-api-native: api service was not removed from public Traefik routing" >&2
+  exit 1
+fi
+if ! grep -q 'traefik.http.services.coherence-api.loadbalancer.server.port=8080' "$compose_out"; then
+  echo "hostinger-api-native: kernel-router Traefik service port missing after compose merge" >&2
+  exit 1
+fi
 
 awk -v sha="$TARGET_SHA" '
   BEGIN {
@@ -115,7 +174,7 @@ jq -n \
   '{project_name: $project_name, content: $content, environment: $environment}' \
   > "$request_json"
 
-echo "hostinger-api-native: deploying project=${PROJECT_NAME} vm=${VM_ID} target=${TARGET_SHA}"
+echo "hostinger-api-native: deploying project=${PROJECT_NAME} vm=${VM_ID} target=${TARGET_SHA} front-door=kernel-router"
 
 http_status="$(
   curl -sS -w '%{http_code}' \

--- a/scripts/runtime_surface_report.py
+++ b/scripts/runtime_surface_report.py
@@ -56,15 +56,13 @@ What is measured vs stated (the honesty bar)
     files; it is offered as evidence of the layering's weight, NOT as a precise
     "fraction of runtime" (wall-clock fraction depends on inputs and is dominated
     by FastAPI+Pydantic+network for any real request — stated, not faked).
-  • Kernel-FIRST has two honest readings, both exact. SERVED = 0: no route is
-    served by the kernel at the LIVE front door (Traefik routes every request to
-    CPython; the 22 kernel-served routes are CPython handlers calling the kernel
-    as a subroutine). CAPABLE = the count of native handlers in the kernel-router
-    manifest (deploy/kernel-router/production-routes.fk) — whole-lifecycle-Form
-    routes whose dispatch mechanism is proven but whose byte-identity to the live
-    twin is NOT yet proven (no harness, none in CI, e2e pending), awaiting that
-    identity proof and then the front-door flip. CAPABLE is the native surface that
-    EXISTS; SERVED is what fronts live traffic.
+  • Kernel-FIRST has two honest readings. CAPABLE = the count of native handlers
+    in the kernel-router manifest (deploy/kernel-router/production-routes.fk):
+    whole-lifecycle-Form routes whose production harness parity has landed.
+    SERVED = CAPABLE only when the live public provenance probe returns
+    X-Form-Router: native-kernel, meaning Traefik is reaching kernel-router as
+    the front door. If the probe is unread or missing that header, SERVED stays 0
+    and the probe record says why.
 
 This is a SENSING instrument — read-only, no behavior change, like the wellness
 probe and the attribution report. It tells the body the unflattering truth about
@@ -82,8 +80,11 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import re
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -118,6 +119,7 @@ _KERNEL_ROUTER_FILES = [
 # is the whole request lifecycle, a categorically deeper move than serve_via_kernel
 # (which keeps the lifecycle in CPython and calls the kernel as a guest subroutine).
 _KERNEL_ROUTER_MANIFEST = ROOT / "deploy" / "kernel-router" / "production-routes.fk"
+_DEFAULT_FRONT_DOOR_PROBE_PATH = "/api/attention/kernel-runtime"
 
 
 def kernel_first_capable_routes() -> list[str]:
@@ -125,14 +127,12 @@ def kernel_first_capable_routes() -> list[str]:
 
     These serve their ENTIRE request lifecycle in Form (X-Form-Router:
     native-kernel) — the categorical step past serve_via_kernel's guest
-    subroutine. They are CAPABLE: a real native handler exists in the manifest and
-    the dispatch mechanism is proven, but they are NOT yet proven byte-identical to
-    the live CPython twin (no harness diffs them, none in CI, e2e status:pending),
-    and NOT yet served at the live front door. The manifest is what the durable
-    runtime-share flip will front with, but until that flip Traefik still routes
-    every request to CPython. So this is the native surface that EXISTS, awaiting
-    its identity proof and then the front-door cutover — distinct from kernel-first
-    SERVED, which stays 0.
+    subroutine. They are CAPABLE: a real native handler exists in the manifest,
+    the dispatch mechanism is proven, and the production-route harness has proven
+    the promoted handlers value-identical to their local CPython oracle. They are
+    served at the live front door only after Traefik points to kernel-router.
+    So this is the native surface that EXISTS — distinct from kernel-first SERVED,
+    which is read from the public X-Form-Router probe.
 
     Read from the manifest's ``(let routes ...)`` block as DATA (the manifest is
     the one source); ``/health`` and other non-``/api`` probes are excluded so the
@@ -195,6 +195,62 @@ def _kernel_route_data_patterns(manifest: Path) -> dict[str, str]:
         if isinstance(pattern, str) and pattern.startswith("/api/"):
             out[route_id] = pattern
     return out
+
+
+def probe_kernel_front_door() -> dict:
+    """Read the public API front-door provenance header.
+
+    The manifest tells us which routes are kernel-first CAPABLE. The live public
+    header tells us whether Traefik is actually sending api.coherencycoin.com to
+    the kernel-router. When the probe route returns X-Form-Router: native-kernel,
+    served count is inferred from the manifest: the same router process owns the
+    manifest and will native-serve every listed handler while fanning out the tail.
+    If the probe is unreachable, the report marks the front door unread instead
+    of preserving the old pre-flip assumption as fact.
+    """
+    api = os.environ.get("COHERENCE_API_BASE", "https://api.coherencycoin.com").rstrip("/")
+    path = os.environ.get("KERNEL_FRONT_DOOR_PROBE_PATH", _DEFAULT_FRONT_DOOR_PROBE_PATH)
+    url = f"{api}{path}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Cache-Control": "no-cache",
+            "Pragma": "no-cache",
+            "User-Agent": "runtime-surface-report/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=4) as resp:
+            body = resp.read(256).decode("utf-8", errors="replace")
+            router = resp.headers.get("X-Form-Router", "")
+            return {
+                "url": url,
+                "reachable": True,
+                "status": resp.status,
+                "x_form_router": router,
+                "kernel_front_door": router == "native-kernel",
+                "body_preview": body,
+            }
+    except urllib.error.HTTPError as exc:
+        body = exc.read(256).decode("utf-8", errors="replace")
+        router = exc.headers.get("X-Form-Router", "")
+        return {
+            "url": url,
+            "reachable": True,
+            "status": exc.code,
+            "x_form_router": router,
+            "kernel_front_door": router == "native-kernel",
+            "body_preview": body,
+        }
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return {
+            "url": url,
+            "reachable": False,
+            "status": None,
+            "x_form_router": "",
+            "kernel_front_door": False,
+            "error": str(exc),
+        }
 
 
 def _load_attribution_module():
@@ -299,6 +355,13 @@ def build_report() -> dict:
 
     capable = kernel_first_capable_routes()
     n_capable = len(capable)
+    front_door = probe_kernel_front_door() if n_capable else {
+        "reachable": False,
+        "kernel_front_door": False,
+        "url": "",
+    }
+    front_door_native = bool(front_door.get("kernel_front_door"))
+    n_kernel_first_served = n_capable if front_door_native else 0
 
     usage_pct = (100.0 * n_served / total_routes) if total_routes else None
     loc_per_route = (cpy["total"] / n_served) if n_served else None
@@ -309,18 +372,17 @@ def build_report() -> dict:
         "kernel_served_routes": n_served,
         "kernel_served_pct": round(usage_pct, 1) if usage_pct is not None else None,
         # kernel-FIRST = the kernel as the FRONT DOOR (whole lifecycle in Form).
-        # Two honest sub-counts the journey needs kept apart:
-        #   SERVED  — served kernel-first at the LIVE front door. Still 0: Traefik
-        #             routes every request to CPython; the manifest is not yet the
-        #             front door (the durable flip is Urs's go + presence).
-        #   CAPABLE — native handlers proven byte-identical in shadow in the router
-        #             manifest, whole lifecycle in Form, awaiting the front-door
-        #             flip. This is the native surface that EXISTS today — the
-        #             runtime-share metric genuinely moving, not route-count.
-        "kernel_first_served_routes": 0,
+        # CAPABLE comes from the manifest. SERVED is inferred from the public
+        # X-Form-Router provenance header on one native probe route; if Traefik
+        # reaches kernel-router with the production manifest, the listed routes
+        # serve native and the tail fans out. If the probe is unread/not-native,
+        # served remains 0 and the probe record says why.
+        "kernel_first_served_routes": n_kernel_first_served,
         "kernel_first_capable_routes": n_capable,
         "kernel_first_capable_route_names": capable,
-        "kernel_first_routes": 0,  # back-compat alias of SERVED: 0 at the front door
+        "kernel_first_front_door_probe": front_door,
+        "kernel_first_served_inferred_from_probe": front_door_native,
+        "kernel_first_routes": n_kernel_first_served,  # back-compat alias of SERVED
         "served_route_names": served_routes,
         # --- Axis 2: the per-route CPython-vs-kernel layering ---
         "kernel_router_cpython_loc": cpy["total"],
@@ -368,6 +430,18 @@ def render_human(r: dict) -> str:
         f"  Served kernel-FIRST at the LIVE front door (kernel as the runtime, "
         f"whole lifecycle in Form): {r['kernel_first_served_routes']}."
     )
+    probe = r.get("kernel_first_front_door_probe") or {}
+    if probe:
+        if probe.get("reachable"):
+            w(
+                f"  Front-door probe: {probe.get('url')} -> status={probe.get('status')} "
+                f"X-Form-Router={probe.get('x_form_router') or '<missing>'}."
+            )
+        else:
+            w(
+                f"  Front-door probe unread: {probe.get('url') or '<unknown>'} "
+                f"({probe.get('error') or 'not reached'})."
+            )
     cap = r.get("kernel_first_capable_routes", 0)
     if cap:
         names = ", ".join(r.get("kernel_first_capable_route_names", []))
@@ -380,12 +454,10 @@ def render_human(r: dict) -> str:
         w("  This is the native surface that EXISTS today: the compute AND the")
         w("  request lifecycle run Form-native, no CPython in the path. It is the")
         w("  runtime-share metric genuinely moving, distinct from route-count.")
-        w("  PROVEN so far: the dispatch MECHANISM (a native route is served")
-        w("  kernel-first, unmatched paths fan out, X-Form-Router labels each).")
-        w("  NOT yet proven: that these 23 handlers are byte-identical to the live")
-        w("  CPython API — no harness diffs them against the twin, none runs in CI,")
-        w("  and the kernel-router e2e evidence is still status:pending. That")
-        w("  byte-identity proof is the cutover's gating step, not the front-door flip.")
+        w("  PROVEN so far: the dispatch mechanism, native/fan-out provenance,")
+        w("  production route name resolution, and production-route harness parity.")
+        w("  The remaining live question is no longer whether the capable surface")
+        w("  exists; it is whether the public front door is currently pointed at it.")
     w("  The 22 kernel-SERVED routes above are a different, shallower thing: each")
     w("  is a CPython handler that calls the kernel as a SUBROUTINE inside the")
     w("  request — the kernel is a guest there. The capable routes flip that: the")
@@ -451,19 +523,16 @@ def render_human(r: dict) -> str:
         if pct is not None
         else "  Still honestly low at the front door"
     )
-    w("  at all (as a guest-subroutine); 0 are SERVED kernel-first — Traefik still")
-    w("  routes every live request to CPython.")
+    w("  at all (as a guest-subroutine). Kernel-first served is read from the")
+    w("  public X-Form-Router probe and the production manifest, not hard-coded.")
     w("")
     if cap:
         w(f"  But the reversal is no longer hypothetical. {cap} routes are now")
         w("  kernel-FIRST CAPABLE: real native handlers in the router manifest, whole")
         w("  lifecycle in Form. The capable count moved 0 → {0}: the native front-door".format(cap))
-        w("  surface EXISTS. What remains before the cutover is TWO things, not one:")
-        w("  (1) prove these handlers byte-identical to the live API (no harness does")
-        w("  this yet, none in CI, e2e evidence status:pending) — the gating proof;")
-        w("  (2) the Traefik → kernel-router flip, a deliberate two-person live-traffic")
-        w("  moment. The surface exists and the mechanism is proven; the handler-")
-        w("  identity proof is the honest work still between here and a safe flip.")
+        w("  surface EXISTS and its harness proof has landed. The remaining live")
+        w("  movement is the Traefik → kernel-router route and the public verifier")
+        w("  that requires X-Form-Router: native-kernel on the probe route.")
     else:
         w("  The reversal (kernel-as-front-door) has no proven native surface yet.")
     w("")

--- a/scripts/test_hostinger_api_native_deploy.sh
+++ b/scripts/test_hostinger_api_native_deploy.sh
@@ -11,12 +11,42 @@ old_sha="5dad3d6f0d7f48495b9644fde0e8d26572962ae1"
 
 mkdir -p "$fixture_dir/bin"
 
-cat >"$fixture_dir/project.json" <<JSON
-{
-  "content": "services:\\n  api:\\n    build:\\n      context: /docker/coherence-network/repo\\n      dockerfile: /docker/coherence-network/Dockerfile.api\\n  web:\\n    build:\\n      context: /docker/coherence-network/repo\\n      dockerfile: /docker/coherence-network/Dockerfile.web\\n      args:\\n        NEXT_PUBLIC_API_URL: \${NEXT_PUBLIC_API_URL}\\n  pulse:\\n    build:\\n      context: /docker/coherence-network/repo/pulse\\n      dockerfile: Dockerfile\\n  discord-bot:\\n    build:\\n      context: /docker/coherence-network\\n      dockerfile: /docker/coherence-network/Dockerfile.discord\\n",
-  "environment": "POSTGRES_DB=coherence\\nPOSTGRES_PASSWORD=real-value-preserved\\nGIT_COMMIT_SHA=${old_sha}\\nDEPLOYED_SHA=${old_sha}\\n"
-}
-JSON
+compose_fixture="$fixture_dir/docker-compose.fixture.yml"
+cat >"$compose_fixture" <<'YAML'
+services:
+  api:
+    build:
+      context: /docker/coherence-network/repo
+      dockerfile: /docker/coherence-network/Dockerfile.api
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.coherence-api.rule=Host(`api.coherencycoin.com`)"
+      - "traefik.http.services.coherence-api.loadbalancer.server.port=8000"
+  web:
+    build:
+      context: /docker/coherence-network/repo
+      dockerfile: /docker/coherence-network/Dockerfile.web
+      args:
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+  pulse:
+    build:
+      context: /docker/coherence-network/repo/pulse
+      dockerfile: Dockerfile
+  discord-bot:
+    build:
+      context: /docker/coherence-network
+      dockerfile: /docker/coherence-network/Dockerfile.discord
+YAML
+
+jq -n \
+  --rawfile content "$compose_fixture" \
+  --arg environment "POSTGRES_DB=coherence
+POSTGRES_PASSWORD=real-value-preserved
+GIT_COMMIT_SHA=${old_sha}
+DEPLOYED_SHA=${old_sha}
+" \
+  '{content: $content, environment: $environment}' \
+  > "$fixture_dir/project.json"
 
 cat >"$fixture_dir/bin/gh" <<'SH'
 #!/usr/bin/env bash
@@ -105,6 +135,13 @@ if ! jq -e --arg sha "$target_sha" '
   and (.content | contains("dockerfile: Dockerfile.web"))
   and (.content | contains("dockerfile: discord-bot/Dockerfile"))
   and (.content | contains("DEPLOYED_SHA: ${DEPLOYED_SHA}"))
+  and (.content | contains("kernel-router:"))
+  and (.content | contains("dockerfile: Dockerfile.kernel-router"))
+  and (.content | contains("ROUTES_FILE: /routes/production-routes.fk"))
+  and (.content | contains("STDLIB_DIR: /app/form/form-stdlib"))
+  and (.content | contains("UPSTREAM_URL: http://api:8000"))
+  and (.content | contains("traefik.enable=false"))
+  and (.content | contains("traefik.http.services.coherence-api.loadbalancer.server.port=8080"))
   and (.environment | contains("POSTGRES_PASSWORD=real-value-preserved"))
   and (.environment | contains("GIT_COMMIT_SHA=" + $sha))
   and (.environment | contains("DEPLOYED_SHA=" + $sha))
@@ -113,4 +150,4 @@ if ! jq -e --arg sha "$target_sha" '
   exit 1
 fi
 
-echo "PASS: hostinger_api_native_deploy preserves provider env and targets git SHA contexts"
+echo "PASS: hostinger_api_native_deploy preserves provider env and flips api front door to kernel-router"

--- a/scripts/verify_web_api_deploy.sh
+++ b/scripts/verify_web_api_deploy.sh
@@ -28,6 +28,7 @@ VERIFY_REQUIRE_TELEGRAM_ALERTS="${VERIFY_REQUIRE_TELEGRAM_ALERTS:-0}"
 VERIFY_REQUIRE_PROVIDER_READINESS="${VERIFY_REQUIRE_PROVIDER_READINESS:-0}"
 VERIFY_REQUIRE_API_HEALTH_SHA="${VERIFY_REQUIRE_API_HEALTH_SHA:-0}"
 VERIFY_REQUIRE_WEB_HEALTH_PROXY_SHA="${VERIFY_REQUIRE_WEB_HEALTH_PROXY_SHA:-0}"
+VERIFY_REQUIRE_KERNEL_FRONT_DOOR="${VERIFY_REQUIRE_KERNEL_FRONT_DOOR:-0}"
 PULSE_RECHECK_SECONDS="${PULSE_RECHECK_SECONDS:-30}"
 
 run_with_retries() {
@@ -433,6 +434,43 @@ check_cors() {
 
   echo "FAIL: CORS origin is not allowed or health endpoint failed"
   return 1
+}
+
+check_kernel_front_door() {
+  local probe_url="${API_URL%/}/api/attention/kernel-runtime"
+  local headers_file="$TMP_DIR/kernel_front_door.headers.txt"
+  local body_file="$TMP_DIR/kernel_front_door.body.json"
+
+  echo
+  echo "==> Kernel front-door check: ${probe_url}"
+
+  local status
+  status="$(run_with_retries_capture "$CURL_RETRIES" "$CURL_RETRY_SLEEP_SECONDS" curl -sS -L -D "$headers_file" -o "$body_file" -w "%{http_code}" \
+    --max-time "$CURL_MAX_TIME" \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+    -H "Cache-Control: no-cache" \
+    "$probe_url" || true)"
+  local router_header
+  router_header="$(awk 'tolower($1) == "x-form-router:" { print $2 }' "$headers_file" | tail -n 1 | tr -d '\r')"
+  echo "HTTP status: ${status:-unknown}"
+  echo "X-Form-Router: ${router_header:-<missing>}"
+
+  if [[ -z "$status" || "$status" -lt 200 || "$status" -ge 400 ]]; then
+    echo "FAIL: native front-door probe endpoint unavailable"
+    head -c 300 "$body_file" || true
+    echo
+    return 1
+  fi
+
+  if [[ "$router_header" != "native-kernel" ]]; then
+    echo "FAIL: public API is not served by the kernel-router front door"
+    head -c 300 "$body_file" || true
+    echo
+    return 1
+  fi
+
+  echo "PASS"
+  return 0
 }
 
 check_persistence_contract() {
@@ -864,6 +902,12 @@ check_api_runtime_sha \
   "${API_URL%/}/api/health" \
   "${API_URL%/}/api/gates/main-head" \
   "$VERIFY_REQUIRE_API_HEALTH_SHA" || fail=1
+if [[ "$VERIFY_REQUIRE_KERNEL_FRONT_DOOR" == "1" ]]; then
+  check_kernel_front_door || fail=1
+else
+  echo
+  echo "==> Skipping kernel front-door gate (VERIFY_REQUIRE_KERNEL_FRONT_DOOR=0)"
+fi
 if [[ "$VERIFY_REQUIRE_PERSISTENCE_CHECK" == "1" ]]; then
   check_persistence_contract "${API_URL%/}/api/health/persistence" || fail=1
 else

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -1642,24 +1642,42 @@ def sense_kernel_api() -> list[str]:
         # WHOLE lifecycle in Form, proven byte-identical in shadow — the CAPABLE
         # surface, read from the one source (runtime_surface_report, no duplicated
         # parse). Track runtime-share, not route-count.
+        runtime_surface = None
         n_capable = None
+        n_kernel_first = None
         rsr_path = ROOT / "scripts" / "runtime_surface_report.py"
         if rsr_path.is_file():
             try:
                 _spec = importlib.util.spec_from_file_location("runtime_surface_report", rsr_path)
                 _rsr = importlib.util.module_from_spec(_spec)  # type: ignore[arg-type]
                 _spec.loader.exec_module(_rsr)  # type: ignore[union-attr]
-                n_capable = len(_rsr.kernel_first_capable_routes())
+                runtime_surface = _rsr.build_report()
+                n_capable = runtime_surface.get("kernel_first_capable_routes")
+                n_kernel_first = runtime_surface.get("kernel_first_served_routes")
             except Exception:
                 n_capable = None
         if n_capable:
-            lines.append(
-                f"  vitality: runtime-share — 0 routes served kernel-FIRST at the front "
-                f"door (those {n_served} run the kernel as a guest-subroutine inside "
-                f"CPython), but {n_capable} are kernel-first CAPABLE: native handlers "
-                "proven byte-identical in shadow, whole lifecycle in Form, awaiting the "
-                "front-door flip (scripts/runtime_surface_report.py)"
-            )
+            probe = (runtime_surface or {}).get("kernel_first_front_door_probe") or {}
+            router = probe.get("x_form_router") or "<missing>"
+            if n_kernel_first:
+                lines.append(
+                    f"  vitality: runtime-share — {n_kernel_first} routes served "
+                    f"kernel-FIRST at the live front door, inferred from "
+                    f"X-Form-Router={router}; {n_capable} routes are capable in the "
+                    "production manifest (scripts/runtime_surface_report.py)"
+                )
+            elif probe.get("reachable"):
+                lines.append(
+                    f"  vitality: runtime-share — 0 routes served kernel-FIRST at the "
+                    f"front door (probe X-Form-Router={router}); {n_capable} are "
+                    "kernel-first CAPABLE and proven in the production-route harness"
+                )
+            else:
+                lines.append(
+                    f"  vitality: runtime-share — live front-door unread; {n_capable} "
+                    "routes are kernel-first CAPABLE and proven in the production-route "
+                    "harness (scripts/runtime_surface_report.py)"
+                )
         else:
             lines.append(
                 "  vitality: runtime-share — those routes run the kernel as a "


### PR DESCRIPTION
## Summary
- bake production-routes.fk and production-routes-data.json into the kernel-router image
- make the Hostinger native deploy compose kernel-router as the public coherence-api Traefik target while keeping api as the private fan-out upstream
- add a public deploy verifier gate that requires X-Form-Router: native-kernel on /api/attention/kernel-runtime
- update runtime-surface and wellness sensing so kernel-first served is read from the public provenance probe instead of hard-coded to 0

## Proof
- make prompt-guide
- make wellness
- scripts/test_hostinger_api_native_deploy.sh
- bash -n scripts/hostinger_api_native_deploy.sh
- bash -n scripts/test_hostinger_api_native_deploy.sh
- bash -n scripts/verify_web_api_deploy.sh
- sh -n deploy/kernel-router/entrypoint.sh
- VERIFY_WEB_API_DEPLOY_SOURCE_ONLY=1 scripts/verify_web_api_deploy.sh http://127.0.0.1:9 http://127.0.0.1:9
- python3 -m py_compile scripts/runtime_surface_report.py scripts/wellness_check.py
- python3 scripts/runtime_surface_report.py --json
- scripts/check_route_manifests.sh
- python3 form/form-kernel-rust/production_routes_harness.py
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-08_kernel_front_door_flip.json --base origin/main --head HEAD
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict

## Notes
- local Docker image build was attempted, but the Docker daemon socket was unavailable in this desktop session; the compose transform, manifest checks, and production-route harness passed.
- before deploy, the public runtime-surface probe reads /api/attention/kernel-runtime as 404 with no X-Form-Router, so kernel_first_served_routes remains 0 by measured provenance until the Hostinger workflow flips traffic.