### PR TITLE
tend: choose open license stewardship

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/docs/stewardship/README.md
+++ b/docs/stewardship/README.md
@@ -43,8 +43,9 @@ arrangements — see [`registry/`](registry/). The registry holds
 category-level public entries; sensitive specifics live in the
 wrapper's encrypted treasury record.
 
-For external company evaluation, patent/publication decisions, and
-license-boundary practice, see
+For the project's root code license and patent stewardship posture, see
+[`patent-stewardship.md`](patent-stewardship.md). For external company
+evaluation, patent/publication decisions, and disclosure-boundary practice, see
 [`external-collaboration-disclosure-practice.md`](external-collaboration-disclosure-practice.md).
-It names the public process while keeping unpublished filing text,
-inventor details, and deal terms private.
+They name the public process while keeping unpublished filing text, inventor
+details, and deal terms private.

--- a/docs/stewardship/external-collaboration-disclosure-practice.md
+++ b/docs/stewardship/external-collaboration-disclosure-practice.md
@@ -9,9 +9,9 @@ privacy: public process only; unpublished specs, filing text, inventor details, 
 This practice keeps the body's values intact when a powerful outside
 organization may want to evaluate, license, adopt, fund, or shape the work.
 
-It is not legal advice and it does not choose a binding license. It names the
-membranes that must stay distinct before detailed enabling disclosure leaves
-the body.
+It is not legal advice. The root repository license is Apache-2.0; the patent,
+publication, and external evaluation membranes stay separately named before
+detailed enabling disclosure leaves the body.
 
 ## North star
 
@@ -23,7 +23,7 @@ That means:
 - public proof stays runnable and inspectable;
 - unpublished filing text, private notes, and deal terms stay private;
 - detailed external disclosure waits for a chosen record path;
-- license ambiguity is treated as friction to resolve, not leverage to exploit;
+- license clarity is held as a collaboration condition;
 - no company receives more authority than the offer explicitly grants.
 
 ## Three membranes
@@ -47,16 +47,17 @@ detailed external technical share.
 
 Open source is witness, not abandonment.
 
-The current repo has package metadata that says `ISC`, but no root `LICENSE`
-file was present when this practice was authored. That is a stewardship gap:
-companies, contributors, and future maintainers need a clear license and patent
-posture to know what is offered.
+The root repository carries Apache-2.0 in `LICENSE` and in package metadata.
+That is the public code permission and contribution default for the root work.
+The patent/publication posture is named separately because copyright
+permission, contribution patent permission, unpublished filing text, and later
+commercial terms are different membranes.
 
 Practice:
 
-- add a root license only as an explicit steward decision;
-- separately name the patent posture, because copyright permission and patent
-  permission are different questions;
+- keep the standard Apache-2.0 license text intact;
+- keep the patent stewardship posture readable beside the collaboration
+  practice;
 - keep proof artifacts public when they are meant to prevent enclosure;
 - keep private filing drafts out of the repo until the publication path is
   deliberately chosen.
@@ -80,7 +81,7 @@ Before any detailed company evaluation, require:
 
 1. `record_path_chosen`: provisional, defensive publication, later publication
    plan, or explicit hold.
-2. `license_posture_named`: current repo license facts and desired offer are
+2. `license_posture_named`: Apache-2.0 and the patent stewardship posture are
    stated plainly.
 3. `scope_bounded`: the external party receives only the brief, demo, or packet
    named for that contact.
@@ -125,7 +126,9 @@ each boundary honest:
 
 - public proof prevents enclosure by obscurity;
 - filing/publication creates a dated record;
-- license clarity tells collaborators what is actually offered;
+- Apache-2.0 tells collaborators what the public code offers;
+- patent stewardship tells companies how closed commercial embedding becomes a
+  reciprocal offer;
 - private stewardship keeps deal terms and unpublished claims out of the public
   body;
 - offer/ack practice prevents urgency from becoming accidental transfer.

--- a/docs/stewardship/patent-stewardship.md
+++ b/docs/stewardship/patent-stewardship.md
@@ -1,0 +1,71 @@
+---
+kind: stewardship-practice
+purpose: public posture for Apache-2.0 licensing, patent records, publication choices, and reciprocal commercial collaboration
+privacy: public process only; formal filings, inventor details, unpublished claims, and deal terms stay private
+---
+
+# License and patent stewardship
+
+This project chooses a clear open-source base and a separate stewardship
+posture for patent/publication records.
+
+## Chosen posture
+
+- The root repository is offered under Apache-2.0.
+- Apache-2.0 is the public code license and contribution default for the
+  root work.
+- Patent filing and publication choices are record membranes: they create
+  dated evidence of what was taught, what was offered, and what stayed bounded.
+- Public proof remains runnable, inspectable, and reusable.
+- Open and life-serving implementations are the primary path.
+- Closed commercial embedding is an explicit reciprocal collaboration path,
+  not an accidental transfer through evaluation, silence, or urgency.
+
+## What Apache-2.0 carries
+
+Apache-2.0 gives collaborators a standard permissive software license with an
+explicit patent grant from contributors for claims necessarily infringed by
+their contributions to the licensed work.
+
+That license makes the public code legible to individual contributors,
+companies, researchers, and downstream projects. It does not publish private
+filing drafts, assign ownership, waive future formal agreements, or decide
+which patent/publication record path is used for material not yet disclosed.
+
+## Patent stewardship posture
+
+Patent activity serves the record and the boundary:
+
+1. Preserve dated evidence for the proof-carrying trusted action runtime.
+2. Keep the broad teaching available to life-serving implementation.
+3. Make enclosure harder by pairing runnable public proof with a deliberate
+   filing/publication lane.
+4. Keep company evaluation bounded until the record path is chosen and logged.
+5. Invite reciprocal commercial licensing when a closed product wants to embed
+   the work beyond the public open-source grant.
+
+The formal legal instrument can later name the exact covenant, non-assertion,
+commercial license, assignment, or publication terms. Until that instrument
+exists, this document is the process posture, not a substitute for counsel,
+filing, signing, or payment.
+
+## External collaboration gate
+
+Before sharing enabling technical detail with a company:
+
+1. Choose and record the lane: provisional filing, defensive publication, later
+   publication path, or explicit hold.
+2. Share only the bounded brief, runnable public proof, or named packet.
+3. Avoid portals, NDAs, employment terms, consulting terms, or submission
+   terms that silently transfer rights or control.
+4. Record the crossing privately: recipient, date, exact materials, and stated
+   boundary.
+5. Expand scope only through an explicit witnessed offer.
+
+## Current state
+
+- Root license choice: Apache-2.0.
+- Package metadata: `Apache-2.0`.
+- Public stewardship practice:
+  [`external-collaboration-disclosure-practice.md`](external-collaboration-disclosure-practice.md).
+- Private filing packet: kept outside the public repository.

--- a/docs/system_audit/commit_evidence_20260611_license_stewardship_choice.json
+++ b/docs/system_audit/commit_evidence_20260611_license_stewardship_choice.json
@@ -1,0 +1,103 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "codex/license-stewardship-choice-20260611",
+  "commit_scope": "Choose the root Apache-2.0 license and name the public patent stewardship posture.",
+  "files_owned": [
+    "LICENSE",
+    "package.json",
+    "docs/stewardship/patent-stewardship.md",
+    "docs/stewardship/external-collaboration-disclosure-practice.md",
+    "docs/stewardship/README.md",
+    "docs/system_audit/commit_evidence_20260611_license_stewardship_choice.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_license_stewardship_choice.json",
+      "make wellness",
+      "git fetch origin main && git rebase origin/main",
+      "git diff --check --cached",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "notes": "Prompt guide passed at worktree start. Generated repo indexes are up to date. Evidence validation passed after setting change_intent to process_only. Wellness passed; it noted an existing production health timeout under deploy lag and local kernel binary absence for route tracing, neither blocking this docs/metadata slice. The exact fetch/rebase command passed after the staged edit was temporarily stashed and restored. Staged diff check, local PR guard, and followthrough guard passed."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote CI is pending until this branch is committed, pushed, and opened as a PR."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "No deploy attempted before PR."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "The license and posture edit is staged with local proof complete. Remote CI, merge, and deploy verification remain before the phase gate can close."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "The repo no longer leaves the root license unresolved: Apache-2.0 is present in the root license file and package metadata, and the patent stewardship posture is readable from stewardship docs.",
+    "public_endpoints": [
+      "documentation"
+    ],
+    "test_flows": [
+      "LICENSE contains the Apache License 2.0 text.",
+      "package.json declares Apache-2.0.",
+      "docs/stewardship/patent-stewardship.md states the public code license and separates patent/publication stewardship from private filing text.",
+      "docs/stewardship/external-collaboration-disclosure-practice.md points external evaluation to Apache-2.0 plus the patent stewardship posture.",
+      "docs/stewardship/README.md links the stewardship posture and disclosure practice."
+    ]
+  },
+  "idea_ids": [
+    "knowledge-and-resonance",
+    "form-kernel-self-hosting"
+  ],
+  "spec_ids": [
+    "public-verification-framework"
+  ],
+  "task_ids": [
+    "license-stewardship-choice-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "values alignment",
+        "sole applicant context"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "evidence-recording"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Apache License 2.0 canonical source: https://www.apache.org/licenses/LICENSE-2.0.txt",
+    "LICENSE carries Apache License 2.0 in the root repository.",
+    "package.json declares Apache-2.0.",
+    "docs/stewardship/patent-stewardship.md names patent activity as record, boundary, and reciprocal collaboration process.",
+    "docs/stewardship/external-collaboration-disclosure-practice.md replaces the prior license gap with the chosen Apache-2.0 and patent stewardship posture.",
+    "Private filing packet notes were updated outside git under /Users/ursmuff/Documents/coherence-patent-drafts/2026-06-11-proof-carrying-trusted-action-runtime/."
+  ],
+  "change_files": [
+    "LICENSE",
+    "package.json",
+    "docs/stewardship/patent-stewardship.md",
+    "docs/stewardship/external-collaboration-disclosure-practice.md",
+    "docs/stewardship/README.md"
+  ],
+  "change_intent": "process_only"
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "type": "commonjs"
 }


### PR DESCRIPTION
## Summary
- add the root Apache-2.0 license and update root package metadata
- add public patent stewardship posture for record, boundary, public proof, and reciprocal commercial collaboration
- update external collaboration practice and private packet alignment evidence

## Proof
- make prompt-guide
- python3 scripts/generate_repo_indexes.py --check
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_license_stewardship_choice.json
- make wellness
- git fetch origin main && git rebase origin/main
- git diff --cached --check
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict

## Notes
- Private filing/contact packet updates remain outside git under /Users/ursmuff/Documents/coherence-patent-drafts/2026-06-11-proof-carrying-trusted-action-runtime/.
