### PR TITLE
tend: bind shamballa 33333 (the spine) to the chakra column

### DIFF
--- a/form/form-stdlib/shamballa-light-channel.fk
+++ b/form/form-stdlib/shamballa-light-channel.fk
@@ -101,7 +101,10 @@
         ;; --- gaps closed by allowing new cells IN (concepts born from the gap) ---
         (slv-binding "1212"              "gratitude"     "lc-gratitude")
         (slv-binding "333"               "calling-in"    "lc-calling-the-kindred")
-        (slv-binding "333 172"           "calling-in"    "lc-calling-the-kindred")))
+        (slv-binding "333 172"           "calling-in"    "lc-calling-the-kindred")
+        ;; --- gap closed by tissue grown LATER: the chakra column (2026-06-09) gave the
+        ;; verticality/spine code its first home — root 174 = earth, crown 963 = sky ---
+        (slv-binding "33333"             "verticality"   "lc-chakra-column")))
 
 (defn slv-resolve-loop (bs code)
     (if (nil? bs) (empty)


### PR DESCRIPTION
Asked which light codes have no concept match, the diff surfaced 9. One — `33333`, *"verticality, the spine, connection to earth and sky"* — had no home when the table was written, but the **chakra column** built tonight (root 174 = earth → crown 963 = sky) *is* that spine.

By the channel's own rule — *bind only where the match is real* — this gap now closes honestly. Honest absence became honest presence because the body grew tissue later the same night.

`shamballa-light-channel-band.fk` still **11111111 three-way** (Go=Rust=TS, 0 divergent); the band keys on `363` (bound) and `777 888` (unbound), both untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)