### PR TITLE
Harden nullable BML JSON emission

### DIFF
--- a/docs/system_audit/commit_evidence_20260611_json_node_string_null_hardening.json
+++ b/docs/system_audit/commit_evidence_20260611_json_node_string_null_hardening.json
@@ -1,0 +1,88 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "codex/bml-read-null-hardening-20260611",
+  "commit_scope": "Harden Form JSON string construction so nullable route data cannot crash the BML front door",
+  "files_owned": [
+    "form/form-kernel-ts/src/kernel.ts",
+    "form/form-stdlib/json.fk",
+    "form/form-stdlib/tests/json-emitter-band.fk"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/tests/json-emitter-band.fk",
+      "./scripts/test_hostinger_deploy_form_paths.sh",
+      "cd form/form-kernel-rust && cargo test source_bml_catalog_template_routes_select_natively_in_rust --quiet",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_json_node_string_null_hardening.json"
+    ],
+    "notes": "Hostinger Auto Deploy run 27335685734 showed the BML front-door compiled 59 routes, then logged repeated form-kernel-rust as_str: Null crash traces during promoted read-route proof. json-node-string now maps runtime kind null to a JSON null node instead of calling intern_trivial_string on Null. The TypeScript kernel now exposes the same value_kind/value-kind native as Rust and Go so the JSON stdlib remains sibling-kernel portable. Passed cross-kernel JSON emitter band, 52-route Hostinger BML deploy path proof, Rust native route-catalog test, and git diff whitespace check."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "notes": "Public deploy verification waits for this stdlib hardening to land and rerun Hostinger Auto Deploy."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local stdlib and BML validation, PR CI, and public deploy proof remain pending."
+  },
+  "idea_ids": [
+    "native-api-lane",
+    "form-native-front-door",
+    "kernel-crash-trace-repair"
+  ],
+  "spec_ids": [
+    "hostinger-bml-front-door-deploy-proof"
+  ],
+  "task_ids": [
+    "bml-read-null-hardening-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5-codex"
+  },
+  "evidence_refs": [
+    "https://github.com/seeker71/Coherence-Network/actions/runs/27335685734",
+    "form/form-kernel-ts/src/kernel.ts#valueKindName",
+    "form/form-stdlib/json.fk#json-node-string"
+  ],
+  "change_files": [
+    "form/form-kernel-ts/src/kernel.ts",
+    "form/form-stdlib/json.fk",
+    "form/form-stdlib/tests/json-emitter-band.fk"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "BML read-route handlers that encounter nullable DB values should emit JSON null instead of crashing a kernel-router worker with as_str: Null.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/ideas/resonance?limit=2",
+      "https://api.coherencycoin.com/api/runtime/events?limit=1&source=api",
+      "https://api.coherencycoin.com/api/household/events?limit=2"
+    ],
+    "test_flows": [
+      "Verify the JSON emitter band preserves null from json-node-string on kernel Null.",
+      "Verify Hostinger Auto Deploy completes the promoted BML read-route canary.",
+      "Verify promoted BML read routes return native proof headers after deploy."
+    ]
+  }
+}

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1356,6 +1356,12 @@ export class Kernel {
     this.registerNative("form-error", catWitness(), (_k, args) => {
       throw new Error(argStr(args, 0));
     });
+    const valueKindNative = (_k: Kernel, args: Value[]): Value => ({
+      kind: "str",
+      str: valueKindName(args[0] ?? { kind: "null" }),
+    });
+    this.registerNative("value_kind", catWitness(), valueKindNative);
+    this.registerNative("value-kind", catWitness(), valueKindNative);
     this.registerNative("source_scan_file", catCall(), (_k, args) =>
       sourceNativeScanText(readFileSync(argStr(args, 0), "utf8"), sourceNativeLexiconFromValue(args[1]!)),
     );
@@ -3511,6 +3517,41 @@ function argNodeID(args: Value[], i: number): NodeID {
   const v = args[i];
   if (v?.kind !== "nodeid") throw new Error(`arg ${i}: expected nodeid`);
   return v.nodeid;
+}
+
+function valueKindName(v: Value): string {
+  switch (v.kind) {
+    case "null":
+      return "null";
+    case "int":
+    case "i8":
+    case "i16":
+    case "u8":
+    case "u16":
+    case "u32":
+    case "i64":
+    case "u64":
+      return "int";
+    case "f32":
+    case "f64":
+      return "float";
+    case "str":
+      return "string";
+    case "bool":
+      return "bool";
+    case "list":
+      return "list";
+    case "closure":
+      return "closure";
+    case "nodeid":
+      return "node_id";
+    case "record":
+      return "record";
+    case "ctor":
+      return "constructor";
+    default:
+      return "unknown";
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/form/form-stdlib/json.fk
+++ b/form/form-stdlib/json.fk
@@ -418,7 +418,10 @@
 ;; string escaping, null/boolean/number selection, and recursive emission live
 ;; here in Form.
 
-(defn json-node-string (s) (intern_trivial_string s))
+(defn json-node-string (s)
+    (if (str_eq (value_kind s) "null")
+        (json-node-null)
+        (intern_trivial_string s)))
 (defn json-node-int (n) (intern_trivial_int n))
 (defn json-node-float-text (s) (intern_trivial_float s))
 (defn json-node-bool (b) (intern_trivial_bool b))

--- a/form/form-stdlib/tests/json-emitter-band.fk
+++ b/form/form-stdlib/tests/json-emitter-band.fk
@@ -15,6 +15,7 @@
             (json-node-pair "score" (json-node-float-text "1.25"))
             (json-node-pair "active" (json-node-bool true))
             (json-node-pair "missing" (json-node-null))
+            (json-node-pair "nullable_string" (json-node-string (_dict_get (_dict_new) "missing")))
             (json-node-pair "control" (json-node-string control-text))
             (json-node-pair "tags"
                 (json-node-array
@@ -22,7 +23,7 @@
 
 (let emitted (json_response_body doc))
 (let expected
-    "{\"name\":\"A\\\"B\",\"path\":\"C:\\\\tmp\",\"count\":3,\"score\":1.25,\"active\":true,\"missing\":null,\"control\":\"a\\u0001b\",\"tags\":[\"x\",\"y\"]}")
+    "{\"name\":\"A\\\"B\",\"path\":\"C:\\\\tmp\",\"count\":3,\"score\":1.25,\"active\":true,\"missing\":null,\"nullable_string\":null,\"control\":\"a\\u0001b\",\"tags\":[\"x\",\"y\"]}")
 
 (let exact-ok (if (str_eq emitted expected) 1 0))
 (let parsed (json_parse_body "json-emitter-band" emitted))


### PR DESCRIPTION
## Summary
- add TypeScript kernel parity for value_kind/value-kind
- make json-node-string emit JSON null for runtime null instead of crashing intern_trivial_string
- add a JSON emitter band case for nullable route data

## Local proof
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/tests/json-emitter-band.fk
- ./scripts/test_hostinger_deploy_form_paths.sh
- cd form/form-kernel-rust && cargo test source_bml_catalog_template_routes_select_natively_in_rust --quiet
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_json_node_string_null_hardening.json
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict