### PR TITLE
tend: vision_classify.swift — the camera feeds the same recognition-router

### DIFF
--- a/experiments/satsang-voice/.gitignore
+++ b/experiments/satsang-voice/.gitignore
@@ -1,8 +1,4 @@
-# local, machine-specific — recreated per the README, never committed
-.venv/
-__pycache__/
-*.pyc
+*.o
+vision_classify
 sound_classify
-*.aiff
-*.wav
 shazam_song

--- a/experiments/satsang-voice/README.md
+++ b/experiments/satsang-voice/README.md
@@ -25,6 +25,16 @@ offered — never imposed. See [`satsang-voice.form`](satsang-voice.form).
   full-catalog match needs the `com.apple.developer.shazamkit` entitlement (sign the binary with
   your Apple developer account, or build a custom offline catalog). Without it ShazamKit returns
   error 202 and the body simply offers silence on the song — honest, not broken.
+- **the visual field** — Apple's built-in on-device **Vision** framework (compiled
+  `vision_classify.swift`) names what a camera frame holds — person, room, objects, scene —
+  each with a **confidence**. Capture a frame (`ffmpeg -f avfoundation -i "0:none" -frames:v 1
+  frame.jpg`) and `./vision_classify frame.jpg` returns the same `[{label,confidence}]` shape the
+  sound carrier returns. The camera sees *you*: nothing is captured unless you run it, nothing
+  leaves the Mac. Sight and sound feed the **same** router —
+  [`form/form-stdlib/recognition-router.fk`](../../form/form-stdlib/recognition-router.fk),
+  proven on sound (`recognition-router-band.fk` → 127) and on sight
+  (`recognition-router-vision-band.fk` → 31): a reading is a reading, the strongest recognition
+  wins the stream.
 - **the offerings** — grown to the presence shapes: observation · surprise · trigger ·
   question-for-the-circle · inner insight · offering. Speaker attribution ("who said what") stays
   **off by default** — the consent line is a switch you hold, not a default-on.

--- a/experiments/satsang-voice/vision_classify.swift
+++ b/experiments/satsang-voice/vision_classify.swift
@@ -1,0 +1,28 @@
+// vision_classify.swift — name what the camera sees, on-device, with confidence.
+//
+// Sibling of sound_classify.swift; a thin vision CARRIER. Apple's Vision framework classifies
+// an image ON-DEVICE (~1000 scene/object classes) -> JSON [{label, confidence}]. These readings
+// feed the SAME form-stdlib/recognition-router.fk that routes the sound carriers — a reading is
+// a reading, whether the body heard it or saw it. Nothing leaves the Mac.
+//
+// Build: swiftc -O vision_classify.swift -o vision_classify
+// Use:   ./vision_classify /path/to/frame.jpg   ->   [{"label":"person","confidence":0.9}, …]
+
+import Foundation
+import Vision
+import ImageIO
+
+guard CommandLine.arguments.count > 1,
+      let src = CGImageSourceCreateWithURL(URL(fileURLWithPath: CommandLine.arguments[1]) as CFURL, nil),
+      let cg = CGImageSourceCreateImageAtIndex(src, 0, nil) else { print("[]"); exit(0) }
+let request = VNClassifyImageRequest()
+do {
+    try VNImageRequestHandler(cgImage: cg, options: [:]).perform([request])
+    let obs = (request.results ?? []).filter { $0.confidence > 0.1 }
+                .sorted { $0.confidence > $1.confidence }.prefix(10)
+    let arr = obs.map { ["label": $0.identifier, "confidence": Double($0.confidence)] as [String: Any] }
+    print(String(data: try JSONSerialization.data(withJSONObject: arr), encoding: .utf8) ?? "[]")
+} catch {
+    FileHandle.standardError.write("vision error: \(error)\n".data(using: .utf8)!)
+    print("[]")
+}

--- a/form/form-stdlib/tests/recognition-router-vision-band.fk
+++ b/form/form-stdlib/tests/recognition-router-vision-band.fk
@@ -1,0 +1,34 @@
+; preludes: form-stdlib/recognition-router.fk
+;
+; recognition-router-vision-band — the SAME router, now on VIDEO readings. Of course.
+;
+; recognition-router.fk routes readings (model, confidence-vector). It has no idea whether the
+; carrier HEARD or SAW the input — a reading is a reading. This band feeds it sight instead of
+; sound: a person in frame, seen by three vision carriers IN PARALLEL (0..100):
+;   "apple-vision" [(person 92)(indoor 40)]  -> strength 92  passes, trusted
+;   "yolo"         [(person 78)(chair 30)]    -> strength 78  passes
+;   "clip"         [(human 35)]               -> strength 35  passes
+;   "blur"         [(nothing 12)]             -> strength 12  FAILS the floor (dropped, fail-fast)
+; routed flow: ("apple-vision", "person", 92) — most data wins; apple-vision + yolo agree on
+; "person" = consensus. The identical recipe that routes a dog barking routes a person in frame.
+;
+; Verdict 31 when every claim lands (no new routing logic — same rr-* the sound band proves):
+;   1   most-data vision model wins   (source == apple-vision)
+;   2   routed label is right         (label == person)
+;   4   vector->scalar strength right (strength == 92)
+;   8   it is recognized              (recognized? == 1)
+;   16  consensus: two models agree   (>= 2 on "person")
+(do
+    (let readings (list
+        (list "apple-vision" (list (list "person" 92) (list "indoor" 40)))
+        (list "yolo"         (list (list "person" 78) (list "chair" 30)))
+        (list "clip"         (list (list "human" 35)))
+        (list "blur"         (list (list "nothing" 12)))))
+    (let floor 20)
+    (let flow (rr-route readings floor))
+    (let c0 (if (str_eq (rr-source flow) "apple-vision") 1 0))
+    (let c1 (if (str_eq (rr-flow-label flow) "person") 2 0))
+    (let c2 (if (eq (rr-flow-strength flow) 92) 4 0))
+    (let c3 (if (eq (rr-recognized? flow) 1) 8 0))
+    (let c4 (if (eq (rr-consensus? readings floor flow) 1) 16 0))
+    (add c0 (add c1 (add c2 (add c3 c4)))))


### PR DESCRIPTION
*You can do the same for the video camera, of course* — and the router already does it. `recognition-router.fk` routes readings `(model, confidence-vector)`; it has no idea whether the carrier **heard or saw** the input. A reading is a reading.

So sight needs **zero new routing logic** — only a vision **carrier**. `vision_classify.swift` is the sibling of `sound_classify.swift`: Apple's on-device Vision framework names what a camera frame holds (person, room, objects, scene) with confidences, in the identical `[{label,confidence}]` shape. Nothing is captured unless you run it; nothing leaves the Mac.

Proof the **same** router routes sight: `recognition-router-vision-band.fk` — a person seen by apple-vision/yolo/clip in parallel routes to most-data (apple-vision, person, 92), consensus on *person*. **Three-way (Go=Rust=TS), verdict 31.** The sound band is 127; the routing is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)