### PR TITLE
tend: comparisons acknowledge 0/1 on every kernel — eq's answer flows straight into arithmetic

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-11_eq_shape_unification.json
+++ b/docs/system_audit/commit_evidence_2026-06-11_eq_shape_unification.json
@@ -1,0 +1,130 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "form-os2/eq-shape",
+  "commit_scope": "The comparison family acknowledges with the 0/1 integer states (axiom-1) on all three kernels: eq/ne/lt/le/gt/ge category arms plus node_eq, value_eq, and str_eq answer Int 0/1 everywhere, so a comparison's answer flows directly into arithmetic with bit-identical results. Logic ops consume truthiness (Go's raw .Bool reads healed); the Go Value-ABI JIT mirrors (cmpV preamble, jitabi compare ops, emitted logic IIFEs) and the TS compile lane's emitCompare carry the same shape, closing the interpreted-vs-JIT split inside Go and TS.",
+  "files_owned": [
+    "form/form-kernel-go/main.go",
+    "form/form-kernel-go/jit_value.go",
+    "form/form-kernel-go/jitabi/jitabi.go",
+    "form/form-kernel-rust/src/main.rs",
+    "form/form-kernel-ts/src/kernel.ts",
+    "form/form-kernel-ts/src/compiler.ts",
+    "form/form-stdlib/primitive-registry.fk",
+    "form/form-stdlib/arena-melt.fk",
+    "form/form-stdlib/tests/eq-shape-band.fk"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/tests/eq-shape-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/arena-melt.fk form-stdlib/tests/arena-melt-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/primitive-registry.fk form-stdlib/tests/primitive-registry-band.fk",
+      "cd form && ./validate.sh <curated compare-sensitive set: float-conversions 31, float-natives 28, classifier-eval 63, choice-receipt -1, learned-primitive 255, persistence 7, fourth-os 15, fourth-match 15, python-bmf-class 34, json-emitter 15, json-codec-bml 8191, pain-metabolism 1023, signal-metabolism 1023>",
+      "cd form/form-kernel-go && go test ./...",
+      "cd form/form-kernel-rust && cargo test --release",
+      "cd form/form-kernel-ts && npx tsx src/<each>.test.ts (18 files)",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-11_eq_shape_unification.json"
+    ],
+    "summary": "eq-shape-band 511/511 three-way: the arena-melt crash shape (mul (eq 2 2) 5) answers 5 on every kernel; unequal annihilates to 0; lt/le/gt/ge chain through add (verdict arm 3); ne through sub; node_eq feeds mul; eq-of-eq compares against the 0/1 states; the float comparison path acknowledges the same integers; str_eq + value_eq answer 0/1. Arena-melt six-file workload re-proves 63 with the divergence note retuned to state what IS. Primitive-registry band holds 63 with node_eq/value_eq/str_eq verifies now arithmetic-fed (the contract proof IS the shape). A 78-workload alphabetical full-suite prefix ran 0-divergent before rebase (all form-samples + the audit/auto/belief/bml-thesis compiler clusters — the str_eq-densest tissue); the full ~460-band suite at ~2 bands/min is not cheap, so the curated compare+math+logic+json+match+fourth set stands as the named minimum, plus all three kernels' own test suites green (go test ok 240s incl. route shapes, cargo 49/49, TS 18/18 files). Latent divergences healed in the same breath: Go logic read .Bool raw so (and 1 2) answered false while Rust/TS answered true; Go math read .Int raw so a bool fed to mul silently became 0 while TS threw and Rust converted; Go's Value-ABI JIT compare returned VBool while its scalar/C lanes already returned 0/1.",
+    "observed_delta": {
+      "eq_shape_band": 511,
+      "arena_melt_workload": 63,
+      "primitive_registry_band": 63,
+      "pain_metabolism_band_on_unified_kernels": 1023,
+      "signal_metabolism_band_on_unified_kernels": 1023,
+      "full_suite_prefix": "78 workloads, 0 divergent",
+      "kernel_unit_tests": "go ok 239.9s, rust 49/49, ts 18/18 files",
+      "comparison_natives_unified": "eq ne lt le gt ge (category) + node_eq value_eq str_eq (natives) -> Int 0/1",
+      "consumers_healed": "Go walker logic arm truthy, Go jit_value emitted logic truthyV, jitabi Eq/Ne/Lt/Le/Gt/Ge/StrEq Int, TS emitCompare ?1:0"
+    },
+    "known_limitations": [
+      {
+        "limitation": "Logic ops (and/or/not) still answer bool — they consume 0/1 truthiness but their own acknowledgment shape is a separate family this stone did not widen into.",
+        "follow_up": "A later breath can fold logic answers into the 0/1 states the same way if the body asks."
+      },
+      {
+        "limitation": "Membership/state predicates (_dict_has, _in, record_has, method_has, record?, framebuffer-observe-active?) keep their bool answers; their registry contracts say so honestly.",
+        "follow_up": "Same family-heal recipe applies when those rows are lifted."
+      },
+      {
+        "limitation": "Bool LITERALS (true/false) in arithmetic positions keep the pre-existing tri-divergence (Rust coerces, Go reads raw, TS throws) — comparison answers no longer reach that edge.",
+        "follow_up": "Composts with the bool kind itself as axiom-1 settles deeper."
+      }
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "summary": "PR gates run evidence validation + the Rust kernel serve smoke; the three-way proof is the local validate.sh discipline recorded here."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "Kernel binaries rebuild on the host from source; no route contract changes (BML handlers use comparisons only in if-positions; go test's server suite passed unchanged)."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "No route changes. A comparison's answer is now an integer state on every carrier: walked, Value-ABI JIT'd, scalar JIT'd, C-emitted, and TS-compiled lanes all agree with each other and with each sibling kernel.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "eq-shape-band three-way; arena-melt six-file workload; primitive-registry band; curated compare-sensitive band set; three kernels' own test suites."
+    ],
+    "summary": "validate.sh three-way green on every named workload."
+  },
+  "phase_gate": {
+    "phase": "form-os2-eq-shape",
+    "gate": "one comparison contract, three carriers, proven by a band that feeds answers straight into arithmetic",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "coordinator retunes linux-as-recipes.form / fourth-kernel.form after all six round-2 stones merge"
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "eq-shape-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "axiom-ground"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "evidence_refs": [
+    "docs/coherence-substrate/core-axioms.form",
+    "form/form-stdlib/tests/eq-shape-band.fk",
+    "docs/system_audit/commit_evidence_2026-06-11_tagged_abi.json"
+  ],
+  "change_files": [
+    "docs/system_audit/commit_evidence_2026-06-11_eq_shape_unification.json",
+    "form/form-kernel-go/main.go",
+    "form/form-kernel-go/jit_value.go",
+    "form/form-kernel-go/jitabi/jitabi.go",
+    "form/form-kernel-rust/src/main.rs",
+    "form/form-kernel-ts/src/kernel.ts",
+    "form/form-kernel-ts/src/compiler.ts",
+    "form/form-stdlib/primitive-registry.fk",
+    "form/form-stdlib/arena-melt.fk",
+    "form/form-stdlib/tests/eq-shape-band.fk"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-kernel-go/jit_value.go
+++ b/form/form-kernel-go/jit_value.go
@@ -233,6 +233,8 @@ func mathV(op int, a, b core.Value) core.Value {
 }
 
 func cmpV(op int, a, b core.Value) core.Value {
+	// Comparisons acknowledge with the 0/1 integer states (axiom-1) —
+	// mirrors the walker's RBasicCompare arm exactly.
 	if a.Kind == core.VFloat || b.Kind == core.VFloat {
 		l := a.AsFloat()
 		r := b.AsFloat()
@@ -251,7 +253,10 @@ func cmpV(op int, a, b core.Value) core.Value {
 		case 5:
 			res = l >= r
 		}
-		return core.Value{Kind: core.VBool, Bool: res}
+		if res {
+			return core.Value{Kind: core.VInt, Int: 1}
+		}
+		return core.Value{Kind: core.VInt, Int: 0}
 	}
 	x := a.Int
 	y := b.Int
@@ -270,7 +275,10 @@ func cmpV(op int, a, b core.Value) core.Value {
 	case 5:
 		res = x >= y
 	}
-	return core.Value{Kind: core.VBool, Bool: res}
+	if res {
+		return core.Value{Kind: core.VInt, Int: 1}
+	}
+	return core.Value{Kind: core.VInt, Int: 0}
 }
 `
 
@@ -430,7 +438,7 @@ func emitVLogic(k *Kernel, op uint32, kids []NodeID, scope *vScope) (string, err
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("func() core.Value { if !(%s).Bool { return core.Value{Kind: core.VBool, Bool: false} }; return core.Value{Kind: core.VBool, Bool: (%s).Bool} }()", a, b), nil
+		return fmt.Sprintf("func() core.Value { if !truthyV(%s) { return core.Value{Kind: core.VBool, Bool: false} }; return core.Value{Kind: core.VBool, Bool: truthyV(%s)} }()", a, b), nil
 	case RLogicOr:
 		if len(kids) != 2 {
 			return "", unsupported("jitv: or expects 2 args")
@@ -443,7 +451,7 @@ func emitVLogic(k *Kernel, op uint32, kids []NodeID, scope *vScope) (string, err
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("func() core.Value { if (%s).Bool { return core.Value{Kind: core.VBool, Bool: true} }; return core.Value{Kind: core.VBool, Bool: (%s).Bool} }()", a, b), nil
+		return fmt.Sprintf("func() core.Value { if truthyV(%s) { return core.Value{Kind: core.VBool, Bool: true} }; return core.Value{Kind: core.VBool, Bool: truthyV(%s)} }()", a, b), nil
 	case RLogicNot:
 		if len(kids) != 1 {
 			return "", unsupported("jitv: not expects 1 arg")
@@ -452,7 +460,7 @@ func emitVLogic(k *Kernel, op uint32, kids []NodeID, scope *vScope) (string, err
 		if err != nil {
 			return "", err
 		}
-		return fmt.Sprintf("core.Value{Kind: core.VBool, Bool: !(%s).Bool}", a), nil
+		return fmt.Sprintf("core.Value{Kind: core.VBool, Bool: !truthyV(%s)}", a), nil
 	}
 	return "", unsupported(fmt.Sprintf("jitv: logic op %d", op))
 }

--- a/form/form-kernel-go/jitabi/jitabi.go
+++ b/form/form-kernel-go/jitabi/jitabi.go
@@ -110,7 +110,7 @@ func Concat(a, b Value) Value {
 
 func StrLen(v Value) Value       { return Int(Len(v)) }
 func StrConcat(a, b Value) Value { return Str(a.AsString() + b.AsString()) }
-func StrEq(a, b Value) Value     { return Bool(a.AsString() == b.AsString()) }
+func StrEq(a, b Value) Value     { return boolInt(a.AsString() == b.AsString()) }
 
 func Substring(s, start, end Value) Value {
 	text := s.AsString()
@@ -235,12 +235,21 @@ func Mod(a, b Value) Value {
 	return Int(a.AsInt() % b.AsInt())
 }
 
-func Eq(a, b Value) Value { return Bool(equal(a, b)) }
-func Ne(a, b Value) Value { return Bool(!equal(a, b)) }
-func Lt(a, b Value) Value { return Bool(compare(a, b) < 0) }
-func Le(a, b Value) Value { return Bool(compare(a, b) <= 0) }
-func Gt(a, b Value) Value { return Bool(compare(a, b) > 0) }
-func Ge(a, b Value) Value { return Bool(compare(a, b) >= 0) }
+// Comparisons acknowledge with the 0/1 integer states (axiom-1) — mirrors
+// the walker's RBasicCompare arm so JIT'd and walked answers are identical.
+func boolInt(b bool) Value {
+	if b {
+		return Int(1)
+	}
+	return Int(0)
+}
+
+func Eq(a, b Value) Value { return boolInt(equal(a, b)) }
+func Ne(a, b Value) Value { return boolInt(!equal(a, b)) }
+func Lt(a, b Value) Value { return boolInt(compare(a, b) < 0) }
+func Le(a, b Value) Value { return boolInt(compare(a, b) <= 0) }
+func Gt(a, b Value) Value { return boolInt(compare(a, b) > 0) }
+func Ge(a, b Value) Value { return boolInt(compare(a, b) >= 0) }
 
 func (v Value) AsInt() int64 {
 	switch v.Kind {

--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -2098,7 +2098,7 @@ func (k *Kernel) registerNatives() {
 		return acc
 	})
 	k.registerNative("str_eq", catCompare(RCompareEq), func(_ *Kernel, args []Value) Value {
-		return Value{Kind: VBool, Bool: args[0].Str == args[1].Str}
+		return boolInt(args[0].Str == args[1].Str)
 	})
 	// int_to_str — value-to-string for trivial leaves. The historical
 	// name reflects its first use (line numbers in cell-trace.fk); its
@@ -3504,18 +3504,18 @@ func (k *Kernel) registerNatives() {
 		if args[0].Kind != VNodeID || args[1].Kind != VNodeID {
 			panic(fmt.Sprintf("node_eq: expected NodeID args, got %v and %v", args[0].Kind, args[1].Kind))
 		}
-		return Value{Kind: VBool, Bool: args[0].Nid == args[1].Nid}
+		return boolInt(args[0].Nid == args[1].Nid)
 	})
-	// value_eq — polymorphic equality across all Value kinds. Returns
-	// true when both args have the same kind AND compare equal within
-	// that kind. Cross-kind returns false (str ≠ nodeid even if they
+	// value_eq — polymorphic equality across all Value kinds. Answers
+	// 1 when both args have the same kind AND compare equal within
+	// that kind. Cross-kind answers 0 (str ≠ nodeid even if they
 	// share text). Use this when a Form-side function holds tagged
 	// values that may be either strings or NodeIDs (e.g. domain/lens
 	// in bmf-symbol-context can be either typed-constant NodeIDs or
 	// string literals). Avoids the str_eq/node_eq fork that previously
 	// forced callers to know which type they held.
 	k.registerNative("value_eq", catCompare(RCompareEq), func(k *Kernel, args []Value) Value {
-		return Value{Kind: VBool, Bool: valueEqual(args[0], args[1])}
+		return boolInt(valueEqual(args[0], args[1]))
 	})
 	// intern_node_at — intern composite + record source attribution.
 	// Engine.fk's parser actions call this so every emitted Recipe carries
@@ -4059,55 +4059,61 @@ func (k *Kernel) walk(n NodeID, env *Frame) Value {
 			rv := k.walk(kids[1], env)
 			// Same width-promotion rule as math: float on either side forces
 			// an IEEE comparison. Pure int/int stays integer. Mirrors Rust.
+			// A comparison acknowledges with the 0/1 integer states (axiom-1,
+			// core-axioms.form) so its answer flows directly into arithmetic —
+			// the same shape every JIT lane already lands at the i64 ABI.
+			// Proven three-way by tests/eq-shape-band.fk.
 			if lv.Kind == VFloat || rv.Kind == VFloat {
 				l := lv.AsFloat()
 				r := rv.AsFloat()
 				switch cat.Inst {
 				case RCompareEq:
-					return Value{Kind: VBool, Bool: l == r}
+					return boolInt(l == r)
 				case RCompareNe:
-					return Value{Kind: VBool, Bool: l != r}
+					return boolInt(l != r)
 				case RCompareLt:
-					return Value{Kind: VBool, Bool: l < r}
+					return boolInt(l < r)
 				case RCompareLe:
-					return Value{Kind: VBool, Bool: l <= r}
+					return boolInt(l <= r)
 				case RCompareGt:
-					return Value{Kind: VBool, Bool: l > r}
+					return boolInt(l > r)
 				case RCompareGe:
-					return Value{Kind: VBool, Bool: l >= r}
+					return boolInt(l >= r)
 				}
 			}
 			a := lv.Int
 			b := rv.Int
 			switch cat.Inst {
 			case RCompareEq:
-				return Value{Kind: VBool, Bool: a == b}
+				return boolInt(a == b)
 			case RCompareNe:
-				return Value{Kind: VBool, Bool: a != b}
+				return boolInt(a != b)
 			case RCompareLt:
-				return Value{Kind: VBool, Bool: a < b}
+				return boolInt(a < b)
 			case RCompareLe:
-				return Value{Kind: VBool, Bool: a <= b}
+				return boolInt(a <= b)
 			case RCompareGt:
-				return Value{Kind: VBool, Bool: a > b}
+				return boolInt(a > b)
 			case RCompareGe:
-				return Value{Kind: VBool, Bool: a >= b}
+				return boolInt(a >= b)
 			}
 
 		case RBasicLogic:
+			// Logic consumes truthiness (so 0/1 comparison answers flow in)
+			// and keeps its bool answer — mirrors Rust's as_bool and TS truthy.
 			switch cat.Inst {
 			case RLogicAnd:
-				if !k.walk(kids[0], env).Bool {
+				if !truthy(k.walk(kids[0], env)) {
 					return Value{Kind: VBool, Bool: false}
 				}
-				return Value{Kind: VBool, Bool: k.walk(kids[1], env).Bool}
+				return Value{Kind: VBool, Bool: truthy(k.walk(kids[1], env))}
 			case RLogicOr:
-				if k.walk(kids[0], env).Bool {
+				if truthy(k.walk(kids[0], env)) {
 					return Value{Kind: VBool, Bool: true}
 				}
-				return Value{Kind: VBool, Bool: k.walk(kids[1], env).Bool}
+				return Value{Kind: VBool, Bool: truthy(k.walk(kids[1], env))}
 			case RLogicNot:
-				return Value{Kind: VBool, Bool: !k.walk(kids[0], env).Bool}
+				return Value{Kind: VBool, Bool: !truthy(k.walk(kids[0], env))}
 			}
 
 		case RBasicCond:
@@ -4537,6 +4543,15 @@ func truthy(v Value) bool {
 		return false
 	}
 	return true
+}
+
+// boolInt — the comparison family's acknowledgment shape: 0/1 integer states
+// (axiom-1) so eq/lt/node_eq/… answers feed arithmetic on every kernel.
+func boolInt(b bool) Value {
+	if b {
+		return Value{Kind: VInt, Int: 1}
+	}
+	return Value{Kind: VInt, Int: 0}
 }
 
 // ---------------------------------------------------------------------------

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -3179,7 +3179,7 @@ impl Kernel {
             acc
         });
         self.register_native("str_eq", cat_compare(RCMP_EQ), |_, _, args| {
-            Value::Bool(args[0].as_str() == args[1].as_str())
+            bool_int(args[0].as_str() == args[1].as_str())
         });
         // int_to_str — value-to-string for trivial leaves. Historical name
         // (first use: line numbers in cell-trace.fk); semantics is "render
@@ -5290,15 +5290,15 @@ impl Kernel {
         // emit-engine.fk's lookup-template) can dispatch on Recipe category
         // by direct NodeID equality. Sibling parity required across Go/TS.
         self.register_native("node_eq", cat_compare(RCMP_EQ), |_, _, args| {
-            Value::Bool(args[0].as_nid() == args[1].as_nid())
+            bool_int(args[0].as_nid() == args[1].as_nid())
         });
-        // value_eq — polymorphic equality across Value kinds. Returns
-        // true when both args have the same kind AND compare equal
-        // within that kind. Cross-kind returns false. Use when a
+        // value_eq — polymorphic equality across Value kinds. Answers
+        // 1 when both args have the same kind AND compare equal
+        // within that kind. Cross-kind answers 0. Use when a
         // Form-side function holds tagged values that may be either
         // strings or NodeIDs — e.g. domain/lens in bmf-symbol-context.
         self.register_native("value_eq", cat_compare(RCMP_EQ), |_, _, args| {
-            Value::Bool(value_equal(&args[0], &args[1]))
+            bool_int(value_equal(&args[0], &args[1]))
         });
         // intern_node_at — intern a composite Recipe AND record its source
         // attribution. Engine.fk's parser actions call this so every emitted
@@ -6388,6 +6388,12 @@ fn switch_key_from_value(k: &mut Kernel, v: &Value) -> Option<NodeID> {
     }
 }
 
+// bool_int — the comparison family's acknowledgment shape: 0/1 integer
+// states (axiom-1) so eq/lt/node_eq/… answers feed arithmetic on every kernel.
+fn bool_int(b: bool) -> Value {
+    Value::Int(b as i64)
+}
+
 fn value_equal(a: &Value, b: &Value) -> bool {
     match (a, b) {
         (Value::Null, Value::Null) => true,
@@ -6526,10 +6532,14 @@ fn walk_inner(k: &mut Kernel, a: &mut Arena, n: NodeID, env: FrameId) -> Value {
                 let rv = walk(k, a, kids[1], env);
                 // Same width-promotion rule as math: float on either side
                 // forces an IEEE comparison. Pure int/int stays integer.
+                // A comparison acknowledges with the 0/1 integer states
+                // (axiom-1, core-axioms.form) so its answer flows directly
+                // into arithmetic — the same shape the JIT's i64 ABI already
+                // lands. Proven three-way by tests/eq-shape-band.fk.
                 if matches!(lv, Value::Float(_)) || matches!(rv, Value::Float(_)) {
                     let l = lv.as_float();
                     let r = rv.as_float();
-                    Value::Bool(match cat.inst {
+                    bool_int(match cat.inst {
                         RCMP_EQ => l == r,
                         RCMP_NE => l != r,
                         RCMP_LT => l < r,
@@ -6541,7 +6551,7 @@ fn walk_inner(k: &mut Kernel, a: &mut Arena, n: NodeID, env: FrameId) -> Value {
                 } else {
                     let l = lv.as_int();
                     let r = rv.as_int();
-                    Value::Bool(match cat.inst {
+                    bool_int(match cat.inst {
                         RCMP_EQ => l == r,
                         RCMP_NE => l != r,
                         RCMP_LT => l < r,

--- a/form/form-kernel-ts/src/compiler.ts
+++ b/form/form-kernel-ts/src/compiler.ts
@@ -466,7 +466,9 @@ function emitCompare(
               : op === RCmp.GE
                 ? ">="
                 : "===";
-  return `((${a}) ${opStr} (${b}))`;
+  // Comparisons acknowledge with the 0/1 integer states (axiom-1) — the
+  // ?1:0 keeps a compiled body's answer boxing as int, mirroring walkCompare.
+  return `(((${a}) ${opStr} (${b})) ? 1 : 0)`;
 }
 
 function emitLogic(

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1602,10 +1602,9 @@ export class Kernel {
       }
       return acc;
     });
-    this.registerNative("str_eq", catCompareEq(), (_k, args) => ({
-      kind: "bool",
-      bool: argStr(args, 0) === argStr(args, 1),
-    }));
+    this.registerNative("str_eq", catCompareEq(), (_k, args) =>
+      boolInt(argStr(args, 0) === argStr(args, 1)),
+    );
     // int_to_str — value-to-string for trivial leaves. Historical name
     // (first use: line numbers in cell-trace.fk); semantics is "render
     // any trivial value as text" so emit-engine.fk's leaf walker can
@@ -2972,17 +2971,17 @@ export class Kernel {
         a.level === b.level &&
         a.type === b.type &&
         a.inst === b.inst;
-      return { kind: "bool", bool: equal };
+      return boolInt(equal);
     });
-    // value_eq — polymorphic equality across Value kinds. Returns true
+    // value_eq — polymorphic equality across Value kinds. Answers 1
     // when both args have the same kind AND compare equal within that
-    // kind. Cross-kind returns false. Use when a Form-side function
+    // kind. Cross-kind answers 0. Use when a Form-side function
     // holds tagged values that may be either strings or NodeIDs —
     // e.g. domain/lens in bmf-symbol-context.
     this.registerNative("value_eq", catCompareEq(), (_k, args) => {
       const a = args[0]!;
       const b = args[1]!;
-      return { kind: "bool", bool: valueEqual(a, b) };
+      return boolInt(valueEqual(a, b));
     });
     this.registerNative("serialize-recipe", catWitness(), (k, args) => {
       const out: number[] = [];
@@ -4380,6 +4379,12 @@ function walkMath(
   return { kind: "int", int: acc };
 }
 
+// boolInt — the comparison family's acknowledgment shape: 0/1 integer states
+// (axiom-1) so eq/lt/node_eq/… answers feed arithmetic on every kernel.
+function boolInt(b: boolean): Value {
+  return { kind: "int", int: b ? 1 : 0 };
+}
+
 function walkCompare(
   k: Kernel,
   op: number,
@@ -4390,9 +4395,13 @@ function walkCompare(
   const av = walk(k, kids[0]!, frame);
   const bv = walk(k, kids[1]!, frame);
 
+  // A comparison acknowledges with the 0/1 integer states (axiom-1,
+  // core-axioms.form) so its answer flows directly into arithmetic —
+  // the shape the compiled lane's JS coercion already implied. Proven
+  // three-way by tests/eq-shape-band.fk.
   if (op === RCmp.EQ || op === RCmp.NE) {
     const equal = valueEqual(av, bv);
-    return { kind: "bool", bool: op === RCmp.EQ ? equal : !equal };
+    return boolInt(op === RCmp.EQ ? equal : !equal);
   }
 
   // Width-mixing in comparisons: if either side is float, compare as float;
@@ -4429,7 +4438,7 @@ function walkCompare(
       default: throw new Error(`compare: unknown op ${op}`);
     }
   }
-  return { kind: "bool", bool: r };
+  return boolInt(r);
 }
 
 function valueEqual(a: Value, b: Value): boolean {

--- a/form/form-stdlib/arena-melt.fk
+++ b/form/form-stdlib/arena-melt.fk
@@ -78,9 +78,9 @@
 ; 16 bytes per cell: the sibling's two long longs (fk_heap_head + fk_heap_tail)
 (defn am-measure2 (alloc live) (list alloc live (sub alloc live) (mul alloc 16) (mul live 16)))
 (defn am-measure (ar root) (am-measure2 (am-hp ar) (len (am-live-slots ar root))))
-; (the innermost claim reduces through if to an integer — a raw eq return
-;  value is kernel-divergent: bool on TS/Go, int on Rust; eq belongs in
-;  if-conditions, integers belong in answers)
+; (eq acknowledges with the 0/1 integer states on every kernel — axiom-1,
+;  proven by tests/eq-shape-band.fk — so a comparison's answer feeds
+;  arithmetic directly; the if-reduction here is style, not necessity)
 (defn am-readout-is (m alloc live dead pb lb)
     (if (eq (nth m 0) alloc)
         (if (eq (nth m 1) live)

--- a/form/form-stdlib/primitive-registry.fk
+++ b/form/form-stdlib/primitive-registry.fk
@@ -214,8 +214,8 @@
             (defn pv-scan-run () (scan_run "  form" 0 0)) 2 1)
         (prim "string_fold" "call" "host-loop fold of (acc char) closure over a string's bytes"
             (defn pv-string-fold () (string_fold "abc" 0 (defn pv-string-fold-step (acc c) (add acc 1)))) 3 1)
-        (prim "str_eq" "compare" "string equality; integers and nodes belong to eq"
-            (defn pv-str-eq () (if (str_eq "a" "a") (if (str_eq "a" "b") 0 1) 0)) 1 1)
+        (prim "str_eq" "compare" "string equality as the 0/1 integer states; integers and nodes belong to eq"
+            (defn pv-str-eq () (add (str_eq "a" "a") (mul (str_eq "a" "b") 7))) 1 1)
         (prim "int_to_str" "method" "renders any trivial value as text (int, bool, null, float passthrough)"
             (defn pv-int-to-str () (str_len (int_to_str 1024))) 4 1)
         (prim "value_str" "method" "sibling-gap (ts): canonical display string of any value"
@@ -460,10 +460,10 @@
             (defn pv-node-type () (node_type (make_nodeid 2 3 4 5))) 4 1)
         (prim "node_inst" "witness" "the inst coordinate of a NodeID"
             (defn pv-node-inst () (node_inst (make_nodeid 2 3 4 5))) 5 1)
-        (prim "node_eq" "compare" "structural NodeID equality; non-NodeID args fail loud"
-            (defn pv-node-eq () (if (node_eq (bp "add") (bp "add")) (if (node_eq (bp "add") (bp "mul")) 0 1) 0)) 1 1)
-        (prim "value_eq" "compare" "polymorphic equality within a kind; cross-kind answers false"
-            (defn pv-value-eq () (if (value_eq 7 7) (if (value_eq 7 "7") 0 1) 0)) 1 1)
+        (prim "node_eq" "compare" "structural NodeID equality as 0/1; non-NodeID args fail loud"
+            (defn pv-node-eq () (add (node_eq (bp "add") (bp "add")) (mul (node_eq (bp "add") (bp "mul")) 7))) 1 1)
+        (prim "value_eq" "compare" "polymorphic equality within a kind as 0/1; cross-kind answers 0"
+            (defn pv-value-eq () (add (value_eq 7 7) (mul (value_eq 7 "7") 7))) 1 1)
         (prim "intern_node_at" "witness" "intern_node plus (file line col) source attribution into the framebuffer"
             (defn pv-intern-node-at () (walk_recipe (intern_node_at (bp "add")
                 (list (intern_trivial_int 2) (intern_trivial_int 3)) "prim-registry-probe.fk" 1 1))) 5 1)

--- a/form/form-stdlib/tests/eq-shape-band.fk
+++ b/form/form-stdlib/tests/eq-shape-band.fk
@@ -1,0 +1,29 @@
+; eq-shape-band.fk — the comparison family's acknowledgment contract: eq/ne/lt/
+; le/gt/ge, node_eq, value_eq, and str_eq answer with the 0/1 integer states
+; (axiom-1, core-axioms.form) on every kernel, so a comparison's answer flows
+; DIRECTLY into arithmetic with bit-identical results — no if-reduction needed.
+; This band deliberately uses mul/sub/lt/le (outside the curated band-verdict
+; subset): feeding comparison answers into arithmetic IS the claim under test.
+; Self-contained — kernel verbs only, no preludes.
+(do
+    ; c0 — the arena-melt crash shape: an equal eq fed straight into mul.
+    (let c0 (if (eq (mul (eq 2 2) 5) 5) 1 0))
+    ; c1 — the unequal case annihilates through mul.
+    (let c1 (if (eq (mul (eq 2 3) 5) 0) 2 0))
+    ; c2 — eq answers chain through add: 1 + 0.
+    (let c2 (if (eq (add (eq 1 1) (eq 1 2)) 1) 4 0))
+    ; c3 — the ordering family in one arithmetic chain: lt+le+gt+ge = 1+1+1+0.
+    (let c3 (if (eq (add (add (lt 1 2) (le 2 2)) (add (gt 3 2) (ge 2 3))) 3) 8 0))
+    ; c4 — ne both ways through sub: 1 - 0.
+    (let c4 (if (eq (sub (ne 1 2) (ne 2 2)) 1) 16 0))
+    ; c5 — node_eq feeds mul: same blueprint ×3, different blueprints add 0.
+    (let c5 (if (eq (add (mul (node_eq (bp "add") (bp "add")) 3)
+                         (node_eq (bp "add") (bp "mul"))) 3) 32 0))
+    ; c6 — the answer is itself comparable: eq-of-eq against the 0/1 states.
+    (let c6 (if (eq (add (eq (eq 5 5) 1) (eq (eq 5 6) 0)) 2) 64 0))
+    ; c7 — the float comparison path acknowledges the same integer states.
+    (let c7 (if (eq (mul (gt 2.5 1.5) 4) 4) 128 0))
+    ; c8 — str_eq and value_eq answer 0/1: positives add to 2, negatives to 0.
+    (let c8 (if (eq (add (add (str_eq "a" "a") (value_eq 7 7))
+                         (add (str_eq "a" "b") (value_eq 7 "7"))) 2) 256 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 c8)))))))))


### PR DESCRIPTION
## The stone (Form-OS round 2)

While proving the arena-melt band (#2831) a cross-kernel divergence surfaced: the raw `eq` primitive returned different value shapes — a raw eq answer crashed TS `math.i32`, silently zeroed Go math (raw `.Int` read of a VBool), and worked only through Rust's `as_int` coercion. The workaround lived as an in-recipe note in `arena-melt.fk` ("answers must reduce through `if` to integers").

**North star: axiom-1 of `core-axioms.form` — states are 0/1/nothing.** Every JIT lane (Go scalar, Go C-emit, Rust i64 ABI, TS JS coercion) already landed comparisons as integers; the interpreters were the laggards.

## One contract, three carriers

- `eq/ne/lt/le/gt/ge` category arms answer **Int 0/1** in the Go/Rust/TS walkers (int and float comparison paths)
- `node_eq`, `value_eq`, `str_eq` natives answer Int 0/1 on all three kernels (the eq name-family healed together)
- Logic ops consume truthiness: Go's walker + emitted Value-ABI logic read `truthy`/`truthyV` instead of raw `.Bool` — `(and 1 2)` now agrees three-way too (it was silently Go-divergent)
- Go Value-ABI mirrors carry the same shape (`cmpV` plugin preamble, `jitabi.Eq/Ne/Lt/Le/Gt/Ge/StrEq`); TS compile lane emits `(a===b)?1:0` — the interpreted-vs-JIT split inside Go and TS closes with the sibling split
- `primitive-registry.fk` rows for node_eq/value_eq/str_eq declare 0/1 and their verifies feed answers through add/mul — the contract proof IS the shape
- `arena-melt.fk`'s divergence note retuned to state what IS

Membership/state predicates (`_dict_has`, `_in`, `record_has`, …) and logic-op answers keep their bool shapes — different families, named as known limitations in the evidence record.

## Proof (three-way, `form/validate.sh`)

| Workload | Verdict |
|---|---|
| `form-stdlib/tests/eq-shape-band.fk` (new) | **511** — `(mul (eq 2 2) 5) = 5` everywhere; unequal annihilates; lt/le/gt/ge chain through add; ne through sub; node_eq feeds mul; eq-of-eq compares against the 0/1 states; float path included |
| arena-melt six-file workload | **63** unchanged |
| primitive-registry band | **63** unchanged |
| pain/signal-metabolism (new on main) | **1023** each on unified kernels |
| curated compare-sensitive set | float-conversions 31 · float-natives 28 · classifier-eval 63 · choice-receipt -1 · learned-primitive 255 · persistence 7 · fourth-os 15 · fourth-match 15 · python-bmf-class 34 · json-emitter 15 · json-codec-bml 8191 |
| full-suite alphabetical prefix | 78 workloads, 0 divergent (all form-samples + audit/auto/belief/bml-thesis compiler clusters) |
| kernel suites | `go test` ok (incl. server route shapes) · cargo 49/49 · TS 18/18 test files |

Evidence: `docs/system_audit/commit_evidence_2026-06-11_eq_shape_unification.json`

Lane note: `jit.go`'s dlopen/install surface untouched (sibling lane); coordinator retunes `linux-as-recipes.form`/`fourth-kernel.form` after all six round-2 stones merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)