### PR TITLE
tend: the .apk is real — built, hosted, linked

### DIFF
--- a/experiments/coherence-sense-android/README.md
+++ b/experiments/coherence-sense-android/README.md
@@ -35,9 +35,14 @@ through the kernel, not in Python.
 
 ## Install the APK
 
-1. Download `coherence-sense-v0-debug.apk` (from the GitHub release).
+1. Download it (3.0 MB, debug-signed):
+   **https://github.com/seeker71/Coherence-Network/releases/download/coherence-sense-v0/coherence-sense-v0-debug.apk**
+   (or open the [`coherence-sense-v0`](https://github.com/seeker71/Coherence-Network/releases/tag/coherence-sense-v0) release).
 2. On the phone: Settings → allow installing from your browser/files app ("unknown sources").
 3. Open the APK; install; launch **Coherence Sense**.
+
+Rebuild + re-publish after changes: `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew assembleDebug` then
+`gh release upload coherence-sense-v0 app/build/outputs/apk/debug/app-debug.apk --clobber`.
 
 It's a **debug-signed** build (no Play Store) — fine for trying it on your own device.
 


### PR DESCRIPTION
Built the Coherence Sense debug `.apk` (gradle `assembleDebug`, 3.0 MB, valid `classes.dex` + manifest) and published it to the [`coherence-sense-v0`](https://github.com/seeker71/Coherence-Network/releases/tag/coherence-sense-v0) release. The README said *"from the GitHub release"* with no link; now it carries the real download URL + the rebuild/re-publish one-liner.

**Download:** https://github.com/seeker71/Coherence-Network/releases/download/coherence-sense-v0/coherence-sense-v0-debug.apk

🤖 Generated with [Claude Code](https://claude.com/claude-code)