### PR TITLE
tend: float→int conversion primitives (round/floor/ceil/trunc) — the float-ML bridge, three-way

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -2419,6 +2419,34 @@ func (k *Kernel) registerNatives() {
 		}
 		return Value{Kind: VInt, Int: n}
 	})
+	// float→int conversions: bridge float compute to integer band verdicts /
+	// quantization codes. floor/ceil/trunc are IEEE-unambiguous; round is
+	// half-away-from-zero (math.Round) to match Rust f64::round and the TS
+	// sign*round(abs) impl. An int argument passes through unchanged.
+	k.registerNative("floor", catMethod(), func(_ *Kernel, args []Value) Value {
+		if args[0].Kind == VFloat {
+			return Value{Kind: VInt, Int: int64(math.Floor(args[0].Float))}
+		}
+		return Value{Kind: VInt, Int: args[0].Int}
+	})
+	k.registerNative("ceil", catMethod(), func(_ *Kernel, args []Value) Value {
+		if args[0].Kind == VFloat {
+			return Value{Kind: VInt, Int: int64(math.Ceil(args[0].Float))}
+		}
+		return Value{Kind: VInt, Int: args[0].Int}
+	})
+	k.registerNative("trunc", catMethod(), func(_ *Kernel, args []Value) Value {
+		if args[0].Kind == VFloat {
+			return Value{Kind: VInt, Int: int64(math.Trunc(args[0].Float))}
+		}
+		return Value{Kind: VInt, Int: args[0].Int}
+	})
+	k.registerNative("round", catMethod(), func(_ *Kernel, args []Value) Value {
+		if args[0].Kind == VFloat {
+			return Value{Kind: VInt, Int: int64(math.Round(args[0].Float))}
+		}
+		return Value{Kind: VInt, Int: args[0].Int}
+	})
 	// Polymorphic `+` for Python: int+int=add, str+str=concat,
 	// list+list=concat, with float promotion on numeric mixes.
 	// Sibling-parity with Rust + TS kernels.

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -3920,6 +3920,27 @@ impl Kernel {
                 Value::Int(if n < 0 { -n } else { n })
             }
         });
+        // float→int conversions: the bridge between float compute and integer
+        // band verdicts / quantization codes. floor/ceil/trunc are IEEE-unambiguous
+        // (agree three-way); round is half-AWAY-from-zero (matches Go math.Round;
+        // TS uses sign*round(abs) because JS Math.round rounds half toward +Inf).
+        // An int argument passes through unchanged.
+        self.register_native("floor", cat_method(), |_, _, args| match &args[0] {
+            Value::Float(f) => Value::Int(f.floor() as i64),
+            _ => Value::Int(args[0].as_int()),
+        });
+        self.register_native("ceil", cat_method(), |_, _, args| match &args[0] {
+            Value::Float(f) => Value::Int(f.ceil() as i64),
+            _ => Value::Int(args[0].as_int()),
+        });
+        self.register_native("trunc", cat_method(), |_, _, args| match &args[0] {
+            Value::Float(f) => Value::Int(f.trunc() as i64),
+            _ => Value::Int(args[0].as_int()),
+        });
+        self.register_native("round", cat_method(), |_, _, args| match &args[0] {
+            Value::Float(f) => Value::Int(f.round() as i64),
+            _ => Value::Int(args[0].as_int()),
+        });
         // Polymorphic `+` for Python compilation: int+int→add,
         // str+str→concat, list+list→concat. The compile-time emitter
         // can't always determine operand types (variables, function

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1972,6 +1972,28 @@ export class Kernel {
       const n = argInt(args, 0);
       return { kind: "int", int: n < 0 ? -n : n };
     });
+    // float→int conversions (bare names, sibling-parity with Go/Rust): bridge
+    // float compute to integer band verdicts / quantization codes. floor/ceil/
+    // trunc are IEEE-unambiguous; round is half-AWAY-from-zero — JS Math.round
+    // rounds half toward +Inf, which would diverge from Rust/Go on negatives,
+    // so we use sign*round(abs). argFloat widens an int arg, so a whole value
+    // passes through. (math_floor/math_ceil stay for Python math.* compat.)
+    this.registerNative("floor", catMethod(), (_k, args) => ({
+      kind: "int",
+      int: Math.floor(argFloat(args, 0)),
+    }));
+    this.registerNative("ceil", catMethod(), (_k, args) => ({
+      kind: "int",
+      int: Math.ceil(argFloat(args, 0)),
+    }));
+    this.registerNative("trunc", catMethod(), (_k, args) => ({
+      kind: "int",
+      int: Math.trunc(argFloat(args, 0)),
+    }));
+    this.registerNative("round", catMethod(), (_k, args) => {
+      const x = argFloat(args, 0);
+      return { kind: "int", int: Math.sign(x) * Math.round(Math.abs(x)) };
+    });
     // Polymorphic `+` for Python: int+int=add, str+str=concat,
     // str+int / int+str = concat-via-stringify, list+list=concat.
     this.registerNative("_plus", catMethod(), (_k, args) => {

--- a/form/form-stdlib/AUTHORING.md
+++ b/form/form-stdlib/AUTHORING.md
@@ -51,6 +51,12 @@ plus `defn · let · do`. (Read `form/form-stdlib/core.fk` — it is the whole v
   (see `feature-vector.fk`'s `fv-hist-loop`).
 - `empty` **constructs** the empty list (`(empty)`, no args) — it is the absence value, **not a
   predicate**. Test emptiness with `(eq (len x) 0)`. See trap 6.
+- This is the **curated band-verdict subset, not the kernel's limit.** `mul`/`sub`/`div` and full IEEE
+  floats all work and **compute deterministically three-way** (proven: integer `mul`, `0.1+0.2`, and a
+  float matvec all → 0 divergent). The kernel is a full numeric engine reading
+  `docs/coherence-substrate/numeric-formats.canonical.json` (19 formats incl. bf16/fp8/nf4/int8/bitnet-158).
+  These are kept out of *bands* only because verdicts stay integer for clean `eq`-parity. For numeric/ML
+  recipes use the full engine, and reduce a float result to an integer verdict with `round`/`floor`/`ceil`/`trunc`.
 
 ## The traps (each one cost a real debugging cycle)
 
@@ -65,7 +71,12 @@ plus `defn · let · do`. (Read `form/form-stdlib/core.fk` — it is the whole v
      the way `classifier-eval.fk` and `self-grounding-classifier.fk` do. Most perception logic is
      counting, selection, and gating — which the primitive set covers exactly.
 
-3. **No floats.** All scores/counts are integers `0..100` — `eq` on floats is unreliable across kernels.
+3. **Float COMPUTE is deterministic; raw-float EQ is the trap.** A fractional float result agrees
+   bit-for-bit three-way (proven); what's unreliable is `eq` on raw floats — and whole-number floats
+   still display inconsistently (`3.0` vs `3`). So compute in float, then reduce to an INTEGER verdict —
+   `(eq (round (mul r 100.0)) 40)` — and `eq` the integer. `round` is half-AWAY-from-zero on every kernel;
+   see `tests/float-conversions-band.fk`. Band SCORES still default to integers `0..100`; floats are the
+   numeric/ML payload, not the verdict.
 
 4. **No `let` inside a `defn` body.** Use nested `defn`s or extra parameters. (`let` is fine only at
    the top level of the band's `(do ...)`.)

--- a/form/form-stdlib/tests/float-conversions-band.fk
+++ b/form/form-stdlib/tests/float-conversions-band.fk
@@ -1,0 +1,29 @@
+; preludes: form-stdlib/core.fk
+;
+; float-conversions-band — the float→int bridge, proven three-way (Go=Rust=TS).
+;
+; This is the pattern that unblocks float ML in proven bands: COMPUTE in float
+; (the kernel does deterministic IEEE fp64 — a fractional dot product agrees
+; bit-for-bit across kernels), then reduce the result to an INTEGER verdict via
+; round/floor/ceil/trunc and eq-compare the integer. Never eq raw floats: that is
+; the only real float trap (and whole-number floats still display inconsistently,
+; 3.0 vs 3 — a separate display bug). round is half-AWAY-from-zero on every kernel
+; (round(-2.5) == -3, not the JS -2) — the negative-half case is the parity catcher.
+;
+; Verdict 31 when every claim lands:
+;   1   a float dot product rounds to its integer verdict   (round(0.4 * 100) == 40)
+;   2   round is half-away-from-zero, not toward +Inf         (round(-2.5) == -3)
+;   4   floor goes toward -Inf                                 (floor(-2.1) == -3)
+;   8   ceil goes toward +Inf                                  (ceil(2.1) == 3)
+;   16  trunc goes toward zero                                 (trunc(-2.9) == -2)
+(do
+    (defn dot (a b)
+        (if (eq (len a) 0) 0.0
+            (add (mul (head a) (head b)) (dot (tail a) (tail b)))))
+    (let r (dot (list 0.5 0.25) (list 0.4 0.8)))   ; 0.2 + 0.2 = 0.4
+    (let c0 (if (eq (round (mul r 100.0)) 40) 1 0))
+    (let c1 (if (eq (round -2.5) -3) 2 0))
+    (let c2 (if (eq (floor -2.1) -3) 4 0))
+    (let c3 (if (eq (ceil 2.1) 3) 8 0))
+    (let c4 (if (eq (trunc -2.9) -2) 16 0))
+    (add c0 (add c1 (add c2 (add c3 c4)))))


### PR DESCRIPTION
First concrete stone toward Form-native models. The kernel does deterministic IEEE float arithmetic (a fractional float matvec agrees bit-for-bit Go=Rust=TS); what was missing is the bridge from a float result to an integer band verdict / a quantization code.

## What
`round`/`floor`/`ceil`/`trunc` (float→int) added to all three kernels.

## Determinism trap caught + handled
`floor`/`ceil`/`trunc` are IEEE-unambiguous, but **round differs**: Rust `f64::round` and Go `math.Round` are half-**away-from-zero**, while JS `Math.round(-2.5)` = `-2` (half toward +∞). The TS impl uses `sign·round(abs)` to match. Proven three-way:
- `[round/floor/ceil/trunc on ±]` → `[3,-3,2,-2,2,-3,3,-2,2,-2]`, 0 divergent
- `tests/float-conversions-band.fk`: a float dot product reduced to an integer verdict → **31, 0 divergent**

## Why it matters
Unblocks float ML in proven bands (compute in float, reduce to an integer verdict via `round`) and the quantization path (`round(127·w/scale)` for int8). AUTHORING.md trap 3 corrected — float *compute* is deterministic; the real trap is eq-on-raw-floats + whole-number display (3.0 vs 3); the primitive set is a curated band subset, not the kernel's limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)