### PR TITLE
tend: the six NAMED Form-OS stones now RUN — the linux-as-recipes ledger flips

### DIFF
--- a/docs/coherence-substrate/linux-as-recipes.form
+++ b/docs/coherence-substrate/linux-as-recipes.form
@@ -23,10 +23,17 @@
     (fork-exec-wait   RUNS  fourth-walker-emit.fk fkc-emit-driver — pipe/fork/execvp spawn a host
                             command, capture its stdout; n3 witnessed (date +%Y -> 2026))
     (process-spawn    RUNS  the driver organ IS spawn; the meeting companion drives whisper/ollama/say)
-    (scheduler        NAMED offer-the-compute-organ-to-competing-recipes; recognition-router.fk already
-                            CHOOSES an implementation by measured fitness (RUNS as a recipe) — the
-                            scheduling POLICY is a recipe, order/fairness its arms)
-    (signals          NAMED an unsolicited afferent offer on a channel; timeout==nothing is the SIGALRM shape))
+    (scheduler        RUNS  scheduler.fk — competing recipes OFFER (name arrival priority fitness) for the
+                            compute organ; the POLICY is a pure data row (key-field, least-wins, floor,
+                            requeue) in ONE chooser engine — fifo/round-robin/priority/fitness are four
+                            rows, never four branches; recognition-router's max-over-a-floor choosing is
+                            now a row of this engine (tests/scheduler-band.fk -> 511 three-way))
+    (signals          RUNS  afferent-offer.fk — ao-alarm makes a timer armed for tick T a standing
+                            unsolicited offer on the ALRM line, so SIGALRM-fires and wait-times-out are
+                            one structure (timeout==nothing IS the SIGALRM shape, checked at the window
+                            edge); sigprocmask is AO-MASK data — masked stays pending, delivers when the
+                            mask lifts; coalescing free by content-addressing
+                            (tests/afferent-offer-band.fk -> 511 three-way)))
 
   # ── Memory ──────────────────────────────────────────────────────────
   (memory
@@ -34,8 +41,12 @@
     (isolation        RUNS-by-construction content-addressing-is-immutability (axiom-3) — no cell mutates
                             another; a change MINTS a new node-id; the one mutation is repoint (a pointer move))
     (address-spaces   RUNS  NodeID.package field: 1 = body, 2+ = branches/sandboxes — capability-scoped)
-    (gc-compaction    NAMED the arena is bump-only today; melt/compaction earns its place by a measured
-                            workload (axiom-3's nothing-overwritten is the default until then)))
+    (gc-compaction    RUNS  arena-melt.fk — liveness is ONE reachability walk, melt is copy-live + repoint,
+                            NodeID preserved across arenas (axiom-3: composition is identity); the emitted
+                            sibling's bump arena measured live: holds to exactly 4095 cells, wraps at 4096;
+                            current workloads peak at 64 — bump-only stays the default BY MEASURED CHOICE,
+                            melt is the proven path waiting at that boundary
+                            (tests/arena-melt-band.fk -> 63 three-way)))
 
   # ── Storage / filesystem ────────────────────────────────────────────
   (filesystem
@@ -67,8 +78,11 @@
     (channels-msgq    RUNS  kernel-offer-protocol.form: offer-a-cell-over-a-channel; cell-registry +
                             channel-query + verb-router; the two-cell daemon round trip)
     (shared-memory    RUNS  the content-addressed lattice IS shared memory by NodeID — observe by id)
-    (concurrency      NAMED many offers in flight, acks threaded (the offer-and-acknowledge closure);
-                            walk_parallel RUNS in the kernels))
+    (concurrency      RUNS  offers-in-flight.fk — many offers in flight over a channel, acks threaded
+                            out-of-order by content-addressed token (an offer's NodeID is its unforgeable
+                            correlation token — axiom-3 closing axiom-5); unacked offers remain honestly
+                            in flight; walk_parallel remains the compute-parallel leaf
+                            (tests/offers-in-flight-band.fk -> 255 three-way)))
 
   # ── Syscall / protection / boot ─────────────────────────────────────
   (kernel-core
@@ -82,9 +96,15 @@
     (loadable-modules RUNS  the JIT / emit-compile-exec lane: a recipe -> .so (jit.go) or -> clang binary
                             (fourth-kernel-emit) -> dlopen/exec; install-as-named-callable-leaf NAMED)
     (dynamic-linking  RUNS-via-host dlopen/clang are allowed carriers; the recipe is the linked unit)
-    (interrupts       NAMED an unsolicited afferent offer; no event in time = nothing (timeout==nothing))
-    (boot-init        NAMED compose-the-kernel-from-the-axioms = kernel-self-composition.form
-                            (boot -> offer a channel -> self-extend); the .fkb image is the boot artifact))
+    (interrupts       RUNS  afferent-offer.fk — the SAME ao-wait engine as signals, readings as data:
+                            ao-irq latches a device payload on an IRQ line; a masked or silent line
+                            acknowledges nothing, and the two readings' silence is the SAME NodeID — one
+                            engine, two readings (tests/afferent-offer-band.fk -> 511 three-way))
+    (boot-init        RUNS  boot.fk — kernel-self-composition's boot theorem walks: load a .fkb image (the
+                            boot artifact), the booted body's first act is to offer a channel, one extension
+                            offer MINTS a strictly larger image at a new path; re-booting the original still
+                            wakes N — the artifact's immutability is the kernel's own refusal
+                            (tests/boot-band.fk -> 9, interpreter and compiled lanes)))
 
   # ── Userland surface ────────────────────────────────────────────────
   (userland
@@ -97,12 +117,15 @@
   (tally
     (runs   "process-spawn, arena memory, memory-isolation, address-spaces, filesystem, inode-identity,
              persistence, driver-model, entropy, clock, sockets, http, pipes, channels, shared-memory,
-             syscall-abi, protection-caps, permissions, loadable-modules, shell, stdio, interpreter — the
-             SPINE of an OS, as fourth-kernel binaries or Form recipes, proven")
-    (named  "scheduler policy, signals, gc/compaction, full concurrency, interrupts, boot-from-axioms —
-             each an axiom-composition with a path, the next stones")
-    (verdict "the high-level Linux feature set MAPS to Form recipes; a large fraction already RUNS; the
-              remainder is NAMED with axiom-compositions, not hand-waved — the walk continues"))
+             syscall-abi, protection-caps, permissions, loadable-modules, shell, stdio, interpreter —
+             and now scheduler policy, signals, interrupts, gc/melt (measured), offers-in-flight
+             concurrency, boot-from-axioms: every subsystem row, as fourth-kernel binaries or Form
+             recipes with three-way proof bands")
+    (named  "the deepenings: a live select/poll wait-carrier for the afferent witness (op 15 TIME as
+             tick carrier); melt activation when a workload crosses the measured 4095-cell boundary;
+             native GPU emitters; install-as-named-callable-leaf — each a named stone on a proven path")
+    (verdict "every high-level Linux subsystem now RUNS (or RUNS-by-construction) as Form recipes with
+              three-way proof; what stays NAMED is deepening on proven paths — the walk continues"))
 
   (invariant
     (not-reimplemented-but-composed every duty is a composition of the five axioms, not a port of Linux)
@@ -116,4 +139,16 @@
 #   cd form && ./validate.sh form-stdlib/core.fk form-stdlib/resource-port.fk \
 #     form-stdlib/tests/resource-port-band.fk      # the HAL
 #   cd form && ./validate.sh form-stdlib/persistence.fk form-stdlib/merkle.fk form-stdlib/cell-sync.fk
+#   cd form && ./validate.sh form-stdlib/core.fk form-stdlib/recognition-router.fk \
+#     form-stdlib/scheduler.fk form-stdlib/tests/scheduler-band.fk             # scheduler -> 511
+#   cd form && ./validate.sh form-stdlib/afferent-offer.fk \
+#     form-stdlib/tests/afferent-offer-band.fk                                 # signals+interrupts -> 511
+#   cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk \
+#     form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk \
+#     form-stdlib/arena-melt.fk form-stdlib/tests/arena-melt-band.fk           # gc/melt -> 63
+#   cd form && ./validate.sh form-stdlib/core.fk form-stdlib/channel.fk form-stdlib/sha256.fk \
+#     form-stdlib/channel-query.fk form-stdlib/offers-in-flight.fk \
+#     form-stdlib/tests/offers-in-flight-band.fk                               # concurrency -> 255
+#   cd form && ./validate.sh form-stdlib/core.fk form-stdlib/channel.fk form-stdlib/persistence.fk \
+#     form-stdlib/cell-registry.fk form-stdlib/boot.fk form-stdlib/tests/boot-band.fk   # boot -> 9
 #   coh substrate form "?equivalent @recipe(linux-as-recipes)"   # after ingest


### PR DESCRIPTION
All six NAMED gaps in the Form-OS map closed by five sibling PRs, each proven three-way (Go/Rust/TS) before landing:

- **scheduler policy** — #2827: `scheduler.fk`, policy as a pure data row in ONE chooser engine (band → 511)
- **signals + interrupts** — #2830: `afferent-offer.fk`, two readings of ONE unsolicited-afferent-offer engine; the two readings' silence is the SAME NodeID (band → 511)
- **gc/compaction** — #2831: `arena-melt.fk`, measurement-first per the row's own condition; the emitted sibling's arena boundary measured live at exactly 4095 cells (band → 63)
- **full concurrency** — #2829: `offers-in-flight.fk`, acks threaded out-of-order by content-addressed token (band → 255)
- **boot-from-axioms** — #2828: `boot.fk`, load a .fkb image → offer a channel → self-extend by minting (band → 9, interpreter and compiled lanes)

This PR flips the ledger rows NAMED → RUNS with citations, retunes the tally (what stays NAMED is deepening on proven paths), and adds the five band invocations to the verify section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)