### PR TITLE
tend: boot-from-axioms — kernel-self-composition's boot theorem runs three-way

### DIFF
--- a/docs/coherence-substrate/kernel-self-composition.form
+++ b/docs/coherence-substrate/kernel-self-composition.form
@@ -30,7 +30,7 @@
     (resources-from  host-kernel.form)                  # the host organs/ports it composes over
     (channels-from   kernel-offer-protocol.form channel-interface-consent.form)
     (persist-by      persistence.fk)                    # the lattice persists
-    (runnable-heart  kernel-satsang.fk host-kernel-cell.fk)  # self-describing parts, circle-witnessed swap, .fkb shrink/expand — running three-way
+    (runnable-heart  kernel-satsang.fk host-kernel-cell.fk boot.fk)  # self-describing parts, circle-witnessed swap, .fkb shrink/expand, boot->offer->self-extend — running three-way
     (version-by      content-addressing)                # axiom-3: new shape = new node-id; old persists = version lineage
     (share-by        merkle.fk federation-addressing.form cell-sync.fk))  # observable/interactable across runtimes by content
 
@@ -90,6 +90,10 @@
     (same-by-content what-one-kernel-proves-another-runs-by-node-id))     # validate.sh = cross-kernel equivalence
 
   # ── Boot — the kernel comes up by composing itself from the axioms ───
+  # RUNS: form/form-stdlib/boot.fk + tests/boot-band.fk (verdict 9, three-way) —
+  # a .fkb image loads, the booted body's first act is to register a reachable
+  # channel, one offer through it MINTS a strictly larger image (the boot
+  # artifact never mutates), and the minted image boots.
   (boot
     (from            the-five-axioms-as-the-only-given)
     (compose         primitives-then-channels-then-ports)  # bottom-up, content-addressed
@@ -144,6 +148,11 @@
 #   cd form && ./validate.sh form-stdlib/core.fk form-stdlib/channel-interface.fk \
 #     form-stdlib/satsang.fk form-stdlib/satsang-field.fk form-stdlib/satsang-share.fk \
 #     form-stdlib/kernel-satsang.fk form-stdlib/tests/kernel-satsang-band.fk
+#   # Boot from axioms — load a .fkb image, offer a channel, self-extend by
+#   # minting (the boot artifact never mutates; the minted image boots):
+#   cd form && ./validate.sh form-stdlib/core.fk form-stdlib/channel.fk \
+#     form-stdlib/persistence.fk form-stdlib/cell-registry.fk \
+#     form-stdlib/boot.fk form-stdlib/tests/boot-band.fk
 #   # The offered channels (cell<->cell):
 #   cd form/form-samples/cross-modal/28-distributed-daemon && ./validate-distributed.sh
 #   # After ingest:

--- a/form/form-kernel-go/bp_table.go
+++ b/form/form-kernel-go/bp_table.go
@@ -71,6 +71,7 @@ var bpTable = map[string][4]uint32{
 	"BML-PARSED-SOURCE-PARSER": {1, 2, 99, 9263},
 	"BML-SOURCE-CARRIER": {1, 2, 99, 9262},
 	"BML-SOURCE-DECLARATION": {1, 2, 99, 9261},
+	"BOOT-QUERY": {1, 2, 99, 1744},
 	"BUCKET": {1, 2, 99, 1840},
 	"CAPABILITIES": {1, 2, 99, 1721},
 	"CELL-CIRCLE": {1, 2, 99, 1704},

--- a/form/form-kernel-rust/src/bp_table.rs
+++ b/form/form-kernel-rust/src/bp_table.rs
@@ -69,6 +69,7 @@ pub static BP_ENTRIES: &[(&str, [u32; 4])] = &[
     ("BML-PARSED-SOURCE-PARSER", [1, 2, 99, 9263]),
     ("BML-SOURCE-CARRIER", [1, 2, 99, 9262]),
     ("BML-SOURCE-DECLARATION", [1, 2, 99, 9261]),
+    ("BOOT-QUERY", [1, 2, 99, 1744]),
     ("BUCKET", [1, 2, 99, 1840]),
     ("CAPABILITIES", [1, 2, 99, 1721]),
     ("CELL-CIRCLE", [1, 2, 99, 1704]),

--- a/form/form-kernel-ts/src/bp_table.ts
+++ b/form/form-kernel-ts/src/bp_table.ts
@@ -69,6 +69,7 @@ export const BP_TABLE: Record<string, [number, number, number, number]> = {
   "BML-PARSED-SOURCE-PARSER": [1, 2, 99, 9263],
   "BML-SOURCE-CARRIER": [1, 2, 99, 9262],
   "BML-SOURCE-DECLARATION": [1, 2, 99, 9261],
+  "BOOT-QUERY": [1, 2, 99, 1744],
   "BUCKET": [1, 2, 99, 1840],
   "CAPABILITIES": [1, 2, 99, 1721],
   "CELL-CIRCLE": [1, 2, 99, 1704],

--- a/form/form-stdlib/blueprint-registry.json
+++ b/form/form-stdlib/blueprint-registry.json
@@ -4088,6 +4088,20 @@
    "pkg": 1,
    "level": 2,
    "type": 99,
+   "inst": 1744,
+   "name": "BOOT-QUERY",
+   "meaning": "a question offered on a booted body's input channel — children (domain, name), the two keys lookup-cell resolves; the same act as an extension offer (axiom-5), distinguished only by category",
+   "aliases": [],
+   "reuse": 1,
+   "defined_in": [
+    "form/form-stdlib/boot.fk"
+   ],
+   "curated": true
+  },
+  {
+   "pkg": 1,
+   "level": 2,
+   "type": 99,
    "inst": 1745,
    "name": "HOLO-ONE",
    "meaning": "The One \u2014 the prima materia, the single source Blueprint all holographic forms differentiate from (the ground every bulk is interned under). Carries its own address, distinct from HANDLER-NOT-FOUND: the source of all forms is not absence.",

--- a/form/form-stdlib/boot.fk
+++ b/form/form-stdlib/boot.fk
@@ -1,0 +1,163 @@
+; boot.fk — boot-from-axioms: the boot theorem of kernel-self-composition
+; as a runnable recipe — load a .fkb image, offer a channel, self-extend
+; by MINTING the next image (the boot artifact itself never mutates).
+;
+; preludes: form-stdlib/channel.fk form-stdlib/persistence.fk form-stdlib/cell-registry.fk
+;
+; The boot sequence from docs/coherence-substrate/kernel-self-composition.form:
+;
+;   (boot (from            the-five-axioms-as-the-only-given)
+;         (compose         primitives-then-channels-then-ports)
+;         (offer-a-channel the-first-act-is-to-offer-a-channel-for-input)
+;         (self-hosting    a-kernel-boots-a-bigger-kernel-it-authored))
+;
+; realized over tissue that already runs:
+;
+;   the boot artifact — a persistence.fk cell store: a .fkb file whose
+;     entries are CELL Recipes. Loading it re-collapses every cell, by
+;     content-addressing, to the same NodeIDs on every sibling kernel
+;     (axiom-3). Reading the image IS the load (axiom-4: observed = real).
+;   offer a channel — the FIRST ACT of a booted body is to become
+;     reachable: open a channel.fk input channel and register it in a
+;     cell-registry.fk directory with the capabilities it chooses
+;     (axiom-4 sovereignty: it offers what it wills; consent is one
+;     interface among many, not the only one).
+;   self-extend — offers arrive on the channel (axiom-5). An extension
+;     offer carries a CELL Recipe; accepting MINTS the next image (seed
+;     cells + offered cells) at a new path. The original image keeps its
+;     shape — axiom-3's strange heart: extension mints, never mutates,
+;     so the version lineage is the sequence of images and rollback is
+;     re-pointing a boot at an older one.
+;   one act — a query travels the same channel as an extension (axiom-5:
+;     to run a cell and to speak to a cell are one act); only the payload
+;     category differs. The ack is a found cell or honest absence.
+;
+; Proven by form-stdlib/tests/boot-band.fk: the seed boots with N cells,
+; one offer extends a minted image to N+1, a query through the offered
+; channel finds the new cell, and re-booting the original image still
+; finds N — a kernel boots a bigger kernel it authored (self-hosting).
+
+;; --- Blueprints -----------------------------------------------------
+;; BOOT-QUERY — the one structural marker this module adds (registry
+;; inst 1744, beside CELL-V0 1740). Children: (domain, name) — the same
+;; two keys persistence.fk's lookup-cell resolves.
+(let BOOT-QUERY (bp "BOOT-QUERY"))
+;; The extension payload is persistence.fk's CELL-V0 — re-derived here
+;; by name; content-addressing makes it the SAME blueprint (names are
+;; query keys, the NodeID is the identity).
+(let BOOT-CELL (bp "CELL-V0"))
+
+;; --- helpers --------------------------------------------------------
+
+(defn bt-nil? (xs) (eq (len xs) 0))
+(defn bt-nth (xs i)
+    (if (eq i 0) (head xs) (bt-nth (tail xs) (sub i 1))))
+
+;; bt-payloads — unwrap every CHANNEL-MSG on a channel to its payload.
+(defn bt-payloads (msgs acc)
+    (if (bt-nil? msgs) acc
+        (bt-payloads (tail msgs)
+            (append acc (list (channel-msg-payload (head msgs)))))))
+
+;; bt-collect-category — every payload of one blueprint category, in
+;; arrival order.
+(defn bt-collect-category (payloads cat acc)
+    (if (bt-nil? payloads) acc
+        (bt-collect-category (tail payloads) cat
+            (if (node_eq (node_category (head payloads)) cat)
+                (append acc (list (head payloads)))
+                acc))))
+
+;; bt-last-of-category — the LAST payload of one category, as a 0-or-1
+;; element list (the body's optional idiom, matching lookup-cell).
+(defn bt-last-of-category (payloads cat acc)
+    (if (bt-nil? payloads) acc
+        (bt-last-of-category (tail payloads) cat
+            (if (node_eq (node_category (head payloads)) cat)
+                (list (head payloads))
+                acc))))
+
+;; bt-adopt — append an already-composed CELL Recipe to a store. A store
+;; is a channel of CELL messages (persistence.fk), so adopting a cell
+;; that crossed a channel lands the identical entry a cell-put of the
+;; same four arguments would — content-addressing is the guarantee.
+(defn bt-adopt (path cell)
+    (channel-append path (channel-message cell)))
+
+;; bt-adopt-all — adopt each cell, then answer with the durable count
+;; read back from disk (the file, not a counter, is the truth).
+(defn bt-adopt-all (path cells)
+    (if (bt-nil? cells) (len (store-cells path))
+        (do (bt-adopt path (head cells))
+            (bt-adopt-all path (tail cells)))))
+
+;; --- boot: load the image, offer a channel ---------------------------
+
+;; boot image-path registry-path channel-path identity -> woke count.
+;; The boot sequence as data the kernel walks:
+;;   1. load  — store-cells re-interns every cell the image holds
+;;   2. offer — create the input channel; register it reachable with
+;;              the capabilities this body chooses ("extend" "query")
+;; Returns how many cells the body woke with; the boot is only as real
+;; as the image that reads back.
+(defn boot (image-path registry-path channel-path identity)
+    (do
+        (let woke (len (store-cells image-path)))
+        (channel-create channel-path)
+        (register-cell registry-path identity channel-path
+            (list "extend" "query"))
+        woke))
+
+;; --- offers into the booted body (the outside cell's side) -----------
+
+;; boot-offer-cell — an extension offer: a CELL Recipe travels to the
+;; body's channel (axiom-5: offer a cell). Returns message count.
+(defn boot-offer-cell (channel-path cell)
+    (channel-append channel-path (channel-message cell)))
+
+;; boot-offer-query — a question is the SAME act as an extension — an
+;; offer on the same channel; only the payload category differs.
+(defn boot-offer-query (channel-path domain name)
+    (channel-append channel-path
+        (channel-message
+            (intern_node BOOT-QUERY
+                (list (intern_trivial_string domain)
+                      (intern_trivial_string name))))))
+
+;; --- self-extend: accept offers by MINTING the next image ------------
+
+;; boot-self-extend image-path channel-path next-image-path -> cell
+;; count of the minted image. Reads the channel, takes every CELL offer
+;; (queries stay queries — they never leak into the image), and writes
+;; seed + offered cells to a NEW store. The original image is untouched:
+;; the version lineage is the sequence of minted images. A mint onto the
+;; seed's own path would mutate the boot artifact — refused (ack 0):
+;; extension mints a new image or does not happen.
+(defn boot-self-extend (image-path channel-path next-image-path)
+    (if (str_eq image-path next-image-path) 0
+        (do
+            (let offered (bt-collect-category
+                             (bt-payloads (channel-read channel-path) (list))
+                             BOOT-CELL (list)))
+            (let seed (store-cells image-path))
+            (cell-store-create next-image-path)
+            (bt-adopt-all next-image-path (append seed offered)))))
+
+;; --- answering a query (the booted body's side) ----------------------
+
+;; boot-pending-query — the latest BOOT-QUERY waiting on the channel,
+;; as a 0-or-1 element list.
+(defn boot-pending-query (channel-path)
+    (bt-last-of-category
+        (bt-payloads (channel-read channel-path) (list))
+        BOOT-QUERY (list)))
+
+;; boot-answer — answer a BOOT-QUERY from a live image. The ack is
+;; axiom-5's: the found cell, or honest absence (empty list) — never a
+;; fabricated one.
+(defn boot-answer (image-path q)
+    (lookup-cell image-path
+        (node_value (bt-nth (node_children q) 0))
+        (node_value (bt-nth (node_children q) 1))))
+
+0

--- a/form/form-stdlib/tests/boot-band.fk
+++ b/form/form-stdlib/tests/boot-band.fk
@@ -1,0 +1,131 @@
+; tests/boot-band.fk — boot-from-axioms band: load, offer, self-extend.
+;
+; preludes: form-stdlib/channel.fk form-stdlib/persistence.fk form-stdlib/cell-registry.fk form-stdlib/boot.fk
+;
+; Proves the boot section of kernel-self-composition.form RUNS: a seed
+; .fkb image boots, the booted body's first act is to offer a channel,
+; one offer through that channel extends it, and the boot artifact never
+; mutates. The strange edge chosen to cover the most boundary in the
+; least code: ONE channel carrying both an extension offer and a query
+; (axiom-5: one act), with the mint and the answer reading different
+; image versions across the extension boundary.
+;
+; That one shape exercises:
+;   - load — the image's cells read back; the boot is as real as the read
+;   - offer — the channel is DISCOVERED through the registry, not assumed
+;   - one act — extension and query travel the same door; only the
+;     payload category differs, and the query never leaks into the image
+;   - mint, never mutate — extension writes a NEW image; minting onto
+;     the seed's own path is refused; re-booting the original still
+;     finds the seed shape (axiom-3's strange heart)
+;   - self-hosting — the minted image boots: a kernel boots a bigger
+;     kernel it authored
+;   - content-addressing — the offered cell crosses channel + mint and
+;     reads back as the same NodeID
+;
+; Band verdict: 9 when every assertion holds across all three kernels.
+;   - 1: the seed image boots with 2 cells (load is real)
+;   - 1: the boot's first act made the body reachable — the registry
+;        finds exactly one cell offering "extend"
+;   - 1: accepting offers mints a 3-cell image — exactly one cell
+;        adopted; the query on the same channel did not leak in
+;   - 1: the pending query, answered from the minted image, finds the
+;        offered cell by name
+;   - 1: the SAME query against the original image is honest absence —
+;        the extension lives only in the minted version
+;   - 1: minting onto the original path is refused and the original
+;        still holds 2 cells
+;   - 1: re-booting the ORIGINAL artifact still wakes 2 (immutability)
+;   - 1: booting the MINTED artifact wakes 3 (self-hosting)
+;   - 1: the offered cell rebuilt from the same arguments is node_eq to
+;        the cell read from the minted image (identity crossed the gap)
+
+(do
+    (let seed-image   "/tmp/boot-band-seed.fkb")
+    (let minted-image "/tmp/boot-band-minted.fkb")
+    (let registry     "/tmp/boot-band-registry.fkb")
+    (let boot-channel "/tmp/boot-band-channel.fkb")
+    (let second-life  "/tmp/boot-band-channel-2.fkb")
+    (let third-life   "/tmp/boot-band-channel-3.fkb")
+
+    ;; A CTOR is structure-first: fields are (key, value) pairs under a
+    ;; FIELDS node — never a flat blob (the persistence-band markers).
+    (let FIELDS (make_nodeid 1 2 99 1741))
+    (let FIELD  (make_nodeid 1 2 99 1742))
+    (defn field (k v)
+        (intern_node FIELD
+            (list (intern_trivial_string k)
+                  (intern_trivial_string v))))
+
+    ;; --- the seed: a kernel of two named cells, durable on disk ------
+    (let bp-organ (make_nodeid 1 8 4 3))
+    (cell-store-create seed-image)
+    (cell-put seed-image "greet" "organ" bp-organ
+              (intern_node FIELDS (list (field "act" "first-contact"))))
+    (cell-put seed-image "pulse" "organ" bp-organ
+              (intern_node FIELDS (list (field "act" "witness"))))
+
+    ;; the world's directory — a registry the boot will register into
+    (channel-create registry)
+
+    ;; --- boot: load the image, offer a channel -----------------------
+    (let woke (boot seed-image registry boot-channel 7))
+    (let woke-ok (if (eq woke 2) 1 0))
+
+    ;; --- the offer is real: an outside cell DISCOVERS the channel ----
+    (let reachable (find-by-capability registry "extend"))
+    (let reach-ok (if (eq (len reachable) 1) 1 0))
+    (let found-channel (reg-channel-path (head reachable)))
+
+    ;; --- one channel, two offers (axiom-5: one act) -------------------
+    (let offered (make-cell-recipe "federate" "organ" bp-organ
+                     (intern_node FIELDS
+                         (list (field "act" "reach-siblings")))))
+    (boot-offer-cell found-channel offered)
+    (boot-offer-query found-channel "organ" "federate")
+
+    ;; --- accept: extension MINTS the next image ----------------------
+    (let minted-count (boot-self-extend seed-image found-channel minted-image))
+    (let mint-ok (if (eq minted-count 3) 1 0))
+
+    ;; --- answer the query from the live (minted) body ----------------
+    (let pending (boot-pending-query found-channel))
+    (let q (head pending))
+    (let live-ans (boot-answer minted-image q))
+    (let ans-ok (if (and (eq (cell-found? live-ans) 1)
+                         (str_eq (cell-name (cell-of live-ans)) "federate"))
+                    1 0))
+
+    ;; --- the version boundary: the SAME query against the original ---
+    (let old-ans (boot-answer seed-image q))
+    (let absent-ok (if (eq (cell-found? old-ans) 0) 1 0))
+
+    ;; --- a mint onto the boot artifact's own path is refused ---------
+    (let refused (boot-self-extend seed-image found-channel seed-image))
+    (let refuse-ok (if (and (eq refused 0)
+                            (eq (len (store-cells seed-image)) 2))
+                       1 0))
+
+    ;; --- re-boot the ORIGINAL artifact: still 2 (axiom-3) ------------
+    (let rewoke (boot seed-image registry second-life 7))
+    (let immut-ok (if (eq rewoke 2) 1 0))
+
+    ;; --- boot the MINTED artifact: the bigger kernel, booted ---------
+    (let bigger (boot minted-image registry third-life 8))
+    (let bigger-ok (if (eq bigger 3) 1 0))
+
+    ;; --- identity crossed channel + mint (content-addressing) --------
+    (let rebuilt (make-cell-recipe "federate" "organ" bp-organ
+                     (intern_node FIELDS
+                         (list (field "act" "reach-siblings")))))
+    (let ca-ok (if (node_eq rebuilt (cell-of live-ans)) 1 0))
+
+    ;; --- verdict ------------------------------------------------------
+    (add woke-ok
+         (add reach-ok
+              (add mint-ok
+                   (add ans-ok
+                        (add absent-ok
+                             (add refuse-ok
+                                  (add immut-ok
+                                       (add bigger-ok ca-ok)))))))))


### PR DESCRIPTION
## Gap

Form-OS map (`docs/coherence-substrate/linux-as-recipes.form`) names it:

> `(boot-init NAMED compose-the-kernel-from-the-axioms = kernel-self-composition.form (boot -> offer a channel -> self-extend); the .fkb image is the boot artifact)`

One of five parallel sibling PRs; the coordinator flips the ledger after all merge — `linux-as-recipes.form` is deliberately untouched here.

## What now RUNS

`form/form-stdlib/boot.fk` composes ONLY existing proven tissue — `persistence.fk` (a .fkb cell store IS the boot artifact), `channel.fk` (the offered input door), `cell-registry.fk` (becoming reachable by capability):

- **boot** — load the image (`store-cells` re-interns every cell; axiom-4: observed = real), then the booted body's FIRST act: open a channel and register it reachable with the capabilities it chooses (`"extend" "query"`).
- **one act** (axiom-5) — an extension offer (a CELL Recipe) and a query travel the SAME channel; only the payload category differs.
- **boot-self-extend** — accepting offers MINTS the next image (seed + offered cells at a NEW path). The boot artifact never mutates: minting onto the seed's own path is refused. Version lineage = the sequence of images (axiom-3).
- **boot-answer** — ack is the found cell or honest absence.

## Proof band — verdict 9, strange-minimal

`form/form-stdlib/tests/boot-band.fk`: one channel carries both an extension offer and a query — the mint takes exactly the cell (the query never leaks into the image); the same query answers *found* from the minted image and *absent* from the original; minting onto the original path is refused; re-booting the original still wakes 2; booting the minted image wakes 3 (**a kernel boots a bigger kernel it authored**); the offered cell crosses channel + mint as the same NodeID.

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/channel.fk \
  form-stdlib/persistence.fk form-stdlib/cell-registry.fk \
  form-stdlib/boot.fk form-stdlib/tests/boot-band.fk
#   ✓ → 9   1 ok, 0 divergent
./validate.sh --binary <same files>
#   ✓ → 9   1 ok, 0 divergent — the band itself runs as a .fkb-lane artifact
```

## Edges in the same commit

- `BOOT-QUERY` registered at `1.2.99.1744` (beside `CELL-V0` 1740); bp tables regenerated for all three kernels; `scan_form_blueprints.py --check` clean (0 unregistered).
- `kernel-self-composition.form` boot block + runnable-heart + How-to-verify now point at the running proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)