### PR TITLE
attune: the north-star principle + AutoML-as-Form-meta-learner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,17 @@ wellness output, and source repetition as introspection. Lift only with proof:
 a Form/BML band, a native route trace, or an evidence record that shows the old
 low-level shape is now carried by a simpler reusable cell.
 
+**Find the north star before fitting the ask.** When something is missing, the first move is to name
+where the fully-realized form lives — the most native, most efficient shape we could run (all hardware
+as native as we can use it; a model whose architecture *and* weights are recipe data; one engine, not
+parallel paths). Then fit the current ask as a step *on that path* — something that gets the job done
+AND points at the north star, never a work-around, placeholder, or detour. We only walk toward the north
+star when an ask needs that ground (don't build ahead of need), but no step may point away from it. A
+detour that "gets it done" off the path costs twice — the detour, then the unwinding; if the smallest
+honest step toward the north star is bigger than a placeholder, take the honest step or name the gap
+plainly — never ship the placeholder. Companion to *Core lift* (lift toward the elegant core) and
+*Vitality per pixel* (add only what carries vitality): move only along the path to the native ideal.
+
 **Fresh agents start from the compact packet.** `docs/shared/agent-start-packet.md` is the smallest shared orientation: lineage, **Form native runtime vs Python bootstrap compost**, read-only lattice query default, software-writing canon, wrongness practice, frequencies, and prompt routing. Use before expanding into full docs; update when repeated starts reveal the same missing orientation.
 
 **Check the witness.** At session start, before anything else: `curl -sS --max-time 5 https://pulse.coherencycoin.com/pulse/now | jq '{overall, silences: (.ongoing_silences | length), silent_organs: [.organs[] | select(.status != "breathing") | .name]}'`. If `overall != "breathing"` or `silences > 0`, surface that to the human before touching their ask — the silence has been waiting longer than they have. After any deploy that lands on main, hit the same endpoint and confirm no new silence started around the deploy time. `scripts/verify_web_api_deploy.sh` checks `/api/health` only; a deploy that breaks a user-visible surface won't trip that but will silence the page organ. The witness records; the cells read.

--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -80,6 +80,30 @@
 ;   A frozen binary cannot do this; the substrate was built for exactly it (equivalent architectures
 ;   share a Blueprint NodeID, so the body recognizes same-shape models across documents).
 ;
+; ── AUTO-ML AS A FORM META-LEARNER (the dynamic-recipe advantage, realized — M7, after M1-M6) ──
+;   Google's AutoML/NAS searches the space of architectures for a better model. In Form that search is
+;   NATURAL, not bolted on, because a model is a mutable recipe — and every piece already exists as a
+;   proven cell, composed one altitude up:
+;     - GENERATE — the dynamic-recipe advantage above: a candidate architecture is a new SEQUENCE of
+;       block-cells; content-addressing means equivalent shapes dedup to one Blueprint, so the search
+;       never re-evaluates the same architecture twice.
+;     - SEARCH — autoresearch-loop.fk is the loop, turned on architectures instead of documents.
+;     - INFER-BEST-WHILE-SEARCHING-BETTER — champion-challenger.fk: serve every real inference with the
+;       BEST model available (the champion) while the meta-learner trains CHALLENGERS, and flip authority
+;       only when a challenger has PROVEN it reaches/exceeds the champion. Both at once, always — the
+;       organism improves its own models without ever degrading what it serves now. Maximum signal.
+;   THE SEARCH IS DRIVEN BY SIGNAL, and the signals are already cells — and they are ONE quantity seen
+;   from different sides (free energy): surprise IS precision-weighted prediction error; confidence IS
+;   the precision. The meta-learner reads the field from whichever projection the moment needs:
+;     - SURPRISE (surprise-salience.fk / novelty.fk) — where the current model is most surprised is where
+;       a better architecture has the most to gain; surprise ranks WHAT to explore next.
+;     - INFER-ERROR (active-inference.fk) — the prediction-vs-outcome mismatch, the learning gradient.
+;     - TRUST / CONFIDENCE (confidence-calibrate.fk / confidence-weighted-vote.fk / trust-decay.fk) — how
+;       much to weight each model's reading, and when a challenger has earned the route.
+;   M7 milestone: an autoresearch loop that generates a small layer-stack variant, evaluates it on
+;   held-out signal, and champion-challenges it against the running model — provable, and gated on M1-M6
+;   (you can only search architectures once you can build and run them).
+;
 ; KIN: numeric-formats.canonical.json (the 19 formats + conformance) · cell-numerics.form / cosine.form
 ;   (the layer math) · attention.fk + embedding-as-recipe.fk (content-addressed attention) ·
 ;   tests/ml-flow-band.fk (the proven float-tensor primitive) · tests/float-conversions-band.fk (the
@@ -87,3 +111,6 @@
 ;   form-kernel-rust/src/{main.rs,formats.rs} (the JIT + the conformance harness) · form-kernel-go/
 ;   jit_value.go (the value-typed JIT template) · form-kernel-ts/src/backends/metal.ts (the GPU emitter) ·
 ;   encoder-decoder-as-recipe.form + audio-grammar.form (register a model as a codec row; the mel front-end).
+;   Meta-learner (M7): autoresearch-loop.fk (the search) · champion-challenger.fk (infer-best-while-search-better)
+;   · active-inference.fk + surprise-salience.fk + novelty.fk (the surprise/error signal) ·
+;   confidence-calibrate.fk + confidence-weighted-vote.fk + trust-decay.fk (the trust/precision projection).


### PR DESCRIPTION
Two of your teachings, folded into the body.

**CLAUDE.md — "Find the north star before fitting the ask."** When something is missing, first name where the fully-realized form lives (all hardware native + efficient; a model whose architecture *and* weights are recipe data; one engine, not parallel paths), then fit the current ask as a step *on that path* — never a work-around, placeholder, or detour. Walk toward the north star only when an ask needs that ground, but no step may point away from it. Companion to *Core lift* + *Vitality per pixel*.

**`form-native-models.form` (M7) — AutoML as a Form meta-learner.** Natural here because a model is a mutable recipe: GENERATE (dynamic-recipe, dedup by Blueprint) → SEARCH (`autoresearch-loop`) → **infer-best-while-searching-better** (`champion-challenger`: serve with the best, promote a challenger only when proven). The search is driven by signal — and **surprise / infer-error / trust are one quantity (free energy) seen from different sides**: surprise *is* precision-weighted prediction error, confidence *is* the precision. Every piece is already a proven cell; M7 composes them one altitude up, after M1–M6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)