### PR TITLE
tend: deploy raises stopped siblings — web+pulse down since the cancelled 14:14Z rollout

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -16,6 +16,49 @@ log() {
   printf '%s — %s\n' "$(timestamp)" "$*" | tee -a "$LOG_FILE"
 }
 
+# A deploy cancelled mid-recreate (concurrency cancel-in-progress) can leave
+# sibling services stopped while the repo and the api container sit aligned
+# at the target SHA — web and pulse down, every Traefik route for them dark,
+# and the witness unable to report the silence it is part of. That exact
+# state shipped on 2026-06-10: the 14:14Z rollout was cancelled by the next
+# push, web never came back, and the next run's "Already flowing" exited 0.
+# So every path through this script calls this: start whatever is stopped
+# (up -d is idempotent for running services), hard-require the public organs
+# (api, web), and name the witness loudly when it is down — a dark witness
+# verifies blind.
+ensure_all_services_up() {
+  local running missing svc
+  running="$(docker compose -f "$COMPOSE_ROOT/docker-compose.yml" ps --format '{{.Service}} {{.State}}' 2>/dev/null | awk '$2=="running" {print $1}')"
+  missing=""
+  for svc in api web pulse; do
+    if ! printf '%s\n' "$running" | grep -qx "$svc"; then
+      missing="${missing} ${svc}"
+    fi
+  done
+  if [[ -z "$missing" ]]; then
+    return 0
+  fi
+  log "services down:${missing} — raising the whole body (docker compose up -d)"
+  if ! docker compose -f "$COMPOSE_ROOT/docker-compose.yml" up -d --wait --wait-timeout 180 2>&1 | tee -a "$LOG_FILE"; then
+    log "compose up --wait failed or unsupported; falling back to plain up -d"
+    docker compose -f "$COMPOSE_ROOT/docker-compose.yml" up -d 2>&1 | tee -a "$LOG_FILE" || true
+  fi
+  local deadline=$(( $(date +%s) + 180 ))
+  for svc in api web; do
+    while ! docker compose -f "$COMPOSE_ROOT/docker-compose.yml" ps --format '{{.Service}} {{.State}}' 2>/dev/null | awk -v s="$svc" '$1==s && $2=="running"' | grep -q .; do
+      if (( $(date +%s) >= deadline )); then
+        log "FAIL: $svc did not reach running state after raise"
+        return 1
+      fi
+      sleep 3
+    done
+  done
+  if ! docker compose -f "$COMPOSE_ROOT/docker-compose.yml" ps --format '{{.Service}} {{.State}}' 2>/dev/null | awk '$1=="pulse" && $2=="running"' | grep -q .; then
+    log "WARN: pulse (the witness) is still not running — the body deploys blind until it breathes"
+  fi
+  log "all core services running"
+}
+
 run_with_timeout() {
   local seconds="$1"
   shift
@@ -83,6 +126,9 @@ RUNNING_SHORT="${RUNNING_SHA:0:12}"
 
 if [[ "$OLD_SHA" == "$TARGET_SHA" && "$RUNNING_SHA" == "$TARGET_SHA" ]]; then
   log "Already flowing at ${TARGET_SHA:0:12} (repo and running API aligned)"
+  # Aligned repo + api is necessary, not sufficient — raise any stopped
+  # siblings (web, pulse) before resting, or this exit masks their silence.
+  ensure_all_services_up || exit 1
   exit 0
 fi
 
@@ -980,6 +1026,10 @@ ensure_kernel_router_canary() {
   elapsed=$((ended - started))
   log "kernel-router canary: running and locally receipt-proven (${elapsed}s)"
 }
+
+# Raise any service a prior cancelled rollout left stopped before the hard
+# checks below — they verify the whole body, not only the rebuilt scope.
+ensure_all_services_up || true
 
 if wait_for_running api; then
   log "api container running"


### PR DESCRIPTION
## Production is down — this PR is the heal

**coherencycoin.com 404s right now** (every page), and **pulse.coherencycoin.com (the witness) is dark**. Timeline from CI:

- 13:36Z — Hostinger deploy for #2767: **success**, web alive and verified
- 14:14Z — deploy for #2765 (full api+web+pulse rebuild, ~32 min in) — **cancelled mid-recreate** by the next push's `cancel-in-progress`
- 14:46Z — deploy for #2768: found repo+api "already flowing" at HEAD, then post-check `FAIL: web container did not reach running state within 180s`

Web and pulse were left stopped; their Traefik labels vanished with the containers, so Traefik answers 404 for both hosts. The api itself is healthy at HEAD (deployed_sha 7cebb0fa). Direct SSH from this network times out (known infra), so the heal rides the deploy workflow's own SSH.

## The fix

`ensure_all_services_up()` in `auto-deploy.sh`, called on every path:

- **already-flowing early exit** — previously `exit 0` while siblings lay stopped; now raises them first (hard verdict)
- **before the post-deploy checks** — they verify the whole body, not only the rebuilt scope

`up -d` is idempotent for running services; api+web are hard-required; a non-breathing pulse logs loudly ("the body deploys blind until it breathes") but stays soft so the witness can never deadlock its own repair.

## Why merging heals

`deploy/`-only diffs aren't in the static allowlist and map to no rebuild bucket → conservative scope `api web pulse` → this deploy force-recreates all three, raising web and pulse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)