### PR TITLE
Add native gate decision receipts

### DIFF
--- a/api/tests/test_native_mutation_public_gate.py
+++ b/api/tests/test_native_mutation_public_gate.py
@@ -32,7 +32,9 @@ def test_public_gate_form_names_header_runner_and_rollback_receipt():
         "defn nmpg-public-gate-header",
         "X-Form-Native-Public-Gate",
         "defn nmpg-public-gate-rollback-receipt-sql",
+        "defn nmpg-decision-receipt-json",
         "public-gate-rollback-receipt",
+        "native-mutation-gate-decision-receipt",
         "defn nmpg-run-idea-create-public-gate",
         "defn nmpg-run-idea-update-public-gate",
         "defn nmpg-run-spec-update-public-gate",
@@ -65,7 +67,7 @@ def test_public_gate_band_executes_across_sibling_kernels():
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
-    assert "→ 1111111" in result.stdout
+    assert "→ 11111111" in result.stdout
 
 
 def test_public_gate_live_script_runs_or_skips_when_pg_missing():
@@ -121,6 +123,9 @@ def test_production_routes_expose_public_gate_without_no_header_flip():
 
     assert '\\"native_public_gate\\":true' in text
     assert '\\"route_local_gate_executes\\":true' in text
+    assert '\\"decision_receipt\\":' in text
+    assert "native-mutation-gate-decision-receipt" in text
+    assert "can_contradict_intent" in text
     assert '\\"executes\\":false' in text
     assert "Requests without either header" in text
     assert "Ordinary no-header traffic remains fanout-python" in text
@@ -146,8 +151,16 @@ def test_public_gate_harness_observes_public_gate_when_kernel_available():
     assert report["public_gate_header_allowed"] is True
     assert report["ordinary_traffic_flip_performed"] is False
     assert report["next_evidence_needed"] == [
+        "public-gate decision receipts in deployed canary traffic",
         "deployed X-Form-Native-Public-Gate canary before any no-header flip",
     ]
+    for case in report["cases"]:
+        assert case["checks"]["decision_receipt_state"] is True
+        assert case["checks"]["decision_receipt_selected_path"] is True
+        assert case["checks"]["decision_receipt_reversible"] is True
+        assert case["checks"]["decision_receipt_signature"] is True
+        assert case["checks"]["both_headers_decision_receipt_state"] is True
+        assert case["checks"]["both_headers_decision_receipt_selected_path"] is True
 
 
 def test_route_forms_name_public_gate_before_deployed_canary():

--- a/deploy/kernel-router/mutation_public_gate_harness.py
+++ b/deploy/kernel-router/mutation_public_gate_harness.py
@@ -238,6 +238,15 @@ def _gate_checks(case: PublicGateCase, observation: HTTPObservation) -> dict[str
     trust = parsed.get("trust_envelope")
     if not isinstance(trust, dict):
         trust = {}
+    decision = parsed.get("decision_receipt")
+    if not isinstance(decision, dict):
+        decision = {}
+    decision_candidates = decision.get("candidates")
+    if not isinstance(decision_candidates, list):
+        decision_candidates = []
+    decision_signature = decision.get("signature")
+    if not isinstance(decision_signature, dict):
+        decision_signature = {}
     reversible_gate = trust.get("reversible_gate")
     if not isinstance(reversible_gate, dict):
         reversible_gate = {}
@@ -257,6 +266,54 @@ def _gate_checks(case: PublicGateCase, observation: HTTPObservation) -> dict[str
         "rollback_receipt_state": receipt.get("state") == "route-local-rollback-receipt",
         "rollback_receipt_node": receipt.get("node_id") == case.node_id,
         "rollback_receipt_rollback": "remove X-Form-Native-Public-Gate" in str(receipt.get("rollback") or ""),
+        "decision_receipt_state": decision.get("state") == "native-mutation-gate-decision-receipt",
+        "decision_receipt_gate": decision.get("gate") == "native_mutation_public_gate",
+        "decision_receipt_protocol": decision.get("protocol") == PUBLIC_GATE_HEADER,
+        "decision_receipt_operation": decision.get("operation") == case.operation,
+        "decision_receipt_node": decision.get("node_id") == case.node_id,
+        "decision_receipt_selected_path": decision.get("selected_path") == PUBLIC_GATE_HEADER,
+        "decision_receipt_outcome": decision.get("outcome") == "success",
+        "decision_receipt_choice": decision.get("choice") == 1,
+        "decision_receipt_candidates": (
+            len(decision_candidates) == 3
+            and any(
+                candidate.get("path") == "fanout-python"
+                and candidate.get("outcome") == "silence"
+                and candidate.get("selected") is False
+                for candidate in decision_candidates
+                if isinstance(candidate, dict)
+            )
+            and any(
+                candidate.get("path") == PREVIEW_HEADER
+                and candidate.get("outcome") == "stop"
+                and candidate.get("selected") is False
+                for candidate in decision_candidates
+                if isinstance(candidate, dict)
+            )
+            and any(
+                candidate.get("path") == PUBLIC_GATE_HEADER
+                and candidate.get("outcome") == "success"
+                and candidate.get("selected") is True
+                for candidate in decision_candidates
+                if isinstance(candidate, dict)
+            )
+        ),
+        "decision_receipt_reversible": (
+            decision.get("ordinary_traffic_flip_performed") is False
+            and decision.get("reversible") is True
+            and decision.get("can_contradict_intent") is True
+            and decision.get("fail") == "rollback-to-fanout-by-removing-public-gate-header"
+            and decision.get("stop") == "ordinary-traffic-unflipped"
+            and decision.get("bma") == "native-mutation-public-gate"
+        ),
+        "decision_receipt_signature": (
+            decision_signature.get("category") == "native-mutation-gate"
+            and decision_signature.get("selected_path") == PUBLIC_GATE_HEADER
+            and decision_signature.get("outcome_code") == 1
+            and decision_signature.get("candidate_count") == 3
+            and decision_signature.get("operation") == case.operation
+            and decision_signature.get("node_id") == case.node_id
+        ),
         "trust_protocol": trust.get("protocol") == PUBLIC_GATE_HEADER,
         "trust_choice_success": trust.get("choice_success") == 1,
         "trust_fail": trust.get("fail") == "rollback-to-fanout-by-removing-public-gate-header",
@@ -342,6 +399,7 @@ def build_gate_report(
         "ordinary_traffic_flip_allowed": False,
         "ordinary_traffic_flip_performed": False,
         "next_evidence_needed": [
+            "public-gate decision receipts in deployed canary traffic",
             "deployed X-Form-Native-Public-Gate canary before any no-header flip",
         ],
     }

--- a/deploy/kernel-router/production-routes.fk
+++ b/deploy/kernel-router/production-routes.fk
@@ -2005,6 +2005,51 @@
     ",\"rollback\":\"remove X-Form-Native-Public-Gate or disable public-gate route row\""
     "}")))
 
+(defn mpg-decision-candidates-json ()
+  (str_concat_all (list
+    "["
+    "{\"path\":\"fanout-python\",\"eligible\":true,\"selected\":false,\"outcome\":\"silence\",\"evidence\":\"no native gate header selects fanout\"}"
+    ",{\"path\":\"X-Form-Native-Preview\",\"eligible\":true,\"selected\":false,\"outcome\":\"stop\",\"evidence\":\"preview observes SQL without public gate execution\"}"
+    ",{\"path\":\"X-Form-Native-Public-Gate\",\"eligible\":true,\"selected\":true,\"outcome\":\"success\",\"evidence\":\"required public-gate header selected native-kernel route\"}"
+    "]")))
+
+(defn mpg-decision-signature-json (operation node-id)
+  (str_concat_all (list
+    "{\"category\":\"native-mutation-gate\""
+    ",\"selected_path\":\"X-Form-Native-Public-Gate\""
+    ",\"outcome_code\":1"
+    ",\"certainty_bucket\":5"
+    ",\"candidate_count\":3"
+    ",\"operation\":" (json_string operation)
+    ",\"node_id\":" (json_string node-id)
+    ",\"who\":\"form-kernel-router\""
+    ",\"where\":\"deploy/kernel-router/production-routes.fk\""
+    "}")))
+
+(defn mpg-decision-receipt-json (operation node-id)
+  (str_concat_all (list
+    "{\"state\":\"native-mutation-gate-decision-receipt\""
+    ",\"receipt_id\":" (json_string (str_concat "decision:X-Form-Native-Public-Gate:" (str_concat operation (str_concat ":" node-id))))
+    ",\"gate\":\"native_mutation_public_gate\""
+    ",\"surface\":\"mutable-ideas-specs\""
+    ",\"operation\":" (json_string operation)
+    ",\"node_id\":" (json_string node-id)
+    ",\"protocol\":\"X-Form-Native-Public-Gate\""
+    ",\"selected_path\":\"X-Form-Native-Public-Gate\""
+    ",\"outcome\":\"success\""
+    ",\"choice\":1"
+    ",\"candidates\":" (mpg-decision-candidates-json)
+    ",\"ordinary_traffic_flip_performed\":false"
+    ",\"silence\":\"fanout-default-when-no-native-header\""
+    ",\"fail\":\"rollback-to-fanout-by-removing-public-gate-header\""
+    ",\"stop\":\"ordinary-traffic-unflipped\""
+    ",\"bma\":\"native-mutation-public-gate\""
+    ",\"reversible\":true"
+    ",\"can_contradict_intent\":true"
+    ",\"proof\":\"deploy/kernel-router/mutation_public_gate_harness.py --json\""
+    ",\"signature\":" (mpg-decision-signature-json operation node-id)
+    "}")))
+
 (defn mpg-trust-envelope-json (operation node-id)
   (str_concat_all (list
     "{\"state\":\"embodied-trust-public-gate\""
@@ -2038,6 +2083,7 @@
       ",\"sql\":" (json_string sql)
       ",\"request_body\":" (json_string body)
       ",\"route_local_rollback_receipt\":" (mpg-rollback-receipt-json operation node-id)
+      ",\"decision_receipt\":" (mpg-decision-receipt-json operation node-id)
       ",\"trust_envelope\":" (mpg-trust-envelope-json operation node-id)
       ",\"runtime\":\"inline\"}"))))
 

--- a/docs/system_audit/commit_evidence_2026-06-09_native_gate_decision_receipts.json
+++ b/docs/system_audit/commit_evidence_2026-06-09_native_gate_decision_receipts.json
@@ -1,0 +1,124 @@
+{
+  "date": "2026-06-09",
+  "thread_branch": "codex/native-gate-decision-receipts-20260609",
+  "commit_scope": "Add compact per-request decision receipts to the native mutation public gate so the gate is observable before any no-header flip.",
+  "files_owned": [
+    "api/tests/test_native_mutation_public_gate.py",
+    "deploy/kernel-router/mutation_public_gate_harness.py",
+    "deploy/kernel-router/production-routes.fk",
+    "docs/system_audit/commit_evidence_2026-06-09_native_gate_decision_receipts.json",
+    "form/form-stdlib/native-mutation-public-gate.fk",
+    "form/form-stdlib/tests/native-mutation-public-gate-band.fk",
+    "specs/native-mutation-public-gate.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "make wellness",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/application-graph-node-port.fk form-stdlib/native-mutation-side-effects.fk form-stdlib/native-mutation-route-side-effects.fk form-stdlib/native-idea-valuation-audit-ledger.fk form-stdlib/native-mutation-public-gate.fk form-stdlib/tests/native-mutation-public-gate-band.fk",
+      "form/scripts/native-mutation-public-gate-test.sh",
+      "python3 deploy/kernel-router/mutation_public_gate_harness.py --json",
+      "cd api && python3 -m pytest -q tests/test_native_mutation_public_gate.py tests/test_native_mutation_ab_observation.py tests/test_ideas_router_form.py tests/test_spec_registry_router_form.py",
+      "python3 -m py_compile deploy/kernel-router/mutation_public_gate_harness.py",
+      "python3 scripts/validate_spec_quality.py --file specs/native-mutation-public-gate.md",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "git diff --check"
+    ],
+    "summary": "The public-gate response now carries decision_receipt alongside the rollback receipt and trust envelope. The receipt names the candidate paths (fanout, preview, public gate), selected path, success outcome, protocol, operation, node, ordinary_traffic_flip_performed=false, reversible rollback, can_contradict_intent=true, and a compact signature. The public-gate harness now fails unless each public-gate request and both-header priority request carries that coherent receipt. Form validation returns 11111111, the throwaway Postgres public-gate fixture returns 111111111, the HTTP harness passes 5/5 cases at confidence 1.0, focused pytest passes 23 tests, and spec/index/whitespace checks pass.",
+    "known_limitations": [
+      {
+        "scope": "ordinary public mutations",
+        "observed": "No ordinary no-header mutation traffic moved. No-header traffic still fans out to FastAPI."
+      },
+      {
+        "scope": "deployed canary",
+        "observed": "The next proof boundary is deployed X-Form-Native-Public-Gate traffic that emits public-gate decision receipts before any no-header flip."
+      },
+      {
+        "scope": "production database",
+        "observed": "No production application database writes were attempted."
+      }
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "Pending push and GitHub checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "No public deploy attempted in this commit. Production remains aligned to the current main until this branch lands."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "A header-gated native public mutation response now exposes a compact decision receipt that makes the gate's selected branch and rollback posture observable.",
+    "public_endpoints": [
+      "POST /api/ideas",
+      "PATCH /api/ideas/{idea_id}",
+      "POST /api/spec-registry",
+      "PATCH /api/spec-registry/{spec_id}",
+      "DELETE /api/spec-registry/{spec_id}",
+      "Header X-Form-Native-Public-Gate"
+    ],
+    "test_flows": [
+      "Form sibling-kernel band proves the decision receipt contract.",
+      "HTTP harness proves public-gate and both-header priority responses carry coherent decision receipts.",
+      "No-header control observations remain fanout-python."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local receipt proof is complete; deployed public-gate canary receipt evidence remains required before any no-header mutation flip."
+  },
+  "idea_ids": [
+    "idea-realization-engine",
+    "data-infrastructure"
+  ],
+  "spec_ids": [
+    "specs/native-mutation-public-gate.md"
+  ],
+  "task_ids": [
+    "native-gate-decision-receipts-20260609",
+    "native-mutation-deployed-public-canary"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "trust-boundary"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "deploy/kernel-router/production-routes.fk::mpg-decision-receipt-json",
+    "form/form-stdlib/native-mutation-public-gate.fk::nmpg-decision-receipt-json",
+    "deploy/kernel-router/mutation_public_gate_harness.py::_gate_checks",
+    "api/tests/test_native_mutation_public_gate.py::test_public_gate_harness_observes_public_gate_when_kernel_available"
+  ],
+  "change_files": [
+    "api/tests/test_native_mutation_public_gate.py",
+    "deploy/kernel-router/mutation_public_gate_harness.py",
+    "deploy/kernel-router/production-routes.fk",
+    "docs/system_audit/commit_evidence_2026-06-09_native_gate_decision_receipts.json",
+    "form/form-stdlib/native-mutation-public-gate.fk",
+    "form/form-stdlib/tests/native-mutation-public-gate-band.fk",
+    "specs/native-mutation-public-gate.md"
+  ],
+  "change_intent": "runtime_fix"
+}

--- a/form/form-stdlib/native-mutation-public-gate.fk
+++ b/form/form-stdlib/native-mutation-public-gate.fk
@@ -22,8 +22,37 @@
             ",\"gate_route\":\"native-kernel\""
             ",\"route_runner\":\"Form-native application graph mutation plus side effects plus idea valuation audit ledger\""
             ",\"route_local_rollback_receipt\":\"persisted\""
+            ",\"decision_receipt\":\"per-request\""
             ",\"ordinary_traffic_flip_performed\":false"
             ",\"rollback\":\"remove X-Form-Native-Public-Gate or disable public-gate route row\""
+            "}")))
+
+    (defn nmpg-decision-receipt-json (gate-id operation node-id)
+        (nms-cat (list
+            "{\"state\":\"native-mutation-gate-decision-receipt\""
+            ",\"receipt_id\":\"decision:X-Form-Native-Public-Gate:" operation ":" node-id "\""
+            ",\"gate_id\":\"" gate-id "\""
+            ",\"gate\":\"native_mutation_public_gate\""
+            ",\"surface\":\"mutable-ideas-specs\""
+            ",\"operation\":\"" operation "\""
+            ",\"node_id\":\"" node-id "\""
+            ",\"protocol\":\"X-Form-Native-Public-Gate\""
+            ",\"selected_path\":\"X-Form-Native-Public-Gate\""
+            ",\"outcome\":\"success\""
+            ",\"choice\":1"
+            ",\"candidates\":["
+                "{\"path\":\"fanout-python\",\"eligible\":true,\"selected\":false,\"outcome\":\"silence\"},"
+                "{\"path\":\"X-Form-Native-Preview\",\"eligible\":true,\"selected\":false,\"outcome\":\"stop\"},"
+                "{\"path\":\"X-Form-Native-Public-Gate\",\"eligible\":true,\"selected\":true,\"outcome\":\"success\"}"
+            "]"
+            ",\"ordinary_traffic_flip_performed\":false"
+            ",\"silence\":\"fanout-default-when-no-native-header\""
+            ",\"fail\":\"rollback-to-fanout-by-removing-public-gate-header\""
+            ",\"stop\":\"ordinary-traffic-unflipped\""
+            ",\"bma\":\"native-mutation-public-gate\""
+            ",\"reversible\":true"
+            ",\"can_contradict_intent\":true"
+            ",\"signature\":{\"category\":\"native-mutation-gate\",\"selected_path\":\"X-Form-Native-Public-Gate\",\"outcome_code\":1,\"candidate_count\":3}"
             "}")))
 
     (defn nmpg-rollback-details-json (gate-id node-id)
@@ -74,9 +103,10 @@
             (nmpg-record-public-gate-rollback-receipt conn gate-id node-id)
             conn))
 
-    ;; 1111111 =
+    ;; 11111111 =
     ;;   public gate contract names explicit header and fanout default
     ;;   rollback receipt SQL is route-local and conflict-safe
+    ;;   per-request decision receipt records the selected branch
     ;;   idea public gate calls the route-side-effect runner
     ;;   idea update public gate calls the valuation audit-ledger runner
     ;;   spec public gate calls the route-side-effect runner
@@ -86,6 +116,7 @@
         (do
             (let contract (nmpg-public-gate-contract-json))
             (let receipt-sql (nmpg-public-gate-rollback-receipt-sql "gate-one" "idea-one"))
+            (let decision (nmpg-decision-receipt-json "gate-one" "update-idea" "idea-one"))
             (let contract-ok (if (eq (nms-and4
                 (nms-contains? contract "public-gate-installed")
                 (nms-contains? contract "X-Form-Native-Public-Gate")
@@ -96,26 +127,31 @@
                 (nms-contains? receipt-sql "route-local-rollback-receipt")
                 (nms-contains? receipt-sql "ON CONFLICT")
                 (nms-contains? receipt-sql "disable public-gate route row")) 1) 10 0))
+            (let decision-ok (if (eq (nms-and4
+                (nms-contains? decision "native-mutation-gate-decision-receipt")
+                (nms-contains? decision "\"selected_path\":\"X-Form-Native-Public-Gate\"")
+                (nms-contains? decision "\"outcome\":\"success\"")
+                (nms-contains? decision "\"can_contradict_intent\":true")) 1) 100 0))
             (let idea-ok (if (eq (nms-and3
                 (nms-contains? "nmpg-run-idea-create-public-gate nmrs-run-idea-create-with-side-effects" "nmpg-run-idea-create-public-gate")
                 (nms-contains? "nmpg-run-idea-create-public-gate nmrs-run-idea-create-with-side-effects" "nmrs-run-idea-create-with-side-effects")
-                (nms-contains? "nmpg-run-idea-create-public-gate nmrs-run-idea-create-with-side-effects" "with-side-effects")) 1) 100 0))
+                (nms-contains? "nmpg-run-idea-create-public-gate nmrs-run-idea-create-with-side-effects" "with-side-effects")) 1) 1000 0))
             (let idea-update-ok (if (eq (nms-and3
                 (nms-contains? "nmpg-run-idea-update-public-gate nival-run-idea-update-with-valuation-audit audit_ledger" "nmpg-run-idea-update-public-gate")
                 (nms-contains? "nmpg-run-idea-update-public-gate nival-run-idea-update-with-valuation-audit audit_ledger" "nival-run-idea-update-with-valuation-audit")
-                (nms-contains? "nmpg-run-idea-update-public-gate nival-run-idea-update-with-valuation-audit audit_ledger" "audit_ledger")) 1) 1000 0))
+                (nms-contains? "nmpg-run-idea-update-public-gate nival-run-idea-update-with-valuation-audit audit_ledger" "audit_ledger")) 1) 10000 0))
             (let spec-ok (if (eq (nms-and3
                 (nms-contains? "nmpg-run-spec-update-public-gate nmrs-run-spec-update-with-side-effects" "nmpg-run-spec-update-public-gate")
                 (nms-contains? "nmpg-run-spec-update-public-gate nmrs-run-spec-update-with-side-effects" "nmrs-run-spec-update-with-side-effects")
-                (nms-contains? "nmpg-run-spec-update-public-gate nmrs-run-spec-update-with-side-effects" "with-side-effects")) 1) 10000 0))
+                (nms-contains? "nmpg-run-spec-update-public-gate nmrs-run-spec-update-with-side-effects" "with-side-effects")) 1) 100000 0))
             (let function-ok (if (eq (nms-and3
                 (nms-contains? "nmpg-record-public-gate-rollback-receipt nmpg-public-gate-rollback-receipt-sql" "nmpg-record-public-gate-rollback-receipt")
                 (nms-contains? "nmpg-record-public-gate-rollback-receipt nmpg-public-gate-rollback-receipt-sql" "nmpg-public-gate-rollback-receipt-sql")
-                (nms-contains? "nmpg-record-public-gate-rollback-receipt nmpg-public-gate-rollback-receipt-sql" "rollback-receipt")) 1) 100000 0))
+                (nms-contains? "nmpg-record-public-gate-rollback-receipt nmpg-public-gate-rollback-receipt-sql" "rollback-receipt")) 1) 1000000 0))
             (let traffic-ok (if (eq (nms-and3
                 (nms-contains? contract "\"ordinary_traffic_flip_performed\":false")
                 (nms-contains? contract "remove X-Form-Native-Public-Gate")
-                (nms-contains? contract "fanout-python")) 1) 1000000 0))
-            (sum (list contract-ok receipt-ok idea-ok idea-update-ok spec-ok function-ok traffic-ok))))
+                (nms-contains? contract "fanout-python")) 1) 10000000 0))
+            (sum (list contract-ok receipt-ok decision-ok idea-ok idea-update-ok spec-ok function-ok traffic-ok))))
 
     0)

--- a/form/form-stdlib/tests/native-mutation-public-gate-band.fk
+++ b/form/form-stdlib/tests/native-mutation-public-gate-band.fk
@@ -5,9 +5,9 @@
 ;           form-stdlib/native-mutation-route-side-effects.fk
 ;           form-stdlib/native-mutation-public-gate.fk
 ;
-; Band verdict: 111111 when the public gate carries an explicit header,
-; persisted rollback receipt SQL, route-side-effect runner binding, and an
-; unflipped ordinary-traffic contract.
+; Band verdict: 11111111 when the public gate carries an explicit header,
+; persisted rollback receipt SQL, per-request decision receipt,
+; route-side-effect runner binding, and an unflipped ordinary-traffic contract.
 
 (do
     (nmpg-public-gate-test))

--- a/specs/native-mutation-public-gate.md
+++ b/specs/native-mutation-public-gate.md
@@ -33,6 +33,7 @@ requirements:
   - "The production route manifest exposes X-Form-Native-Public-Gate rows for mutable ideas/spec routes without changing no-header traffic."
   - "The public-gate harness observes no-header fanout, preview-header SQL preview, public-gate native selection, and public-gate priority when both headers are present."
   - "HTTP public-gate responses stay honest: the header gate executes and emits a rollback receipt shape, while DB execution remains proven in the Form live fixture rather than claimed by the HTTP route."
+  - "Each public-gate HTTP response emits a compact decision receipt naming candidates, selected path, outcome, protocol, reversibility, and a signature so the gate can contradict intent with observable state."
   - "The next boundary is a deployed X-Form-Native-Public-Gate canary before any ordinary no-header flip."
   - "The side-effect ledger keeps rollback receipts as gate-local safety rather than Python parity, so side-effect proof does not justify side effects."
   - "The public-gate Form layer exposes an idea update runner over the native idea valuation audit-ledger carrier."
@@ -83,6 +84,10 @@ reversible gate safety, not evidence that extra domain side effects belong.
 - [ ] **R8**: `native-mutation-public-gate.fk` exposes
   `nmpg-run-idea-update-public-gate` over the native idea valuation audit-ledger
   carrier.
+- [ ] **R9**: Public-gate responses carry `decision_receipt` with
+  `state=native-mutation-gate-decision-receipt`, selected path
+  `X-Form-Native-Public-Gate`, candidate outcomes for fanout/preview/public
+  gate, `can_contradict_intent=true`, and a compact signature.
 
 ## Research Inputs
 
@@ -164,6 +169,9 @@ python3 scripts/validate_spec_quality.py --file specs/native-mutation-public-gat
   `executes:false`; the receipt persistence proof lives in the Form live-PG
   harness.
 - Rollback receipts are gate-local safety rather than Python parity.
+- Decision receipts are per-request gate witnesses: they record what branch was
+  selected and enough signature detail to make the gate observable before the
+  no-header flip.
 - The ledger states that rollback receipts are gate-local safety rather than Python parity.
 - Removing the public-gate header or route row is the reversible rollback for
   the header-gated canary path.


### PR DESCRIPTION
## Summary
- add compact decision_receipt to X-Form-Native-Public-Gate mutation responses
- prove receipt state, selected path, candidate outcomes, reversibility, and signature in the public-gate harness
- update Form public-gate contract/spec/evidence; no no-header mutation traffic flips

## Local proof
- make prompt-guide
- make wellness
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/application-graph-node-port.fk form-stdlib/native-mutation-side-effects.fk form-stdlib/native-mutation-route-side-effects.fk form-stdlib/native-idea-valuation-audit-ledger.fk form-stdlib/native-mutation-public-gate.fk form-stdlib/tests/native-mutation-public-gate-band.fk -> 11111111
- form/scripts/native-mutation-public-gate-test.sh -> 111111111
- python3 deploy/kernel-router/mutation_public_gate_harness.py --json -> 5/5 confidence 1.0
- python3 deploy/kernel-router/mutation_ab_observation_harness.py --json -> 5/5 confidence 1.0
- cd api && python3 -m pytest -q tests/test_native_mutation_public_gate.py tests/test_native_mutation_ab_observation.py tests/test_ideas_router_form.py tests/test_spec_registry_router_form.py -> 23 passed
- cd api && python3 -m ruff check tests/test_native_mutation_public_gate.py ../deploy/kernel-router/mutation_public_gate_harness.py
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-09_native_gate_decision_receipts.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main -> ready_for_push=True

## Boundary
Ordinary no-header traffic remains fanout-python. Next evidence is deployed public-gate decision receipts in canary traffic before any no-header flip.