### PR TITLE
tend: attune Brazilian Portuguese via the pt model, not the English anchor

### DIFF
--- a/api/app/services/translator_backends.py
+++ b/api/app/services/translator_backends.py
@@ -51,6 +51,19 @@ DEFAULT_TIMEOUT_SECONDS = 120
 DEFAULT_LIBRETRANSLATE_URL = "http://libretranslate:5000"
 
 
+# LibreTranslate speaks ISO-639-1 codes with no region tag; our installed
+# locales can carry one (pt-br). Map to the base code the engine loads so a
+# Brazilian-Portuguese reader is attuned via the "pt" model instead of having
+# the request fail-open back to the English anchor. Views still cache under the
+# full locale code; only the engine call is normalized.
+_LT_LANG_CODE = {"pt-br": "pt"}
+
+
+def _lt_lang(code: str) -> str:
+    c = (code or "").strip().lower()
+    return _LT_LANG_CODE.get(c, c.split("-", 1)[0])
+
+
 _logger = logging.getLogger("coherence.translator")
 
 
@@ -140,8 +153,8 @@ class LibreTranslateBackend:
             return "".join(translated_chunks)
         body: dict[str, Any] = {
             "q": text,
-            "source": source_lang,
-            "target": target_lang,
+            "source": _lt_lang(source_lang),
+            "target": _lt_lang(target_lang),
             "format": "text",
         }
         if self.api_key:

--- a/api/tests/test_libretranslate_backend.py
+++ b/api/tests/test_libretranslate_backend.py
@@ -14,6 +14,7 @@ from app.services.translator_backends import (
     AnthropicAttunementBackend,
     LibreTranslateBackend,
     _apply_glossary,
+    _lt_lang,
     register_default_backend,
 )
 from app.services import translator_service
@@ -122,3 +123,34 @@ def test_register_default_uses_translator_config_for_anthropic():
     assert backend.api_url == "https://anthropic.test/messages"
     assert backend.timeout_seconds == 17
     translator_service.set_backend(None)
+
+
+def test_lt_lang_strips_region_to_engine_code():
+    """Region-tagged locales map to the base code LibreTranslate loads."""
+    assert _lt_lang("pt-br") == "pt"   # the locale that was silently failing
+    assert _lt_lang("PT-BR") == "pt"   # case-insensitive
+    assert _lt_lang("fr") == "fr"      # already base — unchanged
+    assert _lt_lang("en") == "en"
+    assert _lt_lang("") == ""          # empty stays empty (no crash)
+
+
+def test_pt_br_request_calls_engine_with_pt():
+    """A pt-br attunement must hit LibreTranslate's 'pt', not 'pt-br' (which
+    the engine doesn't know and would fail-open back to English)."""
+    backend = LibreTranslateBackend(base_url="http://stub")
+    with patch("httpx.Client") as ClientCls:
+        client = MagicMock()
+        client.post = MagicMock(return_value=_mock_translate_response("O pulso"))
+        ClientCls.return_value.__enter__ = MagicMock(return_value=client)
+        ClientCls.return_value.__exit__ = MagicMock(return_value=False)
+        backend.attune(
+            source_markdown="",
+            source_title="The Pulse",
+            source_description="",
+            source_lang="en",
+            target_lang="pt-br",
+            glossary_prompt="",
+        )
+        sent_body = client.post.call_args.kwargs["json"]
+        assert sent_body["target"] == "pt"
+        assert sent_body["source"] == "en"


### PR DESCRIPTION
Part of making content **translatable instead of English-fallback** (your call: self-hosted LibreTranslate).

## The bug
The on-demand attunement backend sent the raw locale code to LibreTranslate. For `pt-br` it asked the engine for `"pt-br"`, which LibreTranslate doesn't load — so the call failed-open and a Brazilian-Portuguese reader got the **English anchor**. That English-as-fallback is the privileged-source default the platform exists to dissolve.

## The fix
Normalize the engine call: `pt-br → pt` (generically strip region to the base ISO-639-1 code). Views still cache under the full locale code; only the LibreTranslate request is normalized. French already matched (`fr → fr`).

## Paired infra (already live on the VPS)
- `libretranslate` service started (was created-but-never-run) and `LT_LOAD_ONLY` corrected from `en,de,es,id` → `en,de,es,fr,id,pt`.
- Installed the missing `en↔fr` and `en↔pt` Argos models into the volume.
- Fixed the healthcheck (`wget`, absent from the image → python urllib).
- Verified end-to-end: `GET /api/concepts/lc-pulse?lang=fr` now returns **"Le pouls"** + French description (cached). pt-br lands once this merges + deploys.

## Tests
`test_lt_lang_strips_region_to_engine_code` (pt-br/PT-BR→pt, fr→fr, ""→"") and `test_pt_br_request_calls_engine_with_pt` (asserts the body sent to the engine uses `pt`). 9/9 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)