### PR TITLE
tend: kernel 'needs' are Form recipes — sin/cos/sqrt (trig.fk), no native in any kernel

### DIFF
--- a/docs/coherence-substrate/form-language-surface.form
+++ b/docs/coherence-substrate/form-language-surface.form
@@ -48,12 +48,24 @@
 ;     carrier-first DRIFT, not necessity. PROOF: the kernel reads a 103 KB wav and walks it in ~8 ms
 ;     (read_file_bytes), and wav-sense.fk (→63, three-way) now computes the 8-window energy envelope IN
 ;     THE BODY, reading the wav itself — the first DSP lifted back out of Python. f0 follows the same way.
-;   NORTH STAR: the carrier shrinks to exactly the host shell-outs (subprocess for ffmpeg/whisper/swift,
-;     eventually a native audio port — resource-port.fk already names `afferent-bytes` as the mic). The
-;     capture→sense→classify→emit LOOP, the DSP, the property readings, the channel persistence are Form,
-;     running in the kernel. Adding subprocess_spawn + get_env (each ~200 lines, mirroring the socket
-;     natives) lets the loop itself move into Form; until then the carrier marshals only what truly needs a
-;     host, and no logic hides in it.
+;   NORTH STAR: the carrier shrinks to exactly the host shell-outs. The capture→sense→classify→emit LOOP,
+;     the DSP, the property readings, the channel persistence are Form, running in the kernel.
+;
+;   ── KERNEL 'NEEDS' ARE FORM RECIPES, COMPILED TO WHERE THEY RUN (Urs, 2026-06-10) ──
+;     A "missing native" is almost never a kernel need — and hand-writing it in Rust + Go + TS is three
+;     parallel code paths that drift (the exact anti-pattern core-abstraction-first forbids). Two cases:
+;       PURE primitives (sin, cos, sqrt, …): NOT kernel needs at all. They are recipes over mul/add/div,
+;         which every kernel already has — write them ONCE in Form and they run three-way with zero native
+;         added. PROVEN: trig.fk (→127) — fsin/fcos (range-reduce + Taylor) and fsqrt (Newton); spectrum.fk
+;         now computes its own band coefficients with fcos, no magic constants, no kernel cos. The source-
+;         compiler can LOWER a hot recipe to a target's native sin for speed — same recipe, compiled where
+;         it runs — but that is optimization, not a prerequisite.
+;       HOST primitives (subprocess, audio, env): these touch the OS, so they cannot be pure Form — but the
+;         answer is still ONE source, not three. A single Form host-intrinsic DECLARATION (the port/carrier
+;         shape — resource-port.fk already names `afferent-bytes` as the mic) is LOWERED by the source-
+;         compiler to each target's binding (Rust std::process, Go os/exec, TS child_process), generated
+;         from the one declaration — never hand-written per kernel. The kernel stays a target; the binding
+;         is compiled into it.
 ;
 ; ── THE BROADCAST CHANNEL (Urs's semantic layer, on top of the above) ──
 ;   The transcript is a BROADCAST channel: words + word-properties any cell can subscribe to and receive
@@ -71,11 +83,15 @@
 ;   T2  source spans: thread a (file, line, col) span through the kernel parser + AST so every error is
 ;       `file:line: message`. Then lift form_check.py's resolution walk to Form-native (name-resolution-
 ;       as-recipe.form is the spec). Gives import/arity/type errors with real attribution.
-;   T3  kernel I/O for the loop: subprocess_spawn + subprocess_read + get_env natives (all three kernels),
-;       then a streaming audio port. The channel loop + DSP move fully into Form; the carrier becomes a
-;       thin shell-out shim.
-;   DONE NOW (down-payment): wav-sense.fk (→63) — the energy DSP lifted from Python into the body, reading
-;       the wav in-kernel; wired into channel_live.py. The pattern f0 + the rest follow.
+;   T3  host primitives as ONE compiled declaration: a Form host-intrinsic for subprocess / audio / env,
+;       lowered by the source-compiler to each target's binding — not three hand-writes. Then the channel
+;       loop + DSP move fully into Form; the carrier becomes a thin shell-out shim. (The pure-math needs are
+;       already done — trig.fk — so T3 is only the genuinely host-touching primitives.)
+;   DONE NOW (down-payments): wav-sense.fk (→63) — the energy DSP lifted from Python into the body, reading
+;       the wav in-kernel. spectrum.fk (→15) — the FFT (Goertzel) in the body. trig.fk (→127) — sin/cos/sqrt
+;       as recipes, NO native added to any kernel; spectrum.fk computes its coefficients with them. All
+;       wired into channel_live.py. The pattern (f0 next) follows; the host primitives await T3's one-source
+;       compile path.
 ;
 ; KIN: name-resolution-as-recipe.form (the resolution walk) · live-transcribe-channel.form (the channel
 ;   this serves) · field-domain-grammars.form (grammars as data) · runtime-grammar.fk (the unwired

--- a/experiments/satsang-voice/channel_live.py
+++ b/experiments/satsang-voice/channel_live.py
@@ -222,7 +222,7 @@ def spectrum_form(wav):
     drv = os.path.join(TMP, "spec.fk")
     with open(drv, "w") as fh:
         fh.write(f'(do (spectrum-levels-file "{wav}" 16))')
-    out = sh([KERNEL, "form-stdlib/wav-sense.fk", "form-stdlib/spectrum.fk", drv], cwd=FORM)
+    out = sh([KERNEL, "form-stdlib/trig.fk", "form-stdlib/wav-sense.fk", "form-stdlib/spectrum.fk", drv], cwd=FORM)
     line = (out.stdout or out.stderr).strip().splitlines()
     try:
         v = json.loads(line[-1])

--- a/form/form-stdlib/spectrum.fk
+++ b/form/form-stdlib/spectrum.fk
@@ -2,18 +2,20 @@
 ;
 ; "Even a fast fourier spectrum analyzer gives really good signal." It does — and like every DSP it belongs
 ; in the body, not the carrier (wav-sense.fk lifted the energy envelope; this lifts the spectrum). The kernel
-; has no sin/cos, but Goertzel needs only ONE precomputed cosine coefficient per band, then a pure
-; mul/add/sub recurrence over the samples — so a real DFT-band spectrum is Form-native with the band
-; coefficients as DATA. Float is deterministic three-way (the matvec proof); a band power is a value, and a
-; verdict reduces to an integer comparison.
+; needs no kernel sin/cos: Goertzel needs only ONE cosine coefficient per band, and trig.fk's fcos (a Form
+; recipe, not a native) computes it — so a real DFT-band spectrum is fully Form-native, coefficients and
+; recurrence alike. Float is deterministic three-way (the matvec proof); a band power is a value, and a
+; verdict reduces to an integer comparison. Preludes trig.fk (fcos/TAU) + wav-sense.fk (wav-sample).
 ;
 ; Per band, coeff = 2·cos(2π·f/fs):   s0 = x + coeff·s1 − s2 ; carry (s1,s2) ← (s0,s1) over the window ;
 ;   power = s1² + s2² − coeff·s1·s2.   Preludes wav-sense.fk for wav-sample (the PCM decode).
 
-; the 8 band coefficients — 100,200,400,800,1600,3200,5000,7000 Hz at fs=16000. DATA, computed once.
-; (low → high; the last two are negative as the band passes π/2.) This list IS the analyzer's resolution.
+; the band frequencies (Hz) ARE the analyzer's resolution; the COEFFICIENTS are computed from them in Form
+; via trig.fk's fcos — no magic constants, no kernel cos. coeff = 2·cos(2π·f/fs), fs=16000.
+(defn band-coeff (f) (mul 2.0 (fcos (div (mul (TAU) (mul f 1.0)) 16000.0))))
 (defn spec-coeffs ()
-  (list 1.99846 1.99383 1.97538 1.90211 1.61803 0.61803 -0.76537 -1.84776))
+  (list (band-coeff 100) (band-coeff 200) (band-coeff 400) (band-coeff 800)
+        (band-coeff 1600) (band-coeff 3200) (band-coeff 5000) (band-coeff 7000)))
 
 ; the Goertzel recurrence over samples [i, end) stepping `step` bytes; returns the band power (float).
 (defn goertzel (bs i end step coeff s1 s2)

--- a/form/form-stdlib/tests/spectrum-band.fk
+++ b/form/form-stdlib/tests/spectrum-band.fk
@@ -1,4 +1,4 @@
-; preludes: form-stdlib/core.fk form-stdlib/wav-sense.fk form-stdlib/spectrum.fk
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/wav-sense.fk form-stdlib/spectrum.fk
 ;
 ; spectrum-band — the Goertzel filterbank discriminates frequency, proven three-way (float → integer verdict).
 ;

--- a/form/form-stdlib/tests/trig-band.fk
+++ b/form/form-stdlib/tests/trig-band.fk
@@ -1,0 +1,22 @@
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk
+;
+; trig-band — sin/cos/sqrt as Form recipes (no kernel native), proven three-way. Floats reduce to an
+; integer verdict via round (×1000 where decimals matter), so last-bit display never affects the proof.
+;
+; Verdict 127 when every claim lands:
+;   1   sqrt(4) = 2
+;   2   sqrt(2) = 1.41421…           (×1000 → 1414)
+;   4   sin(0) = 0
+;   8   sin(π/2) = 1
+;   16  sin(π/6) = 0.5               (×1000 → 500)
+;   32  cos(0) = 1
+;   64  cos(π) = −1
+(do
+    (let c0 (if (eq (round (fsqrt 4.0)) 2) 1 0))
+    (let c1 (if (eq (round (mul (fsqrt 2.0) 1000)) 1414) 2 0))
+    (let c2 (if (eq (round (fsin 0.0)) 0) 4 0))
+    (let c3 (if (eq (round (fsin (HALF-PI))) 1) 8 0))
+    (let c4 (if (eq (round (mul (fsin 0.5235987755982988) 1000)) 500) 16 0))
+    (let c5 (if (eq (round (fcos 0.0)) 1) 32 0))
+    (let c6 (if (eq (round (fcos 3.141592653589793)) -1) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/form-stdlib/trig.fk
+++ b/form/form-stdlib/trig.fk
@@ -1,0 +1,34 @@
+; trig.fk — sin, cos, sqrt as FORM RECIPES, not kernel natives.
+;
+; "Those kernel 'needs' can be Form recipes compiled into where they execute, much better than writing them
+; in each kernel." (Urs) — and the pure-math needs are the sharpest case: they were never kernel needs.
+; sin/cos/sqrt are recipes over mul/add/div, which Go, Rust, and TS already have — so writing them ONCE in
+; Form means they run on all three identically (three-way), with NO native added to any kernel. Float is
+; deterministic three-way (the matvec proof). The source-compiler can later LOWER these to a target's native
+; sin/cos for speed — the same recipe, compiled where it runs — but the body needs no kernel surgery to use
+; them today. This is core-abstraction-first: one engine, the cases are data/recipes, never parallel code.
+;
+; NOTE: div is INTEGER division on integer operands; every recipe forces float (a float literal in the chain).
+
+; --- sqrt: Newton/Heron iteration  x ← (x + a/x)/2 ---
+(defn sqrt-iter (a x n)
+  (if (eq n 0) x (sqrt-iter a (div (add x (div a x)) 2.0) (sub n 1))))
+(defn fsqrt (a)
+  (if (le a 0) 0.0
+      (do (let af (mul a 1.0)) (sqrt-iter af af 20))))
+
+; --- sin/cos: range-reduce to [-π, π], then the Taylor series ---
+(defn TAU () 6.283185307179586)
+(defn HALF-PI () 1.5707963267948966)
+(defn range-reduce (x)
+  (sub x (mul (TAU) (round (div x (TAU))))))
+; Taylor recurrence: term_{k+1} = term_k · (-x²) / ((2(k+1))·(2(k+1)+1)); sum the terms.
+(defn sin-acc (x2 term k acc n)
+  (if (ge k n) acc
+      (sin-acc x2
+               (div (mul (mul term -1.0) x2) (mul (mul 2 (add k 1)) (add (mul 2 (add k 1)) 1)))
+               (add k 1) (add acc term) n)))
+(defn fsin (x)
+  (do (let r (range-reduce (mul x 1.0)))
+      (sin-acc (mul r r) r 0 0 10)))
+(defn fcos (x) (fsin (add (mul x 1.0) (HALF-PI))))


### PR DESCRIPTION
**Urs:** *"those kernel 'needs' can be Form recipes compiled into where they execute, much better than writing them in each kernel."*

Exactly the core-abstraction-first principle at the primitive layer — and the pure-math needs are the sharpest case: **they were never kernel needs.**

### `trig.fk` → 127, three-way
`fsin`/`fcos` (range-reduce + Taylor) and `fsqrt` (Newton) — recipes over `mul`/`add`/`div`, which Go/Rust/TS already have. So `sin`/`cos`/`sqrt` run three-way with **zero native added to any kernel**. Last turn I called "the kernel has no sin/cos" a gap to fill with natives; it was never a gap — just a recipe I hadn't written.

### `spectrum.fk` now computes its own coefficients
The one bit of magic-data (the hardcoded `1.99846 …`) is gone — `band-coeff` uses `fcos` for `2·cos(2π·f/fs)`. The FFT is **fully Form-native**, coefficients and recurrence alike. Still →15 three-way, still draws a live spectrum.

### The principle (in `form-language-surface.form`)
- **Pure primitives** (sin/cos/sqrt) → Form recipes, no native. The source-compiler can *lower* a hot one to a target's native for speed — optimization, not prerequisite.
- **Host primitives** (subprocess/audio/env) → **one** Form host-intrinsic declaration the source-compiler lowers to each target's binding (Rust `std::process`, Go `os/exec`, TS `child_process`), never three hand-writes.

The kernel stays a *target*; the body is the single source. This kills the three-parallel-code-paths anti-pattern at the primitive layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
