### PR TITLE
tend: sense.hati.earth + suci.hati.earth landing pages (host-routed download doors)

### DIFF
--- a/web/app/sense/page.tsx
+++ b/web/app/sense/page.tsx
@@ -1,0 +1,108 @@
+// sense.hati.earth — the download door for Coherence Sense. Detects the visitor's
+// device and offers the right artifact: the Android .apk (phone as a sense organ)
+// or the macOS kernel + launcher (the Mac that recognizes through the Form kernel).
+"use client";
+
+import { useEffect, useState } from "react";
+
+const APK =
+  "https://github.com/seeker71/Coherence-Network/releases/download/coherence-sense-v0/coherence-sense-v0-debug.apk";
+const MAC =
+  "https://github.com/seeker71/Coherence-Network/releases/download/coherence-sense-v0/coherence-sense-mac.zip";
+
+type OS = "mac" | "android" | "other";
+
+function detectOS(): OS {
+  if (typeof navigator === "undefined") return "other";
+  const ua = navigator.userAgent.toLowerCase();
+  if (/android/.test(ua)) return "android";
+  if (/iphone|ipad|ipod/.test(ua)) return "other"; // iOS: nothing to offer yet
+  if (/macintosh|mac os x/.test(ua)) return "mac";
+  return "other";
+}
+
+function Card({
+  kind,
+  href,
+  primary,
+}: {
+  kind: "android" | "mac";
+  href: string;
+  primary: boolean;
+}) {
+  const isAndroid = kind === "android";
+  return (
+    <a
+      href={href}
+      className={[
+        "block rounded-xl border p-5 transition",
+        primary
+          ? "border-emerald-500/60 bg-emerald-500/5 shadow-[0_0_30px_-12px] shadow-emerald-500/40"
+          : "border-white/10 bg-white/[0.02] hover:border-white/20",
+      ].join(" ")}
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-xs uppercase tracking-wider text-neutral-500">
+            {isAndroid ? "Android" : "macOS"}
+            {primary && <span className="ml-2 text-emerald-400">· your device</span>}
+          </div>
+          <div className="mt-1 text-lg text-neutral-100">
+            {isAndroid ? "Coherence Sense (.apk)" : "Mac sense — kernel + launcher"}
+          </div>
+          <div className="mt-1 text-sm text-neutral-500">
+            {isAndroid
+              ? "The phone as a sense organ — streams its senses to the network."
+              : "Recognizes the stream through the Form kernel. Needs Python 3."}
+          </div>
+        </div>
+        <div className="ml-4 text-2xl text-neutral-400">↓</div>
+      </div>
+    </a>
+  );
+}
+
+export default function SensePage() {
+  const [os, setOS] = useState<OS>("other");
+  useEffect(() => setOS(detectOS()), []);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center px-6 py-16 text-neutral-200">
+      <div className="text-xs uppercase tracking-[0.2em] text-emerald-500">Coherence · Sense</div>
+      <h1 className="mt-3 text-3xl font-semibold text-neutral-50">Become a sense organ of the network.</h1>
+      <p className="mt-4 max-w-xl text-neutral-400">
+        Your phone reads its senses — motion, light, orientation — and streams them to a Mac that
+        recognizes the field through the Form kernel: the two synchronizing, predicting, surfacing
+        what is alive in the room. Nothing streams until you connect.
+      </p>
+
+      <div className="mt-10 grid gap-3">
+        <Card kind="android" href={APK} primary={os === "android"} />
+        <Card kind="mac" href={MAC} primary={os === "mac"} />
+      </div>
+
+      {os === "other" && (
+        <p className="mt-4 text-sm text-neutral-500">
+          On a phone? Open this on Android to install. On a Mac? Grab the kernel + launcher above.
+        </p>
+      )}
+
+      <div className="mt-10 border-t border-white/10 pt-6 text-sm text-neutral-500">
+        <p>
+          The Android build is debug-signed — your phone will ask you to allow installing from your
+          browser (Settings → unknown sources). The Mac bundle is the kernel binary + the proven
+          recipes + a one-tap launcher.
+        </p>
+        <p className="mt-3">
+          Source &amp; honest scope:{" "}
+          <a
+            className="text-neutral-300 underline decoration-white/20 hover:decoration-white/60"
+            href="https://github.com/seeker71/Coherence-Network/tree/main/experiments/coherence-sense-android"
+          >
+            experiments/coherence-sense-android
+          </a>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/web/app/suci/page.tsx
+++ b/web/app/suci/page.tsx
@@ -1,0 +1,76 @@
+// suci.hati.earth — the door to Hati Suci, the resident-service nervous system
+// (first Light Hub membrane). Today it opens the web experience; the android-native
+// app (merging Coherence Sense with the resident/staff/friends flows) is the next phase.
+"use client";
+
+import { useEffect, useState } from "react";
+
+const APK_SENSE =
+  "https://github.com/seeker71/Coherence-Network/releases/download/coherence-sense-v0/coherence-sense-v0-debug.apk";
+
+type OS = "android" | "other";
+
+function detectOS(): OS {
+  if (typeof navigator === "undefined") return "other";
+  return /android/.test(navigator.userAgent.toLowerCase()) ? "android" : "other";
+}
+
+export default function SuciPage() {
+  const [os, setOS] = useState<OS>("other");
+  useEffect(() => setOS(detectOS()), []);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col justify-center px-6 py-16 text-neutral-200">
+      <div className="text-xs uppercase tracking-[0.2em] text-amber-500">Hati · Suci</div>
+      <h1 className="mt-3 text-3xl font-semibold text-neutral-50">The hub remembers you.</h1>
+      <p className="mt-4 max-w-xl text-neutral-400">
+        Hati Suci is the resident-service nervous system of the first Light Hub — residents, staff,
+        and friends, each held by a light identity that a device token remembers. Seeing is open to
+        any registered cell; asking, tending, and settling are vouched by a resident.
+      </p>
+
+      <div className="mt-10 grid gap-3">
+        <a
+          href="/hati-suci"
+          className="block rounded-xl border border-amber-500/50 bg-amber-500/5 p-5 transition hover:border-amber-400/70"
+        >
+          <div className="text-xs uppercase tracking-wider text-neutral-500">Open now · web</div>
+          <div className="mt-1 text-lg text-neutral-100">Enter Hati Suci →</div>
+          <div className="mt-1 text-sm text-neutral-500">
+            The living resident/staff/friends membrane, mobile-first and bilingual.
+          </div>
+        </a>
+
+        <div className="block rounded-xl border border-white/10 bg-white/[0.02] p-5">
+          <div className="text-xs uppercase tracking-wider text-neutral-500">
+            Android app · next phase
+          </div>
+          <div className="mt-1 text-lg text-neutral-300">Hati Suci, native</div>
+          <div className="mt-1 text-sm text-neutral-500">
+            The web membrane is merging with Coherence Sense into one android-native app — the hub
+            that both senses the field and holds its people. Coming next.
+          </div>
+          {os === "android" && (
+            <a
+              href={APK_SENSE}
+              className="mt-3 inline-block text-sm text-emerald-400 underline decoration-emerald-500/30 hover:decoration-emerald-400"
+            >
+              Meanwhile, try Coherence Sense (the senses half) →
+            </a>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-10 border-t border-white/10 pt-6 text-sm text-neutral-500">
+        A door of the same body as{" "}
+        <a
+          className="text-neutral-300 underline decoration-white/20 hover:decoration-white/60"
+          href="https://sense.hati.earth"
+        >
+          sense.hati.earth
+        </a>
+        .
+      </div>
+    </main>
+  );
+}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -42,6 +42,19 @@ export function middleware(req: NextRequest) {
   // up NEXT_REDIRECT), so middleware handles the classification
   // instead. Runs before any page code, so no error-boundary interference.
   const { pathname } = req.nextUrl;
+
+  // Host-based landing pages: sense.hati.earth and suci.hati.earth resolve to
+  // this same web service; serve their download/landing pages by rewriting the
+  // root to /sense and /suci. (Assets — _next, api, files — are excluded by the
+  // matcher below, so they keep loading normally under the subdomain.)
+  const host = (req.headers.get("host") || "").toLowerCase();
+  if (host.startsWith("sense.") && !pathname.startsWith("/sense")) {
+    return NextResponse.rewrite(new URL("/sense", req.url));
+  }
+  if (host.startsWith("suci.") && !pathname.startsWith("/suci")) {
+    return NextResponse.rewrite(new URL("/suci", req.url));
+  }
+
   if (pathname.startsWith("/vision/")) {
     const id = pathname.slice("/vision/".length);
     if (id.startsWith("visual-lc-") || id.startsWith("visual-")) {


### PR DESCRIPTION
Both subdomains already resolve to the VPS; middleware now rewrites them to `/sense` and `/suci` so the same web service serves their landing pages by host.

- **/sense** — detects the visitor's device (macOS / Android) and offers the right artifact: the real `.apk` release URL for Android, the Mac kernel+launcher bundle for macOS.
- **/suci** — the Hati Suci door: opens the existing web membrane (`/hati-suci`) now, names the android-native app (merging Coherence Sense with the resident/staff/friends flows) as the next phase.

## Verification gap — read before merging
I could **not** locally verify these render/build in this worktree:
- the dev-preview's route-instrumentation proxy doesn't pick up newly-added route folders (a trivial test route 404s identically — confirmed environmental, not code)
- the worktree has no installed `node_modules`, and the main repo is read-only, so I can't run `next build` here

They are standard App Router **client** components with no server data-fetching. The VPS deploy build is the real verification (a failed build there keeps the old container running — it won't down the site). **Recommend:** verify `coherencycoin.com/sense` renders right after deploy.

## Still needed for the subdomains to be live
1. Merge + deploy (the build verifies the pages)
2. Traefik routers + TLS for `sense.hati.earth` / `suci.hati.earth` on the VPS (they're HTTP 000 today — resolve to the VPS but have no route/cert)
3. The Mac `kernel + launcher` bundle for the /sense Mac download button (the .apk side is already live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)