### PR TITLE
attune: measure the learning claim against a real benchmark — it was toy; correct the overclaims

### DIFF
--- a/docs/coherence-substrate/sensing-lanes.form
+++ b/docs/coherence-substrate/sensing-lanes.form
@@ -96,11 +96,15 @@
 ;               `form-kernel-rust <recipe>.fk <driver>.fk` prints the label at ~5ms. coherence-sense-eval.py is the running
 ;               proof: per accel frame it runs signal-derivative (still/moving) + sequence-predictor (next state) through the
 ;               kernel, the predicted-vs-actual mismatch is the inference-error shown live, AND a nearest-shape CHALLENGER
-;               learns from the signal-derivative CHAMPION online (learning-arc.fk made live — verified: 34 exemplars, 76%
-;               agreement climbing on a real still/moving stream). The carrier only marshals ints in and reads the label out;
-;               the body recognizes AND learns. The phone-native kernel is also BUILT (lane 8: libform_kernel_rust.so exports
-;               form_eval, ARM aarch64). Remaining human-gated work is narrow: the JNI marshaling layer (jstring<->char*) so
-;               the .apk calls form_eval on-device, and felt verification in the room.
+;               runs the learning-arc.fk MECHANISM (intern an exemplar, recognize the nearest). HONEST SCOPE [experiments/
+;               har-benchmark]: that live demo is the mechanism, NOT learning that generalizes — still/moving is a single
+;               threshold (signal-derivative computes it by hand), the demo had no held-out test, 34 samples ~ 24s. On the
+;               real UCI-HAR benchmark nearest-shape reaches ~81% (vs 18% floor, ~96% SOTA) but is a NON-PARAMETRIC memorizer
+;               (model = the whole dataset). The "small model matches SOTA" prize (logistic reg: 3,372 params, 96%) needs a
+;               PARAMETRIC model = integer `mul` in Form + quantized-int inference; that is the real lane, not nearest-shape.
+;               The phone-native kernel is also BUILT (lane 8: libform_kernel_rust.so exports form_eval, ARM aarch64).
+;               Remaining human-gated work is narrow: the JNI marshaling layer (jstring<->char*) so the .apk calls form_eval
+;               on-device, and felt verification in the room.
 ;
 ; ─────────────────────────────────────────────────────────────────────────────────────────
 ; THE CRITICAL PATH (what unblocks the most):

--- a/experiments/coherence-sense-android/README.md
+++ b/experiments/coherence-sense-android/README.md
@@ -15,11 +15,14 @@ the senses are held until then.
   frame, the carrier writes a driver `.fk`, runs `signal-derivative` (still/moving) + `sequence-predictor`
   (the next state) through `form-kernel-rust` (~5ms), and the dashboard shows the **real recognition**,
   the **prediction**, and the **inference-error** (predicted-vs-actual — the learning signal). It also
-  runs the **live learning arc** (`learning-arc.fk`): a `nearest-shape` **challenger** learns from the
-  `signal-derivative` **champion** — each frame it predicts from the exemplars it has interned, is scored
-  against the champion, then learns the frame; the dashboard shows its agreement *climbing* toward the
-  champion as it accumulates exemplars (the Form-native arm reaching the reference, online, on real data).
-  The carrier only marshals integers in and reads the label out; the recognition and the learning are Form.
+  runs the **live learning-arc mechanism** (`learning-arc.fk`): a `nearest-shape` **challenger** interns
+  the `signal-derivative` **champion**'s labels and recognizes the nearest exemplar; the dashboard shows
+  its agreement with the champion. **Honest scope:** this is the *mechanism* (intern → recognize-nearest),
+  not learning that generalizes — still/moving is a single threshold the champion already computes by hand,
+  and there's no held-out test. Measured on the real UCI-HAR benchmark (`../har-benchmark/`), nearest-shape
+  is a weak **non-parametric memorizer** (~81% vs ~96% SOTA; "model" = the whole dataset). The "small model
+  matches SOTA" prize needs a *parametric* model (integer `mul` + quantized inference) — see the benchmark.
+  The carrier only marshals integers in and reads the label out; the recognition is Form, via the kernel.
 - **v1 — phone-native kernel (cdylib BUILT):** *autonomy.* The kernel itself runs **on the phone**.
   `form/form-kernel-rust/build-android.sh` now emits `libform_kernel_rust.so` — an ARM aarch64 shared
   object exporting `form_eval` (the same `run_source` evaluator, behind the `cabi` feature), verified

--- a/experiments/coherence-sense-android/coherence-sense-eval.py
+++ b/experiments/coherence-sense-android/coherence-sense-eval.py
@@ -5,11 +5,13 @@ The witness server (mac-witness-server.py) only watched. This one RECOGNIZES and
 accelerometer stream is fed, per frame, through the proven Form recipes RUN BY THE KERNEL —
 signal-derivative says still vs moving, sequence-predictor calls the next state, and the mismatch
 between the call and the actual next state is the INFERENCE ERROR (the learning signal). It also runs
-the supervision arc live (learning-arc.fk): a nearest-shape CHALLENGER learns from the signal-derivative
-CHAMPION — predicting from interned exemplars, scored against the champion, then learning each frame, its
-agreement climbing toward the champion as it accumulates exemplars (the Form-native arm reaching the
-reference, online). All of it is the body (Form recipes); this server is only the thin carrier that
-marshals numbers in and reads the label out. ~5ms per recognition through the kernel.
+the learning-arc.fk MECHANISM live: a nearest-shape CHALLENGER interns the signal-derivative CHAMPION's
+labels and recognizes the nearest exemplar, agreement shown on the dashboard. HONEST SCOPE: this is the
+mechanism (intern -> recognize-nearest), not learning that generalizes — still/moving is a single
+threshold the champion already computes, and there is no held-out test. Measured on the real UCI-HAR
+benchmark (../har-benchmark/), nearest-shape is a weak non-parametric memorizer (~81% vs ~96% SOTA). All
+of it is the body (Form recipes); this server is only the thin carrier that marshals numbers in and reads
+the label out. ~5ms per recognition through the kernel.
 
 Run from the repo (it needs the kernel binary + form-stdlib):
     cd experiments/coherence-sense-android && python3 coherence-sense-eval.py

--- a/experiments/har-benchmark/RESULTS.md
+++ b/experiments/har-benchmark/RESULTS.md
@@ -1,0 +1,80 @@
+# Is `nearest-shape` actually learning? A real benchmark.
+
+A demo on this Mac showed a `nearest-shape` challenger reaching ~76% "agreement" with a
+`signal-derivative` champion after 34 samples on a still/moving stream, and I called it *learning*.
+**That was a toy claim and it does not survive contact with a real benchmark.** This file is the
+honest measurement — run it yourself: `benchmark.py` against UCI-HAR (the canonical accelerometer
+human-activity-recognition dataset: 30 subjects, 6 activities, 7,352 train / 2,947 held-out test
+windows, ~2.6 hours of labeled accelerometer data).
+
+```
+python3 -m venv env && env/bin/pip install numpy scikit-learn
+# download UCI-HAR to /tmp/ucihar/  (archive.ics.uci.edu dataset 240), then:
+env/bin/python benchmark.py
+```
+
+## What was measured (held-out test accuracy)
+
+| method | test acc | "model" | size |
+|---|---|---|---|
+| majority-class baseline | 18.2% | — | the floor any learner must beat |
+| **nearest-shape — OURS** (quantized features + exact-bin-agreement 1-NN) | **80–82%** | every training exemplar | 4.1M values ≈ **16 MB** |
+| 1-NN euclidean (raw continuous features) | 87.9% | every training exemplar | 16 MB |
+| **logistic regression** (linear, parametric) | **96.1%** | **3,372 params** | **13 KB** |
+| linear SVM | 96.7% | 3,372 params | 13 KB |
+| MLP (1 hidden layer of 64) | 94.6% | 36,358 params | 142 KB |
+| published SOTA (CNN/LSTM/ensembles) | 96–97% | ~50K–1M params | — |
+
+## The learning curve — does nearest-shape generalize, or just memorize?
+
+Held-out test accuracy as the number of interned exemplars grows (this is generalization to *unseen*
+windows, not memorized-train accuracy):
+
+```
+exemplars   10    30    100   300   1,000  3,000  7,352
+test-acc   46.0  55.9  63.3  70.8   76.6   80.6   81.3 %
+```
+
+It **does** climb with data and **does** generalize to held-out windows — so nearest-shape is a real
+learner, not pure memorization. But it is a **weak, non-parametric** one, and it plateaus at ~81%,
+~15 points below a tiny parametric model.
+
+## The honest verdict
+
+1. **The 34-sample / 76% demo was toy.** On the real 6-class task, 34 exemplars reaches ~56%. The
+   demo's still-vs-moving is *linearly separable by a single threshold* — which `signal-derivative`
+   (the "champion") already computes by hand — so its majority-class baseline is ~67% and "+9 points"
+   is noise. And it had **no held-out test**: I measured agreement on the very stream it trained on.
+   "Online agreement on the training stream" is not learning. I overclaimed.
+
+2. **nearest-shape genuinely learns but is not competitive and is not small.** ~81% vs ~96% SOTA, and
+   its "model" is the *entire training set* (16 MB, zero compression) — a memorizer needing thousands
+   of labeled windows. It is the natural classifier for Form's integer-only primitives (quantize +
+   count agreeing bins), but that is its ceiling.
+
+3. **The "small model matches SOTA" prize is real and close — for a PARAMETRIC model.** Logistic
+   regression hits **96.1% with 3,372 params (13 KB)** — matching deep SOTA at ~1/100th–1/1000th the
+   size. "Within 5× and world news" is essentially *already true* on HAR — but it belongs to a
+   parametric model (W·x + b), not to nearest-shape.
+
+4. **The wall, and the real path for Form.** A parametric model needs **multiply** (the dot product
+   W·x). Form's stdlib is integer-only with no `mul` — *for three-way determinism* (floats break
+   Go=Rust=TS parity; integer multiply does not). So the grounded path is **quantized-integer
+   inference**: add an integer `mul` primitive (deterministic across kernels), train a small
+   linear/tiny-MLP offline in float on real data, **quantize the weights to int8**, and ship the
+   integer dot-product as a Form recipe. That yields a ~3 KB integer model at ~95%, provable
+   three-way, Form-native at inference — the genuine headline, and a real kernel extension (the `mul`
+   primitive), not a toy. Training stays in a float carrier; only the quantized model is the body.
+
+## Data-size contrast (why the demo couldn't have learned much)
+
+| | the toy demo | this benchmark |
+|---|---|---|
+| labeled data | ~24 s (34 frames) | ~2.6 h (7,352 windows) |
+| subjects | 1 (simulated) | 30 |
+| classes | 2 (trivially separable) | 6 |
+| held-out test | none | 2,947 windows |
+
+~390× less data, no test split, trivial classes. The honest conclusion: the demo shows the *mechanism*
+(intern an exemplar, recognize the nearest), not *learning that generalizes*. For that, the numbers
+above are what evidence looks like.

--- a/experiments/har-benchmark/benchmark.py
+++ b/experiments/har-benchmark/benchmark.py
@@ -1,0 +1,74 @@
+"""Honest benchmark: is nearest-shape (our Form-native classifier) actually learning?
+Compares our quantized-feature 1-NN against small parametric models + SOTA on UCI-HAR.
+"""
+import time, numpy as np
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.neural_network import MLPClassifier
+from sklearn.svm import LinearSVC
+from sklearn.metrics import accuracy_score
+
+BASE = "/tmp/ucihar/UCI HAR Dataset"
+Xtr = np.loadtxt(f"{BASE}/train/X_train.txt"); ytr = np.loadtxt(f"{BASE}/train/y_train.txt").astype(int)
+Xte = np.loadtxt(f"{BASE}/test/X_test.txt");  yte = np.loadtxt(f"{BASE}/test/y_test.txt").astype(int)
+print(f"data: train {Xtr.shape}  test {Xte.shape}  classes {sorted(set(ytr))}")
+N, D = Xtr.shape
+
+def report(name, acc, model_vals, train_s, note=""):
+    # model_vals = number of stored numbers that constitute "the model"
+    print(f"  {name:<34} acc={acc*100:5.1f}%   model={model_vals:>9,} vals (~{model_vals*4/1024:.0f}KB)   train={train_s:6.2f}s   {note}")
+
+print("\n=== baselines ===")
+maj = np.bincount(ytr).argmax()
+report("majority-class (predict commonest)", (yte == maj).mean(), 1, 0.0, "the floor any 'learner' must beat")
+
+print("\n=== OUR approach: nearest-shape (quantized features + exact-bin-agreement 1-NN) ===")
+# Replicate fv-histogram quantization + ns-sim (count of exactly-equal bins) at scale.
+for Q in (4, 8, 16):
+    edges = [np.quantile(Xtr[:, j], np.linspace(0, 1, Q + 1)[1:-1]) for j in range(D)]
+    Qtr = np.stack([np.digitize(Xtr[:, j], edges[j]) for j in range(D)], 1).astype(np.int8)
+    Qte = np.stack([np.digitize(Xte[:, j], edges[j]) for j in range(D)], 1).astype(np.int8)
+    t = time.time()
+    knn = KNeighborsClassifier(n_neighbors=1, metric="hamming").fit(Qtr, ytr)  # 1-NN by max exact-agreement
+    acc = accuracy_score(yte, knn.predict(Qte))
+    report(f"nearest-shape Q={Q} (1-NN, all exemplars)", acc, N * D, time.time() - t,
+           "NON-PARAMETRIC: 'model' = the whole training set, no compression")
+
+print("\n=== reference: 1-NN on raw continuous features (standard k-NN, no quantization) ===")
+t = time.time()
+knn = KNeighborsClassifier(n_neighbors=1).fit(Xtr, ytr)
+report("1-NN euclidean (raw 561-dim)", accuracy_score(yte, knn.predict(Xte)), N * D, time.time() - t,
+       "also a memorizer: model = all data")
+
+print("\n=== SMALL PARAMETRIC models (the 'small model' candidates — but need floats + multiply) ===")
+t = time.time()
+lr = LogisticRegression(max_iter=2000, C=1.0).fit(Xtr, ytr)
+report("logistic regression (linear)", accuracy_score(yte, lr.predict(Xte)), (D + 1) * 6, time.time() - t,
+       f"{(D+1)*6:,} params — a genuinely SMALL model")
+t = time.time()
+svc = LinearSVC(C=1.0, max_iter=5000).fit(Xtr, ytr)
+report("linear SVM", accuracy_score(yte, svc.predict(Xte)), (D + 1) * 6, time.time() - t, "~SOTA-classical")
+t = time.time()
+mlp = MLPClassifier(hidden_layer_sizes=(64,), max_iter=400, random_state=0).fit(Xtr, ytr)
+nparams = D * 64 + 64 + 64 * 6 + 6
+report("MLP (1 hidden layer of 64)", accuracy_score(yte, mlp.predict(Xte)), nparams, time.time() - t,
+       f"{nparams:,} params")
+
+print("\n=== LEARNING CURVE — does nearest-shape generalize as data grows, or sit at the floor? ===")
+rng = np.random.default_rng(0)
+Q = 8
+edges = [np.quantile(Xtr[:, j], np.linspace(0, 1, Q + 1)[1:-1]) for j in range(D)]
+Qtr_all = np.stack([np.digitize(Xtr[:, j], edges[j]) for j in range(D)], 1).astype(np.int8)
+Qte = np.stack([np.digitize(Xte[:, j], edges[j]) for j in range(D)], 1).astype(np.int8)
+perm = rng.permutation(N)
+print("  exemplars  test-acc  (held-out 2947; this is generalization, not memorized-train)")
+for n in (10, 30, 100, 300, 1000, 3000, N):
+    idx = perm[:n]
+    knn = KNeighborsClassifier(n_neighbors=1, metric="hamming").fit(Qtr_all[idx], ytr[idx])
+    acc = accuracy_score(yte, knn.predict(Qte))
+    print(f"  {n:>9,}  {acc*100:5.1f}%")
+
+print("\n=== published SOTA on UCI-HAR (for scale) ===")
+print("  classical SVM/RF on the 561 features ......... ~96%")
+print("  CNN / LSTM / deep models ...................... ~96-97%  (~50k-1M params)")
+print("  best ensembles ................................ ~97%+")


### PR DESCRIPTION
I called the eval-server's `nearest-shape` demo *learning* (76% agreement, 34 samples, still/moving). It does not survive a real benchmark. This is the honest measurement and the corrections.

## `experiments/har-benchmark/` — our classifier vs parametric models vs SOTA on UCI-HAR
30 subjects · 6 activities · 7,352 train / 2,947 **held-out** test · ~2.6 h of labeled accelerometer data.

| method | test acc | model |
|---|---|---|
| majority baseline | 18.2% | — |
| **nearest-shape (ours)** | **80–82%** | whole dataset, 16 MB — **non-parametric memorizer** |
| 1-NN euclidean (raw) | 87.9% | whole dataset |
| **logistic regression** | **96.1%** | **3,372 params, 13 KB** |
| linear SVM | 96.7% | 3,372 params |
| MLP(64) | 94.6% | 36,358 params |
| deep SOTA | 96–97% | ~50K–1M params |

**Learning curve (held-out):** 10→46%, 100→63%, 1,000→77%, 7,352→81%. nearest-shape *does* generalize (real, if weak), but plateaus ~15 pts below a 13 KB parametric model, and its 'model' is the entire training set.

## The honest verdict
- The 34-sample demo was toy: still/moving is one threshold (majority ~67%), no held-out test — online agreement on the training stream is not learning. I overclaimed.
- nearest-shape is a weak non-parametric memorizer; it is Form's natural classifier (integer-only) but that is its ceiling.
- The 'small model matches SOTA' prize is real (logistic: 3,372 params → 96%) but needs a **parametric** model = integer `mul` in Form (deterministic three-way, unlike floats) + **quantized-int8 inference** shipped as a Form recipe. Train offline in float, quantize, the integer model is the body. That's the genuine path and a real kernel extension.

Corrected the overclaims this exposed: `sensing-lanes` lane 10, the android README, the eval-server docstring — all now name the honest scope and point at the benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)