### PR TITLE
Bound BML front-door deploy canaries

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -857,7 +857,7 @@ ensure_kernel_router_canary() {
   probe_ok=0
   while (( $(date +%s) < deadline )); do
     if docker compose "${compose_args[@]}" exec -T kernel-router-bml-front-door sh -lc \
-      "curl -fsS -D /tmp/kernel-image.headers -o /tmp/kernel-image.body \
+      "curl -fsS --max-time 10 -D /tmp/kernel-image.headers -o /tmp/kernel-image.body \
         -X POST http://127.0.0.1:8080/api/substrate/kernel-image/proposals \
         -H 'Accept: application/json' \
         -H 'Content-Type: application/json' \
@@ -881,7 +881,7 @@ ensure_kernel_router_canary() {
   probe_ok=0
   while (( $(date +%s) < deadline )); do
     if docker compose "${compose_args[@]}" exec -T kernel-router-bml-front-door sh -lc \
-      "curl -fsS -D /tmp/inventory-flow.headers -o /tmp/inventory-flow.body \
+      "curl -fsS --max-time 10 -D /tmp/inventory-flow.headers -o /tmp/inventory-flow.body \
         'http://127.0.0.1:8080/api/inventory/flow?idea_id=__native_inventory_canary__&list_item_limit=1&runtime_window_seconds=3600' \
         -H 'Accept: application/json' \
         && grep -qi '^X-Form-Router: native-kernel' /tmp/inventory-flow.headers \
@@ -903,7 +903,7 @@ ensure_kernel_router_canary() {
   probe_ok=0
   while (( $(date +%s) < deadline )); do
     if docker compose "${compose_args[@]}" exec -T kernel-router-bml-front-door sh -lc \
-      "curl -fsS -D /tmp/inventory-flow-observe.headers -o /tmp/inventory-flow-observe.body \
+      "curl -fsS --max-time 10 -D /tmp/inventory-flow-observe.headers -o /tmp/inventory-flow-observe.body \
         'http://127.0.0.1:8080/api/_form/inventory-flow-observation?idea_id=__native_inventory_canary__&list_item_limit=1&runtime_window_seconds=3600&event_limit=20&warm=1' \
         -H 'Accept: application/json' \
         -H 'X-Form-Observe: 1' \
@@ -927,7 +927,7 @@ ensure_kernel_router_canary() {
   probe_ok=0
   while (( $(date +%s) < deadline )); do
     if docker compose "${compose_args[@]}" exec -T kernel-router-bml-front-door sh -lc \
-      "curl -fsS -D /tmp/kernel-status.headers -o /tmp/kernel-status.body \
+      "curl -fsS --max-time 10 -D /tmp/kernel-status.headers -o /tmp/kernel-status.body \
         'http://127.0.0.1:8080/api/utils/kernel_status' \
         -H 'Accept: application/json' \
         && grep -qi '^X-Form-Router: native-kernel' /tmp/kernel-status.headers \
@@ -951,10 +951,10 @@ ensure_kernel_router_canary() {
   probe_ok=0
   while (( $(date +%s) < deadline )); do
     if docker compose "${compose_args[@]}" exec -T kernel-router-bml-front-door sh -lc \
-      "curl -fsS -D /tmp/agent-tasks-active.headers -o /tmp/agent-tasks-active.body \
+      "curl -fsS --max-time 10 -D /tmp/agent-tasks-active.headers -o /tmp/agent-tasks-active.body \
         'http://127.0.0.1:8080/api/agent/tasks/active' \
         -H 'Accept: application/json' \
-        && curl -fsS -D /tmp/agent-tasks-activity.headers -o /tmp/agent-tasks-activity.body \
+        && curl -fsS --max-time 10 -D /tmp/agent-tasks-activity.headers -o /tmp/agent-tasks-activity.body \
         'http://127.0.0.1:8080/api/agent/tasks/activity?limit=50&offset=0' \
         -H 'Accept: application/json' \
         && grep -qi '^X-Form-Router: native-kernel' /tmp/agent-tasks-active.headers \
@@ -981,10 +981,10 @@ ensure_kernel_router_canary() {
   probe_ok=0
   while (( $(date +%s) < deadline )); do
     if docker compose "${compose_args[@]}" exec -T kernel-router-bml-front-door sh -lc \
-      "curl -fsS -D /tmp/contributors.headers -o /tmp/contributors.body \
+      "curl -fsS --max-time 10 -D /tmp/contributors.headers -o /tmp/contributors.body \
         'http://127.0.0.1:8080/api/contributors?limit=5&offset=0' \
         -H 'Accept: application/json' \
-        && curl -fsS -D /tmp/contributions.headers -o /tmp/contributions.body \
+        && curl -fsS --max-time 10 -D /tmp/contributions.headers -o /tmp/contributions.body \
         'http://127.0.0.1:8080/api/contributions?limit=5&offset=0' \
         -H 'Accept: application/json' \
         && grep -qi '^X-Form-Router: native-kernel' /tmp/contributors.headers \
@@ -1049,7 +1049,7 @@ ensure_kernel_router_canary() {
         'sensings|/api/sensings?limit=2|api_sensings' \
         'translations-page-flow|/api/translations/page/flow|api_translations_entity'; do \
           name=\${spec%%|*}; rest=\${spec#*|}; url=\${rest%%|*}; handler=\${rest#*|}; \
-          if ! curl -fsS -D /tmp/promoted-\${name}.headers -o /tmp/promoted-\${name}.body \
+          if ! curl -fsS --max-time 10 -D /tmp/promoted-\${name}.headers -o /tmp/promoted-\${name}.body \
             \"http://127.0.0.1:8080\${url}\" \
             -H 'Accept: application/json'; then \
               echo \"promoted route curl failed: \${name}\"; \
@@ -1088,7 +1088,7 @@ ensure_kernel_router_canary() {
   probe_ok=0
   while (( $(date +%s) < deadline )); do
     if docker compose "${compose_args[@]}" exec -T kernel-router-bml-front-door sh -lc \
-      "curl -fsS -D /tmp/household-events.headers -o /tmp/household-events.body \
+      "curl -fsS --max-time 10 -D /tmp/household-events.headers -o /tmp/household-events.body \
         'http://127.0.0.1:8080/api/household/events?limit=5' \
         -H 'Accept: application/json' \
         && grep -qi '^X-Form-Router: native-kernel' /tmp/household-events.headers \

--- a/docs/system_audit/commit_evidence_20260611_bml_canary_curl_timeouts.json
+++ b/docs/system_audit/commit_evidence_20260611_bml_canary_curl_timeouts.json
@@ -1,0 +1,83 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "codex/bml-canary-curl-timeouts-20260611",
+  "commit_scope": "Bound BML front-door deploy canary curl probes so a hung promoted route names itself quickly",
+  "files_owned": [
+    "deploy/hostinger/auto-deploy.sh",
+    "scripts/test_hostinger_deploy_form_paths.sh"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "./scripts/test_hostinger_deploy_form_paths.sh",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_bml_canary_curl_timeouts.json",
+      "git diff --check"
+    ],
+    "notes": "Hostinger Auto Deploy run 27336868326 remained in Roll forward VPS beyond the prior fast failure window. The promoted BML read-route canary loop had unbounded curl calls, so a single non-returning route could consume the outer 35m SSH timeout without naming the route. This change bounds BML front-door canary curl calls with --max-time 10 and adds a static guard for the promoted-read loop. Passed the Hostinger BML deploy path proof and git diff whitespace check."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "Hostinger Auto Deploy on main after merge"
+    ],
+    "notes": "A newer main deploy will cancel any older in-progress Hostinger deploy by workflow concurrency and should either complete or fail with a bounded, route-named canary error."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation, PR CI, and deploy proof remain pending."
+  },
+  "idea_ids": [
+    "native-api-lane",
+    "form-native-front-door",
+    "bounded-deploy-proof"
+  ],
+  "spec_ids": [
+    "hostinger-bml-front-door-deploy-proof"
+  ],
+  "task_ids": [
+    "bml-canary-curl-timeouts-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5-codex"
+  },
+  "evidence_refs": [
+    "https://github.com/seeker71/Coherence-Network/actions/runs/27336868326",
+    "deploy/hostinger/auto-deploy.sh#BML-front-door-promoted-read-routes"
+  ],
+  "change_files": [
+    "deploy/hostinger/auto-deploy.sh",
+    "scripts/test_hostinger_deploy_form_paths.sh"
+  ],
+  "change_intent": "process_only",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "BML front-door canary probes should fail within bounded retry windows with the route name instead of hanging until the outer SSH timeout.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/ideas/resonance?limit=2",
+      "https://api.coherencycoin.com/api/runtime/events?limit=1&source=api",
+      "https://api.coherencycoin.com/api/household/events?limit=2"
+    ],
+    "test_flows": [
+      "Verify the deploy path static guard requires bounded promoted-read curl probes.",
+      "Verify Hostinger Auto Deploy either completes or reports the concrete failing BML route promptly."
+    ]
+  }
+}

--- a/scripts/test_hostinger_deploy_form_paths.sh
+++ b/scripts/test_hostinger_deploy_form_paths.sh
@@ -141,6 +141,9 @@ grep -Fq 'X-Form-Handler: \${handler}' "$DEPLOY_SCRIPT" \
 grep -Fq 'X-Form-Python-Authority: false' "$DEPLOY_SCRIPT" \
   || fail "deploy canary does not require promoted BML authority proof"
 
+grep -Fq 'curl -fsS --max-time 10 -D /tmp/promoted-' "$DEPLOY_SCRIPT" \
+  || fail "deploy canary does not bound promoted BML read route curl probes"
+
 grep -Fq 'api_sensings' "$DEPLOY_SCRIPT" \
   || fail "deploy canary does not probe the sensings BML handler"
 


### PR DESCRIPTION
## Summary
- add --max-time 10 to BML front-door local canary curl probes
- preserve route-specific promoted-read diagnostics when a route hangs
- add a static deploy-path guard for bounded promoted read probes

## Local proof
- ./scripts/test_hostinger_deploy_form_paths.sh
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_bml_canary_curl_timeouts.json
- git diff --check
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict