### PR TITLE
tend: the meeting companion — listen/decide/answer/speak, the decision a 4th-kernel binary

### DIFF
--- a/docs/coherence-substrate/meeting-companion.form
+++ b/docs/coherence-substrate/meeting-companion.form
@@ -98,3 +98,28 @@
 ;   shared-sensing.form (the mesh field) · audio-grammar.form (STT/TTS as the audio Language cell) ·
 ;   sensing-lanes.form (Lane 10 — this is that tool) · federated-slices.form (a learned turn-sense is a
 ;   shareable slice — circles teach each other when to listen).
+;
+; ─────────────────────────────────────────────────────────────────────
+; THE 4TH-KERNEL REALIZATION (2026-06-11) — runs tomorrow
+; ─────────────────────────────────────────────────────────────────────
+; The satsang companion above (Python experiments/satsang-voice) is the proven
+; reference loop. This realization puts the DECISION on the fourth kernel and
+; the COMPUTE on host organs it drives — the body's shape (fourth-kernel.form
+; n4/n5/n6 + the driver organ):
+;   STT  whisper.cpp large-v3-turbo (whisper-stream on the mic) — verbatim on jfk.wav
+;   LLM  ollama on 100% GPU (Metal-confirmed) — answers the addressed request
+;   TTS  /usr/bin/say — real audio of the reply
+;   DECISION  a 4th-kernel BINARY: form-stdlib/fourth-match.fk emitted by the Go
+;             kernel + clang into `fkmatch`, scanning each transcript segment over
+;             the BMF cursor (op 17 BUF, the RAM organ holding the scan base) and
+;             answering 1/0 — "was the companion addressed?". The Form cell at
+;             the center; tests/fourth-match-band.fk -> 15 three-way.
+; CARRIER: scripts/meeting_companion.sh wires the organs (whisper-stream | the
+;   4th-kernel matcher | ollama | say) + a rolling context window + a transcript
+;   log. Named honestly as glue to be LIFTED into Form as the walker grows the
+;   file/loop op families (fourth-kernel.form m4e4) — not the destination.
+; WITNESSED tonight: STT verbatim; the matcher 1/0 on real streams; ollama on
+;   GPU answered; say spoke; a TTS->STT round trip transcribed near-verbatim; a
+;   canned segment ran the whole matcher->ollama->say pipeline. AWAITS tomorrow:
+;   the live mic (permission + the room) — the last mile; every piece around it
+;   is proven. Run: scripts/meeting_companion.sh (wake word configurable).

--- a/form/form-stdlib/fourth-match.fk
+++ b/form/form-stdlib/fourth-match.fk
@@ -1,0 +1,54 @@
+; fourth-match.fk — a wake-word matcher as a fourth-walker PROGRAM: does the
+; captured stream (fk_src) contain a fixed needle? The Form decision cell of
+; the meeting companion — whisper (STT) fills fk_src, this 4th-kernel binary
+; decides "addressed to me?", and on 1 the orchestrator drives ollama + say.
+;
+; Built on the streaming-cursor discipline (op 17 BUF, no tokenizer): a scan
+; over the source, a match-at-position inner walk, the base position in the
+; RAM organ (mem[0]) so the one-arg CALL can carry the match index k. The
+; needle bytes are baked from the Form string at authoring (ord/char_at) into
+; a nested compare — the matcher program IS the needle, content-addressed.
+;
+; Functions (CALL by index): 0 entry, 1 scan, 2 match-at, 3 needle-byte(k).
+;   entry      : mem[0] = 0 ; CALL scan
+;   scan       : if BUF(mem[0]) == 0 -> 0 (end, absent)
+;                else if CALL match-at(0) == LEN -> 1 (found)
+;                else mem[0] = mem[0]+1 ; CALL scan
+;   match-at(k): if k == LEN -> LEN ; else if BUF(mem[0]+k) == needle(k)
+;                -> CALL match-at(k+1) ; else 0
+;   needle(k)  : baked nested-if returning needle byte k
+
+(defn fm-seq (a b) (fk-if a b b))                 ; eval a (effect), then b
+(defn fm-getp ()   (fk-get (fk-lit 0)))           ; base scan position
+(defn fm-setp (v)  (fk-set (fk-lit 0) v))
+
+; needle(k): a select-by-equality chain over k -> byte k, baked from the string.
+(defn fm-needle (s) (fm-needle-chain s 0))
+(defn fm-needle-chain (s k)
+    (if (ge k (str_len s)) (fk-lit 0)
+        (fk-if (fk-sub (fk-arg) (fk-lit k))        ; arg - k : 0 when arg==k -> else-branch picks byte k
+               (fm-needle-chain s (add k 1))
+               (fk-lit (ord (char_at s k))))))
+
+; match-at(k): k in ARG, base in mem[0]
+(defn fm-matchat (s)
+    (fk-if (fk-sub (fk-arg) (fk-lit (str_len s)))               ; k - LEN : 0 when k==LEN
+           (fk-if (fk-sub (fk-buf (fk-add (fm-getp) (fk-arg)))  ; BUF(base+k) - needle(k)
+                          (fk-call 3 (fk-arg)))
+                  (fk-lit 0)                                     ; mismatch
+                  (fk-call 2 (fk-add (fk-arg) (fk-lit 1))))      ; match -> next k
+           (fk-lit (str_len s))))                               ; k==LEN -> full match
+
+; scan: walk base across the source
+(defn fm-scan (s)
+    (fk-if (fk-buf (fm-getp))                                   ; BUF(base) != 0 ?
+           (fk-if (fk-sub (fk-call 2 (fk-lit 0)) (fk-lit (str_len s)))  ; match-at(0) - LEN
+                  (fm-seq (fm-setp (fk-add (fm-getp) (fk-lit 1))) (fk-call 1 (fk-lit 0)))  ; advance, rescan
+                  (fk-lit 1))                                    ; full match here -> found
+           (fk-lit 0)))                                         ; end of source -> absent
+
+(defn fm-entry () (fm-seq (fm-setp (fk-lit 0)) (fk-call 1 (fk-lit 0))))
+
+; the four functions, in CALL-index order (entry=0, scan=1, match-at=2, needle=3)
+(defn fm-contains-fns (needle)
+    (list (fm-entry) (fm-scan needle) (fm-matchat needle) (fm-needle needle)))

--- a/form/form-stdlib/tests/fourth-match-band.fk
+++ b/form/form-stdlib/tests/fourth-match-band.fk
@@ -1,0 +1,28 @@
+; preludes: form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/fourth-match.fk
+;
+; fourth-match-band — the wake-word matcher (the companion's Form decision
+; cell) proven three-way at emission: a "does fk_src contain this needle"
+; scanner over the BMF cursor, the base position in the RAM organ, the needle
+; baked from the string. The LIVE 1/0 on real streams (hey kernel -> 1, no
+; wake -> 0) is the audit's half; here the kernels prove the program agrees.
+;
+; Verdict 15 when the matcher holds:
+;   1   fm-contains-fns is four functions (entry, scan, match-at, needle)
+;   2   the matcher reads the cursor — its table carries BUF (tag 17)
+;   4   the driver emission carries the capture organ (execvp + fk_src read)
+;   8   the needle parameterizes — different needles give different emissions
+(do
+    (let fns (fm-contains-fns "kernel"))
+    (let c0 (if (eq (len fns) 4) 1 0))
+
+    (let rows (nth (fkc-flatten-many fns) 0))
+    (let c1 (if (eq (fkd-has-tag rows 17) 1) 2 0))
+
+    (let d (fkc-emit-driver fns))
+    (let c2 (if (ge (str_find d "execvp(argv[1]" 0) 0)
+                (if (ge (str_find d "read(fds[0], fk_src" 0) 0) 4 0) 0))
+
+    (let c3 (if (str_eq d (fkc-emit-driver fns))
+                (if (str_eq d (fkc-emit-driver (fm-contains-fns "ok"))) 0 8) 0))
+
+    (add c0 (add c1 (add c2 c3))))

--- a/scripts/meeting_companion.sh
+++ b/scripts/meeting_companion.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# meeting_companion.sh — a meeting companion that LISTENS (STT), DECIDES whether
+# it was addressed (a 4th-kernel-compiled binary, the Form decision cell), and
+# when asked, ANSWERS with an LLM and SPEAKS the reply (TTS).
+#
+# The body honored: the heavy compute rides host organs the 4th kernel drives —
+#   STT  = whisper-cli / whisper-stream (whisper.cpp, large-v3-turbo) on the mic
+#   LLM  = ollama on the GPU (Metal)
+#   TTS  = /usr/bin/say
+# The DECISION — "was the companion addressed? what is the question?" — is Form:
+# scripts builds a wake-word matcher (form-stdlib/fourth-match.fk) emitted by the
+# Go kernel and compiled by clang into fkmatch; that 4th-kernel binary scans each
+# transcript segment over the BMF cursor and answers 1/0. The orchestration glue
+# below is an honest CARRIER, to be lifted into Form as the walker grows the op
+# families (file/loop) — named, not hidden.
+#
+# Run it tomorrow:
+#   scripts/meeting_companion.sh                 # wake word "kernel", large-v3-turbo
+#   WAKE=companion MODEL=~/whisper-models/ggml-large-v3-turbo.bin scripts/meeting_companion.sh
+# Speak; when you say the wake word in a sentence, it answers that sentence aloud.
+# Ctrl-C to stop. A full transcript is written to the meeting log.
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMDIR="$ROOT/form"
+GO_BIN="$FORMDIR/form-kernel-go/bin-go"
+CLANG="${CLANG:-clang}"
+WAKE="${WAKE:-kernel}"
+MODEL="${MODEL:-$HOME/whisper-models/ggml-large-v3-turbo.bin}"
+LLM="${LLM:-llama3.2:3b}"
+WORK="${WORK:-$HOME/.coherence-meeting}"
+mkdir -p "$WORK"
+LOG="$WORK/transcript-$(date +%Y%m%d-%H%M%S).txt"
+
+need() { command -v "$1" >/dev/null || { echo "FAIL: missing '$1' — $2"; exit 1; }; }
+need "$CLANG" "a C toolchain"
+need whisper-stream "brew install whisper-cpp"
+need ollama "brew install ollama; ollama pull $LLM"
+need say "macOS TTS (built in)"
+[[ -f "$MODEL" ]] || { echo "FAIL: whisper model not at $MODEL — download ggml-large-v3-turbo.bin"; exit 1; }
+[[ -x "$GO_BIN" ]] || (cd "$FORMDIR/form-kernel-go" && go build -o bin-go .)
+
+# ── build the 4th-kernel wake-word matcher (the Form decision cell) ──────
+echo "building the 4th-kernel wake-word matcher for '$WAKE'..."
+DRV="$WORK/match-driver.fk"
+cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/fourth-walker.fk" \
+    "$FORMDIR/form-stdlib/fourth-walker-emit.fk" "$FORMDIR/form-stdlib/fourth-match.fk" > "$DRV"
+printf '(print "==M==")\n(print (fkc-emit-driver (fm-contains-fns "%s")))\n(print "==END==")\n' "$WAKE" >> "$DRV"
+(cd "$FORMDIR" && "$GO_BIN" "$DRV" 2>/dev/null) > "$WORK/match.out"
+sed -n '/^==M==$/,/^==END==$/p' "$WORK/match.out" | sed -e '1d' -e '$d' > "$WORK/fkmatch.c"
+"$CLANG" -O2 -o "$WORK/fkmatch" "$WORK/fkmatch.c"
+FKMATCH="$WORK/fkmatch"
+echo "  fkmatch ready (a binary the 4th kernel compiled; scans each segment over the BMF cursor)"
+
+echo "listening (wake word: '$WAKE', STT: $(basename "$MODEL"), LLM: $LLM on GPU). Ctrl-C to stop."
+echo "transcript -> $LOG"
+echo
+
+# recent rolling context for the LLM (last few segments)
+CTX=""
+# ── listen: whisper-stream emits transcript segments on stdout ───────────
+whisper-stream -m "$MODEL" --step 0 --length 8000 -vth 0.6 2>/dev/null | while IFS= read -r line; do
+    seg="$(printf '%s' "$line" | sed -E 's/^\[[^]]*\][[:space:]]*//; s/^[[:space:]]+//')"
+    [[ -z "$seg" ]] && continue
+    case "$seg" in [* ) continue;; esac
+    printf '%s\n' "$seg" >> "$LOG"
+    CTX="$(printf '%s\n%s' "$CTX" "$seg" | tail -8)"
+    # the 4th-kernel binary decides: was the companion addressed?
+    if [[ "$("$FKMATCH" echo "$seg" 2>/dev/null | head -1)" == "1" ]]; then
+        echo "  [addressed] $seg"
+        prompt="You are a meeting companion. Recent transcript:
+$CTX
+
+The participant addressed you (wake word '$WAKE'). Answer their request in 1-2 spoken sentences, concise and useful."
+        reply="$(printf '%s' "$prompt" | ollama run "$LLM" 2>/dev/null | tr '\n' ' ' | sed 's/  */ /g')"
+        [[ -z "$reply" ]] && reply="I heard you, but I do not have an answer yet."
+        echo "  [reply] $reply"
+        printf '>> %s\n' "$reply" >> "$LOG"
+        say "$reply"
+    fi
+done


### PR DESCRIPTION
For tomorrow's meeting. The body honored: heavy compute rides host organs the 4th kernel drives; the DECISION is Form.

- **STT** — whisper.cpp large-v3-turbo on the mic (transcribed jfk.wav verbatim)
- **LLM** — ollama on **100% GPU** (Metal-confirmed)
- **TTS** — `say`
- **DECISION** — `fourth-match.fk` emitted by the Go kernel + clang into `fkmatch`, a binary that scans each transcript segment over the **BMF cursor** (RAM organ holding the scan base) and answers 1/0 'was the companion addressed?'. `tests/fourth-match-band.fk` → **15 three-way**.

**Witnessed tonight**: STT verbatim; matcher 1/0 on real streams; ollama on GPU answered; say spoke; a **TTS→STT round trip** transcribed near-verbatim; a canned segment ran the whole `matcher→ollama→say` pipeline. **Awaits tomorrow**: the live mic (permission + the room) — the last mile, everything around it proven.

`scripts/meeting_companion.sh` wires the organs, named honestly as a carrier to be lifted into Form (walker file/loop families, m4e4). Extended the existing `meeting-companion.form` (the satsang reference loop) rather than siblinging it.

**Run tomorrow**: `scripts/meeting_companion.sh` (wake word configurable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)