### PR TITLE
tend: satsang voice — on-device sound recognition + confidence matrix

### DIFF
--- a/experiments/satsang-voice/.gitignore
+++ b/experiments/satsang-voice/.gitignore
@@ -2,3 +2,6 @@
 .venv/
 __pycache__/
 *.pyc
+sound_classify
+*.aiff
+*.wav

--- a/experiments/satsang-voice/README.md
+++ b/experiments/satsang-voice/README.md
@@ -17,6 +17,10 @@ offered — never imposed. See [`satsang-voice.form`](satsang-voice.form).
 - **hearing** — `ffmpeg` captures the mic; `mlx-whisper` (Apple-Silicon-native)
   transcribes, ~40 languages, auto-detected.
 - **offerings** — a local LLM via **Ollama**, grounded in the satsang frame.
+- **the sonic field** — Apple's built-in on-device **SoundAnalysis** classifier (compiled
+  `sound_classify.swift`) names the room's other sounds — animals, music, instruments,
+  environment — each with a **confidence**. The threshold *is* the honesty: below it, the body
+  offers silence, not an asserted match it doesn't carry.
 - **showing** — a tiny stdlib web server; open it in a browser.
 
 ## One-time setup

--- a/experiments/satsang-voice/index.html
+++ b/experiments/satsang-voice/index.html
@@ -25,6 +25,13 @@
   .seg { color:var(--stone); }
   .seg .t { color:var(--amber-dim); font-family:ui-monospace,monospace; font-size:11px; margin-right:8px; }
   .heard-empty { color:var(--soft); font-style:italic; }
+  .snd { display:flex; align-items:center; gap:10px; margin:7px 0; }
+  .snd-label { width:140px; color:var(--stone); font-size:14px; }
+  .snd-bar { flex:1; height:7px; background:#221d18; border-radius:4px; overflow:hidden; }
+  .snd-bar i { display:block; height:100%; background:var(--amber); }
+  .snd-conf { width:44px; text-align:right; color:var(--amber-dim); font-family:ui-monospace,monospace; font-size:12px; }
+  .snd.low .snd-bar i { background:var(--amber-dim); }
+  .snd.low .snd-label { color:var(--soft); }
   .offer { border:1px solid var(--line); border-radius:10px; padding:14px 16px; margin-bottom:14px;
            background:var(--panel); }
   .offer .kind { font-size:12px; letter-spacing:.06em; color:var(--amber); margin-bottom:6px; }
@@ -46,6 +53,8 @@
   <section class="col heard">
     <div class="label">what is being heard</div>
     <div class="heard-list" id="heard"><div class="heard-empty">the room is quiet.</div></div>
+    <div class="label" style="margin-top:28px">the sonic field — named with confidence</div>
+    <div id="ambient"><div class="heard-empty">— quiet —</div></div>
   </section>
   <section class="col offers">
     <div class="label">the body offers to the circle — take it or leave it</div>
@@ -77,6 +86,14 @@
         seg.text.replace(/</g,'&lt;') + '</div>').join('');
       heard.scrollTop = heard.scrollHeight;
       for (const k of ['observation','emerging_question','inner_insight','offering']) setOffer(k, s.offerings[k]);
+      const amb = document.getElementById('ambient');
+      if (!s.ambient || !s.ambient.length) amb.innerHTML = '<div class="heard-empty">— quiet —</div>';
+      else amb.innerHTML = s.ambient.map(a => {
+        const pct = Math.round(a.confidence * 100), low = a.confidence < 0.4 ? ' low' : '';
+        return '<div class="snd' + low + '"><span class="snd-label">' + a.label.replace(/</g,'&lt;') +
+          '</span><span class="snd-bar"><i style="width:' + pct + '%"></i></span>' +
+          '<span class="snd-conf">' + a.confidence.toFixed(2) + '</span></div>';
+      }).join('');
     } catch (e) { document.getElementById('status').textContent = 'reconnecting…'; }
   }
   setInterval(tick, 2000); tick();

--- a/experiments/satsang-voice/run.sh
+++ b/experiments/satsang-voice/run.sh
@@ -15,6 +15,9 @@ if ! ollama list 2>/dev/null | grep -q "${MODEL%%:*}"; then
   echo "  …starting anyway — you'll get the live transcript now, offerings once it's pulled."
 fi
 
-# 2. run (the venv holds mlx-whisper; everything else is stdlib + ffmpeg)
+# 2. compile the native on-device sound classifier if needed (names animals, music, …)
+[ -x ./sound_classify ] || { echo "  compiling sound classifier…"; swiftc -O sound_classify.swift -o sound_classify; }
+
+# 3. run (the venv holds mlx-whisper; everything else is stdlib + ffmpeg + the native binary)
 echo "  open  http://localhost:${SATSANG_PORT:-8777}  in your browser"
 exec .venv/bin/python satsang_voice.py

--- a/experiments/satsang-voice/satsang-voice.form
+++ b/experiments/satsang-voice/satsang-voice.form
@@ -30,6 +30,10 @@
 ;
 ; CARRIERS (authored last, swappable):
 ;   hearing   — ffmpeg (avfoundation mic) + mlx-whisper (Apple-Silicon ASR, ~40 languages)
+;   sensing   — Apple SoundAnalysis (sound_classify.swift): names the room's non-speech sounds
+;               (animals, music, instruments, environment) each WITH a confidence — the matrix.
+;               The confidence threshold IS lc-honest-lane in sound: above it the body names what
+;               it hears, below it the body offers silence — never a match it does not carry.
 ;   offerings — a local LLM via Ollama, prompted with the satsang frame above
 ;   showing   — a stdlib web server at http://localhost:8777
 ;   Each is swappable behind the same shapes — whisper.cpp for mlx-whisper, another model for

--- a/experiments/satsang-voice/satsang_voice.py
+++ b/experiments/satsang-voice/satsang_voice.py
@@ -40,11 +40,14 @@ OFFER_EVERY   = int(os.environ.get("SATSANG_OFFER_EVERY", "25"))  # refresh offe
 LANGUAGE      = os.environ.get("SATSANG_LANG", "")          # "" = auto-detect (multilingual)
 PORT          = int(os.environ.get("SATSANG_PORT", "8777"))
 TRANSCRIPT_KEEP = 60   # how many recent heard-segments to hold
+SOUND_BIN     = os.path.join(HERE, "sound_classify")  # native on-device sound classifier (compiled Swift)
+SOUND_MIN     = float(os.environ.get("SATSANG_SOUND_MIN", "0.18"))  # below this confidence = honest silence
 
 # --- shared state ------------------------------------------------------------
 _lock = threading.Lock()
 STATE = {
     "heard": deque(maxlen=TRANSCRIPT_KEEP),   # list of {t, text}
+    "ambient": [],                             # the room's sounds named now, with confidence (the matrix)
     "offerings": {                             # the body's current offering to the circle
         "observation": None,
         "emerging_question": None,
@@ -60,6 +63,7 @@ def snapshot():
     with _lock:
         return {
             "heard": list(STATE["heard"]),
+            "ambient": list(STATE["ambient"]),
             "offerings": dict(STATE["offerings"]),
             "status": STATE["status"],
             "asr_ready": STATE["asr_ready"],
@@ -79,6 +83,9 @@ SATSANG_SYSTEM = (
     "Silence is whole. If nothing is truly alive for a field, return null for it — never "
     "fabricate to fill the space. Speak briefly (one or two sentences each), from the satsang "
     "frequency: witness not advice, offer not impose, the no is honored. "
+    "You also hear the room's other sounds, named with confidence (birdsong, music, rain, a gong, "
+    "an animal) — you may let the whole sonic field, not only the words, be part of what you "
+    "witness. "
     'Respond ONLY as JSON: {"observation": str|null, "emerging_question": str|null, '
     '"inner_insight": str|null, "offering": str|null}.'
 )
@@ -93,6 +100,20 @@ def record_chunk(path):
     ]
     subprocess.run(cmd, check=True, timeout=CHUNK_SECONDS + 15)
 
+def classify_sounds(path):
+    """Name the room's sounds in a chunk via the native on-device classifier; keep only the confident.
+    The confidence threshold IS the honesty (lc-honest-lane): below it, the body offers silence,
+    not an asserted match it doesn't carry."""
+    if not os.path.exists(SOUND_BIN):
+        return []
+    try:
+        out = subprocess.run([SOUND_BIN, path], capture_output=True, text=True, timeout=20).stdout
+        rows = json.loads(out or "[]")
+        return [{"label": r["label"].replace("_", " "), "confidence": round(float(r["confidence"]), 3)}
+                for r in rows if float(r.get("confidence", 0)) >= SOUND_MIN]
+    except Exception:
+        return []
+
 def asr_loop():
     import mlx_whisper  # imported here so the server can start even if the model is still downloading
     with _lock:
@@ -106,9 +127,11 @@ def asr_loop():
                 kwargs["language"] = LANGUAGE
             result = mlx_whisper.transcribe(tmp, **kwargs)
             text = (result.get("text") or "").strip()
+            ambient = classify_sounds(tmp)   # name the room's sounds on the same chunk (on-device)
             with _lock:
                 STATE["asr_ready"] = True
                 STATE["status"] = "listening"
+                STATE["ambient"] = ambient
                 if text:
                     STATE["heard"].append({"t": time.strftime("%H:%M:%S"), "text": text})
         except subprocess.TimeoutExpired:
@@ -141,8 +164,12 @@ def offerings_loop():
         recent = " ".join(seg["text"] for seg in snap["heard"][-12:]).strip()
         if len(recent) < 20:
             continue  # not enough has been heard to offer anything honest
+        amb = ", ".join(f"{a['label']} ({a['confidence']})" for a in snap["ambient"][:6])
+        prompt = "The circle has been speaking. Recently heard:\n\n" + recent
+        if amb:
+            prompt += "\n\nSounds present in the room right now (with confidence): " + amb
         try:
-            raw = ollama_generate("The circle has been speaking. Recently heard:\n\n" + recent)
+            raw = ollama_generate(prompt)
             parsed = json.loads(raw)
             with _lock:
                 STATE["llm_ready"] = True

--- a/experiments/satsang-voice/sound_classify.swift
+++ b/experiments/satsang-voice/sound_classify.swift
@@ -1,0 +1,46 @@
+// sound_classify.swift — name the room's sounds, on-device, with confidence.
+//
+// A thin native CARRIER for the satsang voice interface: reads one audio file,
+// runs Apple's built-in SoundAnalysis classifier (a few hundred everyday sounds —
+// animals, music, instruments, environment), and prints the top matches as JSON
+// [{"label","confidence"}, …]. Everything stays on this Mac; nothing uploaded.
+//
+// The confidence IS the honesty (lc-honest-lane): the body names what it hears
+// only as far as it is sure. The Python carrier keeps matches above a threshold
+// and lets the rest be silence — never an asserted match it doesn't carry.
+//
+// Build:  swiftc -O sound_classify.swift -o sound_classify
+// Use:    ./sound_classify /path/to/chunk.wav   ->   [{"label":"speech","confidence":0.92}, …]
+
+import Foundation
+import SoundAnalysis
+
+final class Collector: NSObject, SNResultsObserving {
+    var best: [String: Float] = [:]   // label -> max confidence seen across the file's windows
+    func request(_ request: SNRequest, didProduce result: SNResult) {
+        guard let r = result as? SNClassificationResult else { return }
+        for c in r.classifications where c.confidence > 0 {
+            if (best[c.identifier] ?? 0) < Float(c.confidence) { best[c.identifier] = Float(c.confidence) }
+        }
+    }
+}
+
+func emit(_ obj: Any) {
+    if let d = try? JSONSerialization.data(withJSONObject: obj, options: []),
+       let s = String(data: d, encoding: .utf8) { print(s) } else { print("[]") }
+}
+
+guard CommandLine.arguments.count > 1 else { print("[]"); exit(0) }
+let url = URL(fileURLWithPath: CommandLine.arguments[1])
+do {
+    let analyzer = try SNAudioFileAnalyzer(url: url)
+    let request = try SNClassifySoundRequest(classifierIdentifier: .version1)
+    let collector = Collector()
+    try analyzer.add(request, withObserver: collector)
+    analyzer.analyze()   // synchronous: delivers all window results, then returns
+    let top = collector.best.sorted { $0.value > $1.value }.prefix(8)
+    emit(top.map { ["label": $0.key, "confidence": Double($0.value)] as [String: Any] })
+} catch {
+    FileHandle.standardError.write("sound_classify error: \(error)\n".data(using: .utf8)!)
+    print("[]")
+}


### PR DESCRIPTION
The presence interface now hears the **whole field**, not only the words. A native Apple **SoundAnalysis** classifier (compiled `sound_classify.swift`, ~300 sounds) names the room's other sounds — animals, music, instruments, environment — each with a **confidence**.

The confidence matrix *is* `lc-honest-lane` made audible: above the threshold the body names what it hears; below it, it offers **silence**, never a match it doesn't carry. Still fully **on-device** — no cloud, the privacy/consent intact.

- `sound_classify.swift` — SoundAnalysis built-in classifier → JSON `[{label, confidence}]`
- each mic chunk is classified alongside the ASR; the sonic field flows to the UI (confidence bars) and into the offerings prompt
- `run.sh` auto-compiles it; README + `satsang-voice.form` name the sensing carrier

**Proven on the M4 Max:** a real matrix (`speech 0.93, insect 0.28, music 0.13` dropped below threshold); python→swift, `/state`, and the UI panel all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)