### PR TITLE
Kernel-router front-door local preflight

### DIFF
--- a/Dockerfile.kernel-router
+++ b/Dockerfile.kernel-router
@@ -17,8 +17,9 @@
 #      (the SAME load-bearing build Dockerfile.api runs; no PyO3 wheel needed here
 #      because this image serves, it is not imported by Python).
 #   2. runtime — a lean debian-slim with ONLY the stripped binary, the form-stdlib
-#      (so a BML-authored manifest can be source-compiled at load via --stdlib),
-#      and the shadow routes manifest. No Rust toolchain in the final image.
+#      (so a source-authored manifest can be source-compiled at load via
+#      --stdlib), and the shadow + production routes manifests. No Rust
+#      toolchain in the final image.
 #
 # SHADOW MODE BY DEFAULT: the baked manifest (deploy/kernel-router/shadow-routes.fk)
 # binds an EMPTY routes list, so EVERY request fans out to ${UPSTREAM_URL}
@@ -26,6 +27,11 @@
 # with the X-Form-Router: fanout-python header as live evidence the router carries
 # the traffic. Promoting a route to native = adding a (path handler) line to the
 # manifest; nothing else in the topology changes.
+#
+# The production manifest is baked beside it at /routes/production-routes.fk,
+# with route metadata at /routes/production-routes-data.json. Switching to it is
+# runtime configuration (`ROUTES_FILE=/routes/production-routes.fk`), not a
+# different image.
 #
 # THIS IMAGE DOES NOT FLIP PRODUCTION. Building and even running this container
 # changes nothing about what fronts api.coherencycoin.com — that is a Traefik
@@ -67,7 +73,8 @@ LABEL org.opencontainers.image.source="https://github.com/seeker71/Coherence-Net
 ENV DEBIAN_FRONTEND=noninteractive \
     KERNEL_ROUTER_PORT=8080 \
     UPSTREAM_URL=http://api:8000 \
-    ROUTES_FILE=/routes/shadow-routes.fk
+    ROUTES_FILE=/routes/shadow-routes.fk \
+    STDLIB_DIR=/app/form/form-stdlib
 
 # Minimal runtime deps: ca-certificates for TLS-capable upstreams, curl only for
 # the healthcheck. The kernel binary is statically-linked-enough Rust; no Python,
@@ -92,10 +99,12 @@ RUN chmod +x /app/bin/form-kernel-rust \
 # stdlib in lets a BML manifest work later without rebuilding the image.
 COPY form/form-stdlib/ /app/form/form-stdlib/
 
-# The shadow routes manifest: an EMPTY routes list -> every path fans out to the
-# upstream. This is the deployable shadow-mode default; mount/replace
-# /routes/shadow-routes.fk to promote native routes.
+# The route manifests: shadow is the deployable default; production carries the
+# current native route surface and its route metadata so promotion is a runtime
+# choice, not a rebuild-time surprise.
 COPY deploy/kernel-router/shadow-routes.fk /routes/shadow-routes.fk
+COPY deploy/kernel-router/production-routes.fk /routes/production-routes.fk
+COPY deploy/kernel-router/production-routes-data.json /routes/production-routes-data.json
 
 # The entrypoint resolves env at RUN time so PORT / UPSTREAM_URL / ROUTES_FILE
 # are container-configurable (compose env, -e flags) without rebuilding.

--- a/deploy/kernel-router/entrypoint.sh
+++ b/deploy/kernel-router/entrypoint.sh
@@ -44,5 +44,11 @@ if [ -n "${KERNEL_ROUTER_WORKERS:-}" ]; then
   set -- "$@" --workers "$KERNEL_ROUTER_WORKERS"
 fi
 
-echo "kernel-router: serve --host $HOST --port $PORT --routes $ROUTES --upstream $UPSTREAM (shadow mode: empty routes -> all fan-out)"
+MODE="selected routes manifest"
+case "$ROUTES" in
+  */shadow-routes.fk) MODE="shadow mode: empty routes -> all fan-out" ;;
+  */production-routes.fk) MODE="production route manifest: native routes + fan-out tail" ;;
+esac
+
+echo "kernel-router: serve --host $HOST --port $PORT --routes $ROUTES --upstream $UPSTREAM ($MODE)"
 exec /app/bin/form-kernel-rust "$@"

--- a/deploy/kernel-router/production-routes.fk
+++ b/deploy/kernel-router/production-routes.fk
@@ -1378,24 +1378,19 @@
     "]"))
 
 (defn route_attention_measurements_json
-  (native_route_count observed_native_route_count observed_path_count total_requests native_requests fanout_requests fanout_path_counts)
-  (str_concat
-    (str_concat
-      (str_concat
-        (str_concat
-          (str_concat "{\"native_route_count\":" (value_str native_route_count))
-          (str_concat ",\"observed_native_route_count\":"
-                      (value_str observed_native_route_count)))
-        (str_concat ",\"observed_path_count\":"
-                    (value_str observed_path_count)))
-      (str_concat ",\"total_requests\":" (value_str total_requests)))
-    (str_concat
-      (str_concat
-        (str_concat ",\"native_requests\":" (value_str native_requests))
-        (str_concat ",\"fanout_requests\":" (value_str fanout_requests)))
-      (str_concat
-        ",\"fanout_path_counts\":"
-        (str_concat (route_attention_fanout_path_counts_json fanout_path_counts) "}")))))
+  (native_route_count observed_native_route_count observed_path_count total_requests native_requests fanout_requests choice_attempts choice_successes choice_failures fanout_path_counts)
+  (str_concat_all (list
+    "{\"native_route_count\":" (value_str native_route_count)
+    ",\"observed_native_route_count\":" (value_str observed_native_route_count)
+    ",\"observed_path_count\":" (value_str observed_path_count)
+    ",\"total_requests\":" (value_str total_requests)
+    ",\"native_requests\":" (value_str native_requests)
+    ",\"fanout_requests\":" (value_str fanout_requests)
+    ",\"choice_attempts\":" (value_str choice_attempts)
+    ",\"choice_successes\":" (value_str choice_successes)
+    ",\"choice_failures\":" (value_str choice_failures)
+    ",\"fanout_path_counts\":" (route_attention_fanout_path_counts_json fanout_path_counts)
+    "}")))
 
 (defn route_attention_matrix_json
   (native_coverage fanout_pressure unobserved_native_pressure native_pressure)
@@ -1434,6 +1429,12 @@
         (str_to_int (assoc "__router_native_requests__" q)))
   (do (let fanout_requests
         (str_to_int (assoc "__router_fanout_requests__" q)))
+  (do (let choice_attempts
+        (str_to_int (assoc "__router_choice_attempts__" q)))
+  (do (let choice_successes
+        (str_to_int (assoc "__router_choice_successes__" q)))
+  (do (let choice_failures
+        (str_to_int (assoc "__router_choice_failures__" q)))
   (do (let router_observation
         (assoc "__router_observation__" q))
   (do (let fanout_path_counts
@@ -1466,6 +1467,9 @@
                         total_requests
                         native_requests
                         fanout_requests
+                        choice_attempts
+                        choice_successes
+                        choice_failures
                         fanout_path_counts))
           (str_concat
             ",\"matrix\":"
@@ -1482,7 +1486,7 @@
               candidate_requests
               candidate_source
               candidate_pressure)
-            "}")))))))))))))))))))))
+            "}"))))))))))))))))))))))))
 
 ; ===========================================================================
 ; Source-language route class surface lowered to KernelHTTPRoute.

--- a/docs/system_audit/commit_evidence_2026-06-09_kernel_front_door_local_preflight.json
+++ b/docs/system_audit/commit_evidence_2026-06-09_kernel_front_door_local_preflight.json
@@ -1,0 +1,107 @@
+{
+  "date": "2026-06-09",
+  "thread_branch": "codex/kernel-front-door-safety-20260608",
+  "commit_scope": "Make the kernel-router front-door path locally provable before another production flip by wiring route-choice/fanout metrics into the native runtime, baking production route assets into the router image, and adding a local curl preflight.",
+  "files_owned": [
+    "Dockerfile.kernel-router",
+    "deploy/kernel-router/entrypoint.sh",
+    "deploy/kernel-router/production-routes.fk",
+    "docs/system_audit/commit_evidence_2026-06-09_kernel_front_door_local_preflight.json",
+    "form/form-kernel-rust/src/formats.rs",
+    "form/form-kernel-rust/src/main.rs",
+    "kernels/KERNEL_AS_ROUTER.md",
+    "scripts/kernel_front_door_local_preflight.sh"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-front-door-safety-20260608 && make prompt-guide",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-front-door-safety-20260608 && make wellness",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-front-door-safety-20260608/form/form-kernel-rust && cargo build --release --bin form-kernel-rust",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-front-door-safety-20260608 && scripts/check_route_manifests.sh",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-front-door-safety-20260608 && scripts/kernel_front_door_local_preflight.sh",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-front-door-safety-20260608/form/form-kernel-rust && cargo test --release",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-front-door-safety-20260608 && bash -n scripts/kernel_front_door_local_preflight.sh deploy/kernel-router/entrypoint.sh",
+      "cd /Users/ursmuff/.claude-worktrees/Coherence-Network/kernel-front-door-safety-20260608 && git diff --check"
+    ],
+    "notes": "Release kernel build is warning-clean. Route manifest name-check passed for production-routes.fk and shadow-routes.fk. Local front-door preflight booted the real local FastAPI app and kernel-router, proved fan-out exactness for /api/version and /api/health, proved native value-contract for /api/utils/coherence_weight, and proved /api/attention/kernel-runtime reports total_requests=4, native_requests=1, fanout_requests=3, choice_attempts=120, choice_successes=2, choice_failures=118. Rust release tests passed: 46 tests."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote CI is pending until this branch is pushed and a PR is opened."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "No production flip or deploy has been performed from this change. Public front door remains FastAPI until a separate remote shadow and Traefik re-point pass the documented gate."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Local proof is complete. CI, PR review, and any production remote-shadow/flip proof remain pending."
+  },
+  "idea_ids": [
+    "native-kernel-front-door",
+    "kernel-router-shadow-first",
+    "form-native-observability"
+  ],
+  "spec_ids": [
+    "kernel-router-front-door-local-preflight",
+    "native-http-route-choice-observability"
+  ],
+  "task_ids": [
+    "kernel-front-door-safety-2026-06-08"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "proof-demand",
+        "warning-attention"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "cargo build --release --bin form-kernel-rust finished with no warnings after route-choice metrics were connected and stale/test-only release surfaces were removed or cfg-gated.",
+    "scripts/check_route_manifests.sh passed: production-routes.fk and shadow-routes.fk both resolve.",
+    "scripts/kernel_front_door_local_preflight.sh passed: image-packaging check passed, fan-out exactness passed for /api/version and /api/health, native value-contract passed for /api/utils/coherence_weight, and native attention metrics moved.",
+    "cargo test --release passed: 46 Rust kernel tests.",
+    "KERNEL_AS_ROUTER.md now records the 2026-06-08 Traefik 404 lesson: start and prove kernel-router before disabling the api router."
+  ],
+  "change_files": [
+    "Dockerfile.kernel-router",
+    "deploy/kernel-router/entrypoint.sh",
+    "deploy/kernel-router/production-routes.fk",
+    "form/form-kernel-rust/src/formats.rs",
+    "form/form-kernel-rust/src/main.rs",
+    "kernels/KERNEL_AS_ROUTER.md",
+    "scripts/kernel_front_door_local_preflight.sh"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "A local kernel-router front-door rehearsal now proves native and fan-out routing plus aggregate route-choice metrics before a production flip; the fan-out streaming arm also increments fanout/total route metrics.",
+    "public_endpoints": [
+      "local http://127.0.0.1:18181/api/version",
+      "local http://127.0.0.1:18181/api/health",
+      "local http://127.0.0.1:18181/api/utils/coherence_weight?values=10,20,30&threshold=15",
+      "local http://127.0.0.1:18181/api/attention/kernel-runtime"
+    ],
+    "test_flows": [
+      "scripts/kernel_front_door_local_preflight.sh"
+    ]
+  }
+}

--- a/form/form-kernel-rust/src/formats.rs
+++ b/form/form-kernel-rust/src/formats.rs
@@ -150,6 +150,7 @@ pub enum ArithOpCode {
 }
 
 impl ArithOpCode {
+    #[cfg(test)]
     pub fn from_str(s: &str) -> Option<Self> {
         Some(match s {
             "add" => ArithOpCode::Add,
@@ -178,18 +179,12 @@ pub const RBASIC_NUMERIC: u32 = 51;
 pub struct FormatRecipe {
     pub node_id: NodeID,
     pub name: String,
-    pub semantic_kind: u32,
-    pub encoding: u32,
     pub bits: u32,
+    #[cfg(test)]
     pub storage_hint: String,
+    #[cfg(test)]
     pub arithmetic_hint: String,
     pub arith_hint_code: u32,
-    pub mantissa_bits: Option<u32>,
-    pub exponent_bits: Option<u32>,
-    pub exponent_bias: Option<u32>,
-    pub posit_n: Option<u32>,
-    pub posit_es: Option<u32>,
-    pub lookup_values: Option<Vec<f64>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -351,18 +346,12 @@ fn intern_format(k: &mut Kernel, cf: &CanonicalFormat) -> FormatRecipe {
     FormatRecipe {
         node_id,
         name: cf.name.clone(),
-        semantic_kind: sk as u32,
-        encoding: enc as u32,
         bits: cf.bits,
+        #[cfg(test)]
         storage_hint: cf.storage_hint.clone(),
+        #[cfg(test)]
         arithmetic_hint: cf.arithmetic_hint.clone(),
         arith_hint_code: hint as u32,
-        mantissa_bits: cf.mantissa_bits,
-        exponent_bits: cf.exponent_bits,
-        exponent_bias: cf.exponent_bias,
-        posit_n: cf.posit_n,
-        posit_es: cf.posit_es,
-        lookup_values: cf.lookup_values.clone(),
     }
 }
 
@@ -608,10 +597,6 @@ impl FormatTable {
         h
     }
 
-    pub fn get(&self, h: u32) -> &FormatRecipe {
-        &self.by_handle[h as usize]
-    }
-
     pub fn register_all(&mut self, lib: &FormatLibrary) {
         for r in &lib.recipes {
             self.register(r);
@@ -633,6 +618,7 @@ impl FormatTable {
 
     // apply — Pass 1 hot-path entry. Same surface as apply_arith but routes
     // through the cached handler.
+    #[cfg(test)]
     pub fn apply(&mut self, fmt: &FormatRecipe, op: u32, a: NumVal, b: NumVal) -> NumVal {
         let h = self.register(fmt);
         self.handler(h, op)(a, b)

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -473,6 +473,17 @@ impl Trace {
         self.choice_failures += 1;
     }
 
+    pub(crate) fn record_route_choice(&mut self, choice: &RouteChoice<'_>) {
+        for decision in &choice.decisions {
+            self.record_choice_attempt();
+            if decision.selected {
+                self.record_choice_success();
+            } else {
+                self.record_choice_failure();
+            }
+        }
+    }
+
     pub(crate) fn arm_name(arm_ty: u32) -> &'static str {
         match arm_ty {
             RB_BLOCK => "BLOCK",
@@ -892,6 +903,7 @@ impl Kernel {
     /// NameIDs here exactly as the `record_new` native does (main.rs ~2051), so
     /// a record marshalled from Python and one built by `record_new` in Form
     /// are the same shape — `record_get`/`record_has` read both identically.
+    #[cfg(feature = "pyo3")]
     pub(crate) fn make_record(&mut self, blueprint: NodeID, pairs: Vec<(String, Value)>) -> Value {
         let fields: Vec<(NameID, Value)> = pairs
             .into_iter()
@@ -4627,11 +4639,6 @@ impl EmittedExpr {
         }
     }
 
-    fn src(&self) -> &str {
-        match self {
-            EmittedExpr::Int(s) | EmittedExpr::Bool(s) => s.as_str(),
-        }
-    }
 }
 
 /// Tracks compile-time scope while emitting. `vars` maps NameID → Rust
@@ -6149,14 +6156,6 @@ fn cat_list_nat() -> NodeID {
         inst: 1,
     }
 }
-fn cat_transmute() -> NodeID {
-    NodeID {
-        pkg: 1,
-        level: LEVEL_BASIC,
-        ty: RB_TRANSMUTE,
-        inst: 1,
-    }
-}
 fn cat_field_primitive(ty: u32) -> NodeID {
     NodeID {
         pkg: 1,
@@ -6568,6 +6567,9 @@ struct RouterMetrics {
     fanout_requests: u64,
     local_control_requests: u64,
     native_error_requests: u64,
+    choice_attempts: u64,
+    choice_successes: u64,
+    choice_failures: u64,
     observed_paths: HashSet<String>,
     observed_native_paths: HashSet<String>,
     observed_fanout_paths: HashSet<String>,
@@ -6582,6 +6584,9 @@ struct RouterMetricsSnapshot {
     fanout_requests: u64,
     local_control_requests: u64,
     native_error_requests: u64,
+    choice_attempts: u64,
+    choice_successes: u64,
+    choice_failures: u64,
     observed_path_count: usize,
     observed_native_route_count: usize,
     observed_fanout_path_count: usize,
@@ -6644,6 +6649,18 @@ impl RouterMetrics {
         }
     }
 
+    fn record_route_choice(&mut self, choice: &RouteChoice<'_>) {
+        let attempts = choice.decisions.len() as u64;
+        let successes = choice
+            .decisions
+            .iter()
+            .filter(|decision| decision.selected)
+            .count() as u64;
+        self.choice_attempts += attempts;
+        self.choice_successes += successes;
+        self.choice_failures += attempts.saturating_sub(successes);
+    }
+
     fn snapshot(&self, native_route_count: usize) -> RouterMetricsSnapshot {
         let fanout_path_counts = self.fanout_path_counts();
         let next_bml_candidate = Self::next_bml_candidate(&fanout_path_counts);
@@ -6657,6 +6674,9 @@ impl RouterMetrics {
             fanout_requests: self.fanout_requests,
             local_control_requests: self.local_control_requests,
             native_error_requests: self.native_error_requests,
+            choice_attempts: self.choice_attempts,
+            choice_successes: self.choice_successes,
+            choice_failures: self.choice_failures,
             observed_path_count: self.observed_paths.len(),
             observed_native_route_count: self.observed_native_paths.len(),
             observed_fanout_path_count: self.observed_fanout_paths.len(),
@@ -6685,6 +6705,12 @@ fn router_metrics_snapshot(
 fn record_router_metrics(metrics: &Arc<Mutex<RouterMetrics>>, path: &str, router: &str) {
     if let Ok(mut guard) = metrics.lock() {
         guard.record(path, router);
+    }
+}
+
+fn record_router_choice_metrics(metrics: &Arc<Mutex<RouterMetrics>>, choice: &RouteChoice<'_>) {
+    if let Ok(mut guard) = metrics.lock() {
+        guard.record_route_choice(choice);
     }
 }
 
@@ -7381,6 +7407,10 @@ fn handle_request(
         &query_data,
         &request_body,
     );
+    record_router_choice_metrics(router_metrics, &route_choice);
+    if let Some(trace) = &mut k.trace {
+        trace.record_route_choice(&route_choice);
+    }
     if let Some(selection) = route_choice.selected.as_ref() {
         let route = selection.route;
         // NATIVE: served entirely in Form, no Python in the path.
@@ -7507,6 +7537,7 @@ fn handle_request(
         // an unframed one; Connection per the client's intent). This arm does its
         // OWN client write (head + streamed body) and returns the client keep-alive
         // verdict directly — it does NOT fall through to the buffered emit below.
+        record_router_metrics(router_metrics, &path, "fanout-python");
         return fanout_stream_to_client(
             stream,
             keep_alive,
@@ -9701,6 +9732,18 @@ fn router_observation_value(metrics: &RouterMetricsSnapshot) -> Value {
             "next_bml_candidate",
             router_bml_candidate_value(&metrics.next_bml_candidate),
         ),
+        (
+            "choice_attempts",
+            Value::Int(metrics.choice_attempts as i64),
+        ),
+        (
+            "choice_successes",
+            Value::Int(metrics.choice_successes as i64),
+        ),
+        (
+            "choice_failures",
+            Value::Int(metrics.choice_failures as i64),
+        ),
     ])
 }
 
@@ -9767,6 +9810,18 @@ fn router_context_data(
         (
             "__router_native_error_requests__".to_string(),
             Value::Str(metrics.native_error_requests.to_string().into()),
+        ),
+        (
+            "__router_choice_attempts__".to_string(),
+            Value::Str(metrics.choice_attempts.to_string().into()),
+        ),
+        (
+            "__router_choice_successes__".to_string(),
+            Value::Str(metrics.choice_successes.to_string().into()),
+        ),
+        (
+            "__router_choice_failures__".to_string(),
+            Value::Str(metrics.choice_failures.to_string().into()),
         ),
         (
             "__router_observation__".to_string(),
@@ -9945,6 +10000,9 @@ mod router_context_tests {
             fanout_requests: 3,
             local_control_requests: 1,
             native_error_requests: 0,
+            choice_attempts: 52,
+            choice_successes: 18,
+            choice_failures: 34,
             observed_path_count: 5,
             observed_native_route_count: 4,
             observed_fanout_path_count: 1,
@@ -9979,6 +10037,9 @@ mod router_context_tests {
         assert_eq!(str_for(&pairs, "__router_native_requests__"), "17");
         assert_eq!(str_for(&pairs, "__router_fanout_requests__"), "3");
         assert_eq!(str_for(&pairs, "__router_local_control_requests__"), "1");
+        assert_eq!(str_for(&pairs, "__router_choice_attempts__"), "52");
+        assert_eq!(str_for(&pairs, "__router_choice_successes__"), "18");
+        assert_eq!(str_for(&pairs, "__router_choice_failures__"), "34");
         assert_eq!(str_for(&pairs, "__router_observed_path_count__"), "5");
         assert_eq!(
             str_for(&pairs, "__router_observed_native_route_count__"),

--- a/kernels/KERNEL_AS_ROUTER.md
+++ b/kernels/KERNEL_AS_ROUTER.md
@@ -795,14 +795,17 @@ flip inserts the kernel-router *between* Traefik and api: Traefik routes
 the kernel-router is *proven* across the rungs above AND packaged as a standalone
 deployable server. The Rust binary still ships inside the api container for the
 inline-PyO3 path; alongside it there is now a **standalone kernel-router image +
-shadow manifest + compose service** that runs `cli_serve` as a front door:
+shadow manifest + production manifest + compose service** that runs `cli_serve`
+as a front door:
 
 - [`Dockerfile.kernel-router`](../Dockerfile.kernel-router) — a multi-stage image
   reusing `Dockerfile.api`'s proven `kernel-builder` (same `FROM
   rust:1.86-slim-bookworm`, same `cargo build --release --bin form-kernel-rust &&
   strip`), then a lean `debian-slim` runtime carrying ONLY the stripped binary,
-  the form-stdlib (so a source manifest can be source-compiled later), and the
-  shadow manifest. No Rust toolchain in the final image.
+  the form-stdlib, the shadow manifest, and the production manifest plus its
+  route-data JSON. No Rust toolchain in the final image. The image defaults to
+  `ROUTES_FILE=/routes/shadow-routes.fk`; switching to
+  `/routes/production-routes.fk` is runtime configuration, not a rebuild.
 - [`deploy/kernel-router/shadow-routes.fk`](../deploy/kernel-router/shadow-routes.fk)
   — the shadow manifest: an EMPTY `(let routes (list))`. `build_route_specs`
   accepts an empty list (an empty list is a valid list, not an error), so ZERO
@@ -910,13 +913,14 @@ door is FastAPI.
 - [`form/form-kernel-rust/router_header_passthrough_harness.py`](../form/form-kernel-rust/router_header_passthrough_harness.py) — the bidirectional header-passthrough proof: against a mock echo upstream, the client's end-to-end request headers (Authorization/Cookie/Accept/X-Probe/User-Agent + Content-Type on POST) reach the upstream with Host rewritten and the client Content-Length/Connection stripped, and the upstream's Set-Cookie/Cache-Control/custom headers relay back while its hop-by-hop Transfer-Encoding does not; against the REAL FastAPI app, `/api/health` relays with `Content-Type: application/json` (the upstream's real type, not text/plain) and a native route still serves text/plain in Form. Tears both upstreams down.
 - [`form/form-kernel-rust/router_real_app_harness.py`](../form/form-kernel-rust/router_real_app_harness.py) — the REAL-app proof: boots `app.main:app` under uvicorn (dev sqlite), stands the kernel-router in front of it, proves native-in-Form (value == the live app's) + GET/POST fan-out to the actual FastAPI, and measures the proxy-hop overhead vs the native-route saving. Repeatable; tears both down.
 - [`form/form-kernel-rust/examples/router-real-app-proof.fk`](../form/form-kernel-rust/examples/router-real-app-proof.fk) — the real-app manifest: one native route (`/api/utils/weighted_average`, parsing its float query args and running sum(v*w)/sum(w) in Form), the rest fanned out to the real app.
-- [`deploy/kernel-router/production-routes.fk`](../deploy/kernel-router/production-routes.fk) — the PRODUCTION manifest (the durable flip's native surface): eleven promoted `/api/utils` routes (`coherence_weight`, `nodeid_distance`, `nodeid_compatibility`, `weighted_average`, `simpson_diversity`, `idea_score`, `marginal_cc_return`, `breath_balance`, `shannon_entropy`, `softmax_weights`, `grounded_value`) served NATIVELY in Form, each emitting the FULL JSON response object byte-identical to its FastAPI twin (params parsed from the request alist via `split_commas`, JSON built with `value_str` + `str_concat`, `runtime:"inline"` matching production); everything else fans out. Float accumulators are left-associated to match CPython's `sum()` bit-for-bit; the entropy routes carry `math_log`/`round_ndigits`, `breath_balance` reproduces CPython's `-0.0` exactly, and `grounded_value` folds eleven host-derived scalars (the value/realization/confidence reduction of `compute_idea_metrics`) through `min2`/`max2`/`_plus` with the `[0.05,0.95]` confidence clamp.
-- [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py) — the PROMOTION proof: boots the real `app.main:app` as the CPython oracle, stands the kernel-router (production manifest) in front, and for all eleven routes over representative + edge params (48 cases, incl. adversarial floats, `-0.0`, deterministic + uniform softmax, and `grounded_value`'s confidence float-assoc artifact + clamp/zero-guards) proves the native response value-identical to the local oracle (runtime provenance normalized out) AND — with `--live` — FULL-BODY byte-identical to the live production api; measures native (~0.24 ms) vs CPython-served (~11 ms) latency, the ~45x runtime-share win. Read-only against the live api; tears the local app + router down.
+- [`deploy/kernel-router/production-routes.fk`](../deploy/kernel-router/production-routes.fk) — the PRODUCTION manifest (the durable flip's native surface): twenty-two promoted `/api/utils` routes plus `/health` and `/api/attention/kernel-runtime` served NATIVELY in Form. Each promoted utility route emits the FULL JSON response object byte-identical to its FastAPI twin in production; the attention route projects live kernel-router metrics in Form, including route-choice attempts/success/failures.
+- [`form/form-kernel-rust/production_routes_harness.py`](../form/form-kernel-rust/production_routes_harness.py) — the PROMOTION proof: boots the real `app.main:app` as the CPython oracle, stands the kernel-router (production manifest) in front, and proves promoted native responses value-identical to the local oracle (runtime provenance normalized out) and, with `--live`, full-body byte-identical to the live production api. Read-only against the live api; tears the local app + router down.
+- [`scripts/kernel_front_door_local_preflight.sh`](../scripts/kernel_front_door_local_preflight.sh) — the local front-door rehearsal: builds the release kernel, checks manifests and image packaging, boots the real local API and kernel-router, curls fan-out/native paths, and asserts native/fanout/choice metrics move before any push or production flip.
 - [`api/app/services/form_kernel_bridge.py`](../api/app/services/form_kernel_bridge.py) — `serve_via_kernel`, the guest-subroutine path this reverses.
 
 ### The deployable artifact (the kernel-router as a standalone server)
 
-- [`Dockerfile.kernel-router`](../Dockerfile.kernel-router) — the standalone serve image: stage 1 reuses `Dockerfile.api`'s proven `kernel-builder` (`FROM rust:1.86-slim-bookworm`, `cargo build --release --bin form-kernel-rust && strip`); stage 2 is a lean `debian:bookworm-slim` runtime carrying ONLY the stripped binary, the form-stdlib (for a future source manifest's `--stdlib`), the shadow manifest, and the entrypoint. `KERNEL_ROUTER_PORT` / `UPSTREAM_URL` / `ROUTES_FILE` are env-configurable. No Rust toolchain in the final image.
+- [`Dockerfile.kernel-router`](../Dockerfile.kernel-router) — the standalone serve image: stage 1 reuses `Dockerfile.api`'s proven `kernel-builder` (`FROM rust:1.86-slim-bookworm`, `cargo build --release --bin form-kernel-rust && strip`); stage 2 is a lean `debian:bookworm-slim` runtime carrying ONLY the stripped binary, the form-stdlib, the shadow manifest, the production manifest, the production route-data JSON, and the entrypoint. `KERNEL_ROUTER_PORT` / `UPSTREAM_URL` / `ROUTES_FILE` are env-configurable. No Rust toolchain in the final image.
 - [`deploy/kernel-router/shadow-routes.fk`](../deploy/kernel-router/shadow-routes.fk) — the shadow manifest: an EMPTY `(let routes (list))`. `build_route_specs` accepts an empty list, so zero routes are native and EVERYTHING fans out — a transparent proxy with `X-Form-Router: fanout-python` as live evidence.
 - [`deploy/kernel-router/entrypoint.sh`](../deploy/kernel-router/entrypoint.sh) — resolves `KERNEL_ROUTER_HOST` (default `0.0.0.0` in-container so the front door is reachable across the boundary) / `KERNEL_ROUTER_PORT` / `UPSTREAM_URL` / `ROUTES_FILE` (+ optional `STDLIB_DIR` / `KERNEL_ROUTER_WORKERS`) at run time and `exec`s `form-kernel-rust serve` — container-configurable without a rebuild.
 - [`deploy/kernel-router/docker-compose.kernel-router.yml`](../deploy/kernel-router/docker-compose.kernel-router.yml) — a DEFINED-BUT-INACTIVE overlay service (build: `Dockerfile.kernel-router`, `--upstream http://api:8000`). A SEPARATE overlay the production deploy never includes; its Traefik labels are present but COMMENTED, so merging it changes nothing about production routing. Uncommenting them (and dropping the api service's own rule) is the flip — Urs's intent.
@@ -1008,3 +1012,38 @@ step; Traefik routing was never touched.
 the one label set, drop the api service's own rule). That is the single move that
 touches live traffic; it is Urs's intent (given), staged carefully on top of this
 proven shadow.
+
+## Local front-door preflight — the gate before another flip
+
+The 2026-06-08 Hostinger API-native deploy attempt proved the missing gate:
+Traefik returned its default `404 page not found` because the live api labels were
+disabled before a running kernel-router service was observable behind the same
+public route. The absence of `X-Form-Router` on the public 404 was the signal:
+the request never reached the kernel-router or the FastAPI upstream. The rollback
+restored Traefik to `api:8000`; the front door is currently FastAPI again.
+
+Before any future production re-point, run the local rehearsal:
+
+```
+scripts/kernel_front_door_local_preflight.sh
+```
+
+What it proves locally, with the real FastAPI app as upstream:
+
+- release `form-kernel-rust` builds with no warnings;
+- `production-routes.fk` and `shadow-routes.fk` pass the manifest name gate;
+- `Dockerfile.kernel-router` bakes the stdlib, shadow manifest, production
+  manifest, and production route-data JSON;
+- `/api/version` and `/api/health` fan out byte-identically through the
+  kernel-router with `X-Form-Router: fanout-python`;
+- `/api/utils/coherence_weight` is served natively with
+  `X-Form-Router: native-kernel` and matches the local API value contract after
+  normalizing the environment-dependent `runtime` provenance field;
+- `/api/attention/kernel-runtime` is served natively and reports aggregate route
+  metrics including `total_requests`, `native_requests`, `fanout_requests`, and
+  route-choice `choice_attempts`, `choice_successes`, `choice_failures`.
+
+The remote flip shall have the same order: start kernel-router beside api, prove
+host-local fan-out and native headers through the router, prove the service is
+running and reachable from Traefik's network, then repoint Traefik. Do not
+disable the api router first.

--- a/scripts/kernel_front_door_local_preflight.sh
+++ b/scripts/kernel_front_door_local_preflight.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+API_DIR="${ROOT_DIR}/api"
+KERNEL_DIR="${ROOT_DIR}/form/form-kernel-rust"
+KERNEL_BIN="${KERNEL_DIR}/target/release/form-kernel-rust"
+ROUTES_FILE="${ROOT_DIR}/deploy/kernel-router/production-routes.fk"
+STDLIB_DIR="${ROOT_DIR}/form/form-stdlib"
+API_PORT="${API_PORT:-18180}"
+ROUTER_PORT="${ROUTER_PORT:-18181}"
+API_BASE="http://127.0.0.1:${API_PORT}"
+ROUTER_BASE="http://127.0.0.1:${ROUTER_PORT}"
+TMP_DIR="$(mktemp -d)"
+API_PID=""
+ROUTER_PID=""
+
+cleanup() {
+  if [[ -n "${ROUTER_PID}" ]] && kill -0 "${ROUTER_PID}" >/dev/null 2>&1; then
+    kill "${ROUTER_PID}" >/dev/null 2>&1 || true
+    wait "${ROUTER_PID}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${API_PID}" ]] && kill -0 "${API_PID}" >/dev/null 2>&1; then
+    kill "${API_PID}" >/dev/null 2>&1 || true
+    wait "${API_PID}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 2
+  fi
+}
+
+need cargo
+need curl
+need lsof
+
+select_python() {
+  local candidate
+  for candidate in "${API_DIR}/.venv/bin/python" "${API_DIR}/.venv/bin/python3" "$(command -v python3 || true)"; do
+    if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+      if "${candidate}" -c "import fastapi, uvicorn" >/dev/null 2>&1; then
+        echo "${candidate}"
+        return 0
+      fi
+    fi
+  done
+  return 1
+}
+
+PYTHON_BIN="$(select_python || true)"
+if [[ -z "${PYTHON_BIN}" ]]; then
+  echo "could not find a Python with fastapi and uvicorn installed" >&2
+  exit 2
+fi
+
+port_must_be_free() {
+  local port="$1"
+  if lsof -tiTCP:"${port}" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "port ${port} is already in use; choose API_PORT/ROUTER_PORT or stop the listener" >&2
+    exit 2
+  fi
+}
+
+wait_for_http() {
+  local url="$1"
+  local attempts="${2:-60}"
+  local code=""
+  for _ in $(seq 1 "${attempts}"); do
+    code="$(curl -s -o /dev/null -w "%{http_code}" "${url}" || true)"
+    if [[ "${code}" =~ ^2[0-9][0-9]$ ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timed out waiting for ${url}; last status=${code:-none}" >&2
+  return 1
+}
+
+header_value() {
+  local headers_file="$1"
+  local key="$2"
+  awk -v key="${key}" 'tolower($1)==tolower(key) { $1=""; sub(/^ /,""); print }' \
+    "${headers_file}" | tr -d '\r' | tail -1
+}
+
+json_value_contract() {
+  "${PYTHON_BIN}" - "$1" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    obj = json.load(fh)
+obj.pop("runtime", None)
+print(json.dumps(obj, separators=(",", ":")))
+PY
+}
+
+check_image_packaging() {
+  local dockerfile="${ROOT_DIR}/Dockerfile.kernel-router"
+  grep -q 'STDLIB_DIR=/app/form/form-stdlib' "${dockerfile}"
+  grep -q 'COPY deploy/kernel-router/shadow-routes.fk /routes/shadow-routes.fk' "${dockerfile}"
+  grep -q 'COPY deploy/kernel-router/production-routes.fk /routes/production-routes.fk' "${dockerfile}"
+  grep -q 'COPY deploy/kernel-router/production-routes-data.json /routes/production-routes-data.json' "${dockerfile}"
+  echo "PASS image-packaging route manifests and stdlib default are baked"
+}
+
+check_fanout_exact() {
+  local name="$1"
+  local route_path="$2"
+  local direct_body="${TMP_DIR}/${name}.direct.body"
+  local router_body="${TMP_DIR}/${name}.router.body"
+  local router_headers="${TMP_DIR}/${name}.router.headers"
+  local direct_code router_code router
+
+  direct_code="$(curl -s -o "${direct_body}" -w "%{http_code}" "${API_BASE}${route_path}")"
+  router_code="$(curl -s -D "${router_headers}" -o "${router_body}" -w "%{http_code}" "${ROUTER_BASE}${route_path}")"
+  router="$(header_value "${router_headers}" "x-form-router:")"
+
+  if ! cmp -s "${direct_body}" "${router_body}"; then
+    echo "FAIL fanout-exact ${name}: body mismatch for ${route_path}" >&2
+    exit 1
+  fi
+  if [[ "${direct_code}" != "${router_code}" || "${router}" != "fanout-python" ]]; then
+    echo "FAIL fanout-exact ${name}: direct=${direct_code} router=${router_code} x-form-router=${router}" >&2
+    exit 1
+  fi
+  echo "PASS fanout-exact ${name} status=${router_code} router=${router} bytes=$(wc -c < "${router_body}" | tr -d ' ')"
+}
+
+check_native_value_contract() {
+  local name="$1"
+  local route_path="$2"
+  local direct_body="${TMP_DIR}/${name}.direct.body"
+  local router_body="${TMP_DIR}/${name}.router.body"
+  local router_headers="${TMP_DIR}/${name}.router.headers"
+  local direct_code router_code router direct_contract router_contract
+
+  direct_code="$(curl -s -o "${direct_body}" -w "%{http_code}" "${API_BASE}${route_path}")"
+  router_code="$(curl -s -D "${router_headers}" -o "${router_body}" -w "%{http_code}" "${ROUTER_BASE}${route_path}")"
+  router="$(header_value "${router_headers}" "x-form-router:")"
+  direct_contract="$(json_value_contract "${direct_body}")"
+  router_contract="$(json_value_contract "${router_body}")"
+
+  if [[ "${direct_code}" != "200" || "${router_code}" != "200" || "${router}" != "native-kernel" ]]; then
+    echo "FAIL native-value ${name}: direct=${direct_code} router=${router_code} x-form-router=${router}" >&2
+    exit 1
+  fi
+  if [[ "${direct_contract}" != "${router_contract}" ]]; then
+    echo "FAIL native-value ${name}: value contract mismatch for ${route_path}" >&2
+    exit 1
+  fi
+  echo "PASS native-value ${name} status=${router_code} router=${router} bytes=$(wc -c < "${router_body}" | tr -d ' ')"
+}
+
+check_attention_metrics() {
+  local body="${TMP_DIR}/attention.body"
+  local headers="${TMP_DIR}/attention.headers"
+  local code router
+  code="$(curl -s -D "${headers}" -o "${body}" -w "%{http_code}" "${ROUTER_BASE}/api/attention/kernel-runtime")"
+  router="$(header_value "${headers}" "x-form-router:")"
+  if [[ "${code}" != "200" || "${router}" != "native-kernel" ]]; then
+    echo "FAIL native-attention: status=${code} x-form-router=${router}" >&2
+    exit 1
+  fi
+  "${PYTHON_BIN}" - "${body}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    measurements = json.load(fh)["measurements"]
+for key in ("choice_attempts", "choice_successes", "choice_failures", "total_requests", "native_requests", "fanout_requests"):
+    if key not in measurements:
+        raise SystemExit(f"missing measurement {key}")
+if measurements["fanout_requests"] < 2:
+    raise SystemExit(f"fanout_requests did not include fan-out probes: {measurements['fanout_requests']}")
+if measurements["native_requests"] < 1:
+    raise SystemExit(f"native_requests did not include native probe: {measurements['native_requests']}")
+if measurements["total_requests"] < 3:
+    raise SystemExit(f"total_requests did not include prior probes: {measurements['total_requests']}")
+if measurements["choice_attempts"] <= 0 or measurements["choice_failures"] <= 0:
+    raise SystemExit("choice counters did not move")
+print(
+    "total_requests={total_requests} native_requests={native_requests} "
+    "fanout_requests={fanout_requests} choice_attempts={choice_attempts} "
+    "choice_successes={choice_successes} choice_failures={choice_failures}".format(**measurements)
+)
+PY
+  echo "PASS native-attention status=${code} router=${router} bytes=$(wc -c < "${body}" | tr -d ' ')"
+}
+
+port_must_be_free "${API_PORT}"
+port_must_be_free "${ROUTER_PORT}"
+
+echo "kernel-front-door-local-preflight: building release kernel"
+(cd "${KERNEL_DIR}" && cargo build --release --bin form-kernel-rust)
+
+echo "kernel-front-door-local-preflight: checking route manifests"
+"${ROOT_DIR}/scripts/check_route_manifests.sh"
+check_image_packaging
+
+echo "kernel-front-door-local-preflight: starting API ${API_BASE}"
+(
+  cd "${API_DIR}"
+  COH_ENV=dev "${PYTHON_BIN}" -m uvicorn app.main:app --host 127.0.0.1 --port "${API_PORT}" --log-level warning
+) >"${TMP_DIR}/api.log" 2>&1 &
+API_PID="$!"
+wait_for_http "${API_BASE}/api/health" 90
+
+echo "kernel-front-door-local-preflight: starting kernel-router ${ROUTER_BASE}"
+(
+  cd "${KERNEL_DIR}"
+  "${KERNEL_BIN}" serve \
+    --host 127.0.0.1 \
+    --port "${ROUTER_PORT}" \
+    --workers 2 \
+    --routes "${ROUTES_FILE}" \
+    --stdlib "${STDLIB_DIR}" \
+    --upstream "${API_BASE}"
+) >"${TMP_DIR}/router.log" 2>&1 &
+ROUTER_PID="$!"
+wait_for_http "${ROUTER_BASE}/api/health" 90
+
+check_fanout_exact version /api/version
+check_fanout_exact health /api/health
+check_native_value_contract coherence_weight '/api/utils/coherence_weight?values=10,20,30&threshold=15'
+check_attention_metrics
+
+echo "PASS: local kernel front-door preflight"


### PR DESCRIPTION
## Summary
- wire kernel-router route-choice/fanout/native metrics into the native runtime and Form attention route
- bake shadow + production route manifests and route-data into the kernel-router image
- add a local front-door preflight that boots the real local API + kernel-router and curls fan-out/native paths before any production flip
- document the 2026-06-08 Traefik 404 lesson: prove kernel-router before disabling the API router

## Proof
- `make prompt-guide`
- `make wellness`
- `git fetch origin main && git rebase origin/main`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-09_kernel_front_door_local_preflight.json`
- `scripts/kernel_front_door_local_preflight.sh`
- `cd form/form-kernel-rust && cargo test --release`
- `bash -n scripts/kernel_front_door_local_preflight.sh deploy/kernel-router/entrypoint.sh && git diff --check`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`

## Local curl evidence
`kernel_front_door_local_preflight.sh` passed:
- fan-out exact `/api/version`: 200, `X-Form-Router: fanout-python`
- fan-out exact `/api/health`: 200, `X-Form-Router: fanout-python`
- native `/api/utils/coherence_weight?values=10,20,30&threshold=15`: 200, `X-Form-Router: native-kernel`
- native `/api/attention/kernel-runtime`: `total_requests=4 native_requests=1 fanout_requests=3 choice_attempts=120 choice_successes=2 choice_failures=118`
