### PR TITLE
tend: extend BML listener deploy proof budget

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -741,14 +741,19 @@ ensure_kernel_router_canary() {
 
   for service in "${canary_services[@]}"; do
     local listener_probe_path="/api/attention/kernel-runtime"
+    local listener_wait_seconds=90
+    local listener_curl_timeout_seconds=5
     if [[ "$service" == "kernel-router-bml-front-door" ]]; then
       listener_probe_path="/api/utils/kernel_status"
+      listener_wait_seconds=360
+      listener_curl_timeout_seconds=10
     fi
-    deadline=$(( $(date +%s) + 90 ))
+    log "kernel-router canary: waiting for ${service} listener at ${listener_probe_path} (${listener_wait_seconds}s budget)"
+    deadline=$(( $(date +%s) + listener_wait_seconds ))
     listener_ready=0
     while (( $(date +%s) < deadline )); do
       if docker compose "${compose_args[@]}" exec -T "$service" sh -lc \
-        "curl -fsS --max-time 5 -o /dev/null http://127.0.0.1:8080${listener_probe_path}" \
+        "curl -fsS --max-time ${listener_curl_timeout_seconds} -o /dev/null http://127.0.0.1:8080${listener_probe_path}" \
         >/dev/null 2>&1; then
         listener_ready=1
         break
@@ -756,7 +761,9 @@ ensure_kernel_router_canary() {
       sleep 3
     done
     if [[ "$listener_ready" != "1" ]]; then
-      log "FAIL: $service listener did not accept local HTTP at ${listener_probe_path} within 90s"
+      log "FAIL: $service listener did not accept local HTTP at ${listener_probe_path} within ${listener_wait_seconds}s"
+      docker compose "${compose_args[@]}" ps 2>&1 | tee -a "$LOG_FILE" || true
+      docker compose "${compose_args[@]}" logs --tail=120 "$service" 2>&1 | tee -a "$LOG_FILE" || true
       exit 1
     fi
   done

--- a/docs/system_audit/commit_evidence_20260611_bml_listener_wait_budget.json
+++ b/docs/system_audit/commit_evidence_20260611_bml_listener_wait_budget.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "codex/bml-listener-wait-budget-20260611",
+  "commit_scope": "Give the Hostinger BML front-door listener canary enough warm-up budget and failure diagnostics",
+  "files_owned": [
+    "deploy/hostinger/auto-deploy.sh"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "bash -n deploy/hostinger/auto-deploy.sh",
+      "git diff --check",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_bml_listener_wait_budget.json"
+    ],
+    "notes": "The previous repaired canary used the right cheap native BML route but still gave the BML front-door only 90s. The BML front-door listener now has a 360s startup budget and emits compose ps plus service logs before failing. Local syntax, diff hygiene, and evidence validation passed."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "notes": "Public deploy verification waits for this deploy-script repair to land and rerun Hostinger Auto Deploy."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local script validation is complete; PR CI and public deploy proof remain pending."
+  },
+  "idea_ids": [
+    "native-api-lane",
+    "form-native-front-door"
+  ],
+  "spec_ids": [
+    "hostinger-bml-front-door-deploy-proof"
+  ],
+  "task_ids": [
+    "bml-listener-wait-budget-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5-codex"
+  },
+  "evidence_refs": [
+    "https://github.com/seeker71/Coherence-Network/actions/runs/27333832426",
+    "deploy/hostinger/auto-deploy.sh#ensure_kernel_router_canary"
+  ],
+  "change_files": [
+    "deploy/hostinger/auto-deploy.sh"
+  ],
+  "change_intent": "process_only",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Hostinger Auto Deploy should allow the BML front-door service to finish its first-listen warm-up before running the deeper native BML route proofs, and should return useful logs if it still cannot listen.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/utils/kernel_status",
+      "https://api.coherencycoin.com/api/ideas/resonance?limit=2",
+      "https://api.coherencycoin.com/api/household/events?limit=2"
+    ],
+    "test_flows": [
+      "Verify Hostinger Auto Deploy completes the Roll forward VPS job.",
+      "Verify promoted BML read routes return native proof headers after the repaired deploy.",
+      "Verify full public deploy script passes against API and web."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- give the Hostinger BML front-door listener canary a 360s warm-up budget instead of the generic 90s window
- keep the cheap native /api/utils/kernel_status listener probe before deeper BML route canaries
- emit compose ps and service logs if the listener still misses the budget

## Validation
- bash -n deploy/hostinger/auto-deploy.sh
- git diff --check
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_bml_listener_wait_budget.json
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict

Repairs Hostinger Auto Deploy run https://github.com/seeker71/Coherence-Network/actions/runs/27333832426.