### PR TITLE
tend: the GPU emitter lane runs — Metal matvec emitter-as-recipe, bit-exact on real silicon

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -109,6 +109,17 @@
 ;        20,077x) — that is where Form-native model SPEED lives today, not the in-process JIT. Two
 ;        routes forward: fix the in-process dispatch realization, OR wire the model through the
 ;        proven emit-compile-exec lane. Evidence: commit_evidence_2026-06-11_jit_realization_gap.json.]
+;        [GPU LANE RUNS (the metal.ts port, realized as recipe): jte-matvec-msl in jit-tensor-emit.fk
+;        emits the MSL matvec from the SAME emitter-as-recipe discipline — one thread per output row,
+;        inner loop j DOWN (tb-dot's right-fold), mul/add split through a named temporary so no
+;        compiler contraction can change the op order; fp32 is the lane MSL declares (no f64 in device
+;        code — the cross-precision discipline above, both sides held to declared precision).
+;        tests/metal-emit-band.fk → 7 three-way. LIVE WITNESS scripts/metal_matvec_audit.sh (M4 Max,
+;        mathMode=safe, 30 dispatches after warm): 1280×1280 parity 1280/1280 BIT-EXACT, gpu_kernel
+;        0.401 ms vs cpu same-fold-order fp32 1.263 ms; 4096×4096 parity 4096/4096 bit-exact,
+;        0.958 ms vs 12.664 ms (13.2×). Named open: kernel-resident Metal carrier (in-process
+;        dispatch beside rustc/dlopen), bf16/half per format-arith semantics, batching only when a
+;        model stone needs it. Evidence: commit_evidence_2026-06-11_metal_matvec_emitter.json.]
 ;   M6  whisper-tiny block 0 — carrier loads openai/whisper-tiny safetensors (or mlx-community/whisper-tiny,
 ;        already referenced in experiments/satsang-voice), encodes block-0 weights via M2, runs M4 over
 ;        them, matches the HF reference activation within epsilon. First real model in the body. (Even

--- a/docs/system_audit/commit_evidence_2026-06-11_metal_matvec_emitter.json
+++ b/docs/system_audit/commit_evidence_2026-06-11_metal_matvec_emitter.json
@@ -1,0 +1,128 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "form-os2/metal-matvec",
+  "commit_scope": "The native GPU emitter lane's smallest honest stone: jte-matvec-msl in form/form-stdlib/jit-tensor-emit.fk emits a Metal Shading Language matvec kernel from the SAME emitter-as-recipe discipline as the proven Rust sibling (one quote-free Form string, fname parameterized, inner loop accumulating j DOWN in tb-dot's exact right-fold). Proven three-way byte-stable by tests/metal-emit-band.fk (verdict 7). LIVE GPU WITNESS on this host: scripts/metal_matvec_audit.sh drives the emission through the Go kernel's mouth, the Metal runtime compiles it (makeLibrary, mathMode=safe), and value parity is BIT-EXACT on every output row against a CPU fp32 right-fold in the recipe's own op order. fp32 is the lane MSL declares (no f64 in device code); the mul and add are split through a named temporary so no compiler contraction can change the recipe's op order.",
+  "files_owned": [
+    "form/form-stdlib/jit-tensor-emit.fk",
+    "form/form-stdlib/tests/metal-emit-band.fk",
+    "scripts/metal_matvec_audit.sh",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/jit-tensor-emit.fk form-stdlib/tests/metal-emit-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/jit-tensor-emit.fk form-stdlib/tests/jit-tensor-emit-band.fk",
+      "scripts/metal_matvec_audit.sh",
+      "scripts/metal_matvec_audit.sh 4096 4096 30"
+    ],
+    "summary": "Band three-way: metal-emit-band -> 7, 0 divergent (full emitted MSL equals canonical text; name parameterizes; emission deterministic). Sibling rust band unchanged -> 7, 0 divergent. LIVE GPU WITNESS MEASURED (Apple M4 Max, Metal 4, arm64 Darwin 26.3.1, Metal runtime compile makeLibrary mathMode=safe, one warm dispatch then 30 timed): 1280x1280 fp32 matvec parity 1280/1280 rows bit-exact (max_abs_diff=0.0), gpu_kernel 0.401 ms median (gpuStartTime..gpuEndTime window), gpu_wall 0.519 ms median (includes commit+wait), cpu fp32 right-fold one thread (swiftc -O) 1.263 ms. 4096x4096: parity 4096/4096 bit-exact, gpu_kernel 0.958 ms, gpu_wall 1.072 ms, cpu 12.664 ms (13.2x kernel-window at the larger dim; at 1280^2 dispatch overhead dominates and the honest wall ratio is 2.4x). The CPU row is the recipe's exact fold order in fp32 -- sequential dependence, no vectorization possible -- which is the conformance reference, not a tuned BLAS. Parity gated every timing row.",
+    "observed_delta": {
+      "band_verdict": 7,
+      "band_divergent": 0,
+      "emitted_msl_bytes": 417,
+      "witness_1280": {
+        "parity_bitexact_rows": "1280/1280",
+        "max_abs_diff": 0.0,
+        "gpu_kernel_ms_median": 0.401,
+        "gpu_wall_ms_median": 0.519,
+        "cpu_fp32_rightfold_ms": 1.263
+      },
+      "witness_4096": {
+        "parity_bitexact_rows": "4096/4096",
+        "max_abs_diff": 0.0,
+        "gpu_kernel_ms_median": 0.958,
+        "gpu_wall_ms_median": 1.072,
+        "cpu_fp32_rightfold_ms": 12.664
+      },
+      "conditions": "Apple M4 Max, Metal 4, macOS 26.3.1 arm64, MTLCompileOptions mathMode=safe (IEEE, no fast-math), 30 timed dispatches after one warm, deterministic integer-derived input cells over 256, single-thread CPU reference in the recipe's own fold order compiled swiftc -O"
+    },
+    "known_limitations": [
+      {
+        "limitation": "fp32 lane only: MSL has no double in device code, so the fp64 bit-for-bit lane the Rust emission carries cannot exist on this GPU. The honest cross-precision discipline (form-native-models.form): the precision the emission declares is the precision both sides are held to -- fp32 GPU vs fp32 CPU in the same op order, bit-exact.",
+        "follow_up": "bf16/half lanes parameterize the same emission with format-arith.fk semantics when needed; metal.ts already carries the simdgroup_matrix<bf16,8,8> hint shapes for the dense path."
+      },
+      {
+        "limitation": "The witness carrier is swiftc + Metal.framework through the driver-organ idiom (host-resource-access), not a kernel-resident GPU port. The kernel's mouth emits; the host compiles and dispatches. A kernel-resident Metal carrier (the GPU organ beside rustc/dlopen) is the named-open next stone, same shape as M5's remaining kernel-resident wiring.",
+        "follow_up": "When the model fast-path needs in-process GPU dispatch, lift the runner's five moves (compile, three buffers, dispatch, readback) into a kernel native gated by the same parity discipline."
+      },
+      {
+        "limitation": "At 1280x1280 the GPU win over one CPU thread is dispatch-bound (2.4x wall); the kernel-window ratio grows with dim (13.2x at 4096^2). One matvec per command buffer is the measured shape -- a real model batches many ops per buffer, which is exactly what this single proven stone refuses to speculate about.",
+        "follow_up": "Batching/persistent-buffer shapes arrive only when a model stone needs them, parity-gated the same way."
+      }
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "summary": "validate.sh runs metal-emit-band in the default suite via its preludes header; CI three-way gate applies."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "Stdlib recipe + band + host witness script; no route or service change. Rides normal merge."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "New capability: the body can emit a GPU compute kernel (MSL) from a Form recipe and prove the emitted text three-way; the host witness proves the GPU computes the recipe's exact fp32 result bit-for-bit on real hardware.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "validate.sh band (three kernels agree on the emitted text, verdict 7)",
+      "metal_matvec_audit.sh (Form emits -> Metal runtime compiles -> dispatch -> bit-exact parity gates measured rows)"
+    ],
+    "summary": "Emitted-and-parity-gated RUNS on Apple M4 Max; rows measured with conditions named."
+  },
+  "phase_gate": {
+    "phase": "m5-gpu-lane",
+    "gate": "the GPU emitter lane moves from NAMED to RUNS: emitter-as-recipe emits MSL, three-way byte-stable, live GPU value parity bit-exact, rows measured",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "kernel-resident Metal carrier (in-process dispatch beside rustc/dlopen); bf16/half lanes via format-arith semantics; batching only when a model stone needs it"
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "metal-matvec-emitter-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "form-os-arc"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "measurement"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/jit-tensor-emit.fk",
+    "form/form-stdlib/tests/metal-emit-band.fk",
+    "scripts/metal_matvec_audit.sh",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "change_files": [
+    "form/form-stdlib/jit-tensor-emit.fk",
+    "form/form-stdlib/tests/metal-emit-band.fk",
+    "scripts/metal_matvec_audit.sh",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-11_metal_matvec_emitter.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/jit-tensor-emit.fk
+++ b/form/form-stdlib/jit-tensor-emit.fk
@@ -19,3 +19,21 @@
   (str_concat "#[no_mangle] pub unsafe extern fn "
   (str_concat fname
               " (w: *const f64, x: *const f64, y: *mut f64, rows: i64, cols: i64) { let r = rows as usize; let c = cols as usize; let mut i = 0usize; while i < r { let row = w.add(i * c); let mut acc = 0.0f64; let mut j = c; while j > 0 { j -= 1; acc = *row.add(j) * *x.add(j) + acc; } *y.add(i) = acc; i += 1; } }")))
+
+; jte-matvec-msl — the SAME emitter discipline pointed at the GPU: Metal Shading Language source
+; for the matvec, one thread per output row (rows are independent — parallelism without touching
+; the fold), inner loop accumulating j DOWN exactly like tb-dot and the rust emission above.
+;
+; The fp32 lane is the honest one: MSL has no f64 in device code, so the precision this emission
+; declares is float — and the conformance gate holds BOTH sides to it (a CPU fp32 right-fold in the
+; same op order, per form-native-models' cross-precision discipline). The multiply and add are split
+; through a named temporary (p, then acc) so no conformant Metal compiler can contract them into an
+; fma — bit-for-bit means mul-then-add as two roundings, the recipe's own order, on any carrier.
+; MEASURED on this shape (M4 Max, mathMode safe, 1280x1280): 1280/1280 rows bit-exact vs the CPU
+; fp32 right-fold. No #include needed — kernel/device/constant/uint are language-level, so the
+; source stays one quote-free line, a plain Form string like its rust sibling.
+
+(defn jte-matvec-msl (fname)
+  (str_concat "kernel void "
+  (str_concat fname
+              "(device const float* w [[buffer(0)]], device const float* x [[buffer(1)]], device float* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const float* row = w + i * cols; float acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; float p = row[j] * x[j]; acc = p + acc; } y[i] = acc; }")))

--- a/form/form-stdlib/tests/metal-emit-band.fk
+++ b/form/form-stdlib/tests/metal-emit-band.fk
@@ -1,0 +1,22 @@
+; preludes: form-stdlib/jit-tensor-emit.fk
+;
+; metal-emit-band — the GPU matvec emitter as recipe, proven three-way: the emitted MSL
+; kernel source is byte-identical across kernels (str_eq against the canonical text), the
+; function name parameterizes cleanly, and the emission is deterministic. The text carries
+; tb-dot's exact right-fold (j counts DOWN) with the multiply and add split through a named
+; temporary so no Metal compiler contraction can change the recipe's op order — the same
+; conformance-by-construction the rust emission rides, declared at fp32 (MSL has no f64).
+;
+; Verdict 7 when the emission lands:
+;   1   the full emitted MSL for form_matvec_f32 equals the canonical text
+;   2   a different name lands in the same frame (emission is a function, not a constant)
+;   4   two emissions of the same name are str_eq (deterministic text — the crystallization
+;       cache's ground: same emission, same cell)
+(do
+    (let want "kernel void form_matvec_f32(device const float* w [[buffer(0)]], device const float* x [[buffer(1)]], device float* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const float* row = w + i * cols; float acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; float p = row[j] * x[j]; acc = p + acc; } y[i] = acc; }")
+    (let got (jte-matvec-msl "form_matvec_f32"))
+    (let other (jte-matvec-msl "mv2"))
+    (let c0 (if (str_eq got want) 1 0))
+    (let c1 (if (str_eq other (str_concat "kernel void " (str_concat "mv2" "(device const float* w [[buffer(0)]], device const float* x [[buffer(1)]], device float* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const float* row = w + i * cols; float acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; float p = row[j] * x[j]; acc = p + acc; } y[i] = acc; }"))) 2 0))
+    (let c2 (if (str_eq (jte-matvec-msl "form_matvec_f32") got) 4 0))
+    (add c0 (add c1 c2)))

--- a/scripts/metal_matvec_audit.sh
+++ b/scripts/metal_matvec_audit.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# metal_matvec_audit.sh — GPU witness for the Form MSL matvec emitter (jte-matvec-msl in
+# form/form-stdlib/jit-tensor-emit.fk): the kernel's mouth prints the Form-emitted MSL, the
+# host Metal runtime compiles it (mathMode safe — IEEE, no fast-math), one thread per output
+# row dispatches over deterministic input cells, and VALUE PARITY against a CPU fp32
+# right-fold in the recipe's exact op order (j counts DOWN, mul-then-add as two roundings)
+# gates the timing rows — a row only counts when every output row is bit-exact.
+#
+# Carriers: form-kernel-go (the mouth; the band proves the text byte-identical three-way),
+# swiftc + Metal.framework (the driver-organ idiom — allowed host carriers per
+# host-kernel.form host-resource-access); the emitter intelligence lives in the body.
+# fp32 is the lane MSL declares (no f64 in device code); both sides are held to it.
+#
+# Run:  scripts/metal_matvec_audit.sh [rows cols iters]   (defaults 1280 1280 30)
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMDIR="$ROOT/form"
+GO_BIN="$FORMDIR/form-kernel-go/bin-go"
+ROWS="${1:-1280}"; COLS="${2:-1280}"; ITERS="${3:-30}"
+
+if [[ "$(uname -s)" != "Darwin" ]] || ! command -v swiftc >/dev/null; then
+    echo "SKIP  no Darwin/Metal toolchain on this host — the GPU witness needs an Apple GPU + swiftc"
+    exit 2
+fi
+if [[ ! -x "$GO_BIN" ]]; then
+    echo "  building go kernel..." >&2
+    (cd "$FORMDIR/form-kernel-go" && go build -o bin-go .)
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/fkmetal.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+# ── 1. Form emits the MSL; the kernel is only the mouth ──────────────────
+cat "$FORMDIR/form-stdlib/jit-tensor-emit.fk" > "$work/driver.fk"
+cat >> "$work/driver.fk" <<'EOF'
+(print "==MSL==")
+(print (jte-matvec-msl "form_matvec_f32"))
+(print "==END==")
+EOF
+(cd "$FORMDIR" && "$GO_BIN" "$work/driver.fk" 2>/dev/null) > "$work/emit.out"
+sed -n '/^==MSL==$/,/^==END==$/p' "$work/emit.out" | sed -e '1d' -e '$d' > "$work/matvec.metal"
+if ! grep -q 'kernel void form_matvec_f32' "$work/matvec.metal"; then
+    echo "FAIL  emission did not produce the MSL kernel — see $work/emit.out"; exit 1
+fi
+echo "emitted MSL: $(wc -c < "$work/matvec.metal" | tr -d ' ') bytes, every byte authored by the Form recipe"
+
+# ── 2. The witness runner — dumb carrier: buffers, dispatch, compare, time ──
+cat > "$work/runner.swift" <<'EOF'
+// metal matvec witness — runtime-compile Form-emitted MSL, parity-gate, time. Carrier only.
+import Metal
+import Foundation
+
+let args = CommandLine.arguments
+let mslPath = args[1], fname = args[2]
+let rows = Int(args[3])!, cols = Int(args[4])!, iters = Int(args[5])!
+
+let src = try String(contentsOfFile: mslPath, encoding: .utf8)
+guard let dev = MTLCreateSystemDefaultDevice() else { print("SKIP no Metal device"); exit(2) }
+let opts = MTLCompileOptions()
+opts.mathMode = .safe   // IEEE-conformant: no fast-math reassociation/contraction
+let lib = try dev.makeLibrary(source: src, options: opts)
+guard let fn = lib.makeFunction(name: fname) else { print("FAIL function \(fname) absent"); exit(1) }
+let pso = try dev.makeComputePipelineState(function: fn)
+
+// deterministic input cells — integer-derived over 256 (exactly representable)
+var w = [Float](repeating: 0, count: rows * cols)
+var x = [Float](repeating: 0, count: cols)
+for i in 0..<rows { for j in 0..<cols {
+    w[i*cols + j] = Float((i*31 + j*17) % 1000 - 500) / 256.0
+}}
+for j in 0..<cols { x[j] = Float((j*13) % 1000 - 500) / 256.0 }
+
+// CPU reference — the recipe's exact right-fold (j DOWN), fp32, mul then add (two roundings)
+var yref = [Float](repeating: 0, count: rows)
+let t0 = DispatchTime.now()
+for i in 0..<rows {
+    var acc: Float = 0.0
+    var j = cols
+    while j > 0 { j -= 1; let p = w[i*cols + j] * x[j]; acc = p + acc }
+    yref[i] = acc
+}
+let cpuMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e6
+
+let q = dev.makeCommandQueue()!
+let bw = dev.makeBuffer(bytes: w, length: w.count*4)!
+let bx = dev.makeBuffer(bytes: x, length: x.count*4)!
+let by = dev.makeBuffer(length: rows*4)!
+var ur = UInt32(rows), uc = UInt32(cols)
+
+func dispatchOnce() -> (wall: Double, gpu: Double) {
+    let cb = q.makeCommandBuffer()!
+    let enc = cb.makeComputeCommandEncoder()!
+    enc.setComputePipelineState(pso)
+    enc.setBuffer(bw, offset: 0, index: 0)
+    enc.setBuffer(bx, offset: 0, index: 1)
+    enc.setBuffer(by, offset: 0, index: 2)
+    enc.setBytes(&ur, length: 4, index: 3)
+    enc.setBytes(&uc, length: 4, index: 4)
+    enc.dispatchThreads(MTLSize(width: rows, height: 1, depth: 1),
+        threadsPerThreadgroup: MTLSize(width: min(pso.maxTotalThreadsPerThreadgroup, rows), height: 1, depth: 1))
+    enc.endEncoding()
+    let s = DispatchTime.now()
+    cb.commit(); cb.waitUntilCompleted()
+    let wall = Double(DispatchTime.now().uptimeNanoseconds - s.uptimeNanoseconds) / 1e6
+    let gpu = (cb.gpuEndTime - cb.gpuStartTime) * 1000.0
+    return (wall, gpu)
+}
+
+_ = dispatchOnce() // warm: pipeline + first-touch
+let ygpu = by.contents().bindMemory(to: Float.self, capacity: rows)
+var exact = 0; var maxAbs: Float = 0
+for i in 0..<rows {
+    if ygpu[i].bitPattern == yref[i].bitPattern { exact += 1 }
+    maxAbs = max(maxAbs, abs(ygpu[i] - yref[i]))
+}
+var walls: [Double] = []; var gpus: [Double] = []
+for _ in 0..<iters { let r = dispatchOnce(); walls.append(r.wall); gpus.append(r.gpu) }
+walls.sort(); gpus.sort()
+print("parity_bitexact_rows=\(exact)/\(rows) max_abs_diff=\(maxAbs)")
+print("gpu_wall_ms_median=\(String(format: "%.3f", walls[walls.count/2])) gpu_kernel_ms_median=\(String(format: "%.3f", gpus[gpus.count/2])) iters=\(iters)")
+print("cpu_fp32_rightfold_ms=\(String(format: "%.3f", cpuMs))")
+print("device=\(dev.name)")
+if exact != rows { exit(1) }
+EOF
+
+swiftc -O -o "$work/runner" "$work/runner.swift" 2>"$work/swiftc.err" || {
+    echo "FAIL  swiftc could not build the witness runner:"; cat "$work/swiftc.err"; exit 1; }
+
+# ── 3. Parity gates the rows ─────────────────────────────────────────────
+echo "witness (${ROWS}x${COLS} fp32 matvec, ${ITERS} timed dispatches after one warm):"
+if ! "$work/runner" "$work/matvec.metal" form_matvec_f32 "$ROWS" "$COLS" "$ITERS" | sed 's/^/  /'; then
+    echo "FAIL  value parity broken — timing rows do not count"; exit 1
+fi
+echo
+echo "conditions: $(uname -m) $(uname -s) $(sw_vers -productVersion 2>/dev/null), Metal runtime compile" \
+     "(makeLibrary, mathMode=safe), gpu_wall includes commit+wait, gpu_kernel is the GPU execution" \
+     "window (gpuStartTime..gpuEndTime), cpu row is one thread in the recipe's own fold order"
+echo "ok — parity held and the rows are real; the emitter recipe is form-stdlib/jit-tensor-emit.fk (jte-matvec-msl)"


### PR DESCRIPTION
## The stone

The linux-as-recipes gpu row named native GPU emitters as a lane for the model fast-path. This PR moves that lane from NAMED to RUNS with the smallest honest stone: **a Form recipe that emits the Metal (MSL) matvec kernel from the same emitter-as-recipe discipline as the proven Rust sibling** (`jte-matvec-rust`, 20,077× measured lineage).

## What ships

- **`form/form-stdlib/jit-tensor-emit.fk`** — `jte-matvec-msl`: emits the MSL matvec as one quote-free Form string, fname parameterized. One thread per output row (rows independent — parallelism without touching the fold); inner loop accumulates j DOWN, tb-dot's exact right-fold; the multiply and add are split through a named temporary so no conformant Metal compiler can contract them into an fma — the recipe's op order survives on any carrier. No `#include` needed: the source stays a plain one-line Form string like its Rust sibling.
- **`form/form-stdlib/tests/metal-emit-band.fk`** — verdict **7, 0 divergent** three-way (Go/Rust/TS): emitted text equals canonical byte-for-byte; name parameterizes; emission deterministic (the crystallization-cache ground).
- **`scripts/metal_matvec_audit.sh`** — the live GPU witness, fourth_kernel_audit.sh's emit-compile-exec idiom pointed at Metal: Go kernel mouth prints the Form-emitted MSL → Metal runtime compiles it (`makeLibrary`, `mathMode=.safe` — IEEE, no fast-math) → dispatch over deterministic input cells → **value parity gates every timing row**.
- **`docs/coherence-substrate/form-native-models.form`** — M5 GPU-lane block updated (the milestone's home; the linux-as-recipes gpu row is left for the coordinator's retune).
- **`docs/system_audit/commit_evidence_2026-06-11_metal_matvec_emitter.json`** — measured rows, validated.

## Measured (Apple M4 Max, Metal 4, macOS 26.3.1 arm64, mathMode=safe, 30 dispatches after one warm)

| dims | parity | gpu_kernel (median) | gpu_wall (median) | cpu fp32 same-fold (1 thread, swiftc -O) |
|------|--------|--------------------|-------------------|------------------------------------------|
| 1280×1280 | **1280/1280 bit-exact** (max_abs_diff=0.0) | 0.401 ms | 0.519 ms | 1.263 ms |
| 4096×4096 | **4096/4096 bit-exact** | 0.958 ms | 1.072 ms | 12.664 ms (13.2×) |

fp32 is the lane MSL declares (no f64 in device code) — per form-native-models' cross-precision discipline, both sides are held to the declared precision, and they agree to the last bit. At 1280² the win is dispatch-bound (2.4× wall); the kernel-window ratio grows with dim. The CPU row is the recipe's own fold order (sequential dependence, unvectorizable) — the conformance reference, not a tuned BLAS.

## Lanes honest

- RUNS: emitted + three-way byte-stable + live GPU value parity bit-exact, rows measured with conditions.
- Named open: kernel-resident Metal carrier (in-process dispatch beside rustc/dlopen), bf16/half lanes per format-arith semantics, batching only when a model stone needs it. No speculative buffer framework — ONE matvec, proven.

## Proof

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/jit-tensor-emit.fk form-stdlib/tests/metal-emit-band.fk
# ✓ → 7, 0 divergent
scripts/metal_matvec_audit.sh
# parity 1280/1280 bit-exact; rows above
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)