### PR TITLE
tend: n3 — the driver organ (fork/exec/pipe), the keystone the model stones ride

### DIFF
--- a/docs/coherence-substrate/fourth-kernel.form
+++ b/docs/coherence-substrate/fourth-kernel.form
@@ -322,10 +322,13 @@
                            fork-loop holding. THE api-on-a-4th-kernel-binary,
                            real. Next: read the request line off the cursor and
                            route (m4e3); JSON body from substrate values)
-          (n3-driver       fork/exec/pipe emission variant: spawn argv-given
-                           command, capture stdout into fk_src, the program
-                           parses it with the BMF CURSOR — a live subprocess
-                           stream under the streaming matcher)
+          (n3-driver       [SHIPPED] fkc-emit-driver: pipe/fork/execvp spawn
+                           the argv-given command, its stdout captured into
+                           fk_src, the PROGRAM parses that LIVE stream with the
+                           BMF cursor. Witnessed: drive printf 31337 -> 31337,
+                           drive date +%Y -> 2026 (the year off live date
+                           stdout). tests/fourth-driver-band.fk -> 15 three-way.
+                           THE keystone: TTS/STT/LLM are this organ + a parser)
           (n4-tts          drive /usr/bin/say through n3 — TTS physical;
                            model-class TTS (piper et al) named after)
           (n5-stt          brew whisper-cpp + largest whisper model feasible

--- a/form/form-stdlib/fourth-walker-emit.fk
+++ b/form/form-stdlib/fourth-walker-emit.fk
@@ -219,6 +219,25 @@
         (fkd-seq (fkd-ch (ord (char_at s i))) (fkresp-from s (add i 1)))))
 (defn fkresp (s) (fkresp-from s 0))
 
+; ── n3 — the DRIVER organ: fork/exec/pipe a host command, its stdout into ──
+; fk_src, then the PROGRAM parses that stream with the BMF cursor. This is
+; the keystone the model stones ride: the sibling does not reimplement TTS,
+; STT, or an LLM — it DRIVES the host's own (say, whisper-cpp, ollama)
+; through this organ and parses/measures the result (host-resource-access:
+; allow-presence + measure-health). argv[1..] is the command + args; the
+; captured bytes land in fk_src (the same buffer the universal loader fills),
+; so op 17 BUF and the streaming cursor read a LIVE subprocess.
+(defn fkc-driver-main-text ()
+    "extern int pipe(int *); extern int fork(void); extern int dup2(int,int); extern int close(int); extern long read(int,void*,unsigned long); extern int execvp(const char*, char* const*); extern void _exit(int); extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fds[2]; if (pipe(fds) < 0) { return 2; } int pid = fork(); if (pid == 0) { dup2(fds[1], 1); close(fds[0]); close(fds[1]); execvp(argv[1], &argv[1]); _exit(127); } close(fds[1]); long total = 0; long g; while ((g = read(fds[0], fk_src + total, 262143 - total)) > 0) { total = total + g; } fk_src[total] = 0; close(fds[0]); long long a = 0; fk_pv(fk_walk(fk_fn[0], a)); return 0; }")
+
+(defn fkc-emit-driver2 (flat)
+    (str_concat (fkc-pr-text)
+    (str_concat (fkc-decl-many-text (nth flat 0) (nth flat 1))
+    (str_concat (fkc-walk-many-text)
+                (fkc-driver-main-text)))))
+
+(defn fkc-emit-driver (fns) (fkc-emit-driver2 (fkc-flatten-many fns)))
+
 ; ── the UNIVERSAL walker — no baked program: load a table FILE and run it ──
 ; One binary, many programs. The table file (fkc-table-file) is plain ints —
 ; function count, roots, row count, rows — read through the fs afferent port

--- a/form/form-stdlib/tests/fourth-driver-band.fk
+++ b/form/form-stdlib/tests/fourth-driver-band.fk
@@ -1,0 +1,31 @@
+; preludes: form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk
+;
+; fourth-driver-band — n3 proven three-way: the DRIVER organ (fork/exec/pipe a
+; host command, capture its stdout into fk_src, then the PROGRAM parses that
+; live stream with the BMF cursor). This is the keystone the model stones ride:
+; the sibling drives the host's TTS/STT/LLM and parses the result, never
+; reimplements it. The live driving — date +%Y -> 2026 parsed off the pipe — is
+; the audit's half; here the kernels prove the driver emission agrees.
+;
+; (No length pin: emission byte-length shifts as sibling cells add ops in
+; parallel; the band asserts structure, which is stable.)
+;
+; Verdict 15 when the driver surface holds:
+;   1   the driver emission carries pipe(fds) — the capture channel
+;   2   it carries fork() and execvp(argv[1] — spawn the host command
+;   4   it reads the child stdout into fk_src — the cursor's stream
+;   8   the emission is deterministic and parameterized by the parser program
+(do
+    (defn curb () (fk-buf (fk-get (fk-lit 0))))
+    (let p1 (fk-buf (fk-lit 0)))
+    (let p2 (fk-add (fk-buf (fk-lit 0)) (fk-buf (fk-lit 1))))
+    (let d1 (fkc-emit-driver (list p1)))
+
+    (let c0 (if (ge (str_find d1 "pipe(fds)" 0) 0) 1 0))
+    (let c1 (if (ge (str_find d1 "fork()" 0) 0)
+                (if (ge (str_find d1 "execvp(argv[1]" 0) 0) 2 0) 0))
+    (let c2 (if (ge (str_find d1 "read(fds[0], fk_src" 0) 0) 4 0))
+    (let c3 (if (str_eq d1 (fkc-emit-driver (list p1)))
+                (if (str_eq d1 (fkc-emit-driver (list p2))) 0 8) 0))
+
+    (add c0 (add c1 (add c2 c3))))

--- a/scripts/fourth_kernel_audit.sh
+++ b/scripts/fourth_kernel_audit.sh
@@ -436,5 +436,35 @@ fi
 echo "  the response BODY is the program's PUTC bytes; the net lifecycle is the constant main (the organ)"
 
 echo
+# ── 14. n3 — the DRIVER organ: fork/exec/pipe a host command, parse its stdout ──
+# The keystone the model stones ride: the binary spawns a host command, captures
+# its stdout into fk_src, and the PROGRAM parses that LIVE stream with the cursor.
+cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/fourth-walker.fk" \
+    "$FORMDIR/form-stdlib/fourth-walker-emit.fk" > "$work/drv-driver.fk"
+cat >> "$work/drv-driver.fk" <<'EOF'
+(defn seqq (a b) (fk-if a b b))
+(defn adv () (fk-set (fk-lit 0) (fk-add (fk-get (fk-lit 0)) (fk-lit 1))))
+(defn x2 () (fk-add (fk-arg) (fk-arg)))
+(defn x10 () (fk-add (fk-add (x2) (x2)) (fk-add (fk-add (x2) (x2)) (x2))))
+(defn curb () (fk-buf (fk-get (fk-lit 0))))
+(let numf (fk-if (fk-le (fk-lit 48) (curb)) (fk-if (fk-le (curb) (fk-lit 57)) (seqq (adv) (fk-call 1 (fk-add (x10) (fk-sub (fk-buf (fk-sub (fk-get (fk-lit 0)) (fk-lit 1))) (fk-lit 48))))) (fk-arg)) (fk-arg)))
+(let entry (fk-call 1 (fk-lit 0)))
+(print "==DRV==")
+(print (fkc-emit-driver (list entry numf)))
+(print "==END==")
+EOF
+(cd "$FORMDIR" && "$GO_BIN" "$work/drv-driver.fk" 2>/dev/null) > "$work/drv.out"
+sed -n '/^==DRV==$/,/^==END==$/p' "$work/drv.out" | sed -e '1d' -e '$d' > "$work/fkdrv.c"
+"$CLANG" -O2 -o "$work/fkdrv" "$work/fkdrv.c"
+d_pf="$("$work/fkdrv" printf 31337 | head -1)"
+d_yr="$("$work/fkdrv" date +%Y | head -1)"
+echo "n3 the driver organ (fork/exec/pipe a host command; parse its stdout with the BMF cursor):"
+echo "  drive 'printf 31337' -> $d_pf   drive 'date +%Y' -> $d_yr (the year parsed off live date stdout)"
+if [[ "$d_pf" != "31337" ]]; then
+    echo "FAIL  driver did not parse the piped subprocess stdout"; exit 1
+fi
+echo "  the host command's stdout flows into fk_src; the cursor reads a LIVE subprocess — the organ TTS/STT/LLM ride"
+
+echo
 echo "conditions: $(uname -m) $(uname -s), clang -O2, full-process invocations (startup included)"
 echo "ok — parity held and the rows are real; the spec is docs/coherence-substrate/fourth-kernel.form"


### PR DESCRIPTION
The keystone for n4/n5/n6. `fkc-emit-driver`: pipe/fork/execvp spawn the argv-given host command, its stdout captured into `fk_src`, and the PROGRAM parses that **live stream** with the BMF cursor.

Witnessed in the audit: drive `printf 31337` → 31337; drive `date +%Y` → **2026** (the year parsed off live `date` stdout). The sibling drives the host's own TTS/STT/LLM and parses/measures the result — never reimplements it (host-resource-access: allow-presence + measure-health).

`tests/fourth-driver-band.fk` → **15, three-way** — structural assertions (pipe/fork/execvp/read-into-fk_src present, deterministic, parameterized), no fragile length pin since the tag space shifts under parallel cells.

Next: n4 (drive `say` — TTS), n5 (whisper-cpp — STT), n6 (the 115 GB dolphin-mixtral — the largest local LLM), all riding this organ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)