### PR TITLE
tend: gc/compaction by measurement — arena melt recipe + live 4095 boundary (Form-OS gap: gc-compaction)

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-11_arena_melt_measured_workload.json
+++ b/docs/system_audit/commit_evidence_2026-06-11_arena_melt_measured_workload.json
@@ -1,0 +1,90 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "form-os/arena-melt",
+  "commit_scope": "Close the linux-as-recipes gc-compaction gap by its own condition: a measured arena workload first, then melt/compaction as a Form recipe over the content-addressed lattice. arena-melt.fk models the m4e2 emitted arena (rows of head/tail, bump pointer, slot 0 sentinel), carries ONE generic reachability walk (liveness = reachability from named roots), a memory-pressure readout (allocated/live/dead/peak-bytes/live-bytes), a content-addressed cons (same composition = same cell, axiom-3 inside the arena), and melt = copy-live-into-a-fresh-arena + caller repoint, with ms-intern as the lattice witness that NodeIDs are preserved across arenas.",
+  "files_owned": [
+    "form/form-stdlib/arena-melt.fk",
+    "form/form-stdlib/tests/arena-melt-band.fk",
+    "docs/system_audit/commit_evidence_2026-06-11_arena_melt_measured_workload.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/arena-melt.fk form-stdlib/tests/arena-melt-band.fk",
+      "clang -O2 on fkc-emit-universal output, then chain-then-LEN table runs at n in {64, 1000, 4095, 4096, 4200}",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-11_arena_melt_measured_workload.json",
+      "python3 scripts/generate_repo_indexes.py"
+    ],
+    "notes": "Band verdict 63 with 0 divergent across Go/Rust/TS. One kernel-divergence trap was caught and named during authoring: a raw eq return value is bool on TS/Go and int on Rust (TS crashes math.i32 when the bool reaches mul); the fix reduces every answer through if to an integer. The live-binary measurement ran on the emitted universal walker (clang lane, same as scripts/fourth_kernel_audit.sh)."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote CI three-way validation pending until the branch is pushed and the PR opens."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Recipe + band + evidence only; no route or service behavior changes. No deploy required beyond normal main rollout."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Local three-way proof and live-binary measurement are green; commit, push, PR, and coordinator ledger flip of linux-as-recipes.form (gc-compaction NAMED -> measured + recipe RUNS) remain."
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "arena-melt-gc-compaction-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "form-os-map"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude-code",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "measurement",
+        "validation",
+        "evidence-recording"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "evidence_refs": [
+    "Three-way band proof: arena-melt-band verdict 63, 0 divergent (Go/Rust/TS) — readout, exact-copy melt, lattice-witnessed NodeID preservation, intern dedup dividend, churn workload, sibling boundary.",
+    "Recipe-lane churn measurement (deterministic, proven in-band): rebuild a 4-cell chain 16 times -> allocated 64 cells, live 4, dead 60, peak 1024 bytes, live 64 bytes; melt compacts to exactly 4 cells.",
+    "Live emitted-sibling measurement (fkc-emit-universal via clang; chain-then-LEN program): n=64 -> LEN 64 (64 tag-19 allocations); n=1000 -> 1000; n=4095 -> 4095 (the boundary HOLDS at exactly the 4095-cell capacity); n=4096 -> 0 (the root pointer wraps onto the null sentinel — the allocation is lost); n=4200 -> 104 (the chain torn at the wrap: 4200 live cells measure 104).",
+    "Measured verdict for the ledger: bump-only suffices while a workload's allocations stay at or under 4095 cells between roots (current fourth-kernel workloads peak far below; the band's churn peaks at 64); past the boundary the carrier overwrites — melt is the proven recipe that keeps live sets under it, dormant by measured choice until a workload crosses.",
+    "Identity invariant: ms-same on am-content of the root before and after melt answers 1 in all three kernels — same composition computes the same NodeID in either arena; the slot index was carrier, never identity (core-axioms.form axiom-3)."
+  ],
+  "change_files": [
+    "form/form-stdlib/arena-melt.fk",
+    "form/form-stdlib/tests/arena-melt-band.fk"
+  ],
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "No route behavior changes. The stdlib gains the gc-compaction lane: a memory-pressure workload (am-churn), a measured arena readout (am-measure), and melt/compaction as a recipe (am-melt: copy-reachable through a content-addressed cons + caller repoint), with the lattice witnessing NodeID preservation across arenas. The emitted sibling's arena stays bump-only by measured choice; its 4095-cell boundary is now measured and named.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "arena-melt-band proves readout, exact-live-copy melt, lattice-witnessed identity preservation, intern dedup, churn measurement, and the sibling boundary, three-way at 63 with 0 divergent.",
+      "Audit lane end-to-end: fkc-emit-universal -> clang -> chain-then-LEN table runs measure the live arena boundary: 4095 holds, 4096 wraps to the sentinel (LEN 0), 4200 tears to 104."
+    ],
+    "summary": "validate.sh 1 ok 0 divergent at verdict 63; live emitted-binary boundary measured at exactly 4095 cells."
+  },
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/arena-melt.fk
+++ b/form/form-stdlib/arena-melt.fk
@@ -1,0 +1,137 @@
+; arena-melt.fk — gc/compaction for the m4e2 arena heap as recipes: liveness is
+; reachability from a named root, melt is copy-live-into-a-fresh-arena through a
+; content-addressed cons, and the one mutation is the caller repointing its root
+; (linux-as-recipes.form memory.gc-compaction; core-axioms.form axiom-3).
+;
+; The model mirrors the emitted sibling's arena (fourth-walker-emit.fk, m4e2):
+; fk_heap_head/fk_heap_tail are rows of (head, tail); fk_hp is the bump pointer;
+; slot 0 is the null sentinel. The sibling packs each boxed value into one
+; machine word — figure v as v<<1, pointer p as (p<<1)|1; the model keeps the
+; same two fields as visible composition: a box is (list kind value) with
+; kind 0 = figure, kind 1 = pointer, and (1 0) the null/EMPTY box.
+;
+; What each door teaches:
+;   am-cons     the sibling's tag-19 move — bump-only allocation; nothing is
+;               overwritten (axiom-3 as the default carrier discipline)
+;   am-live     ONE generic reachability walk — liveness IS reachability from
+;               named roots; no separate mark/sweep machinery in any kernel
+;   am-measure  the memory-pressure readout (allocated live dead peak-bytes
+;               live-bytes) at 16 bytes/cell — the sibling's two long longs
+;   am-intern   content-addressed cons: same (head, tail) composition IS the
+;               same cell (axiom-3 brought INTO the arena) — bump-only gives
+;               equal content distinct slots; intern cannot
+;   am-melt     compaction = copy each live cell into a fresh arena through
+;               am-intern; figures carry as-is; the OLD arena stays whole —
+;               a change MINTS new cells, the one mutation is repoint
+;   am-content  resolve an arena composition to its lattice cell (ms-intern):
+;               the lattice computes the SAME NodeID from the same composition
+;               in either arena — the witness that melt preserved identity
+;   am-churn    the measured workload: rebuild an l-cell chain r times; every
+;               build but the last is garbage (the root moved on)
+;
+; The sibling's carrier holds 4095 cells (4096 slots, slot 0 the sentinel);
+; past it the bump wraps and overwrites — measured live on the emitted binary:
+; chain-then-LEN answers n up to exactly n=4095, then 0 at n=4096 (the root
+; wraps onto the sentinel) and 104 at n=4200 (the chain torn at the wrap).
+; Melt keeps live sets under the boundary; bump-only stays the right default
+; while a workload's measured allocations sit below it.
+
+; ── the arena — the m4e2 shape as composition ────────────────────────────
+(defn am-new () (list 0 (empty)))
+(defn am-hp (ar) (nth ar 0))
+(defn am-rows (ar) (nth ar 1))
+
+(defn am-fig (v) (list 0 v))
+(defn am-ptr (p) (list 1 p))
+(defn am-null () (list 1 0))
+(defn am-val (box) (nth box 1))
+(defn am-is-cell (box) (if (eq (nth box 0) 1) (if (eq (nth box 1) 0) 0 1) 0))
+(defn am-box-eq (a b) (if (eq (nth a 0) (nth b 0)) (if (eq (nth a 1) (nth b 1)) 1 0) 0))
+
+; am-cons — the sibling's tag-19 move: bump, hold (head tail), hand back the
+; new pointer. Returns (list arena box). Nothing is overwritten.
+(defn am-cons (ar h t)
+    (list (list (add (am-hp ar) 1) (cons (list h t) (am-rows ar)))
+          (am-ptr (add (am-hp ar) 1))))
+
+; rows are newest-first: slot k of 1..hp lives at position hp-k
+(defn am-cell (ar p) (nth (am-rows ar) (sub (am-hp ar) p)))
+(defn am-head (ar box) (if (am-is-cell box) (nth (am-cell ar (am-val box)) 0) (am-null)))
+(defn am-tail (ar box) (if (am-is-cell box) (nth (am-cell ar (am-val box)) 1) (am-null)))
+
+; am-len / am-nth — the tag-22/23 reads: follow tails to the null sentinel
+(defn am-len (ar box) (if (am-is-cell box) (add 1 (am-len ar (am-tail ar box))) 0))
+(defn am-nth (ar box k) (if (eq k 0) (am-head ar box) (am-nth ar (am-tail ar box) (sub k 1))))
+
+; ── liveness — ONE generic reachability walk from a named root ───────────
+; Heads may be pointers too (trees); the walk descends both fields, marks each
+; slot once, and counts shared cells once — the kernels' walking shape, reused.
+(defn am-seen (acc p) (if (eq (len acc) 0) 0 (if (eq (head acc) p) 1 (am-seen (tail acc) p))))
+(defn am-live (ar box acc)
+    (if (am-is-cell box)
+        (if (am-seen acc (am-val box)) acc
+            (am-live ar (am-head ar box) (am-live ar (am-tail ar box) (cons (am-val box) acc))))
+        acc))
+(defn am-live-slots (ar root) (am-live ar root (empty)))
+
+; ── the measured readout — (allocated live dead peak-bytes live-bytes) ───
+; 16 bytes per cell: the sibling's two long longs (fk_heap_head + fk_heap_tail)
+(defn am-measure2 (alloc live) (list alloc live (sub alloc live) (mul alloc 16) (mul live 16)))
+(defn am-measure (ar root) (am-measure2 (am-hp ar) (len (am-live-slots ar root))))
+; (the innermost claim reduces through if to an integer — a raw eq return
+;  value is kernel-divergent: bool on TS/Go, int on Rust; eq belongs in
+;  if-conditions, integers belong in answers)
+(defn am-readout-is (m alloc live dead pb lb)
+    (if (eq (nth m 0) alloc)
+        (if (eq (nth m 1) live)
+            (if (eq (nth m 2) dead)
+                (if (eq (nth m 3) pb) (if (eq (nth m 4) lb) 1 0) 0) 0) 0) 0))
+
+; ── am-intern — content-addressed cons (axiom-3 in the arena) ────────────
+; Search existing rows for the same (head tail) composition; same composition
+; IS the same cell, so the pointer comes back instead of a new slot.
+(defn am-cell-is (cell h t) (if (am-box-eq (nth cell 0) h) (am-box-eq (nth cell 1) t) 0))
+(defn am-find2 (rows k h t)
+    (if (eq (len rows) 0) 0
+        (if (eq (am-cell-is (head rows) h t) 1) k (am-find2 (tail rows) (sub k 1) h t))))
+(defn am-find (ar h t) (am-find2 (am-rows ar) (am-hp ar) h t))
+(defn am-intern2 (ar h t k) (if (eq k 0) (am-cons ar h t) (list ar (am-ptr k))))
+(defn am-intern (ar h t) (am-intern2 ar h t (am-find ar h t)))
+
+; ── am-melt — compaction as copy-reachable + repoint ─────────────────────
+; Walk the live composition; figures and the null carry as-is; each live cell
+; re-interns into the fresh arena bottom-up. Returns (list new-arena new-root).
+; The OLD arena is untouched — a change MINTS new cells (axiom-3); the one
+; mutation is the CALLER repointing its root at the returned box. Rollback is
+; keeping the old root: nothing was destroyed.
+(defn am-melt3 (st2 tb) (am-intern (nth st2 0) (nth st2 1) tb))
+(defn am-melt2 (oar box st) (am-melt3 (am-melt oar (am-head oar box) (nth st 0)) (nth st 1)))
+(defn am-melt (oar box nar)
+    (if (am-is-cell box) (am-melt2 oar box (am-melt oar (am-tail oar box) nar))
+        (list nar box)))
+(defn am-melt-root (ar root) (am-melt ar root (am-new)))
+
+; ── am-content — the lattice witness ─────────────────────────────────────
+; Resolve a boxed value to its lattice cell through the intern door:
+;   figure v -> (0 . v)      null -> (1 . 0)      cell -> (2 . (head . tail))
+; Same composition computes the same NodeID in either arena — the slot index
+; was only the carrier; identity lives in the composition (axiom-3).
+(defn am-content (ar box)
+    (if (am-is-cell box)
+        (ms-intern (ms-cell 2) (ms-intern (am-content ar (am-head ar box))
+                                          (am-content ar (am-tail ar box))))
+        (if (eq (nth box 0) 0)
+            (ms-intern (ms-cell 0) (ms-cell (nth box 1)))
+            (ms-intern (ms-cell 1) (ms-cell 0)))))
+
+; ── am-churn — the memory-pressure workload ──────────────────────────────
+; Build an l-cell chain (figures l-1..0); rebuild it r times; every build but
+; the last is garbage — the root moved on. allocated = l*r, live = l.
+(defn am-chain2 (st n) (am-cons (nth st 0) (am-fig (sub n 1)) (nth st 1)))
+(defn am-chain (ar n) (if (eq n 0) (list ar (am-null)) (am-chain2 (am-chain ar (sub n 1)) n)))
+(defn am-churn2 (st l r) (am-churn (nth st 0) l (sub r 1)))
+(defn am-churn (ar l r) (if (eq r 1) (am-chain ar l) (am-churn2 (am-chain ar l) l r)))
+
+; ── the sibling's carrier boundary ───────────────────────────────────────
+; 4096 emitted slots with slot 0 reserved as the sentinel: 4095 live cells.
+(defn am-sibling-capacity () 4095)

--- a/form/form-stdlib/tests/arena-melt-band.fk
+++ b/form/form-stdlib/tests/arena-melt-band.fk
@@ -1,0 +1,72 @@
+; preludes: form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/arena-melt.fk
+;
+; arena-melt-band — gc/compaction earns its place by measurement, three-way:
+; a five-cell arena where three cells hang from the root and two are garbage.
+; Melt copies exactly the three, bytes shrink 80 -> 48, and the lattice
+; witnesses the root's NodeID PRESERVED across arenas — same composition,
+; same identity; the slot index was carrier, never identity.
+;
+; Verdict 63 when the melt holds:
+;   1   the readout: 5 allocated, 3 live (reachability from the root), 2 dead,
+;       80 peak bytes, 48 live bytes
+;   2   melt copies exactly the live three (new hp 3; the chain reads back
+;       9,8,7) and the OLD arena stays whole (hp still 5, the garbage head
+;       still readable — nothing overwritten)
+;   4   identity: ms-same on old-root content vs melted-root content answers 1;
+;       the garbage composition is NOT the root's (the negative stays 0)
+;   8   the intern dividend: two bump slots carrying ONE composition melt to
+;       ONE cell (3 live slots -> 2 cells), identity still preserved
+;   16  the churn workload measured: rebuild a 4-chain 16 times ->
+;       (64 4 60 1024 64); melt -> 4 cells, chain length 4
+;   32  the sibling boundary: the emitted universal walker carries the
+;       bump-only arm, the measured churn peak (64) sits under the 4095-cell
+;       carrier, and the 1024th rebuild of the same 4-chain crosses it
+(do
+    ; the strange-minimal arena: two garbage cells first, then the 3-chain root
+    (let s1 (am-cons (am-new) (am-fig 42) (am-null)))
+    (let s2 (am-cons (nth s1 0) (am-fig 43) (nth s1 1)))
+    (let s3 (am-cons (nth s2 0) (am-fig 7) (am-null)))
+    (let s4 (am-cons (nth s3 0) (am-fig 8) (nth s3 1)))
+    (let s5 (am-cons (nth s4 0) (am-fig 9) (nth s4 1)))
+    (let oar (nth s5 0))
+    (let root (nth s5 1))
+
+    (let c0 (if (eq (am-readout-is (am-measure oar root) 5 3 2 80 48) 1) 1 0))
+
+    (let melted (am-melt-root oar root))
+    (let nar (nth melted 0))
+    (let nroot (nth melted 1))
+    (let c1 (if (eq (am-hp nar) 3)
+                (if (eq (am-val (am-head nar nroot)) 9)
+                    (if (eq (am-val (am-nth nar nroot 1)) 8)
+                        (if (eq (am-val (am-nth nar nroot 2)) 7)
+                            (if (eq (am-hp oar) 5)
+                                (if (eq (am-val (am-head oar (nth s2 1))) 43) 2 0) 0) 0) 0) 0) 0))
+
+    (let c2 (if (eq (ms-same (am-content oar root) (am-content nar nroot)) 1)
+                (if (eq (ms-same (am-content oar (nth s2 1)) (am-content nar nroot)) 0) 4 0) 0))
+
+    ; two slots, one composition: bump-only cannot know; intern can
+    (let t1 (am-cons (am-new) (am-fig 7) (am-null)))
+    (let t2 (am-cons (nth t1 0) (am-fig 7) (am-null)))
+    (let t3 (am-cons (nth t2 0) (nth t1 1) (nth t2 1)))
+    (let tmelt (am-melt-root (nth t3 0) (nth t3 1)))
+    (let c3 (if (eq (len (am-live-slots (nth t3 0) (nth t3 1))) 3)
+                (if (eq (am-hp (nth tmelt 0)) 2)
+                    (if (eq (ms-same (am-content (nth t3 0) (nth t3 1))
+                                     (am-content (nth tmelt 0) (nth tmelt 1))) 1) 8 0) 0) 0))
+
+    ; the measured workload: 16 rebuilds of a 4-chain — 64 allocated, 4 live
+    (let w (am-churn (am-new) 4 16))
+    (let wmelt (am-melt-root (nth w 0) (nth w 1)))
+    (let c4 (if (eq (am-readout-is (am-measure (nth w 0) (nth w 1)) 64 4 60 1024 64) 1)
+                (if (eq (am-hp (nth wmelt 0)) 4)
+                    (if (eq (am-len (nth wmelt 0) (nth wmelt 1)) 4) 16 0) 0) 0))
+
+    ; the sibling carrier: bump-only today (the emitted arm), boundary at 4095
+    (let uni (fkc-emit-universal))
+    (let c5 (if (ge (str_find uni "fk_hp = fk_hp + 1" 0) 0)
+                (if (ge (am-sibling-capacity) (nth (am-measure (nth w 0) (nth w 1)) 0))
+                    (if (gt (mul 4 1024) (am-sibling-capacity)) 32 0) 0) 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))


### PR DESCRIPTION
One of five sibling PRs closing NAMED gaps from `docs/coherence-substrate/linux-as-recipes.form`. This one: **memory.gc-compaction** — honored by the map's own condition: *melt/compaction earns its place by a measured workload*. The measurement is the first stone; the melt recipe follows exactly as far as it demands.

## What lands

- **`form/form-stdlib/arena-melt.fk`** — the gc/compaction lane as recipes over the content-addressed model of the m4e2 arena (the exact shape `fourth-walker-emit.fk` emits: head/tail rows, bump pointer, slot-0 sentinel):
  - `am-live` — **one generic reachability walk**: liveness = reachability from named roots; no hand-coded mark/sweep in any kernel
  - `am-measure` — the memory-pressure readout `(allocated live dead peak-bytes live-bytes)` at the sibling's 16 bytes/cell
  - `am-intern` — content-addressed cons: same composition IS the same cell (axiom-3 inside the arena, where bump-only cannot know)
  - `am-melt` / `am-melt-root` — **compaction = copy-reachable + repoint**: live cells re-intern into a fresh arena; the old arena stays whole (nothing overwritten); the one mutation is the caller repointing its root
  - `am-content` — the lattice witness: `ms-intern` computes the SAME NodeID from the same composition in either arena
  - `am-churn` — the workload: rebuild an l-chain r times; every root but the last moves on
- **`form/form-stdlib/tests/arena-melt-band.fk`** — strange-minimal: five cells, three live from the root, two garbage; melt copies exactly the three, 80 → 48 bytes, **NodeID preserved across arenas** (the heart), the garbage's negative stays 0, two bump slots holding one composition melt to ONE cell, churn measured, sibling boundary named.
- **`docs/system_audit/commit_evidence_2026-06-11_arena_melt_measured_workload.json`** — the measured claims in their own lane.

## Proof

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk \
  form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk \
  form-stdlib/arena-melt.fk form-stdlib/tests/arena-melt-band.fk
→ 63   ·   1 ok, 0 divergent (Go / Rust / TS)
```

## Measured workload (live, on the emitted sibling binary)

`fkc-emit-universal` → clang → chain-then-LEN table runs:

| n (cells) | LEN read back | tag-19 allocations |
|---|---|---|
| 64 | 64 | 64 |
| 1000 | 1000 | 1000 |
| **4095** | **4095** — boundary holds exactly | 4095 |
| **4096** | **0** — root wraps onto the null sentinel | 4096 |
| **4200** | **104** — chain torn at the wrap | 4200 |

Recipe-lane churn (proven in-band, deterministic): 16 rebuilds of a 4-chain → allocated 64, live 4, dead 60, peak 1024 B, live 64 B; melt compacts to exactly 4.

## For the ledger flip (coordinator)

`gc-compaction`: the measurement RUNS (band + live boundary), the melt recipe RUNS (proven three-way at 63); the emitted sibling's arena stays **bump-only by measured choice** — current workloads peak far below the 4095-cell carrier boundary, and `arena-melt.fk` is the named, proven path waiting at it. `linux-as-recipes.form` untouched here per coordination.

Also caught + named in-recipe: a raw `eq` return value is kernel-divergent (bool on TS/Go, int on Rust; TS crashes math.i32 when it reaches `mul`) — answers reduce through `if` to integers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)