### PR TITLE
tend: prove BML kernel image route as native

### DIFF
--- a/deploy/front-door/api.bml
+++ b/deploy/front-door/api.bml
@@ -689,7 +689,7 @@ section [form.bml] {
         let requested_action = api-json-field-value-or(body, "requested_action", "preview");
         let source_label = api-json-field-value-or(body, "source_label", "");
         let canonical_source = read_file(str_concat(repo_root(), "/form/form-stdlib/bml/kernel-core.bml"));
-        api-ok-json(api-kip-proposal-json(source, grammar, source_label, requested_action, canonical_source));
+        api-native-ok-json("api_substrate_kernel_image_proposals", api-kip-proposal-json(source, grammar, source_label, requested_action, canonical_source));
     }
     def anonymous-trace-hash-id(kind, value) {
         let digest = sha256(api-str-to-bytes(str_concat(kind, str_concat(":", value))));

--- a/docs/system_audit/commit_evidence_20260611_bml_kernel_image_native_proof.json
+++ b/docs/system_audit/commit_evidence_20260611_bml_kernel_image_native_proof.json
@@ -1,0 +1,83 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "codex/bml-kernel-image-native-proof-20260611",
+  "commit_scope": "Repair the BML kernel-image proposal route native proof headers required by Hostinger deploy canaries",
+  "files_owned": [
+    "deploy/front-door/api.bml"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "./scripts/test_hostinger_deploy_form_paths.sh",
+      "pytest -q api/tests/test_runtime_web_api_provenance.py",
+      "cd form/form-kernel-rust && cargo test source_bml_catalog_template_routes_select_natively_in_rust --quiet",
+      "git diff --check",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_bml_kernel_image_native_proof.json"
+    ],
+    "notes": "Hostinger Auto Deploy run 27334498511 proved the BML listener was live, then failed because the kernel-image proposal handler returned JSON without native proof headers. The handler now uses api-native-ok-json with handler api_substrate_kernel_image_proposals. Static BML ingress coverage, API provenance tests, Rust BML catalog selection, diff hygiene, and evidence-file validation passed."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "notes": "Public deploy verification waits for this BML native-proof repair to land and rerun Hostinger Auto Deploy."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local BML route validation is complete; PR CI and public deploy proof remain pending."
+  },
+  "idea_ids": [
+    "native-api-lane",
+    "form-native-front-door"
+  ],
+  "spec_ids": [
+    "hostinger-bml-front-door-deploy-proof"
+  ],
+  "task_ids": [
+    "bml-kernel-image-native-proof-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5-codex"
+  },
+  "evidence_refs": [
+    "https://github.com/seeker71/Coherence-Network/actions/runs/27334498511",
+    "deploy/front-door/api.bml#api_substrate_kernel_image_proposals"
+  ],
+  "change_files": [
+    "deploy/front-door/api.bml"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "The BML front-door direct kernel-image proposal route should return X-Form-Handler: api_substrate_kernel_image_proposals and X-Form-Python-Authority: false before the deploy script advances into the read-route canaries.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/substrate/kernel-image/proposals",
+      "https://api.coherencycoin.com/api/ideas/resonance?limit=2",
+      "https://api.coherencycoin.com/api/household/events?limit=2"
+    ],
+    "test_flows": [
+      "Verify Hostinger Auto Deploy completes the BML kernel-image proposal route canary.",
+      "Verify promoted BML read routes return native proof headers after deploy.",
+      "Verify full public deploy script passes against API and web."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- route the BML kernel-image proposal handler through api-native-ok-json
- preserve the same proposal JSON body while adding X-Form-Handler and X-Form-Python-Authority proof headers
- repair the Hostinger deploy canary failure from run 27334498511

## Validation
- ./scripts/test_hostinger_deploy_form_paths.sh
- pytest -q api/tests/test_runtime_web_api_provenance.py
- cd form/form-kernel-rust && cargo test source_bml_catalog_template_routes_select_natively_in_rust --quiet
- git diff --check
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_bml_kernel_image_native_proof.json
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict

Repairs Hostinger Auto Deploy run https://github.com/seeker71/Coherence-Network/actions/runs/27334498511.