### PR TITLE
tend: stop serializing English bundle into every page; localize Bali home card

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -91,7 +91,13 @@ export default async function RootLayout({
     ? headerLang
     : DEFAULT_LOCALE;
   const messages = getMessages(lang);
-  const fallback = getMessages(DEFAULT_LOCALE);
+  // The active bundle is always complete — key parity is enforced at build by
+  // validate_locale_surfaces — so the client needs no separate English
+  // fallback. Shipping one would serialize the entire English bundle into
+  // every page's HTML (a non-English locale would carry the full en text in
+  // its source). The server-side createTranslator keeps its own en fallback
+  // for defense in depth; the client carries only the active tongue.
+  const fallback = messages;
   const t = createTranslator(lang);
   return (
     <html lang={lang} suppressHydrationWarning>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -528,19 +528,17 @@ export default async function Home() {
               className="group rounded-2xl border border-emerald-500/35 bg-gradient-to-b from-emerald-500/10 to-card/30 hover:from-emerald-500/15 p-5 transition-colors"
             >
               <p className="text-[11px] uppercase tracking-[0.18em] text-emerald-500/90 mb-1">
-                {baliGroundPath.copy.eyebrow}
+                {t("home.groundBaliEyebrow")}
               </p>
               <p className="text-base text-foreground font-light mb-1">
                 {baliGroundPath.copy.title}
               </p>
               <p className="text-xs text-foreground/80 leading-relaxed">
-                {baliGroundPath.copy.body}
+                {t("home.groundBaliBody")}
               </p>
-              {baliGroundPath.copy.cta && (
-                <p className="text-xs text-emerald-400/85 mt-3 group-hover:text-emerald-400 transition-colors">
-                  {baliGroundPath.copy.cta}
-                </p>
-              )}
+              <p className="text-xs text-emerald-400/85 mt-3 group-hover:text-emerald-400 transition-colors">
+                {t("home.groundBaliCta")}
+              </p>
             </AttributedInternalLink>
           )}
           <AttributedInternalLink

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1486,7 +1486,10 @@
     "groundWithUsTitle": "Für Gemeinschaften, Einzelne und Dienste überall",
     "groundWithUsBody": "Lies, was der Körper anbietet, die sieben Richtungen, um die er sich ordnet, und wie sich arbeitende Leben einweben.",
     "groundWithUsCta": "/with-us lesen →",
-    "deployLog": "Deployment-Protokoll"
+    "deployLog": "Deployment-Protokoll",
+    "groundBaliEyebrow": "Gemeinschaftsort auf Bali",
+    "groundBaliBody": "Eine direkte Tür für Landhüter zum Bali-Wohnort-Entwurf: Quellskizze, Klimalogik, geteilte Räume, private Nester, Materialien und das nächste baubare Paket.",
+    "groundBaliCta": "/silence/built durchgehen →"
   },
   "time": {
     "justNow": "gerade eben",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1576,7 +1576,10 @@
     "groundWithUsTitle": "For communities, individuals, and services anywhere",
     "groundWithUsBody": "Read what the body offers, the seven directions it organizes around, and how working lives weave in.",
     "groundWithUsCta": "Read /with-us →",
-    "deployLog": "deploy log"
+    "deployLog": "deploy log",
+    "groundBaliEyebrow": "Bali living compound",
+    "groundBaliBody": "A direct doorway for land stewards into the Bali compound proposal: source sketch, climate logic, shared rooms, private nests, materials, and the next buildable packet.",
+    "groundBaliCta": "Walk through /silence/built →"
   },
   "time": {
     "justNow": "just now",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1486,7 +1486,10 @@
     "groundWithUsTitle": "Para comunidades, individuos y servicios en cualquier lugar",
     "groundWithUsBody": "Lee lo que el cuerpo ofrece, las siete direcciones en torno a las que se organiza, y cómo se entretejen las vidas activas.",
     "groundWithUsCta": "Leer /with-us →",
-    "deployLog": "registro de despliegue"
+    "deployLog": "registro de despliegue",
+    "groundBaliEyebrow": "Un lugar de vida en Bali",
+    "groundBaliBody": "Una puerta directa para guardianes de la tierra hacia la propuesta del lugar de vida en Bali: boceto fuente, lógica climática, espacios compartidos, nidos privados, materiales y el próximo paquete construible.",
+    "groundBaliCta": "Recorrer /silence/built →"
   },
   "time": {
     "justNow": "justo ahora",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1576,7 +1576,10 @@
     "groundWithUsTitle": "Pour les communautés, les individus et les services, où qu'ils soient",
     "groundWithUsBody": "Lisez ce que le corps offre, les sept directions autour desquelles il s'organise, et comment des vies actives s'y tissent.",
     "groundWithUsCta": "Lire /with-us →",
-    "deployLog": "journal de déploiement"
+    "deployLog": "journal de déploiement",
+    "groundBaliEyebrow": "Un lieu de vie à Bali",
+    "groundBaliBody": "Une porte directe pour les gardien·ne·s de la terre vers la proposition du lieu de vie à Bali : esquisse source, logique climatique, espaces partagés, nids privés, matériaux et le prochain lot constructible.",
+    "groundBaliCta": "Parcourir /silence/built →"
   },
   "time": {
     "justNow": "à l'instant",

--- a/web/messages/id.json
+++ b/web/messages/id.json
@@ -1486,7 +1486,10 @@
     "groundWithUsTitle": "Untuk komunitas, individu, dan layanan di mana pun",
     "groundWithUsBody": "Baca apa yang ditawarkan tubuh ini, tujuh arah yang menjadi porosnya, dan bagaimana kehidupan yang bekerja menenun masuk.",
     "groundWithUsCta": "Baca /with-us →",
-    "deployLog": "log penyebaran"
+    "deployLog": "log penyebaran",
+    "groundBaliEyebrow": "Tempat hidup bersama di Bali",
+    "groundBaliBody": "Pintu langsung bagi penjaga tanah menuju proposal hunian Bali: sketsa sumber, logika iklim, ruang bersama, sarang pribadi, material, dan paket bangun berikutnya.",
+    "groundBaliCta": "Telusuri /silence/built →"
   },
   "time": {
     "justNow": "baru saja",

--- a/web/messages/pt-br.json
+++ b/web/messages/pt-br.json
@@ -1576,7 +1576,10 @@
     "groundWithUsTitle": "Para comunidades, indivíduos e serviços em qualquer lugar",
     "groundWithUsBody": "Leia o que o corpo oferece, as sete direções em torno das quais ele se organiza, e como vidas em atividade se tecem.",
     "groundWithUsCta": "Ler /with-us →",
-    "deployLog": "registro de implantação"
+    "deployLog": "registro de implantação",
+    "groundBaliEyebrow": "Uma comunidade de vida em Bali",
+    "groundBaliBody": "Uma porta direta para guardiões da terra entrarem na proposta da comunidade em Bali: esboço-fonte, lógica climática, espaços compartilhados, ninhos privados, materiais e o próximo pacote construível.",
+    "groundBaliCta": "Percorrer /silence/built →"
   },
   "time": {
     "justNow": "agora mesmo",


### PR DESCRIPTION
Follow-up to #2684 — driven by a real **language classifier** (lingua) run over the browser's *visible rendered text*, after a reviewer found "Meet the body that can answer back" in the page source.

## Two leaks key-parity couldn't see

1. **Embedded English fallback bundle.** The root layout passed `getMessages("en")` as `MessagesProvider`'s client `fallback`, so every non-English page serialized the **entire English bundle** into its HTML source. That's where "Meet the body that can answer back" lived — not rendered, but present in `view-source`. Key parity is enforced at build, so the active bundle is always complete; the client needs no English fallback (the server translator keeps its own). → non-English HTML no longer carries the English bundle (verified: `grep` count 1 → 0).

2. **Bali "ground" card.** Pulled English-only copy from `getEntryPathForSurface` (no `lang`). Externalized eyebrow/body/cta to `home.groundBali*` across all six tongues — like the come-in/silence/with-us cards. Kept the project's proper name.

## Method (answering "do you have a classifier?")

Playwright extracts the page's **visible** `innerText` (not raw HTML, which embeds bundles + RSC payload); **lingua** classifies each block. Verdict: chrome classifies **100% in-tongue** — remaining English flags are brand terms ("Coherence Network", "Form Playground") or false positives from English URL slugs in CTAs ("Lire /with-us →"). 

## Honest remaining boundary

Visible English that remains is **purely content**: concept/idea bodies (`lc-pulse` description, idea names) and presence-trace lineage (Bloomurian/Mose/Matias) — the content-attunement pipeline, separate from chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)