### PR TITLE
tend: the Go JIT's typed natives reach the dispatch arm — fib38 8.1s → 0.13s (62×)

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-11_jit_dispatch_fix.json
+++ b/docs/system_audit/commit_evidence_2026-06-11_jit_dispatch_fix.json
@@ -1,0 +1,113 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "worktree-agent-afafcc4210018427a",
+  "commit_scope": "Fixed the Go in-process JIT realization gap measured in commit_evidence_2026-06-11_jit_realization_gap.json. Root cause: jitRecipeNeedsValueABI (form/form-kernel-go/jit.go) treated the recipe's structural name slots — an IDENT's name child (a TrivString), an FNCALL's static callee, a LET's binding name — as runtime string values. Every real body contains one of those, so EVERY jit_compile was forced onto the boxed Value-only ABI: jc.I64 was never built, the dispatch arm took guard 3 (boxed Value), and the boxed native ran at walker speed — which is why walker fib38 (8.10s) and 'JIT' fib38 (7.92s) were indistinguishable. The fix makes the pre-filter structure-aware: IDENT nodes are never string values, a LET scans only its bound value, an FNCALL with a static callee scans only its argument slots. Two companions: (1) the f64 leg refuses float mod (Go has no float %, and the walker's float mod is floor-mod) so a mod-using int recipe no longer poisons the combined plugin build — i64 carries it natively (collatzlen: jit_compile 0 → 1); (2) a peephole emits direct-comparison conditions as raw Go booleans (measured neutral; closes the bool→scalar→!=0 round trip). Go-only change — the three-way validate.sh bands run on the walker, never the JIT.",
+  "files_owned": [
+    "form/form-kernel-go/jit.go",
+    "form/form-kernel-go/jit_test.go",
+    "kernels/JIT_GAP_LEDGER.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form/form-kernel-go && go test ./...",
+      "cd form && ./validate.sh",
+      "time form-kernel-go --expr '(do (defn fib ...) (do (jit_compile \"fib\") (fib 38)))'",
+      "form-kernel-go --expr '... (jit_compile \"fib\") (let t0 (now_unix_ms)) (fib 38) (let t1 (now_unix_ms)) ...'  (compute-only)"
+    ],
+    "summary": "MEASURED (arm64 Darwin, M4 Max), same ground as the gap record. Instrumentation first: pre-fix, jitCompileClosureGo emitted abis:1 (I64=false F64=false Value=true) and the dispatch arm was reached exactly once taking guard 3 (boxed Value) — root cause candidate (a), with the precise mechanism being the pre-filter misclassifying structural name slots, not the plugin build failing. Post-fix: abis:3 (I64=true F64=true Value=true), dispatch takes guard 1 (i64) exactly once, the native carries the whole recursion. fib38: walker 8.10s / pre-fix JIT 7.92s → post-fix compute 0.127–0.133s (62x over walker, within 1.4x of handwritten Go's 0.095s), end-to-end 1.48s including the one-time go-build plugin compile. Secondary realization: the 2000-hit auto-compile path now also lands a usable i64 native mid-run — an un-annotated walker fib38 finishes in ~0.92s. All debug instrumentation removed before commit; the fix ships with jit_test.go pinning both the pre-filter classification and the i64 artifact + single-dispatch realization.",
+    "observed_delta": {
+      "pre_fix_abis_emitted": "value only (I64 nil)",
+      "post_fix_abis_emitted": "i64 + f64 + value",
+      "dispatch_guard_taken_pre_fix": "guard 3 (boxed Value)",
+      "dispatch_guard_taken_post_fix": "guard 1 (i64), exactly 1 dispatch hit",
+      "walker_fib38_s": 8.1,
+      "pre_fix_jit_fib38_s": 7.92,
+      "post_fix_jit_fib38_compute_s": 0.13,
+      "post_fix_jit_fib38_end_to_end_s": 1.48,
+      "handwritten_go_fib38_s": 0.095,
+      "compute_speedup_vs_walker": "62x",
+      "verdict": "native speed realized on the recursive int workload"
+    },
+    "known_limitations": [
+      {
+        "limitation": "Plugin .so is rebuilt per kernel process (~1.3s) and form-jit-* temp dirs accumulate (55,559 stale dirs found in $TMPDIR); the bodyKey is content-addressed so a durable cache would make warm compiles ~0.",
+        "follow_up": "kernels/JIT_GAP_LEDGER.md gap #2 (OPEN)."
+      },
+      {
+        "limitation": "Emitted i64 native is ~1.4x handwritten Go on fib38; auto-compile builds synchronously mid-walk (first hot crossing pays the full build).",
+        "follow_up": "kernels/JIT_GAP_LEDGER.md gaps #3 and #4 (OPEN)."
+      }
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "summary": "Go-kernel-local change; form/validate.sh three-way bands (walker-only) green locally, go test ./... green locally (184s). CI runs the same gates on the PR."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "Kernel-internal performance fix; rides the normal main deploy. No route shape changes."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "After (jit_compile \"fib\"), a recursive int call runs on the typed i64 native instead of the boxed Value native: fib38 compute drops from ~8s to ~0.13s. Walker remains the honest fallback for shapes the typed emitters reject; the boxed Value ABI remains the carrier for genuinely string/list-shaped bodies (TestValueJITMatchesWalker still green).",
+    "public_endpoints": [
+      "GET /api/_form/ideas-observation"
+    ],
+    "test_flows": [
+      "jit_test.go: TestJITValueABIPreFilterSkipsNameSlots (pre-filter classification), TestIntJITTypedDispatchCarriesRecursion (i64 artifact built + answer matches walker + exactly 1 dispatch crossing)",
+      "jit_value_test.go: TestValueJITMatchesWalker (string-shaped body still compiles and matches walker)"
+    ],
+    "summary": "Measured before/after on the exact workload from the gap record; regression tests pin the mechanism."
+  },
+  "phase_gate": {
+    "phase": "jit-exercise",
+    "gate": "the in-process JIT dispatch realizes native speed on a recursive int workload",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "gap #2 (content-addressed durable plugin cache) makes warm compiles ~0; the form-native-models lane can now weigh the in-process JIT against the fourth-kernel emit-compile-exec lane with both realized"
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "jit-realization-gap-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "fix",
+        "measurement"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "evidence_refs": [
+    "docs/system_audit/commit_evidence_2026-06-11_jit_realization_gap.json",
+    "kernels/JIT_GAP_LEDGER.md"
+  ],
+  "change_files": [
+    "form/form-kernel-go/jit.go",
+    "form/form-kernel-go/jit_test.go",
+    "kernels/JIT_GAP_LEDGER.md",
+    "docs/system_audit/commit_evidence_2026-06-11_jit_dispatch_fix.json"
+  ],
+  "change_intent": "runtime_fix"
+}

--- a/form/form-kernel-go/jit.go
+++ b/form/form-kernel-go/jit.go
@@ -539,6 +539,12 @@ func emitGoMath(k *Kernel, op uint32, kids []NodeID, scope *goCompileScope) (str
 	case RMathModulo:
 		opStr = "%"
 		valueOp = "jitabi.Mod"
+		if scope.abi == goJITABIf64 {
+			// Go has no float %, and the walker's float mod is floor-mod —
+			// the f64 leg refuses so the combined plugin build stays clean
+			// while the i64 and Value legs carry the shape.
+			return "", unsupported("jit: float mod not in f64 subset")
+		}
 	default:
 		return "", unsupported(fmt.Sprintf("jit: math op %d", op))
 	}
@@ -596,10 +602,6 @@ func emitGoCond(k *Kernel, op uint32, kids []NodeID, scope *goCompileScope) (str
 	if len(kids) < 2 {
 		return "", unsupported("jit: cond expects at least 2 kids")
 	}
-	cond, err := emitGoExpr(k, kids[0], scope)
-	if err != nil {
-		return "", err
-	}
 	then, err := emitGoExpr(k, kids[1], scope)
 	if err != nil {
 		return "", err
@@ -615,12 +617,94 @@ func emitGoCond(k *Kernel, op uint32, kids []NodeID, scope *goCompileScope) (str
 		els = scope.scalarZero() // if-without-else returns null in walker; JIT subset returns 0
 	}
 	scalar := scope.scalarType()
+	if scope.abi != goJITABIValue {
+		// Direct-comparison condition emits as a raw Go boolean — skips the
+		// bool→scalar→!=0 round trip so the native branch matches what a
+		// hand-written Go function would compile to.
+		if boolSrc, ok, err := emitGoCondBool(k, kids[0], scope); err != nil {
+			return "", err
+		} else if ok {
+			return fmt.Sprintf("(func() %s { if %s { return %s }; return %s }())",
+				scalar, boolSrc, scope.cast(then), scope.cast(els)), nil
+		}
+	}
+	cond, err := emitGoExpr(k, kids[0], scope)
+	if err != nil {
+		return "", err
+	}
 	if scope.abi == goJITABIValue {
 		return fmt.Sprintf("(func() %s { if jitabi.Truthy(%s) { return %s }; return %s }())",
 			scalar, cond, then, els), nil
 	}
 	return fmt.Sprintf("(func() %s { if (%s) != 0 { return %s }; return %s }())",
 		scalar, cond, scope.cast(then), scope.cast(els)), nil
+}
+
+// emitGoCondBool — when a condition node is a direct comparison (either the
+// lowered RBasicCompare arm or the FNCALL sugar eq/ne/lt/le/gt/ge), emit it
+// as a native Go boolean expression. Returns ok=false for any other shape so
+// the caller falls back to the scalar-truthiness path.
+func emitGoCondBool(k *Kernel, node NodeID, scope *goCompileScope) (string, bool, error) {
+	if node.Level == LevelTrivial {
+		return "", false, nil
+	}
+	cat := k.category(node)
+	var op uint32
+	var operands []NodeID
+	switch {
+	case cat.Type == RBasicCompare:
+		op = cat.Inst
+		operands = k.children(node)
+	case cat.Type == RBasicFnCall:
+		kids := k.children(node)
+		if len(kids) != 3 {
+			return "", false, nil
+		}
+		name, ok := jitStaticCallName(k, kids[0])
+		if !ok {
+			return "", false, nil
+		}
+		mapped, ok := map[string]uint32{
+			"eq": RCompareEq, "ne": RCompareNe, "lt": RCompareLt,
+			"le": RCompareLe, "gt": RCompareGt, "ge": RCompareGe,
+		}[name]
+		if !ok {
+			return "", false, nil
+		}
+		op = mapped
+		operands = kids[1:]
+	default:
+		return "", false, nil
+	}
+	if len(operands) != 2 {
+		return "", false, nil
+	}
+	var opStr string
+	switch op {
+	case RCompareEq:
+		opStr = "=="
+	case RCompareNe:
+		opStr = "!="
+	case RCompareLt:
+		opStr = "<"
+	case RCompareLe:
+		opStr = "<="
+	case RCompareGt:
+		opStr = ">"
+	case RCompareGe:
+		opStr = ">="
+	default:
+		return "", false, nil
+	}
+	a, err := emitGoExpr(k, operands[0], scope)
+	if err != nil {
+		return "", false, err
+	}
+	b, err := emitGoExpr(k, operands[1], scope)
+	if err != nil {
+		return "", false, err
+	}
+	return fmt.Sprintf("(%s %s %s)", a, opStr, b), true, nil
 }
 
 func emitGoBlock(k *Kernel, op uint32, kids []NodeID, scope *goCompileScope) (string, error) {
@@ -1140,6 +1224,15 @@ func jitNodeIsListExpr(k *Kernel, node NodeID) bool {
 	return k.category(node).Type == RBasicList
 }
 
+// jitRecipeNeedsValueABI — pre-filter deciding whether the typed i64/f64
+// ABIs are even attempted. A TrivString counts as a runtime string value
+// only in value position; the recipe's structural name slots — an IDENT's
+// name child, an FNCALL's static callee, a LET's binding name — are the
+// tree's shape, not data, and must not force the boxed Value-only ABI.
+// The asymmetry that keeps this safe: a false negative costs nothing (the
+// i64/f64 emitters still reject genuinely string-shaped bodies and the
+// build loop skips them), while a false positive silently boxes every call
+// — the typed natives are what give recursive int workloads native speed.
 func jitRecipeNeedsValueABI(k *Kernel, node NodeID) bool {
 	if node.Level == LevelTrivial {
 		return node.Type == TrivString
@@ -1149,13 +1242,31 @@ func jitRecipeNeedsValueABI(k *Kernel, node NodeID) bool {
 		return true
 	}
 	kids := k.children(node)
-	if cat.Type == RBasicFnCall && len(kids) > 0 {
-		if name, ok := jitStaticCallName(k, kids[0]); ok {
-			switch name {
-			case "list", "empty", "cons", "head", "tail", "len", "nil?", "concat", "nth",
-				"str_len", "str_concat", "str_eq", "substring", "char_at", "ord",
-				"byte_to_str", "scan_run":
-				return true
+	switch cat.Type {
+	case RBasicIdent:
+		// The name child is structure, not a string value.
+		return false
+	case RBasicBlock:
+		if cat.Inst == RBlockLet && len(kids) == 2 {
+			// kids[0] is the binding-name slot; only the bound value is data.
+			return jitRecipeNeedsValueABI(k, kids[1])
+		}
+	case RBasicFnCall:
+		if len(kids) > 0 {
+			if name, ok := jitStaticCallName(k, kids[0]); ok {
+				switch name {
+				case "list", "empty", "cons", "head", "tail", "len", "nil?", "concat", "nth",
+					"str_len", "str_concat", "str_eq", "substring", "char_at", "ord",
+					"byte_to_str", "scan_run":
+					return true
+				}
+				// Static callee resolved — scan only the argument slots.
+				for _, kid := range kids[1:] {
+					if jitRecipeNeedsValueABI(k, kid) {
+						return true
+					}
+				}
+				return false
 			}
 		}
 	}

--- a/form/form-kernel-go/jit_test.go
+++ b/form/form-kernel-go/jit_test.go
@@ -1,0 +1,121 @@
+// jit_test.go — the typed i64 JIT ABI is built and carries recursion natively.
+//
+// Regression ground: the Value-ABI pre-filter (jitRecipeNeedsValueABI) once
+// treated the recipe's structural name slots — an IDENT's name child, an
+// FNCALL's static callee, a LET's binding name — as runtime string values.
+// Every real body contains one of those, so every compile was forced onto
+// the boxed Value-only ABI: jc.I64 stayed nil and recursive int workloads
+// ran at walker speed (fib 38 ≈ 8s where the realized i64 native is ~0.13s).
+// These tests pin both halves: the pre-filter classification and the actual
+// i64 artifact + single-dispatch realization.
+
+package main
+
+import "testing"
+
+func TestJITValueABIPreFilterSkipsNameSlots(t *testing.T) {
+	k := NewKernel()
+	root := readRootFromSource(k, `(do
+  (defn fib (n) (if (lt n 2) n (add (fib (sub n 1)) (fib (sub n 2)))))
+  (defn withlet (a) (do (let b (mul a 2)) (add a b)))
+  (defn slen (s) (str_len s))
+  0)`)
+	env := NewFrame(nil)
+	k.walk(root, env)
+
+	body := func(name string) NodeID {
+		v, ok := env.Lookup(k.internName(name))
+		if !ok || v.Kind != VClosure {
+			t.Fatalf("%s closure missing from top-level env", name)
+		}
+		return v.Cl.Body
+	}
+	if jitRecipeNeedsValueABI(k, body("fib")) {
+		t.Fatal("pure-int recursive body classified as Value-only: name slots are structure, not string values")
+	}
+	if jitRecipeNeedsValueABI(k, body("withlet")) {
+		t.Fatal("let-binding body classified as Value-only: the binding-name slot is structure")
+	}
+	if !jitRecipeNeedsValueABI(k, body("slen")) {
+		t.Fatal("string-op body must keep the Value-only ABI")
+	}
+}
+
+func TestIntJITTypedDispatchCarriesRecursion(t *testing.T) {
+	// fib 14 walks 1219 calls — under the auto-compile hot threshold, so the
+	// baseline stays a pure walk and jit_compile below does the only build.
+	src := `
+(defn fib (n) (if (lt n 2) n (add (fib (sub n 1)) (fib (sub n 2)))))
+(do
+  (let walked (fib 14))
+  (let compiled (jit_compile "fib"))
+  (let jitted (fib 14))
+  (list walked compiled jitted))
+`
+	k := NewKernel()
+	root := readRootFromSource(k, src)
+	env := NewFrame(nil)
+	result := k.walk(root, env)
+	if result.Kind != VList || len(result.List) != 3 {
+		t.Fatalf("want 3-list, got %v", result)
+	}
+	walked, compiled, jitted := result.List[0], result.List[1], result.List[2]
+	if compiled.Kind != VInt || compiled.Int != 1 {
+		t.Fatalf("jit_compile fib: want 1, got %v", compiled)
+	}
+	if walked.Kind != VInt || walked.Int != 377 || jitted.Kind != VInt || jitted.Int != 377 {
+		t.Fatalf("fib 14: want 377 walked and jitted, got %v / %v", walked, jitted)
+	}
+	v, ok := env.Lookup(k.internName("fib"))
+	if !ok || v.Kind != VClosure {
+		t.Fatal("fib closure missing from top-level env")
+	}
+	jc := k.jitCompiledGo[nodeIDKey(v.Cl.Body)]
+	if jc == nil || jc.I64 == nil {
+		t.Fatal("typed i64 ABI missing — recursive int calls would run boxed at walker speed")
+	}
+	if hits := k.jitDispatchHits[v.Cl.Body]; hits != 1 {
+		t.Fatalf("native must carry the whole recursion in one crossing: want 1 dispatch hit, got %d", hits)
+	}
+}
+
+func TestIntJITModRecipeBuildsTypedABI(t *testing.T) {
+	// mod has no f64 leg (Go lacks float %, and the walker's float mod is
+	// floor-mod); the f64 refusal must skip that leg without poisoning the
+	// combined plugin build, so i64 still carries the int shape natively.
+	src := `
+(defn collatzlen (n acc)
+  (if (le n 1) acc
+      (if (eq (mod n 2) 0)
+          (collatzlen (div n 2) (add acc 1))
+          (collatzlen (add (mul n 3) 1) (add acc 1)))))
+(do
+  (let compiled (jit_compile "collatzlen"))
+  (list compiled (collatzlen 27 0)))
+`
+	k := NewKernel()
+	root := readRootFromSource(k, src)
+	env := NewFrame(nil)
+	result := k.walk(root, env)
+	if result.Kind != VList || len(result.List) != 2 {
+		t.Fatalf("want 2-list, got %v", result)
+	}
+	compiled, jitted := result.List[0], result.List[1]
+	if compiled.Kind != VInt || compiled.Int != 1 {
+		t.Fatalf("jit_compile collatzlen: want 1, got %v", compiled)
+	}
+	if jitted.Kind != VInt || jitted.Int != 111 {
+		t.Fatalf("collatzlen 27: want 111, got %v", jitted)
+	}
+	v, ok := env.Lookup(k.internName("collatzlen"))
+	if !ok || v.Kind != VClosure {
+		t.Fatal("collatzlen closure missing from top-level env")
+	}
+	jc := k.jitCompiledGo[nodeIDKey(v.Cl.Body)]
+	if jc == nil || jc.I64 == nil {
+		t.Fatal("typed i64 ABI missing for mod-using int recipe")
+	}
+	if jc.F64 != nil {
+		t.Fatal("f64 leg must refuse float mod rather than emit invalid Go")
+	}
+}

--- a/kernels/JIT_GAP_LEDGER.md
+++ b/kernels/JIT_GAP_LEDGER.md
@@ -4,19 +4,24 @@ Working ledger for the Go kernel's in-process JIT (`form/form-kernel-go/jit.go`
 + the dispatch arm in `main.go`). Every row is a gap **measured or read from the
 code**, with its evidence and status. The JIT is Go-only — the three-way bands
 run on the walker, so JIT fixes carry no parity risk; the walker stays
-canonical truth. Companion finding record:
-`docs/system_audit/commit_evidence_2026-06-11_jit_realization_gap.json`.
+canonical truth. Companion finding records:
+`docs/system_audit/commit_evidence_2026-06-11_jit_realization_gap.json` (the gap),
+`docs/system_audit/commit_evidence_2026-06-11_jit_dispatch_fix.json` (the fix).
 
 Status: `OPEN` · `AGENT-ASSIGNED` (a sub-agent is on it) · `FIXED (PR)` ·
 `BY-DESIGN` (named refusal, honest fallback to the walker).
 
 | # | Gap | Evidence | Status |
 |---|-----|----------|--------|
-| 1 | **Dispatch realization: compiled native not carrying recursive int workloads.** `jit_compile fib` returns 1, the emitted C self-recurses natively, yet JIT fib38 7.92s ≈ walker 8.10s (routed native would be 100×+). Suspects: (a) i64 plugin build silently failing → Value-ABI boxing per call; (b) `jc.I64` nil → guard miss → walker fallthrough; (c) top-level call not reaching the dispatch arm. | measured 2026-06-11; main.go ~4255–4331; evidence JSON above | AGENT-ASSIGNED (fable, worktree) |
+| 1 | **Dispatch realization: compiled native not carrying recursive int workloads.** Was: JIT fib38 7.92s ≈ walker 8.10s. Root cause (instrumented): `jitRecipeNeedsValueABI` read the recipe's structural name slots — an IDENT's name child, an FNCALL's static callee, a LET's binding name — as runtime string values; every real body contains one, so EVERY compile was forced onto the boxed Value-only ABI (`jc.I64` never built; guard 3 ran the boxed native at walker speed). Fix: pre-filter skips name slots; f64 leg refuses float `mod` so mod-using int recipes keep their typed build (Go has no float `%`). After: fib38 compute **0.13s (62×)**, within 1.4× of handwritten Go's 0.095s; end-to-end 1.48s incl. the one-time plugin build; guard 1 (i64) crossed exactly once. | measured 2026-06-11 before/after; fix evidence JSON above; regression pinned by `form/form-kernel-go/jit_test.go` | FIXED (PR #2825) |
 | 2 | **Per-call dispatch overhead even when routed**: `jitCompiledGo` map lookup + arg-kind scan + three ABI guards on *every* call (jit.go header notes "FNCALL closure dispatch checks the map on every call"). For hot recursive shapes the native carries inner recursion, but every *top-level* call repays the scan. | read 2026-06-11, jit.go:27 | OPEN |
 | 3 | **Logic ops not in the i64/f64 subset** (`jit: logic ops not in subset`, jit.go:436). Recipes with and/or/not fall back. | read 2026-06-11 | OPEN — lower to C `&&`/`!`-style branchless ints |
 | 4 | **Nested defn refused** (`jit: nested defn not in subset`, jit.go:463). Any recipe with an inner helper falls back entirely. | read 2026-06-11 | OPEN — lift nested defns as siblings in the plugin (the emitter already has `plan.helpers`) |
-| 5 | **String literals require Value ABI** (jit.go:491); **floats require f64 ABI** (jit.go:497) — fine as routing, but combined int+string shapes drop to boxing. | read 2026-06-11 | BY-DESIGN today; revisit with tagged ABI learn
+| 5 | **String literals require Value ABI** (jit.go:491); **floats require f64 ABI** (jit.go:497) — fine as routing, but combined int+string shapes drop to boxing. | read 2026-06-11 | BY-DESIGN today; revisit with tagged ABI learn |
+| 6 | **Plugin `.so` rebuilt per process; temp dirs accumulate.** Every kernel process `MkdirTemp`s a fresh `form-jit-*` dir and re-runs `go build` (~1.3s) even for an already-seen bodyKey; 55,559 stale dirs found in `$TMPDIR` on the dev machine. The bodyKey is content-addressed — a durable on-disk cache keyed by bodyKey + toolchain version would make warm compiles ~0 and stop the accumulation. | measured 2026-06-11 during the gap-1 fix | OPEN |
+| 7 | **Emitted i64 native ~1.4× handwritten Go.** fib38: emitted native 0.13s vs handwritten 0.095s. The IIFE-wrapped cond/compare emission is largely inlined by the Go compiler (a direct-bool cond peephole landed with gap #1 and measured neutral); the remaining delta (plugin PIC codegen? exported wrapper?) is unexplored. Matters only once workloads saturate the native path. | measured 2026-06-11 | OPEN |
+| 8 | **Auto-compile (2000-hit threshold) builds synchronously mid-walk.** The hot-path promotion in the FNCALL dispatch arm calls `jitCompileClosureGo` inline, so the first hot crossing pays the full ~1.3s plugin build inside the user's call. Now that the artifact is realized (gap #1), an async build that lets the walker continue until the artifact lands would remove the stall. | read 2026-06-11; visible in any un-annotated hot run | OPEN |
+
 ## Exercise log — measured coverage probes (2026-06-11, claude, worktree)
 
 Exercised `jit_compile` / `jit_compile_value` across shapes to map what the
@@ -35,16 +40,17 @@ because fixing it realizes every COMPILES row below at once.
 | nested INNER defn | `(do (defn inner ...) (inner n))` | **REFUSED** → gap #4 (confirmed by measurement) |
 
 **Strategic read:** the emitter is not the bottleneck for model arithmetic —
-float compute, vectors, cross-calls, and let all lower today. The single
-keystone is gap #1: the compiled native is not realized at runtime. When the
-sub-agent lands gap #1, re-run these probes with timing — float and list
-workloads should drop to native speed in the same breath. Then gaps #3/#4 widen
-coverage further (masks/gating need logic; inner helpers need nested-defn lift).
+float compute, vectors, cross-calls, and let all lower today. Gap #1 landed
+(PR #2825): the typed natives are realized at dispatch. Next: re-run these
+probes with timing — float and list workloads should drop to native speed in
+the same breath. Then gaps #3/#4 widen coverage further (masks/gating need
+logic; inner helpers need nested-defn lift), and gap #6 (durable plugin cache)
+turns the ~1.3s per-process compile into a one-time cost per recipe shape.
 
 ### Turn-key fix-sketches for the follow-on gaps (read from jit.go, 2026-06-11)
 
-Ready to pick up once gap #1 (dispatch realization) lands. Each names the exact
-site and the lowering. These are SMALL, Go-only, no parity risk.
+Each names the exact site and the lowering. These are SMALL, Go-only, no
+parity risk.
 
 - **Gap #3 — logic ops** (`jit.go:436`, `case RBasicLogic`). Today: `unsupported`.
   Lowering: emit C/Go boolean expressions over the int subset. `and` →
@@ -64,8 +70,14 @@ site and the lowering. These are SMALL, Go-only, no parity risk.
   params + known helpers. Unblocks: any recipe factored with inner helpers.
 
 - **Gap #2 — per-call dispatch overhead** (the map lookup + arg-kind scan on every
-  top-level call). After gap #1, profile whether this matters: for deep-recursive
-  shapes the native carries the inner loop so it's a one-time cost; for
-  many-distinct-top-level-calls (a model's per-token loop) it could add up. Lift
-  only with a measured row showing it dominates — otherwise leave it (the scan is
-  cheap relative to any real compute). Don't pre-optimize.
+  top-level call). With gap #1 landed, profile whether this matters: for
+  deep-recursive shapes the native carries the inner loop so it's a one-time
+  cost; for many-distinct-top-level-calls (a model's per-token loop) it could
+  add up. Lift only with a measured row showing it dominates — otherwise leave
+  it (the scan is cheap relative to any real compute). Don't pre-optimize.
+
+- **Gap #6 — durable plugin cache.** `jitCompileClosureGo` already keys
+  in-memory reuse by the content-addressed bodyKey; persist the same key on
+  disk (`~/.cache/form-jit/<toolchain>/<bodyKey>/plugin.so`), `plugin.Open` an
+  existing artifact before invoking `go build`, and the per-process MkdirTemp
+  (and its accumulation) composts away.


### PR DESCRIPTION
## What

Fixes the in-process Go JIT realization gap measured in `commit_evidence_2026-06-11_jit_realization_gap.json`: `jit_compile` returned 1 and the emitter was correct, yet recursive int workloads ran at walker speed (walker fib38 8.10s vs JIT 7.92s).

## Root cause (instrumented, not guessed)

`jitRecipeNeedsValueABI` in `form/form-kernel-go/jit.go` treated the recipe's **structural name slots** — an IDENT's name child (a TrivString), an FNCALL's static callee, a LET's binding name — as runtime string values. Every real body contains one, so **every** compile was forced onto the boxed Value-only ABI (`abis: 1`, `I64=nil`). The dispatch arm then took guard 3 (boxed Value), whose per-op boxing runs at walker speed. Instrumentation showed the arm reached exactly once with `I64=false F64=false Value=true` — root-cause candidate (a), with the misclassifying pre-filter as the precise mechanism (introduced 82fe0854, 2026-06-08).

## Fix

- Pre-filter is structure-aware: name slots are shape, not data (IDENT → never a string value; LET scans only its bound value; static-callee FNCALL scans only argument slots). False negatives stay safe — the typed emitters still reject genuinely string-shaped bodies.
- f64 leg refuses float `mod` (Go has no float `%`; walker float mod is floor-mod) so a mod-using int recipe no longer poisons the combined plugin build — `jit_compile` for collatzlen went 0 → 1 with i64 carrying it.
- Peephole: direct-comparison conditions emit as raw Go booleans (measured neutral).

## Measured (arm64 Darwin, M4 Max)

| | fib38 |
|---|---|
| walker (gap record) | 8.10s |
| pre-fix JIT (boxed) | 7.92s |
| **post-fix JIT compute** | **0.127–0.133s (62×)** |
| post-fix end-to-end (incl. one-time plugin build) | 1.48s |
| handwritten Go reference | 0.095s |

Dispatch crosses guard 1 (i64) exactly once; the native carries the whole recursion. The 2000-hit auto-compile path now also lands a usable native mid-run (un-annotated walker fib38 → ~0.92s).

## Safety

Go-kernel-only; the three-way `form/validate.sh` bands run on the walker, never the JIT. `go test ./...` green (191.8s) including new `jit_test.go` pinning the pre-filter classification, the i64 artifact + single-crossing dispatch, and the mod-recipe build. Gap ledger opened at `kernels/JIT_GAP_LEDGER.md` (#1 FIXED; #2 durable plugin cache, #3 1.4× vs handwritten, #4 synchronous mid-walk auto-compile named OPEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)