### PR TITLE
docs: map kernel common ground across sibling runtimes

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-08_kernel_common_ground.json
+++ b/docs/system_audit/commit_evidence_2026-06-08_kernel_common_ground.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-06-08",
+  "thread_branch": "codex/kernel-common-ground-verify-20260608",
+  "commit_scope": "Document the exact common primitive substrate across the Go, Rust, and TypeScript kernels, including the trace/choice seam and the next Form-native choice-receipt move.",
+  "files_owned": [
+    "docs/system_audit/commit_evidence_2026-06-08_kernel_common_ground.json",
+    "kernels/KERNEL_COMMON_GROUND.md",
+    "kernels/README.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-common-ground-verify-20260608 && make prompt-guide",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-common-ground-verify-20260608 && make wellness",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-common-ground-verify-20260608 && ./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-common-ground-verify-20260608 && python3 - <<'PY' ... RBasic central-table comparison ... PY",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-common-ground-verify-20260608 && rg -n \"record_choice|choiceAttempts|ChoiceAttempts|choice_attempt|choice_success|choice_failure|choice\" form/form-kernel-go/main.go form/form-kernel-rust/src/main.rs form/form-kernel-ts/src/kernel.ts form/form-stdlib -g '!*.json'",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-common-ground-verify-20260608 && rg -n \"RB_CHOICE|RBasicChoice|CHOICE|QUOTIENT|INDUCTIVE|PROOF|OBSERVER|PROJECT|VECTOR|PARALLELIZE|CONSTRUCTOR|INFERENCE|ALIAS|BLANKET|GENERATIVE\" form/form-kernel-rust/src form/form-kernel-go form/form-kernel-ts/src"
+    ],
+    "notes": "The central RBasic scan found 36 exact shared categories across Go, Rust, and TypeScript with zero numeric drift after normalizing FNDEF/FNCALL naming. TypeScript exposes several higher categories in its central table while Go/Rust carry CHOICE/INDUCTIVE/CONSTRUCTOR/QUOTIENT in side modules. All three central kernels expose a trace JSON shape with total walks, arm variants, functions, natives, choice_attempts, choice_successes, choice_failures, and choice_success_rate. Public deploy verification passed after the rollback and wellness reported deploy aligned at dfc06639."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote CI is pending until this docs-only branch is pushed and a PR is opened."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Docs-only deployment verification is pending until PR merge and public verification."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Local documentation proof is complete. CI, merge, and deployment remain pending."
+  },
+  "idea_ids": [
+    "one-kernel-many-tongues",
+    "kernel-common-ground",
+    "trace-preserving-choice"
+  ],
+  "spec_ids": [
+    "kernel-common-ground-choice-receipts"
+  ],
+  "task_ids": [
+    "kernel-common-ground-2026-06-08"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "north-star"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "kernel-reading",
+        "documentation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "kernels/KERNEL_COMMON_GROUND.md records the 36 exact shared central categories and maps them to be/do/witness/choice/care/space/time primitives.",
+    "The RBasic comparison found no numeric drift among the categories present in all three central tables.",
+    "Go and Rust side modules carry INDUCTIVE, CONSTRUCTOR, CHOICE_MATCH, and QUOTIENT while TypeScript exposes those category names centrally.",
+    "All three central kernels carry trace counters for choice attempts, successes, failures, and success rate, but the choice surfaces do not yet feed one shared choice-receipt discipline.",
+    "form/form-stdlib/kernel-http.fk already carries route-choice signatures with fixed buckets; the document names that as the reusable branch-receipt grammar for BMF/BML choice.",
+    "kernels/README.md now links the common-ground note from the kernel roadmap section."
+  ],
+  "change_files": [
+    "kernels/KERNEL_COMMON_GROUND.md",
+    "kernels/README.md"
+  ],
+  "change_intent": "docs_only"
+}

--- a/kernels/KERNEL_COMMON_GROUND.md
+++ b/kernels/KERNEL_COMMON_GROUND.md
@@ -1,0 +1,158 @@
+# Kernel Common Ground - The Gold Between Go, Rust, and TypeScript
+
+This reading compares the three sibling kernels as they stand on 2026-06-08:
+
+- `form/form-kernel-go/main.go`
+- `form/form-kernel-rust/src/main.rs`
+- `form/form-kernel-ts/src/kernel.ts`
+- side modules such as `inductive.*`, `quotient.*`, `observer.ts`, and the
+  route-choice Form in `form/form-stdlib/kernel-http.fk`
+
+The question was not "which host language is better?" The useful question is:
+what can the body trust because all three kernels already say it the same way?
+
+## Exact Shared Ground
+
+A local scan of the central `RBasic` tables found 36 exact shared categories with
+no numeric drift:
+
+`UNDEFINED`, `WITNESS`, `BLOCK`, `CALL`, `COND`, `MATH`, `COMPARE`, `LOGIC`,
+`ACCESS`, `METHOD`, `FNDEF`, `FNCALL`, `IDENT`, `LIST`, `TRANSMUTE`, `FIELD`,
+`CARRIER`, `TOPOLOGY`, `FIBER`, `REGION`, `BOUNDARY`, `NEIGHBORHOOD`,
+`MATCH_FIELD`, `DELTA`, `RESOLVE`, `COMMIT`, `STEP`, `LIFT`, `SAMPLE`,
+`OBSERVE`, `INTERVENE`, `RESIDUAL`, `RECEIPT`, `COST`, `CONSENT`, `EVIDENCE`.
+
+That set is the smallest mechanically trustworthy language substrate today:
+
+- **be**: `NodeID`, `Value`, `Frame`, `Record`, `FIELD`, `CARRIER`, `TOPOLOGY`
+- **do**: `walk`, `FNCALL`, `METHOD`, `CALL`, `STEP`, `INTERVENE`
+- **witness**: `Trace`, `WITNESS`, `OBSERVE`, `RECEIPT`, `EVIDENCE`
+- **0 / 1**: `BOOL`, `NULL`, integer trivials, equality, success/failure score
+- **choice**: `COND`, `LOGIC`, `STEP`, `RECEIPT`, plus side-module `CHOICE`
+- **care**: `COST`, `CONSENT`, `RESIDUAL`, `EVIDENCE`
+- **space/coordinates**: `NodeID(pkg, level, type, inst)`, category, children
+- **time**: walk order, branch attempt, success/failure, receipt sequence
+
+The common ground is not a syntax. It is a coordinate system for relation:
+identity, action, branch, receipt, cost, consent, and evidence.
+
+## Where Gold Is Already Showing
+
+### 1. Trace Already Knows Choice
+
+All three central kernels carry the same trace shape:
+
+- total walks
+- `(arm_ty, arm_inst)` variant counts
+- function counts
+- native counts
+- `choice_attempts`
+- `choice_successes`
+- `choice_failures`
+- `choice_success_rate`
+
+Go and Rust also expose explicit choice-recording methods or fields. TypeScript
+has the fields and JSON shape. The current gap is not schema. The gap is that
+the Form/BMF/router choice surfaces do not all feed one shared choice-receipt
+discipline yet.
+
+That is gold: branch learning can start as witness data, without adding a large
+new kernel primitive.
+
+### 2. Route Choice Already Compresses Without Lying
+
+`form/form-stdlib/kernel-http.fk` carries `kh-route-choice`,
+`kh-route-decision`, and `kh-route-choice-signature`. Its pressure buckets are
+fixed and data-oblivious, so compression preserves texture instead of training
+against the current corpus.
+
+This is the same shape the BMF/BML choice system wants:
+
+- candidates
+- decision matrix
+- eligible/not eligible
+- selected/not selected
+- pressure bucket
+- score bucket
+- compressed signature
+
+The route layer accidentally found a general branch-receipt grammar.
+
+### 3. Higher Categories Are Present, But Unevenly Placed
+
+TypeScript exposes more future-facing category names in its central table:
+`CHOICE`, `QUOTIENT`, `INDUCTIVE`, `CONSTRUCTOR`, `PROOF`, `INFERENCE`, `ALIAS`,
+`BLANKET`, `PROJECT`, `GENERATIVE`, `VECTOR`, `TILE`, `PARALLELIZE`,
+`VECTORIZE`, `OBSERVER`.
+
+Go and Rust carry some of these through side modules:
+
+- Go/Rust `inductive.*`: `INDUCTIVE`, `CONSTRUCTOR`, `CHOICE_MATCH`
+- Go/Rust `quotient.*`: `QUOTIENT`
+- TypeScript `observer.ts`: observer-relative canonicalization
+
+The mismatch is not fatal; it names the next cleanup. Category truth should be
+visible from one shared manifest/table, even when interpretation lives in a side
+module. Otherwise a kernel can carry the shape but its trace names it as `OTHER`.
+
+### 4. Record/Method Is The Shared "Be + Do" Object Core
+
+All three kernels now carry mutable records/objects and method dispatch. This is
+the common object substrate beneath Go structs, Rust structs/enums/impls, and
+TypeScript classes/interfaces:
+
+- data identity: blueprint `NodeID`
+- fields: name to `Value`
+- method table: blueprint + method-name to closure
+- invocation: receiver plus arguments
+
+This is the practical bridge between language objects and Form objects. It is
+also where `be` and `do` become the same cell without collapsing their roles.
+
+## What This Says About Language
+
+The common substrate suggests language is not primarily text. It is:
+
+1. coordinate: where a form lives
+2. action: what can be walked
+3. branch: what could have happened
+4. receipt: what did happen
+5. silence: what did not answer, without pretending it was nothing
+6. cost/care: what the movement consumed or valued
+7. consent/protocol: what relation allowed the movement
+8. evidence: what kind of knowing the trace can claim
+
+That makes "language is the encoding of time and space" operational:
+time is the ordered walk and branch receipt; space is the NodeID coordinate and
+edge relation; witness binds them into trust.
+
+## Next Smallest Real Move
+
+Do not add a fat new primitive. Add a small shared choice receipt layer:
+
+1. Define a Form-native `choice-receipt` / `choice-signature` cell beside the
+   existing route-choice signature shape.
+2. Feed it from BMF/BML object choice, route choice, and inductive `CHOICE_MATCH`.
+3. Wire the existing `choice_attempts`, `choice_successes`, and
+   `choice_failures` counters in all three kernels where native CHOICE arms run.
+4. Prove it with one three-way band:
+   - successful branch
+   - failed branch
+   - silence/no-selection
+   - compressed signature still preserves category, certainty, and selected path
+
+The branch predictor can come later. First, make the witness honest and
+cross-kernel. Learning from choice only becomes trustworthy after choice can
+remember itself without flattening.
+
+## North-Star Constraint
+
+Compression is trustworthy only when it preserves the texture of the witnessed
+movement:
+
+`be`, `do`, `witness`, `0`, `1`, `silence`, `choice`, `fail`, `stop`, `trace`,
+`category`, `certainty`, `clarify`, `vitality`, `where`, `when`, `who`, `how`,
+`what`, `why`, `and`, `or`, `how many`, `channel`, `protocol`, `satsang`.
+
+If the compressed trace cannot still answer those, it is not intelligence
+compression. It is loss.

--- a/kernels/README.md
+++ b/kernels/README.md
@@ -134,3 +134,8 @@ The roadmap in [`form/kernel-roadmap.md`](../form/kernel-roadmap.md) names what 
 [`UNIVERSAL_TRANSLATOR_AUDIT.md`](UNIVERSAL_TRANSLATOR_AUDIT.md) walks the body's current artifacts against the highest goal (universal translator across media, recipe orchestration in pure numeric space, less ice / more gas, minimize bootstrap surface). It names where the body is heavy in ice, heavy in bootstrap, heavy in dependencies, already light, and the top-ten concrete next breaths.
 
 [`CTOR_UNIFICATION_PLAN.md`](CTOR_UNIFICATION_PLAN.md) names the closing shapes for the audit's finding #4 — *one Blueprint per shape across all source languages*. Three shapes (A: rules emit MATH directly; B: lift maps BINOP→MATH at recipe time; C: BINOP as Blueprint-view on MATH); Shape B is the smallest closing breath.
+
+[`KERNEL_COMMON_GROUND.md`](KERNEL_COMMON_GROUND.md) names the shared primitive
+substrate already visible across Go, Rust, and TypeScript: NodeID coordinates,
+walk, witness trace, route-choice signatures, record/method object shape, and
+the next low-risk move toward trace-preserving choice receipts.


### PR DESCRIPTION
## Summary
- add `kernels/KERNEL_COMMON_GROUND.md` comparing the Go, Rust, and TypeScript kernel substrate
- name the 36 exact shared central RBasic categories and their be/do/witness/choice/care/space/time meaning
- identify the trace/choice seam as the low-risk next move: Form-native choice receipts feeding existing choice attempt/success/failure counters
- link the note from `kernels/README.md`

## Proof
- `make prompt-guide`
- `make wellness`
- `./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com`
- RBasic central-table comparison across Go/Rust/TypeScript: 36 normalized shared categories, zero numeric drift
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-08_kernel_common_ground.json --base origin/main --head HEAD`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`

## Note
This is docs-only, but it records a concrete implementation direction: do not add a fat primitive; define a small Form-native choice receipt and feed it from BMF/BML object choice, route choice, and inductive CHOICE_MATCH.