### PR TITLE
tend: the afferent witness goes live — ao-wait breathing op 15 TIME on the fourth kernel

### DIFF
--- a/form/form-stdlib/afferent-live.fk
+++ b/form/form-stdlib/afferent-live.fk
@@ -1,0 +1,108 @@
+; afferent-live.fk — the live select/poll wait-carrier: ao-wait's verdict (the
+; SAME afferent-offer.fk engine, arms unchanged) lowered onto a fourth-walker
+; program where op 15 TIME feeds real ticks — the host clock organ, not data.
+;
+; This closes the next-stone afferent-offer.form names: "a host carrier where
+; op 15 TIME feeds real ticks and a fourth-kernel select/poll witness shows a
+; live timeout yielding nothing". No parallel engine is grown: the dispatch /
+; nothing DECISION is made by ao-wait itself (the function proven → 511) at
+; composition time, on the offer ticks as relative seconds; what the lowered
+; program adds is exactly the temporal half the deterministic band could not
+; witness — blocking, arrival, expiry on the real clock:
+;
+;   guard   (LE t0+rel-at now)        the armed offer ARRIVES when the clock
+;                                     reaches its tick — ao-deliverable?'s
+;                                     window check, breathing
+;   window  (LE now t0+rel-deadline)  the wait is open while the clock is
+;                                     inside the window (inclusive, the
+;                                     band's 9-vs-10 edge, live)
+;   nothing                           the clock passes the deadline with no
+;                                     deliverable offer → the nothing-ack,
+;                                     after REAL elapsed time
+;
+; An engine verdict of AO-NOTHING lowers the guard to LIT 0 — the dispatch
+; door composed shut, so the program can only time out: timeout==nothing on
+; a wall clock. A dispatch verdict carries the engine's own handler name
+; (PUTC bytes), offer tick, and payload into the program.
+;
+; Poll granularity composes from existing ops (no new op minted): a two-level
+; tail-position countdown (fn 2 × fn 3) bounds walk-steps between TIME polls,
+; so the wait holds for seconds without unbounded recursion depth.
+;
+; The program (4 fns; RAM 0 = t0, RAM 1 = now; ack = name \n elapsed \n value):
+;   fn 0  t0 := TIME; enter the loop
+;   fn 1  now := TIME; dispatch | keep-waiting | nothing
+;   fn 2  delay: grain × fn 3        fn 3  countdown grain
+;
+; Deterministic proof: tests/afferent-live-band.fk → 63 three-way (Go/Rust/TS).
+; Live proof: scripts/fourth_kernel_audit.sh "live afferent witness" section —
+; the universal fourth-kernel binary blocks on the real clock: no event yields
+; nothing after the deadline truly elapses; an armed timer's tick dispatches.
+
+;; sequence a then b, b's value kept (IF-seq: both arms b; for organ writes)
+(defn aolv-seq (a b) (fk-if a b b))
+
+;; fn 3 — the inner countdown: tail-position CALL, depth-bounded by grain
+(defn aolv-count-fn ()
+    (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0)
+           (fk-call 3 (fk-sub (fk-arg) (fk-lit 1)))))
+
+;; fn 2 — the poll-granularity delay: grain outer steps, each an inner countdown
+(defn aolv-delay-fn (grain)
+    (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0)
+           (aolv-seq (fk-call 3 (fk-lit grain))
+                     (fk-call 2 (fk-sub (fk-arg) (fk-lit 1))))))
+
+;; elapsed seconds on the real clock: now - t0 (RAM 1 - RAM 0)
+(defn aolv-elapsed () (fk-sub (fk-get (fk-lit 1)) (fk-get (fk-lit 0))))
+
+;; the acknowledgment made visible: PUTC name, newline, elapsed, newline → value
+(defn aolv-ack (name value)
+    (fkd-seq (fkresp name)
+    (fkd-seq (fkd-ch 10)
+    (fkd-seq (fkd-num (aolv-elapsed))
+    (fkd-seq (fkd-ch 10) value)))))
+
+;; the dispatch door: the engine's nothing composes it SHUT (LIT 0); a
+;; dispatch verdict opens it on arrival — the offer's tick reached by the clock
+(defn aolv-guard (verdict)
+    (if (eq (ao-nothing? verdict) 1)
+        (fk-lit 0)
+        (fk-le (fk-add (fk-get (fk-lit 0))
+                       (fk-lit (ao-offer-at (ao-dispatch-offer verdict))))
+               (fk-get (fk-lit 1)))))
+
+;; the dispatch arm: handler name and payload travel FROM the engine's cells
+(defn aolv-arm (verdict)
+    (if (eq (ao-nothing? verdict) 1)
+        (fk-lit 0)
+        (aolv-ack (ao-dispatch-handler verdict)
+                  (fk-lit (node_value (ao-offer-payload (ao-dispatch-offer verdict)))))))
+
+;; fn 1 — the select/poll loop: poll the clock, dispatch first (inclusive
+;; edge), keep waiting inside the window, acknowledge nothing past it
+(defn aolv-loop-fn (verdict rel-deadline grain)
+    (aolv-seq (fk-set (fk-lit 1) (fk-time))
+        (fk-if (aolv-guard verdict)
+               (aolv-arm verdict)
+               (fk-if (fk-le (fk-get (fk-lit 1))
+                             (fk-add (fk-get (fk-lit 0)) (fk-lit rel-deadline)))
+                      (aolv-seq (fk-call 2 (fk-lit grain)) (fk-call 1 (fk-lit 0)))
+                      (aolv-ack "nothing" (fk-lit 0))))))
+
+;; fn 0 — anchor t0 on the real clock, enter the wait
+(defn aolv-entry-fn ()
+    (aolv-seq (fk-set (fk-lit 0) (fk-time)) (fk-call 1 (fk-lit 0))))
+
+;; the whole carrier: ao-wait — THE engine — makes the decision on ticks as
+;; relative seconds; the program carries that verdict onto the host clock
+(defn aolv-fns2 (verdict rel-deadline grain)
+    (list (aolv-entry-fn)
+          (aolv-loop-fn verdict rel-deadline grain)
+          (aolv-delay-fn grain)
+          (aolv-count-fn)))
+
+(defn aolv-fns (table mask pending rel-deadline grain)
+    (aolv-fns2 (ao-wait table mask pending rel-deadline) rel-deadline grain))
+
+0

--- a/form/form-stdlib/tests/afferent-live-band.fk
+++ b/form/form-stdlib/tests/afferent-live-band.fk
@@ -1,0 +1,53 @@
+; preludes: form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/afferent-offer.fk form-stdlib/afferent-live.fk
+;
+; afferent-live-band — the live wait-carrier's COMPOSITION proven three-way:
+; ao-wait (the engine proven → 511) decides dispatch|nothing on ticks as
+; data, and the lowering carries exactly that verdict into a fourth-walker
+; program whose tick source is op 15 TIME. The strange-minimal edge is the
+; deterministic band's own: the alarm armed AT tick 9 vs 10 against
+; deadline 9 — here pinning what each verdict COMPOSES, one tick apart.
+; The blocking behavior on a real clock is the audit's half
+; (scripts/fourth_kernel_audit.sh, "live afferent witness").
+;
+; Verdict 63 when the lowering is faithful:
+;   1   NO event: the engine's nothing composes the dispatch door SHUT —
+;       the guard is LIT 0, so the program can only time out
+;   2   the alarm AT the deadline (inclusive edge): the dispatch verdict
+;       composes the guard as the ARRIVAL comparison (LE — the clock
+;       reaching the offer's tick)
+;   4   the alarm one tick past: nothing again — timeout==nothing carried
+;       into the live lowering at the same one-tick edge
+;   8   the program breathes the host clock: the flattened table carries
+;       op 15 TIME and op 12 CALL (the poll loop + granularity delay)
+;   16  the engine's cells ride into the program: the latched IRQ payload
+;       (LIT 42) and the handler name's bytes (LIT 107, the k of on-key)
+;       are rows in the table
+;   32  the carrier is deterministic data: the table-file text equals
+;       itself across two emissions, and the program is exactly 4 functions
+(do
+    (let live-table (ao-table (list (ao-entry (ao-sig-alrm) "on-alarm")
+                                    (ao-entry (ao-irq-keyboard) "on-key"))))
+    (let no-mask (ao-mask (list)))
+
+    (let g-silent (aolv-guard (ao-wait live-table no-mask (list) 9)))
+    (let c0 (if (and (eq (fk-tag g-silent) 1) (eq (ms-value (fk-body g-silent)) 0)) 1 0))
+
+    (let g-edge (aolv-guard (ao-wait live-table no-mask (list (ao-alarm 9)) 9)))
+    (let c1 (if (eq (fk-tag g-edge) 5) 2 0))
+
+    (let g-past (aolv-guard (ao-wait live-table no-mask (list (ao-alarm 10)) 9)))
+    (let c2 (if (and (eq (fk-tag g-past) 1) (eq (ms-value (fk-body g-past)) 0)) 4 0))
+
+    (let silent-rows (nth (fkc-flatten-many (aolv-fns live-table no-mask (list) 9 7)) 0))
+    (let c3 (if (and (eq (fkd-has-tag silent-rows 15) 1)
+                     (eq (fkd-has-tag silent-rows 12) 1)) 8 0))
+
+    (let key-fns (aolv-fns live-table no-mask (list (ao-irq (ao-irq-keyboard) 3 42)) 9 7))
+    (let key-rows (nth (fkc-flatten-many key-fns) 0))
+    (let c4 (if (and (eq (fkd-has-lit key-rows 42) 1)
+                     (eq (fkd-has-lit key-rows 107) 1)) 16 0))
+
+    (let c5 (if (and (str_eq (fkc-table-file key-fns) (fkc-table-file key-fns))
+                     (eq (len key-fns) 4)) 32 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/scripts/fourth_kernel_audit.sh
+++ b/scripts/fourth_kernel_audit.sh
@@ -423,6 +423,7 @@ PORT=8231
 "$work/fkapi" "$PORT" & API_PID=$!
 n=0; while [ $n -lt 40 ]; do
     if curl -sS --max-time 1 -o /dev/null "http://127.0.0.1:$PORT/" 2>/dev/null; then break; fi
+    sleep 0.1   # refused is instant; give the freshly-exec'd server real time to bind
     n=$((n+1))
 done
 code="$(curl -sS --max-time 3 -w '%{http_code}' -o "$work/body.txt" "http://127.0.0.1:$PORT/health" 2>/dev/null)"
@@ -552,6 +553,68 @@ if [[ "$fp1" != "42" || "$fp2" != "111" ]]; then
     echo "FAIL  Form-source parse-and-run broke"; exit 1
 fi
 echo "  the parser is recursive-descent over the source string (a cursor, no tokenizer); op-gap to full bands is m4e4 (defn/let/do/str_*)"
+
+echo
+# ── 18. the live afferent witness — afferent-offer.fk's ao-wait on the real ──
+# clock. The engine (proven → 511 with ticks as data) makes the dispatch|nothing
+# decision at composition; the lowered program (afferent-live.fk) blocks on
+# op 15 TIME through the SAME universal binary. No event in the window →
+# nothing after REAL elapsed time (timeout==nothing, live); an armed timer's
+# tick arrives → its handler fires with the payload — the SIGALRM shape
+# witnessed on a wall clock.
+cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/fourth-walker.fk" \
+    "$FORMDIR/form-stdlib/fourth-walker-emit.fk" "$FORMDIR/form-stdlib/afferent-offer.fk" \
+    "$FORMDIR/form-stdlib/afferent-live.fk" > "$work/ao-driver.fk"
+cat >> "$work/ao-driver.fk" <<'EOF'
+(let live-table (ao-table (list (ao-entry (ao-sig-alrm) "on-alarm")
+                                (ao-entry (ao-irq-keyboard) "on-key"))))
+(let no-mask (ao-mask (list)))
+(print "==TKEY==")
+(print (fkc-table-file (aolv-fns live-table no-mask (list (ao-irq (ao-irq-keyboard) 0 42)) 2 1000)))
+(print "==TALARM==")
+(print (fkc-table-file (aolv-fns live-table no-mask (list (ao-alarm 1)) 2 1000)))
+(print "==TNOTHING==")
+(print (fkc-table-file (aolv-fns live-table no-mask (list) 1 1000)))
+(print "==END==")
+EOF
+(cd "$FORMDIR" && "$GO_BIN" "$work/ao-driver.fk" 2>/dev/null) > "$work/ao.out"
+sed -n '/^==TKEY==$/,/^==TALARM==$/p' "$work/ao.out" | sed -e '1d' -e '$d' > "$work/t-ao-key.txt"
+sed -n '/^==TALARM==$/,/^==TNOTHING==$/p' "$work/ao.out" | sed -e '1d' -e '$d' > "$work/t-ao-alarm.txt"
+sed -n '/^==TNOTHING==$/,/^==END==$/p' "$work/ao.out" | sed -e '1d' -e '$d' > "$work/t-ao-nothing.txt"
+
+ao_run() { # table-file -> "ack elapsed value wall_s time-polls"
+    python3 - "$work/fkwu" "$1" <<'PY'
+import subprocess, sys, time
+t0 = time.perf_counter()
+out = subprocess.run([sys.argv[1], sys.argv[2], "0"], capture_output=True, text=True).stdout.splitlines()
+wall = time.perf_counter() - t0
+print(out[0], out[1], out[2], f"{wall:.3f}", out[17])
+PY
+}
+
+read -r k_ack k_el k_val k_wall k_polls <<<"$(ao_run "$work/t-ao-key.txt")"
+read -r a_ack a_el a_val a_wall a_polls <<<"$(ao_run "$work/t-ao-alarm.txt")"
+read -r n_ack n_el n_val n_wall n_polls <<<"$(ao_run "$work/t-ao-nothing.txt")"
+echo "live afferent witness (ao-wait's verdict breathing op 15 TIME; the SAME universal binary):"
+echo "  latched irq        -> $k_ack elapsed=${k_el}s payload=$k_val wall=${k_wall}s time-polls=$k_polls (already-arrived offer dispatches now)"
+echo "  armed timer (1s)   -> $a_ack elapsed=${a_el}s payload=$a_val wall=${a_wall}s time-polls=$a_polls (the tick ARRIVED on the host clock)"
+echo "  no event, 1s wait  -> $n_ack elapsed=${n_el}s value=$n_val wall=${n_wall}s time-polls=$n_polls (live timeout==nothing, past the deadline)"
+if [[ "$k_ack" != "on-key" || "$k_val" != "42" ]] || [[ "$k_el" != "0" && "$k_el" != "1" ]]; then
+    echo "FAIL  latched-irq dispatch broke"; exit 1
+fi
+if [[ "$a_ack" != "on-alarm" || "$a_el" != "1" || "$a_val" != "0" ]]; then
+    echo "FAIL  armed-timer dispatch broke — the tick did not arrive as the SIGALRM shape"; exit 1
+fi
+if ! python3 -c "import sys; sys.exit(0 if float('$a_wall') < 2.0 else 1)"; then
+    echo "FAIL  the armed timer did not beat its 2s window"; exit 1
+fi
+if [[ "$n_ack" != "nothing" || "$n_el" != "2" || "$n_val" != "0" ]]; then
+    echo "FAIL  live timeout did not acknowledge nothing"; exit 1
+fi
+if ! python3 -c "import sys; sys.exit(0 if float('$n_wall') >= 1.0 else 1)"; then
+    echo "FAIL  the nothing came BEFORE the deadline elapsed — not a live wait"; exit 1
+fi
+echo "  the engine's arms are afferent-offer.fk's, unchanged; only the tick source went live (band: tests/afferent-live-band.fk -> 63)"
 
 echo
 echo "conditions: $(uname -m) $(uname -s), clang -O2, full-process invocations (startup included)"


### PR DESCRIPTION
## The stone (Form-OS round 2 — live afferent witness lane)

`afferent-offer.form`'s next-stones block names it exactly: *"a host carrier where op 15 TIME feeds real ticks and a fourth-kernel select/poll witness shows a live timeout yielding nothing"*. The linux-as-recipes tally names the same: *"a live select/poll wait-carrier for the afferent witness (op 15 TIME as tick carrier)"*.

## How it closes — the SAME engine, no parallel implementation

`form/form-stdlib/afferent-live.fk` lowers **ao-wait's own verdict** onto a fourth-walker program:

- `ao-wait` (the engine proven → 511, arms untouched — `afferent-offer.fk` has **zero edits**) makes the dispatch|nothing decision at composition, on offer ticks as relative seconds.
- The lowered program adds exactly the temporal half the deterministic band could not witness: blocking, arrival, expiry on the **host clock organ (op 15 TIME)**.
- An `AO-NOTHING` verdict composes the dispatch door **shut** (`LIT 0`) — the program can only time out: timeout==nothing on a wall clock. A dispatch verdict carries the engine's own handler name (PUTC bytes), offer tick, and payload into the program.
- Poll granularity composes from **existing ops** (two-level tail-position countdown between TIME polls) — no new op minted, per the prefer-composition rule.
- Runs on the **same universal fourth-kernel binary** the audit's OS face already builds — no new emitter variant, no new clang target.

## Live lane — `scripts/fourth_kernel_audit.sh`, new "live afferent witness" section

```
live afferent witness (ao-wait's verdict breathing op 15 TIME; the SAME universal binary):
  latched irq        -> on-key elapsed=0s payload=42 wall=0.003s time-polls=2 (already-arrived offer dispatches now)
  armed timer (1s)   -> on-alarm elapsed=1s payload=0 wall=0.784s time-polls=78 (the tick ARRIVED on the host clock)
  no event, 1s wait  -> nothing elapsed=2s value=0 wall=1.970s time-polls=198 (live timeout==nothing, past the deadline)
```

Assertions: handler + payload exact; armed timer beats its 2s window; the nothing only **after** the deadline truly elapsed (wall >= 1.0s, internal elapsed = 2s > deadline). Full audit green end-to-end (`ok — parity held and the rows are real`, arm64 Darwin, clang -O2). Section cost ≈ 3s.

Also healed in the same script: the net-organ readiness loop fired 40 refused curls in ~40ms with no sleep, so a freshly-exec'd server under load never got to bind — reproduced as two consecutive full-audit failures (`HTTP 000` + kill) before the heal; the loop now breathes 0.1s between attempts and the section serves `HTTP 200` again.

## Deterministic lane — three-way band

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk \
  form-stdlib/fourth-walker-emit.fk form-stdlib/afferent-offer.fk form-stdlib/afferent-live.fk \
  form-stdlib/tests/afferent-live-band.fk
  ✓  ... → 63        (1 ok, 0 divergent — Go/Rust/TS)
```

Claims: nothing-verdict composes the guard shut · the 9-vs-10 deadline edge pins the lowering one tick apart · TIME + CALL rows present in the flattened table · payload (LIT 42) and handler-name bytes (LIT 107, the k of on-key) ride from the engine's cells · 4 functions, deterministic text.

## Lane discipline

New carrier + band + audit section only. Untouched: `afferent-offer.fk`, `fourth-walker-emit.fk` (arena/loader regions), eq primitive, `linux-as-recipes.form` / `fourth-kernel.form` / `afferent-offer.form` (coordinator retunes), `blueprint-registry.json` (zero new blueprints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
