### PR TITLE
tend: web vitest reads the body as it is — i18n chrome, paginated rows, global ambient backdrop; CI now runs it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,3 +80,7 @@ jobs:
       - name: Build web
         run: |
           cd web && npm ci --allow-git=none && npm run build
+
+      - name: Test web
+        run: |
+          cd web && npm run test

--- a/.github/workflows/thread-gates.yml
+++ b/.github/workflows/thread-gates.yml
@@ -205,6 +205,11 @@ jobs:
         run: |
           cd web && npm ci --allow-git=none && npm run build
 
+      - name: Test web
+        if: steps.changed_surfaces.outputs.web == 'true'
+        run: |
+          cd web && npm run test
+
       - name: Install PR triage dependencies
         if: github.event_name == 'pull_request'
         run: |

--- a/web/tests/homepage-readability.test.ts
+++ b/web/tests/homepage-readability.test.ts
@@ -157,19 +157,24 @@ describe("spec task_e647f5766a54f6f1: form placeholder contrast (idea_submit_for
   });
 });
 
-describe("spec task_e647f5766a54f6f1: background gradients preserved (page.tsx)", () => {
+describe("spec task_e647f5766a54f6f1: background gradients preserved (page.tsx + globals.css)", () => {
   const pageSource = readWebFile("app/page.tsx");
+  const globalsSource = readWebFile("app/globals.css");
 
-  it("ambient glow blur element is still present", () => {
-    // The soft ambient background glow must not have been removed
-    expect(pageSource).toContain("blur-[120px]");
+  it("ambient glow is carried by the site-wide backdrop", () => {
+    // The soft ambient glow lives in globals.css: warm radial gradients on
+    // <html> plus fixed body::before blooms, tuned per theme (spec
+    // ux-homepage-readability R6).
+    expect(globalsSource).toContain("body::before");
+    const radialBlooms = globalsSource.match(/radial-gradient\(/g) ?? [];
+    expect(radialBlooms.length).toBeGreaterThanOrEqual(6);
   });
 
   it("background gradient on card elements is preserved", () => {
     expect(pageSource).toContain("bg-gradient-to-b");
   });
 
-  it("bg-primary/10 ambient fill is preserved", () => {
-    expect(pageSource).toContain("bg-primary/10");
+  it("ambient backdrop carries blooms in light mode too", () => {
+    expect(globalsSource).toMatch(/html\.light body::before/);
   });
 });

--- a/web/tests/integration/page-data-source.test.ts
+++ b/web/tests/integration/page-data-source.test.ts
@@ -107,13 +107,13 @@ const PAGE_ASSERTIONS: PageAssertion[] = [
     route: "/contributions",
     file: "app/contributions/page.tsx",
     apiHints: ["/api/contributions", "/api/coherence/score", "/api/assets", "getApiBase()"],
-    dynamicHints: [/filteredRows\.slice/, /liveCoherenceScore/, /contributorNames/],
+    dynamicHints: [/filteredRows\.map/, /liveCoherenceScore/, /contributorNames/],
   },
   {
     route: "/assets",
     file: "app/assets/page.tsx",
     apiHints: ["/api/assets", "getApiBase()"],
-    dynamicHints: [/filteredRows\.slice/, /status === "ok"/, /`\/assets\/\$\{encodeURIComponent\(a\.id\)\}`/],
+    dynamicHints: [/filteredRows\.map/, /assets\.loading/, /`\/assets\/\$\{encodeURIComponent\(a\.id\)\}`/],
   },
   {
     route: "/assets/[asset_id]",
@@ -205,7 +205,10 @@ describe("each page renders dynamic API content", () => {
 describe("fallback messages carry data-placeholder attribute", () => {
   it("keeps explicit fallback or loading messages in scoped pages", () => {
     const requiredAnnotations: Array<{ file: string; textHint: string }> = [
-      { file: "app/page.tsx", textHint: "No recent activity yet. Be the first to share an idea." },
+      // Homepage fallback copy is i18n: the page renders the message key and
+      // the en bundle carries the visible text.
+      { file: "app/page.tsx", textHint: 't("home.emptyActivity")' },
+      { file: "messages/en.json", textHint: '"emptyActivity": "No recent activity yet. Be the first to share an idea."' },
       { file: "app/diagnostics/page.tsx", textHint: "The diagnostics API is not reachable right now." },
       { file: "app/specs/page.tsx", textHint: "No specs are visible yet. Once lineage or registry data lands, this page will show the linked ideas, contributors, and implementation proof automatically." },
       { file: "app/usage/page.tsx", textHint: "Provider stats are not available right now. Check back once the API is connected." },

--- a/web/tests/presence-page-static.test.ts
+++ b/web/tests/presence-page-static.test.ts
@@ -12,11 +12,17 @@ function readWebFile(relativePath: string): string {
 describe("external presence profile page", () => {
   const source = readWebFile("components/presence/PresencePage.tsx");
   const personPageSource = readWebFile("app/people/[id]/page.tsx");
+  const messagesSource = readWebFile("messages/en.json");
 
   it("surfaces richer external profile sections", () => {
-    expect(source).toContain("At a glance");
-    expect(source).toContain("Presence map");
-    expect(source).toContain("Entry points");
+    // Section chrome is i18n: the component renders presence.* message keys
+    // and the en bundle carries the visible copy.
+    expect(source).toContain('t("presence.atAGlance")');
+    expect(source).toContain('t("presence.presenceMap")');
+    expect(source).toContain('t("presence.entryPoints")');
+    expect(messagesSource).toContain('"atAGlance": "At a glance"');
+    expect(messagesSource).toContain('"presenceMap": "Presence map"');
+    expect(messagesSource).toContain('"entryPoints": "Entry points"');
   });
 
   it("keeps the external source and graph node as first-class exits", () => {


### PR DESCRIPTION
Five web vitest tests drifted from pages that legitimately evolved, unseen because the web CI step only ran `npm run build`. Each drift was traced to its commit before healing the test side:

| Test | Drift | Evolution |
|------|-------|-----------|
| homepage-readability: ambient glow ×2 | per-hero blur orbs (`blur-[120px]`, `bg-primary/10`) removed in 685073c7f | glow is carried site-wide by `globals.css` (html backdrop + `body::before` blooms, both themes — spec `ux-homepage-readability` R6); tests guard the backdrop where it lives, card `bg-gradient-to-b` still on the page |
| presence-page-static: richer sections | i18n lift #1449 moved section chrome into messages | tests assert both sides: component renders `presence.*` keys, en bundle carries the copy |
| page-data-source: dynamic bindings | pagination #1490 replaced `filteredRows.slice` with `.map` on /contributions and /assets, and assets' `status === "ok"` machine with `assets.loading` | hints follow the live bindings (the assets drift was masked behind the contributions failure until it was healed) |
| page-data-source: fallback messages | multilingual #1004 moved homepage empty-activity copy to `home.emptyActivity` | annotation asserts the key in the page and the copy in the bundle |

No page behavior changed — every page kept the guarded function under a new carrier; only the tests' sensing was stale.

**CI edge**: both `test.yml` and `thread-gates.yml` gain a `Test web` step (`npm run test` = `vitest run`, 140 tests, ~0.5s) right after the web build, so the next page evolution is sensed in the same breath instead of drifting.

Verified: `cd web && npx vitest run` → 23 files, 140/140 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)