### PR TITLE
tend: n1/n2 — the net organ + the api served on a binary the 4th kernel compiled

### DIFF
--- a/docs/coherence-substrate/fourth-kernel.form
+++ b/docs/coherence-substrate/fourth-kernel.form
@@ -309,13 +309,19 @@
         # binary compiled by the 4th kernel" — honest ladder, each stone
         # shipped + witnessed separately; any cell may pick up the next one:
         (overnight-ladder
-          (n1-net-organ    socket ops in a server-variant emission: the
-                           constant main owns socket/bind/listen/accept via
-                           quoteless externs; the PROGRAM's PUTC bytes become
-                           the response — the net organ physical)
-          (n2-api-binary   one real route: an fkw-emitted binary serves
-                           health-shaped JSON on a port; curl witnesses;
-                           THE api-on-a-4th-kernel-binary seed)
+          (n1-net-organ    [SHIPPED] socket/bind/listen/accept/fork own the
+                           net organ in a server-variant main (fkc-emit-server,
+                           quoteless externs); dup2(cfd,1) makes the PROGRAM's
+                           PUTC bytes the response body; the request is drained
+                           and the connection shut down cleanly. fkresp folds a
+                           string into a PUTC-chain responder. tests/fourth-net-
+                           band.fk -> 15 three-way)
+          (n2-api-binary   [SHIPPED] a binary the 4th kernel compiled serves
+                           HTTP 200 + JSON; the audit curls it live — GET
+                           /health -> 200 sub-millisecond, three requests, the
+                           fork-loop holding. THE api-on-a-4th-kernel-binary,
+                           real. Next: read the request line off the cursor and
+                           route (m4e3); JSON body from substrate values)
           (n3-driver       fork/exec/pipe emission variant: spawn argv-given
                            command, capture stdout into fk_src, the program
                            parses it with the BMF CURSOR — a live subprocess

--- a/form/form-stdlib/fourth-walker-emit.fk
+++ b/form/form-stdlib/fourth-walker-emit.fk
@@ -190,6 +190,35 @@
 
 (defn fkc-emit-many (fns) (fkc-emit-many2 (fkc-flatten-many fns)))
 
+; ── n1/n2 — the NET organ + the api-on-a-4th-kernel-binary ──────────────
+; A server-variant main owns the net organ through quoteless externs:
+; socket/bind/listen/accept, then dup2(fd, 1) repoints stdout to the
+; accepted connection so the PROGRAM's PUTC bytes ARE the response. The
+; program is a pure responder (fn 0 PUTCs a full HTTP/1.0 response, the
+; connection closed after — HTTP/1.0 connection-close, which curl honors).
+; The kernel-resource lifecycle is the constant main (the organ); the body
+; the program serves is Form. Port is argv[1] (default 8080).
+(defn fkc-server-main-text ()
+    "extern int socket(int,int,int); extern int bind(int,const void*,unsigned int); extern int listen(int,int); extern long accept(int,void*,void*); extern int close(int); extern int dup2(int,int); extern int fflush(void*); extern int fork(void); extern void _exit(int); extern int setsockopt(int,int,int,const void*,unsigned int); extern long read(int,void*,unsigned long); extern int shutdown(int,int); extern int atoi(const char *); static char fk_rq[8192]; struct fk_sa { unsigned char len; unsigned char fam; unsigned char p[2]; unsigned int addr; unsigned char z[8]; }; int main(int argc, char **argv) { long long port = 8080; if (argc > 1) { port = atoi(argv[1]); } int sfd = socket(2, 1, 0); int yes = 1; setsockopt(sfd, 65535, 4, &yes, 4); struct fk_sa a; a.len = 16; a.fam = 2; a.p[0] = (port >> 8) & 255; a.p[1] = port & 255; a.addr = 0; for (int z = 0; z < 8; z = z + 1) { a.z[z] = 0; } if (bind(sfd, &a, 16) < 0) { return 1; } listen(sfd, 16); while (1) { long cfd = accept(sfd, 0, 0); if (cfd < 0) { continue; } if (fork() == 0) { read((int)cfd, fk_rq, 8192); dup2((int)cfd, 1); fk_walk(fk_fn[0], 0); fflush(0); shutdown((int)cfd, 2); _exit(0); } close((int)cfd); } return 0; }")
+
+(defn fkc-emit-server2 (flat)
+    (str_concat (fkc-pr-text)
+    (str_concat (fkc-decl-many-text (nth flat 0) (nth flat 1))
+    (str_concat (fkc-walk-many-text)
+                (fkc-server-main-text)))))
+
+(defn fkc-emit-server (fns) (fkc-emit-server2 (fkc-flatten-many fns)))
+
+; fkresp — a responder PROGRAM (cells) that PUTCs the bytes of a Form string,
+; one PUTC per byte (ord off char_at), sequenced by fkd-seq (ADD over PUTC=0).
+; The string IS the whole HTTP/1.0 response; fold it once, get a program-as-
+; cells the net main serves. Authoring-time recursion over the string; the
+; emitted program is a flat PUTC chain — a static response, no input read yet.
+(defn fkresp-from (s i)
+    (if (eq i (str_len s)) (fk-lit 0)
+        (fkd-seq (fkd-ch (ord (char_at s i))) (fkresp-from s (add i 1)))))
+(defn fkresp (s) (fkresp-from s 0))
+
 ; ── the UNIVERSAL walker — no baked program: load a table FILE and run it ──
 ; One binary, many programs. The table file (fkc-table-file) is plain ints —
 ; function count, roots, row count, rows — read through the fs afferent port

--- a/form/form-stdlib/tests/fourth-net-band.fk
+++ b/form/form-stdlib/tests/fourth-net-band.fk
@@ -1,0 +1,33 @@
+; preludes: form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk
+;
+; fourth-net-band — n1/n2 proven three-way: the NET organ (a server-variant
+; main owning socket/bind/listen/accept/fork through quoteless externs) and
+; the responder builder (fkresp folds a string into a PUTC-chain program).
+; The dup2(fd,1) move makes the PROGRAM's PUTC bytes the response body. The
+; live serving — a real binary answering curl with 200 + JSON, sub-ms — is
+; the audit's half; here the kernels prove the server emission agrees.
+;
+; Verdict 15 when the net surface holds:
+;   1   fkresp folds bytes to PUTC rows — "hi" gives LIT 104, PUTC, LIT 105,
+;       PUTC chained by ADD-sequencing over a LIT 0 base
+;   2   the server emission carries the net organ externs — socket(2,1,0),
+;       fork(), accept(sfd ... — found by str_find
+;   4   the server emission is 4365 bytes for the "hi" responder and
+;       deterministic (same fns -> same text)
+;   8   a different responder string gives a different emission (the body the
+;       net main serves is the program, parameterized)
+(do
+    (let resp (fkresp "hi"))
+    (let c0 (if (str_eq (fkc-rows-text (fkc-flatten resp)) "{1,104,0,0},{9,0,0,0},{1,105,0,0},{9,2,0,0},{1,0,0,0},{3,3,4,0},{3,1,5,0},") 1 0))
+
+    (let srv (fkc-emit-server (list resp)))
+    (let c1 (if (ge (str_find srv "socket(2, 1, 0)" 0) 0)
+                (if (ge (str_find srv "fork()" 0) 0)
+                    (if (ge (str_find srv "accept(sfd" 0) 0) 2 0) 0) 0))
+
+    (let c2 (if (eq (str_len srv) 4365)
+                (if (str_eq srv (fkc-emit-server (list resp))) 4 0) 0))
+
+    (let c3 (if (str_eq srv (fkc-emit-server (list (fkresp "yo")))) 0 8))
+
+    (add c0 (add c1 (add c2 c3))))

--- a/scripts/fourth_kernel_audit.sh
+++ b/scripts/fourth_kernel_audit.sh
@@ -405,5 +405,36 @@ if [[ "$m_a" != "42" || "$m_b" != "9001" ]]; then
 fi
 
 echo
+# ── 13. n1/n2 — the NET organ + the api on a 4th-kernel-compiled binary ──
+# A server-variant binary owns socket/bind/listen/accept/fork; the responder
+# program's PUTC bytes (dup2'd to the connection) are the body. Live curl.
+cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/fourth-walker.fk" \
+    "$FORMDIR/form-stdlib/fourth-walker-emit.fk" > "$work/srv-driver.fk"
+cat >> "$work/srv-driver.fk" <<'EOF'
+(let resp (fkresp "HTTP/1.0 200 OK\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{\"status\":\"ok\",\"served_by\":\"fourth-kernel-binary\"}"))
+(print "==SRV==")
+(print (fkc-emit-server (list resp)))
+(print "==END==")
+EOF
+(cd "$FORMDIR" && "$GO_BIN" "$work/srv-driver.fk" 2>/dev/null) > "$work/srv.out"
+sed -n '/^==SRV==$/,/^==END==$/p' "$work/srv.out" | sed -e '1d' -e '$d' > "$work/api.c"
+"$CLANG" -O2 -o "$work/fkapi" "$work/api.c"
+PORT=8231
+"$work/fkapi" "$PORT" & API_PID=$!
+n=0; while [ $n -lt 40 ]; do
+    if curl -sS --max-time 1 -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null; then break; fi
+    n=$((n+1))
+done
+code="$(curl -sS --max-time 3 -w '%{http_code}' -o "$work/body.txt" "http://127.0.0.1:$PORT/health" 2>/dev/null)"
+t="$(curl -sS --max-time 3 -w '%{time_total}' -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null)"
+kill -9 "$API_PID" 2>/dev/null
+echo "n1/n2 the api served on a binary the 4th kernel compiled (net organ: socket/bind/accept/fork):"
+echo "  GET /health -> HTTP $code in ${t}s  body: $(cat "$work/body.txt")"
+if [[ "$code" != "200" ]]; then
+    echo "FAIL  fourth-kernel api binary did not serve 200"; exit 1
+fi
+echo "  the response BODY is the program's PUTC bytes; the net lifecycle is the constant main (the organ)"
+
+echo
 echo "conditions: $(uname -m) $(uname -s), clang -O2, full-process invocations (startup included)"
 echo "ok — parity held and the rows are real; the spec is docs/coherence-substrate/fourth-kernel.form"


### PR DESCRIPTION
First two stones of the overnight ladder.

**n1 — the net organ**: `fkc-emit-server` — a server-variant main owns socket/bind/listen/accept/fork through quoteless externs; `dup2(cfd,1)` makes the PROGRAM's PUTC bytes the response body; the request is drained and the connection shut down cleanly (fork-per-connection — no RST). `fkresp` folds a Form string into a PUTC-chain responder, so the served body is itself a program.

**n2 — the api on a 4th-kernel binary**: the audit curls it live — `GET /health -> HTTP 200` + JSON in **sub-millisecond**, three requests, the accept-loop holding. The api on a binary the fourth kernel compiled, real.

`tests/fourth-net-band.fk` → **15, three-way** (a bool/int trap in my band's c3 surfaced as a TS divergence — `str_eq` returns a boolean node, must not be crossed with int via `eq`; fixed, the kernel was right). The audit's net section builds, serves, and curls end to end.

Next on the ladder: n3 fork/exec/pipe driver (subprocess stdout under the BMF cursor) → n4 TTS → n5 STT → n6 the 115 GB LLM → n7 the band ratchet → n8 emitted assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)