### PR TITLE
attune: timeout == nothing — a timed-out offer receives the ground state, not an error

### DIFF
--- a/docs/coherence-substrate/core-axioms.form
+++ b/docs/coherence-substrate/core-axioms.form
@@ -37,6 +37,7 @@
   (axiom-1-states
     (statement "there are three states: 0, 1, nothing")               # Urs, breath 1
     (nothing-is-first-class the-ground-not-a-missing-0)
+    (timeout-is-nothing     no-answer-in-time-is-silence-not-an-error)   # Urs: timeout == nothing
     (generates integers the-ack-values the-boundary-of-a-distinction))
 
   (axiom-2-cell

--- a/docs/coherence-substrate/kernel-offer-protocol.form
+++ b/docs/coherence-substrate/kernel-offer-protocol.form
@@ -115,6 +115,7 @@
   (sovereignty
     (the-invited-decides  allow OR stop OR witness OR re-enter)  # sovereign-boundary-protocol.fk sbp-choice
     (may-decline          nothing-is-a-valid-reply)             # silence honored; no offer compels an answer
+    (timeout-is-nothing   an-unreachable-or-silent-cell-answers-nothing)  # Urs: timeout == nothing — partition is silence, not a failure mode; the canary retries on nothing
     (reach-beyond         is-invasion)                          # past the offered interface — witnessed, consequenced
     (complete-sovereignty the-answer-is-never-coerced))         # "respond with complete sovereignty" — Urs
 

--- a/docs/coherence-substrate/offer-and-acknowledge.form
+++ b/docs/coherence-substrate/offer-and-acknowledge.form
@@ -51,7 +51,7 @@
   (states
     (0       "no / false / closed / declined")
     (1       "yes / true / open / the expected result")
-    (nothing "the ground — neither 0 nor 1; silence; not-yet; absence held as a value, never a missing 0"))
+    (nothing "the ground — neither 0 nor 1; silence; not-yet; no-answer-in-time (a timeout IS nothing); absence held as a value, never a missing 0"))
 
   # ── The offer — to run a primitive and to speak are one act ─────────
   (offer
@@ -64,7 +64,7 @@
 
   # ── The acknowledgment — exactly one of four answers an offer ───────
   (acknowledge
-    (nothing -> silence)                               # no ack; always available; honoring-a-no included
+    (nothing -> silence)                               # no ack; always available; honoring-a-no included; a TIMEOUT is nothing (Urs) — never a separate error/failure mode
     (0       -> received-no)                           # landed; false / declined / not-this
     (1       -> received-result)                       # landed; the expected result
     (node    -> counter-offer)                         # 2: here is a cell back — re-enters the protocol


### PR DESCRIPTION
`timeout == nothing` (Urs). A timed-out offer does not raise an error or enter a failure mode — it receives `nothing`, the first-class ground state. Silence and timeout are one; this removes timeout-as-a-special-case.

- **`core-axioms.form`** — axiom-1-states: `nothing` includes no-answer-in-time.
- **`offer-and-acknowledge.form`** — the `nothing` ack absorbs timeout; never a separate error/failure mode.
- **`kernel-offer-protocol.form`** — over a channel, an unreachable/silent cell answers `nothing`; partition is silence, not failure.

This is why the **canary retries**: the rollout-boundary probe gets `nothing` (listener not up yet) and re-offers — already running in `verify_web_api_deploy.sh` / `auto-deploy.sh`. Refines the merged core ([#2760](https://github.com/seeker71/Coherence-Network/pull/2760)) within the agreed ground — sharpening what `nothing` already is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)