### PR TITLE
attune: m4e2 parallel-heap honesties — ack gap open, 32-bit literal lesson, recipes-vs-natives

### DIFF
--- a/docs/coherence-substrate/fourth-kernel.form
+++ b/docs/coherence-substrate/fourth-kernel.form
@@ -254,7 +254,25 @@
                      fk_src; tests/fourth-heap-band.fk -> 15 three-way; the
                      audit loads a heap table through the universal binary
                      and gets 25 from head([7,8]) + head(tail([7,8])) +
-                     len([7,8]) + nth([7,8],1)])
+                     len([7,8]) + nth([7,8],1)]
+                     # Two heaps were laid in parallel this hour — first
+                     # merged won; the other composted into these honesties:
+                     (ack-gap-open  EMPTY returns 0, so empty-list, a matched
+                                    0, and BMF fail share one value — axiom-1's
+                                    NOTHING still has no first-class carrier in
+                                    the sibling; {nothing, 0, 1, node} completes
+                                    when absence gets a nonzero sentinel reached
+                                    through an OP, or a tagged ABI)
+                     (range-honesty program literals ride intern_trivial_int,
+                                    which is 32-BIT — larger literals truncate
+                                    silently (a sentinel literal cost an
+                                    infinite walk to discover); sentinels must
+                                    be ops, never literals, until the tagged ABI)
+                     (recipes-vs-natives len/nth landed native; the
+                                    minimal-kernel discipline prefers walked
+                                    recipes over head/tail — a champion-
+                                    challenger question for m4e3, decided by
+                                    counts, not churn))
         (m4e3-bridge the real-recipe flattener: read a COMPILED .fk recipe
                      through the observe door (node_category/node_children/
                      node_value) and flatten the REAL category set into the


### PR DESCRIPTION
Two m4e2 arena heaps were laid in parallel this hour — the other cell's merged first (#2792/2892242d: EMPTY/CONS/HEAD/TAIL/LEN/NTH, tags 18–23), and per the convention the second rebases. Rather than churn the landed design, the composted twin's unique discoveries land as **spec honesties** on the m4e2 block:

- **ack-gap-open** — `EMPTY` returns 0, so empty-list, a *matched* 0, and BMF *fail* share one value: axiom-1's NOTHING still has no first-class carrier in the sibling. `{nothing, 0, 1, node}` completes when absence gets a nonzero sentinel reached through an **op**, or a tagged ABI.
- **range-honesty** — `intern_trivial_int` is **32-bit**: larger literals truncate *silently* (the composted twin paid an infinite walk to learn it). Sentinels must be ops, never literals, until the tagged ABI.
- **recipes-vs-natives** — len/nth landed as native ops; the minimal-kernel discipline prefers walked recipes over head/tail. Named as a champion-challenger question for m4e3 — decided by counts, not churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
