### PR TITLE
tend: OpenClaw skill requires coh, not retired cc binary

### DIFF
--- a/skills/coherence-network/SKILL.md
+++ b/skills/coherence-network/SKILL.md
@@ -7,14 +7,14 @@ metadata:
     "openclaw":
       {
         "emoji": "🔗",
-        "requires": { "bins": ["cc"] },
+        "requires": { "bins": ["coh"] },
         "install":
           [
             {
               "id": "node",
               "kind": "node",
               "package": "coherence-cli",
-              "bins": ["cc"],
+              "bins": ["coh"],
               "label": "Install Coherence CLI (npm)",
             },
           ],

--- a/skills/coherence-network/SKILL.template.md
+++ b/skills/coherence-network/SKILL.template.md
@@ -6,14 +6,14 @@ metadata:
     "openclaw":
       {
         "emoji": "🔗",
-        "requires": { "bins": ["cc"] },
+        "requires": { "bins": ["coh"] },
         "install":
           [
             {
               "id": "node",
               "kind": "node",
               "package": "coherence-cli",
-              "bins": ["cc"],
+              "bins": ["coh"],
               "label": "Install Coherence CLI (npm)",
             },
           ],


### PR DESCRIPTION
## What

The OpenClaw skill's install/require block named the binary `cc`, but the CLI was renamed `cc → coh` in v0.13.0 (macOS clang conflict). `coherence-cli`'s `package.json` `bin` field only provides `coh`/`coherence` — so an OpenClaw instance satisfying this skill would look for a `cc` binary the published CLI never installs.

Fix points both `requires.bins` and the node-install `bins` at `coh`, in the template (source of truth) and the regenerated `SKILL.md`.

## How found

Scheduled public-presence review. CLI/API/web/docs/npm cross-links and live examples all check out; this binary-name drift was the one functional gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)