### PR TITLE
tend: mel-frame in pure Form (M6 first move) + deploy field-docs sync repair

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -419,12 +419,28 @@ sync_field_docs() {
     return 0
   fi
 
+  # The api container may still be settling right after a force-recreate (exec races the fresh
+  # container and its exit code would fail a deploy whose site is already up — seen on f51a968).
+  # Retry briefly; fail honestly only if the sync truly cannot land.
+  local target_parent attempt ok
   for target_parent in /app/docs /app/api/docs; do
     log "field docs: syncing docs/field to api:${target_parent}/field"
-    docker compose exec -T api sh -lc "mkdir -p '${target_parent}' && rm -rf '${target_parent}/field'" \
-      2>&1 | tee -a "$LOG_FILE"
-    docker compose cp "$REPO_DIR/docs/field" "api:${target_parent}/field" \
-      2>&1 | tee -a "$LOG_FILE"
+    ok=0
+    for attempt in 1 2 3; do
+      if docker compose exec -T api sh -lc "mkdir -p '${target_parent}' && rm -rf '${target_parent}/field'" \
+           2>&1 | tee -a "$LOG_FILE" \
+         && docker compose cp "$REPO_DIR/docs/field" "api:${target_parent}/field" \
+           2>&1 | tee -a "$LOG_FILE"; then
+        ok=1
+        break
+      fi
+      log "field docs: attempt ${attempt} failed (container may still be settling); retrying in 5s"
+      sleep 5
+    done
+    if [[ "$ok" != 1 ]]; then
+      log "FATAL field docs: sync to ${target_parent} failed after 3 attempts"
+      return 1
+    fi
   done
 }
 

--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -91,6 +91,12 @@
 ;        already referenced in experiments/satsang-voice), encodes block-0 weights via M2, runs M4 over
 ;        them, matches the HF reference activation within epsilon. First real model in the body. (Even
 ;        smaller first: the mel front-end — STFT + an 80-row filterbank — matching whisper.log_mel.)
+;        [mel front-end frame SHIPPED: form-stdlib/mel-frame.fk + tests/mel-frame-band.fk → 1023,
+;        three-way. One whisper-style STFT frame fully Form-native in the spectrum.fk lineage: hann is
+;        fcos, bin power is the Goertzel recurrence, a mel row is its slaney (bins, weights) support as
+;        data, log10 is trig.fk's new fln. Matches torch.stft frame 5 / librosa slaney / whisper's
+;        clamp-log lane at 1e-6. The full 80×3000 spectrogram is this recipe walked — speed is M5's
+;        JIT stone, not a new shape. Remaining for M6: safetensors carrier + block-0 activation match.]
 ;   Parallel, not gated on the above: the recognition-router + ensemble-vote + champion-challenger +
 ;     learning-arc already run N classifiers on one chunk, compared, all learning, the router escalating
 ;     to a richer recipe on events — A/B/C/D over the same samples. The deterministic Form layer is what

--- a/form/form-stdlib/mel-frame.fk
+++ b/form/form-stdlib/mel-frame.fk
@@ -1,0 +1,40 @@
+; mel-frame.fk — the mel front-end's frame shape: whisper's own front door, computed IN THE BODY.
+;
+; form-native-models.form M6 names the smallest first move toward whisper-tiny: the mel front-end —
+; STFT + mel filterbank — matching whisper.log_mel. This recipe carries one FRAME of that pipeline,
+; fully Form-native in the spectrum.fk lineage: the hann window is fcos, the DFT bin power is the
+; Goertzel recurrence over the windowed samples, a mel row is its (bins, slaney-weights) support as
+; DATA, and log10 is trig.fk's fln. torch.stft frame 5 (hop 160, n_fft 400, center) is the interior
+; frame this matches — the band proves it against the torch/numpy fp64 reference. The full 80×3000
+; spectrogram is the same recipe walked 80×3000 times; making that fast is M5's JIT stone, not a new
+; shape. Preludes trig.fk (fsin/fcos/TAU/fln/flog10).
+
+; hann (periodic, torch.hann_window): w[n] = 0.5 − 0.5·cos(2πn/N)
+(defn mf-hann (n N)
+  (sub 0.5 (mul 0.5 (fcos (div (mul (TAU) (mul n 1.0)) (mul N 1.0))))))
+
+; a windowed test frame, generated in the body: sample off+n of sin(2πf·s/sr), times the window
+(defn mf-frame (f sr off N n)
+  (if (ge n N) (empty)
+      (cons (mul (fsin (div (mul (TAU) (mul f (add off n))) (mul sr 1.0))) (mf-hann n N))
+            (mf-frame f sr off N (add n 1)))))
+
+; Goertzel over a sample list: |DFT bin|² with one cosine coefficient (spectrum.fk's recurrence,
+; walking a list instead of wav bytes)
+(defn mf-goertzel (xs coeff s1 s2)
+  (if (eq (len xs) 0)
+      (sub (add (mul s1 s1) (mul s2 s2)) (mul coeff (mul s1 s2)))
+      (mf-goertzel (tail xs) coeff (sub (add (head xs) (mul coeff s1)) s2) s1)))
+(defn mf-bin-power (xs k N)
+  (mf-goertzel xs (mul 2.0 (fcos (div (mul (TAU) (mul k 1.0)) (mul N 1.0)))) 0.0 0.0))
+
+; a mel row's energy: slaney weights · bin powers over the row's support (bins + weights are DATA
+; from the filterbank cell, exactly as spectrum.fk carries its band coefficients)
+(defn mf-mel-energy (xs ks ws N)
+  (if (eq (len ks) 0) 0.0
+      (add (mul (head ws) (mf-bin-power xs (head ks) N))
+           (mf-mel-energy xs (tail ks) (tail ws) N))))
+
+; whisper's log lane: log10(clamp(mel, 1e-10))
+(defn mf-log-clamped (e) (if (lt e 0.0000000001) -10.0 (flog10 e)))
+(defn mf-log-mel (xs ks ws N) (mf-log-clamped (mf-mel-energy xs ks ws N)))

--- a/form/form-stdlib/tests/mel-frame-band.fk
+++ b/form/form-stdlib/tests/mel-frame-band.fk
@@ -1,0 +1,39 @@
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/mel-frame.fk
+;
+; mel-frame-band — one whisper-style mel frame against the torch/numpy fp64 reference, three-way.
+; The frame: sin(2π·440·s/16000), samples 600..999 (torch.stft frame 5, hop 160, n_fft 400 — the
+; interior frame, no padding; torch vs direct DFT agree at 1.8e-12), periodic hann. 440 Hz IS bin 11,
+; so the powers are exact hann leakage: P11 = (N/4)² = 10000, P10 = P12 = 2500, P9 ≈ 0. Mel rows
+; 10/11/12 are the slaney filterbank's rows (librosa, the same family whisper ships), each with
+; two-bin support, weights as data. log10 values match whisper's log lane before normalization.
+;
+; Verdict 1023 when the frame lands:
+;   1    P11·100 → 1000000        (the on-bin power, (400/4)²)
+;   2    P12·100 → 250000         (hann leakage, exactly a quarter)
+;   4    |P9| < 1e-5              (an off-support bin is honestly silent)
+;   8    mel row 11 ·1e4 → 2263993
+;   16   mel row 10 ·1e4 → 993143
+;   32   log10 mel 11 ·1e6 → 2354875
+;   64   log10 mel 10 ·1e6 → 1997012
+;   128  log10 mel 12 ·1e6 → 1776154
+;   256  the clamp lane: log of silence → exactly -10
+;   512  flog10(1000) → 3         (the new ln recipe, on a value the reader can check by eye)
+(do
+    (let xs (mf-frame 440.0 16000 600 400 0))
+    (let p11 (mf-bin-power xs 11 400))
+    (let p12 (mf-bin-power xs 12 400))
+    (let p9  (mf-bin-power xs 9 400))
+    (let m10 (mf-mel-energy xs (list 10 11) (list 0.01990821771323681 0.004954374860972166) 400))
+    (let m11 (mf-mel-energy xs (list 11 12) (list 0.021899040788412094 0.0029635531827807426) 400))
+    (let l12 (mf-log-mel xs (list 12 13) (list 0.02388986200094223 0.0009727313299663365) 400))
+    (let c0 (if (eq (round (mul p11 100.0)) 1000000) 1 0))
+    (let c1 (if (eq (round (mul p12 100.0)) 250000) 2 0))
+    (let c2 (if (lt (if (lt p9 0.0) (sub 0.0 p9) p9) 0.00001) 4 0))
+    (let c3 (if (eq (round (mul m11 10000.0)) 2263993) 8 0))
+    (let c4 (if (eq (round (mul m10 10000.0)) 993143) 16 0))
+    (let c5 (if (eq (round (mul (mf-log-clamped m11) 1000000.0)) 2354875) 32 0))
+    (let c6 (if (eq (round (mul (mf-log-clamped m10) 1000000.0)) 1997012) 64 0))
+    (let c7 (if (eq (round (mul l12 1000000.0)) 1776154) 128 0))
+    (let c8 (if (eq (round (mul (mf-log-clamped 0.0) 1000000.0)) -10000000) 256 0))
+    (let c9 (if (eq (round (mul (flog10 1000.0) 1000000.0)) 3000000) 512 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 c9))))))))))

--- a/form/form-stdlib/trig.fk
+++ b/form/form-stdlib/trig.fk
@@ -32,3 +32,24 @@
   (do (let r (range-reduce (mul x 1.0)))
       (sin-acc (mul r r) r 0 0 10)))
 (defn fcos (x) (fsin (add (mul x 1.0) (HALF-PI))))
+
+; --- ln/log10: split x = m·2^e with m in [1,2), atanh series on z=(m-1)/(m+1) (z <= 1/3, 14 terms
+; reach fp64 depth). Same posture as sin/cos: a recipe over mul/add/div, no kernel native. x > 0.
+(defn LN2 () 0.6931471805599453)
+(defn LOG10-INV () 0.4342944819032518)
+(defn ln-exp-up (a e) (if (ge a 2.0) (ln-exp-up (mul a 0.5) (add e 1)) e))
+(defn ln-exp-down (a e) (if (lt a 1.0) (ln-exp-down (mul a 2.0) (sub e 1)) e))
+(defn ln-exponent (a) (if (ge a 1.0) (ln-exp-up a 0) (ln-exp-down a 0)))
+(defn ln-mantissa (a)
+  (if (ge a 2.0) (ln-mantissa (mul a 0.5)) (if (lt a 1.0) (ln-mantissa (mul a 2.0)) a)))
+(defn ln-ser (z2 zpow j acc n)
+  (if (ge j n) acc
+      (ln-ser z2 (mul zpow z2) (add j 1)
+              (add acc (div (mul zpow z2) (add (mul 2 (add j 1)) 1.0))) n)))
+(defn ln-m (m)
+  (do (let z (div (sub m 1.0) (add m 1.0)))
+      (mul 2.0 (add z (ln-ser (mul z z) z 0 0.0 14)))))
+(defn fln (x)
+  (do (let xf (mul x 1.0))
+      (add (mul (ln-exponent xf) (LN2)) (ln-m (ln-mantissa xf)))))
+(defn flog10 (x) (mul (fln x) (LOG10-INV)))


### PR DESCRIPTION
## What this grows

Two movements, both proven before shipping:

### 1. mel-frame — whisper's front door in pure Form (M6's named first move)

`form/form-stdlib/mel-frame.fk` + `tests/mel-frame-band.fk` → **verdict 1023, Go/Rust/TS, 0 divergent.**

One whisper-style STFT frame fully Form-native, in the `spectrum.fk` lineage:
- hann window via `fcos` (periodic, = `torch.hann_window(400)`)
- DFT bin power via the Goertzel recurrence over windowed samples
- mel rows as slaney `(bins, weights)` data from librosa's filterbank — the same family whisper ships
- log10 via `trig.fk`'s **new `fln`/`flog10`** (atanh series — ln joins sin/cos/sqrt as recipes, no kernel native); whisper's `clamp(1e-10).log10()` lane carried exactly

Matches `torch.stft` frame 5 (hop 160, n_fft 400 — interior frame, torch vs direct DFT agree at 1.8e-12), with the 440 Hz on-bin tone showing exact hann leakage (P11=10000, P12=2500). `trig-band` (127) and `spectrum-band` (15) hold after the extension. The full 80×3000 spectrogram is this recipe walked — speed is M5's JIT stone, not a new shape. Remaining for M6: the safetensors carrier + block-0 activation match.

### 2. Deploy repair — field-docs sync raced the recreated container

On merge `f51a968`, `Hostinger Auto Deploy` reported failure while the site was actually up (api/web/pulse started, sha live, witness breathing): `sync_field_docs`' `docker compose exec` raced the just-force-recreated api container and its exit code failed the run. Unlike its sibling `sync_form_stdlib`, it had no tolerance. Now it retries up to 3× with 5s breath, and fails honestly only if the sync truly cannot land — never silently skipping.

After this merges, a `workflow_dispatch` of Hostinger Auto Deploy completes the field-docs sync for current main.

https://claude.ai/code/session_0176zkDxodG49JbCwZeZspEm

---
_Generated by [Claude Code](https://claude.ai/code/session_0176zkDxodG49JbCwZeZspEm)_