### PR TITLE
tend: n8 — the Form-emitted machine code made visible (otool on the walker binary)

### DIFF
--- a/docs/coherence-substrate/fourth-kernel.form
+++ b/docs/coherence-substrate/fourth-kernel.form
@@ -346,8 +346,10 @@
           (n7-ratchet      m4e3 flattener first click: ONE compiled .fk band
                            through the observe door onto the table; fkw runs
                            it; bands-on-fourth-arm 0 -> 1)
-          (n8-assembly     otool -tv on emitted binaries in the audit — the
-                           Form-emitted ARM64 assembly visible)
+          (n8-assembly     [SHIPPED] otool -tvV on the emitted walker in the
+                           audit shows real ARM64 (stp/ldr/adrp/lsl) — the
+                           whole arc visible: Form recipe -> emitted C ->
+                           machine code; the instruction count reported)
           (honesty         all-424-bands is a WALK not a night — families
                            climb as ops land (strings next); model COMPUTE
                            rides host organs by design — the sibling

--- a/scripts/fourth_kernel_audit.sh
+++ b/scripts/fourth_kernel_audit.sh
@@ -512,5 +512,21 @@ fi
 echo "  the model COMPUTE rides the host organ; the 4th-kernel binary drives it and counts the output (host-resource-access)"
 
 echo
+# ── 16. n8 — the Form-emitted machine code, made visible ────────────────
+# Disassemble the emitted walker: Form recipe -> emitted C -> real ARM64.
+if command -v otool >/dev/null && [[ -x "$work/fkwu" ]]; then
+    insns="$(otool -tvV "$work/fkwu" 2>/dev/null | grep -cE '^[0-9a-f]{16}')"
+    echo "n8 the Form-emitted machine code (otool on the universal walker binary):"
+    echo "  the recipe walker is $insns native instructions; first ops of fk_walk:"
+    otool -tvV "$work/fkwu" 2>/dev/null | grep -A 6 '_fk_walk:' | head -7 | sed 's/^/    /'
+    echo "  Form recipe -> emitted C -> $(uname -m) machine code — the whole arc, real"
+elif command -v objdump >/dev/null && [[ -x "$work/fkwu" ]]; then
+    echo "n8 the Form-emitted machine code (objdump):"
+    objdump -d "$work/fkwu" 2>/dev/null | grep -A 6 '<fk_walk>:' | head -7 | sed 's/^/    /'
+else
+    echo "n8 disassembler (otool/objdump) absent — skipped"
+fi
+
+echo
 echo "conditions: $(uname -m) $(uname -s), clang -O2, full-process invocations (startup included)"
 echo "ok — parity held and the rows are real; the spec is docs/coherence-substrate/fourth-kernel.form"


### PR DESCRIPTION
The audit disassembles the emitted universal walker: `fk_walk` is real ARM64 (`stp`/`ldr`/`adrp`/`lsl`), instruction count reported. The whole arc visible end to end: **Form recipe → emitted C → machine code**. Falls back to objdump; skipped where neither present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)