### PR TITLE
tend: voxtral arms in voice_io — transcript oracle docked, TTS gap named

### DIFF
--- a/experiments/satsang-voice/voice_io.py
+++ b/experiments/satsang-voice/voice_io.py
@@ -9,8 +9,15 @@ the words count, voice-traits' transcript-trust scales by the recognizer's own c
 
   TTS  — piper (rhasspy, free, local onnx voice; COH_PIPER_VOICE names the .onnx)
          → espeak-ng fallback (apt/brew install, formant synth — robotic but honest and tiny)
-  STT  — faster-whisper (free, CPU int8, ~40 languages)
+         (Voxtral-4B-TTS exists — mistralai, CC BY-NC weights, research lane — but its runtime
+          is vLLM with a flow-matching decoder not yet in plain transformers; that arm is an open
+          gap until a vLLM host carries it, named here rather than stubbed.)
+  STT  — faster-whisper (free, CPU int8, ~40 languages) — also the GATE oracle: its
+         no_speech_prob is the speechiness voiced.fk gates on
          → mlx-whisper fallback (Apple-Silicon)
+         → Voxtral-Mini-3B (mistralai, Apache 2.0, transformers-native) as the TRANSCRIPT oracle
+           when COH_VOXTRAL=1 — an LLM decoder with no calibrated no_speech_prob, so it never
+           gates; it only speaks once the gate is already open. Each oracle for what it measures.
 
 The round-trip is the witness: text → TTS → wav → loudness + speechiness → voiced.fk gate →
 STT → transcript. A synthesis the recognizer can't hear as speech fails the gate — the loop
@@ -71,6 +78,24 @@ def stt(wav):
         return "", "?", None, None
 
 
+def voxtral_stt(wav):
+    # the transcript oracle (Apache 2.0, transformers >= 4.54): rich multilingual hearing, no
+    # calibrated speechiness — call only behind an open voiced gate. Opt-in (9 GB of weights).
+    if os.environ.get("COH_VOXTRAL") != "1":
+        return None
+    try:
+        import torch
+        from transformers import VoxtralForConditionalGeneration, AutoProcessor
+        mid = "mistralai/Voxtral-Mini-3B-2507"
+        proc = AutoProcessor.from_pretrained(mid)
+        model = VoxtralForConditionalGeneration.from_pretrained(mid, dtype=torch.bfloat16)
+        inputs = proc.apply_transcription_request(language="en", audio=wav, model_id=mid)
+        out = model.generate(**inputs, max_new_tokens=128)
+        return proc.batch_decode(out[:, inputs.input_ids.shape[1]:], skip_special_tokens=True)[0].strip()
+    except Exception:
+        return None
+
+
 def roundtrip(text):
     wav = os.path.join(TMP, "roundtrip.wav")
     mouth = tts(text, wav)
@@ -89,6 +114,9 @@ def roundtrip(text):
     print(f"gate  ▸ {['silence', 'audible', 'voiced'][gate]}  (speechiness {sp}) → transcript-trust {trust}/9")
     if gate >= 2:
         print(f"stt   ▸ {ear} [{lang}] heard: “{heard}”")
+        vox = voxtral_stt(wav)
+        if vox is not None:
+            print(f"stt   ▸ voxtral-mini-3b heard: “{vox}”")
     else:
         print(f"stt   ▸ transcript withheld — the body doesn't trust words below the voiced gate")
 


### PR DESCRIPTION
## What this grows

Mistral's speech models dock into the voice channel's reading shapes — each oracle for what it actually measures:

- **Voxtral-Mini-3B** (Apache 2.0, transformers ≥ 4.54 native) joins `voice_io.py`'s `stt()` as the **transcript oracle** behind `COH_VOXTRAL=1` (opt-in — 9 GB of weights). It's an LLM decoder with no calibrated `no_speech_prob`, so **faster-whisper keeps the gate**: Voxtral only speaks once `voiced.fk`'s voiced gate is already open. The round-trip witness prints both hearings side by side when the arm is awake.
- **Voxtral-4B-TTS** (CC BY-NC 4.0 weights — research lane; commercial via Mistral's API) has a vLLM-only runtime today (flow-matching decoder not yet in plain transformers). That arm is an **open gap named in the docstring**, not a stub — it docks the moment a vLLM host carries it. Piper holds the mouth meanwhile.

## Verified live (Linux CPU, this session)

The exact code path this PR ships, run end to end: Piper spoke the round-trip sentence, and Voxtral-Mini-3B (bf16, CPU — 50 s load, 58 s transcribe) heard it back **verbatim**:

```
VOXTRAL HEARD: The circle is listening, and every voice returns with care.
```

https://claude.ai/code/session_0176zkDxodG49JbCwZeZspEm