### PR TITLE
tend: the GPU lane's precision becomes data — half and bfloat rows on one MSL emit spine

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -96,8 +96,9 @@
 ;        (whisper-large d_model): interpreted walk 43.05 s; Form-emitted rustc native 2.1 ms; SAME
 ;        value at 1e-15 granularity; 20,077× from one naive single-threaded loop. Remaining for M5:
 ;        the kernel-resident wiring (buffer bridge intern_node SEQUENCE ↔ flat slice, install-as-
-;        named-callable-leaf, melt-when-cool, cost-aware trigger), format-parameterized emission
-;        (bf16/int8 per format-arith.fk semantics), canon matmul vectors, and the GPU/BLAS organ.]
+;        named-callable-leaf, melt-when-cool, cost-aware trigger), format-parameterized emission on
+;        the NATIVE CDYLIB lane (the MSL lane carries f16/bf16 as format rows below; int8 remains),
+;        canon matmul vectors, and the GPU/BLAS organ.]
 ;        ── JIT REALIZATION GAP (measured 2026-06-11, exercising the JIT) ──
 ;        The EMITTER is correct: jit_emit_c on fib lowers to native self-recursive C
 ;        (form_fib calls form_fib directly). But the IN-PROCESS jit_compile dispatch does NOT
@@ -109,17 +110,23 @@
 ;        20,077x) — that is where Form-native model SPEED lives today, not the in-process JIT. Two
 ;        routes forward: fix the in-process dispatch realization, OR wire the model through the
 ;        proven emit-compile-exec lane. Evidence: commit_evidence_2026-06-11_jit_realization_gap.json.]
-;        [GPU LANE RUNS (the metal.ts port, realized as recipe): jte-matvec-msl in jit-tensor-emit.fk
-;        emits the MSL matvec from the SAME emitter-as-recipe discipline — one thread per output row,
-;        inner loop j DOWN (tb-dot's right-fold), mul/add split through a named temporary so no
-;        compiler contraction can change the op order; fp32 is the lane MSL declares (no f64 in device
-;        code — the cross-precision discipline above, both sides held to declared precision).
-;        tests/metal-emit-band.fk → 7 three-way. LIVE WITNESS scripts/metal_matvec_audit.sh (M4 Max,
-;        mathMode=safe, 30 dispatches after warm): 1280×1280 parity 1280/1280 BIT-EXACT, gpu_kernel
-;        0.401 ms vs cpu same-fold-order fp32 1.263 ms; 4096×4096 parity 4096/4096 bit-exact,
-;        0.958 ms vs 12.664 ms (13.2×). Named open: kernel-resident Metal carrier (in-process
-;        dispatch beside rustc/dlopen), bf16/half per format-arith semantics, batching only when a
-;        model stone needs it. Evidence: commit_evidence_2026-06-11_metal_matvec_emitter.json.]
+;        [GPU LANE RUNS, PRECISION AS DATA (the metal.ts port, realized as recipe): jit-tensor-emit.fk
+;        carries ONE emit spine (jte-matvec-msl-spine) and format ROWS (jte-msl-elem/jte-msl-acc:
+;        f32→float, f16→half, bf16→bfloat storage, fp32 accumulator in every lane — M1's
+;        accumulate-wide-store-lane semantics, one RNE rounding at the store boundary, load exact,
+;        mul/add split through a named temporary so no compiler contraction can change the op order,
+;        inner loop j DOWN = tb-dot's right-fold). tests/metal-emit-band.fk → 31 three-way (each
+;        lane's emitted MSL byte-stable). LIVE WITNESS scripts/metal_matvec_audit.sh (M4 Max,
+;        mathMode=safe, 30 dispatches after warm; CPU reference computed in the lane's own conversion
+;        chain, parity gated bit-exact in the lane's storage format — bf16's store-RNE fires on
+;        essentially every row, so agreement proves the format's own tie rule, never a tolerance):
+;        1280² all three lanes parity BIT-EXACT, gpu_kernel f32 0.417 / f16 0.305 / bf16 0.328 ms;
+;        4096² all bit-exact, f32 0.895 vs cpu 13.553 (15.1×), f16 0.811 vs 12.540 (15.5×),
+;        bf16 0.823 vs 12.729 ms (15.5×). MSL bfloat is Metal 3.1+ — the runner gates at runtime
+;        and skips-with-name where absent (this host carries it). Named open: kernel-resident Metal
+;        carrier (in-process dispatch beside rustc/dlopen), batching only when a model stone needs
+;        it. Evidence: commit_evidence_2026-06-11_metal_matvec_emitter.json (fp32 first stone),
+;        commit_evidence_2026-06-11_metal_format_lanes.json (half/bfloat lanes).]
 ;   M6  whisper-tiny block 0 — carrier loads openai/whisper-tiny safetensors (or mlx-community/whisper-tiny,
 ;        already referenced in experiments/satsang-voice), encodes block-0 weights via M2, runs M4 over
 ;        them, matches the HF reference activation within epsilon. First real model in the body. (Even

--- a/docs/system_audit/commit_evidence_2026-06-11_metal_format_lanes.json
+++ b/docs/system_audit/commit_evidence_2026-06-11_metal_format_lanes.json
@@ -1,0 +1,125 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "form-os3/metal-formats",
+  "commit_scope": "The GPU emitter lane grows half and bfloat: jit-tensor-emit.fk now carries ONE emit spine (jte-matvec-msl-spine) with precision as DATA — format rows (jte-msl-elem: f32->float, f16->half, bf16->bfloat; jte-msl-acc: fp32 accumulator in every lane, M1 format-arith's accumulate-wide-store-lane semantics). Each lane's emitted MSL is proven byte-stable three-way (tests/metal-emit-band.fk -> 31), and the live GPU witness gates each lane's value parity BIT-EXACT IN THE LANE'S OWN STORAGE FORMAT against a CPU reference computed in the same conversion chain (load exact -> fp32 right-fold in the recipe's op order -> one round-to-nearest-even store into the lane format) — the gate is the format's own semantics, never a tolerance.",
+  "files_owned": [
+    "form/form-stdlib/jit-tensor-emit.fk",
+    "form/form-stdlib/tests/metal-emit-band.fk",
+    "scripts/metal_matvec_audit.sh",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/jit-tensor-emit.fk form-stdlib/tests/metal-emit-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/jit-tensor-emit.fk form-stdlib/tests/jit-tensor-emit-band.fk",
+      "scripts/metal_matvec_audit.sh",
+      "scripts/metal_matvec_audit.sh 4096 4096 30"
+    ],
+    "summary": "Band three-way: metal-emit-band -> 31, 0 divergent (f32/f16/bf16 emitted MSL each equals its canonical text; name parameterizes; emission deterministic). Sibling rust band unchanged -> 7. LIVE GPU WITNESS MEASURED (Apple M4 Max, arm64 Darwin 26.3.1, makeLibrary mathMode=safe, one warm then 30 timed dispatches, deterministic integer-derived inputs n/256 chosen exactly representable in each lane format so input quantization is the identity): 1280x1280 parity bit-exact in lane format all three lanes (f32 1280/1280 gpu_kernel 0.417 ms cpu 1.217; f16 1280/1280 0.305 ms cpu 1.133; bf16 1280/1280 0.328 ms cpu 1.068). 4096x4096 all bit-exact (f32 0.895 ms vs cpu 13.553 = 15.1x; f16 0.811 vs 12.540 = 15.5x; bf16 0.823 vs 12.729 = 15.5x). The bf16 store-RNE rounding fires on essentially every output row (accumulated fp32 values exceed 8 significand bits), so bit-exact agreement proves the GPU honors the format's round-half-to-even tie rule — format-arith's fq-rne — not that rounding was avoided. MSL bfloat is Metal 3.1+: the runner gates at runtime (exit 3, skip-with-name) where the toolchain lacks it; this host carries it, so all three lanes ran live.",
+    "observed_delta": {
+      "band_verdict": 31,
+      "band_divergent": 0,
+      "emitted_msl_bytes": { "f32": 438, "f16": 433, "bf16": 444 },
+      "witness_1280": {
+        "f32":  { "parity_bitexact_rows": "1280/1280", "max_abs_diff": 0.0, "gpu_kernel_ms_median": 0.417, "gpu_wall_ms_median": 0.560, "cpu_rightfold_ms": 1.217 },
+        "f16":  { "parity_bitexact_rows": "1280/1280", "max_abs_diff": 0.0, "gpu_kernel_ms_median": 0.305, "gpu_wall_ms_median": 0.436, "cpu_rightfold_ms": 1.133 },
+        "bf16": { "parity_bitexact_rows": "1280/1280", "max_abs_diff": 0.0, "gpu_kernel_ms_median": 0.328, "gpu_wall_ms_median": 0.498, "cpu_rightfold_ms": 1.068 }
+      },
+      "witness_4096": {
+        "f32":  { "parity_bitexact_rows": "4096/4096", "max_abs_diff": 0.0, "gpu_kernel_ms_median": 0.895, "gpu_wall_ms_median": 1.133, "cpu_rightfold_ms": 13.553 },
+        "f16":  { "parity_bitexact_rows": "4096/4096", "max_abs_diff": 0.0, "gpu_kernel_ms_median": 0.811, "gpu_wall_ms_median": 0.963, "cpu_rightfold_ms": 12.540 },
+        "bf16": { "parity_bitexact_rows": "4096/4096", "max_abs_diff": 0.0, "gpu_kernel_ms_median": 0.823, "gpu_wall_ms_median": 0.982, "cpu_rightfold_ms": 12.729 }
+      },
+      "conditions": "Apple M4 Max, macOS 26.3.1 arm64, MTLCompileOptions mathMode=safe (IEEE, no fast-math), 30 timed dispatches after one warm, single-thread CPU reference in the lane's own conversion chain compiled swiftc -O; inputs lane-exact by construction (f32/f16: |n|<=500 within 9 significand bits, bf16: |n|<=128 within 8); CPU bf16 carrier is the +0x7FFF+lsb round-half-to-even fold over fp32 bit patterns, CPU f16 carrier is Swift's native Float16 (arm64)"
+    },
+    "known_limitations": [
+      {
+        "limitation": "The accumulator row is fp32 in every current lane (accumulate-wide-store-lane). A lane that accumulates IN the storage format (format-arith's fq-dot shape, every partial re-quantized) is expressible as a new format row over the same spine but has no consumer yet.",
+        "follow_up": "Add the narrow-accumulate row only when a model stone declares those semantics; the spine already takes accty as data."
+      },
+      {
+        "limitation": "The witness carrier remains swiftc + Metal.framework through the driver-organ idiom; the kernel-resident Metal carrier (in-process dispatch beside rustc/dlopen) stays the named-open next stone.",
+        "follow_up": "Lift the runner's five moves into a kernel native when the model fast-path needs in-process GPU dispatch, parity-gated the same way."
+      },
+      {
+        "limitation": "One matvec per command buffer; the 16-bit lanes halve memory traffic (visibly faster kernels at 1280^2) but a real model batches many ops per buffer.",
+        "follow_up": "Batching/persistent-buffer shapes arrive only when a model stone needs them."
+      }
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "summary": "validate.sh runs metal-emit-band in the default suite via its preludes header; CI three-way gate applies."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "Stdlib recipe + band + host witness script; no route or service change. Rides normal merge."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "New capability: the body emits half- and bfloat-precision GPU compute kernels from the SAME Form emitter spine with precision as a data row, proves each lane's text three-way, and proves on real hardware that the GPU computes each format's exact semantics bit-for-bit (including bfloat's round-half-to-even store).",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "validate.sh band (three kernels agree on every lane's emitted text, verdict 31)",
+      "metal_matvec_audit.sh (Form emits per lane -> Metal runtime compiles -> dispatch -> bit-exact parity in the lane's storage format gates measured rows; bf16 runtime-gated on Metal 3.1+)"
+    ],
+    "summary": "All three precision lanes emitted, parity-gated, and measured live on Apple M4 Max; rows recorded with conditions named."
+  },
+  "phase_gate": {
+    "phase": "m5-gpu-lane",
+    "gate": "the GPU lane's precision becomes DATA: one emit spine, f16/bf16 as format rows, three-way byte-stable, live parity bit-exact per the format's own semantics",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "kernel-resident Metal carrier (in-process dispatch beside rustc/dlopen); batching only when a model stone needs it"
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "metal-format-lanes-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "form-os-arc"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "measurement"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/jit-tensor-emit.fk",
+    "form/form-stdlib/tests/metal-emit-band.fk",
+    "scripts/metal_matvec_audit.sh",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-11_metal_matvec_emitter.json"
+  ],
+  "change_files": [
+    "form/form-stdlib/jit-tensor-emit.fk",
+    "form/form-stdlib/tests/metal-emit-band.fk",
+    "scripts/metal_matvec_audit.sh",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-11_metal_format_lanes.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/jit-tensor-emit.fk
+++ b/form/form-stdlib/jit-tensor-emit.fk
@@ -20,20 +20,54 @@
   (str_concat fname
               " (w: *const f64, x: *const f64, y: *mut f64, rows: i64, cols: i64) { let r = rows as usize; let c = cols as usize; let mut i = 0usize; while i < r { let row = w.add(i * c); let mut acc = 0.0f64; let mut j = c; while j > 0 { j -= 1; acc = *row.add(j) * *x.add(j) + acc; } *y.add(i) = acc; i += 1; } }")))
 
-; jte-matvec-msl — the SAME emitter discipline pointed at the GPU: Metal Shading Language source
-; for the matvec, one thread per output row (rows are independent — parallelism without touching
-; the fold), inner loop accumulating j DOWN exactly like tb-dot and the rust emission above.
+; jte-matvec-msl-spine — the SAME emitter discipline pointed at the GPU: Metal Shading Language
+; source for the matvec, one thread per output row (rows are independent — parallelism without
+; touching the fold), inner loop accumulating j DOWN exactly like tb-dot and the rust emission
+; above. ONE spine; precision arrives as DATA (elemty = the lane's storage type, accty = the
+; accumulator type), so half and bfloat are rows, never copies of the emitter.
 ;
-; The fp32 lane is the honest one: MSL has no f64 in device code, so the precision this emission
-; declares is float — and the conformance gate holds BOTH sides to it (a CPU fp32 right-fold in the
-; same op order, per form-native-models' cross-precision discipline). The multiply and add are split
-; through a named temporary (p, then acc) so no conformant Metal compiler can contract them into an
-; fma — bit-for-bit means mul-then-add as two roundings, the recipe's own order, on any carrier.
-; MEASURED on this shape (M4 Max, mathMode safe, 1280x1280): 1280/1280 rows bit-exact vs the CPU
-; fp32 right-fold. No #include needed — kernel/device/constant/uint are language-level, so the
-; source stays one quote-free line, a plain Form string like its rust sibling.
+; The conversion chain the spine declares (per format-arith's cross-precision discipline — each
+; side held to its declared precision, the gate defined BY the format's own semantics):
+;   load    elemty -> accty   exact (every half/bfloat value is representable in fp32)
+;   mul/add in accty          two roundings, split through the named temporary p so no
+;                             conformant Metal compiler can contract them into an fma
+;   store   accty -> elemty   ONE rounding, round-to-nearest-even (MSL conversions and
+;                             format-arith's fq-rne agree on the tie rule)
+; For the fp32 lane the conversions are identities — the spine names the chain uniformly.
+; MEASURED on this shape (M4 Max, mathMode safe): every lane's output rows bit-exact vs a CPU
+; reference computed in the same chain (scripts/metal_matvec_audit.sh). No #include needed —
+; kernel/device/constant/uint/half/bfloat are language-level, so the source stays one quote-free
+; line, a plain Form string like its rust sibling.
 
-(defn jte-matvec-msl (fname)
+(defn jte-matvec-msl-spine (fname elemty accty)
   (str_concat "kernel void "
   (str_concat fname
-              "(device const float* w [[buffer(0)]], device const float* x [[buffer(1)]], device float* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const float* row = w + i * cols; float acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; float p = row[j] * x[j]; acc = p + acc; } y[i] = acc; }")))
+  (str_concat "(device const "
+  (str_concat elemty
+  (str_concat "* w [[buffer(0)]], device const "
+  (str_concat elemty
+  (str_concat "* x [[buffer(1)]], device "
+  (str_concat elemty
+  (str_concat "* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const "
+  (str_concat elemty
+  (str_concat "* row = w + i * cols; "
+  (str_concat accty
+  (str_concat " acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; "
+  (str_concat accty
+  (str_concat " p = "
+  (str_concat accty
+  (str_concat "(row[j]) * "
+  (str_concat accty
+  (str_concat "(x[j]); acc = p + acc; } y[i] = "
+  (str_concat elemty "(acc); }")))))))))))))))))))))
+
+; format rows — the lane's MSL storage type and accumulator type as data. The accumulator is
+; fp32 in every current lane (M1 format-arith's e.g.: accumulate wide, store in the lane format,
+; one rounding at the boundary); a future lane that accumulates differently is a new row here,
+; not a new emitter. "bf16" carries the Metal-version gate: MSL bfloat is Metal 3.1+ — the live
+; witness checks at runtime and skips-with-name where absent.
+(defn jte-msl-elem (fmt) (if (str_eq fmt "f16") "half" (if (str_eq fmt "bf16") "bfloat" "float")))
+(defn jte-msl-acc (fmt) "float")
+
+(defn jte-matvec-msl-fmt (fname fmt) (jte-matvec-msl-spine fname (jte-msl-elem fmt) (jte-msl-acc fmt)))
+(defn jte-matvec-msl (fname) (jte-matvec-msl-fmt fname "f32"))

--- a/form/form-stdlib/tests/metal-emit-band.fk
+++ b/form/form-stdlib/tests/metal-emit-band.fk
@@ -1,22 +1,30 @@
 ; preludes: form-stdlib/jit-tensor-emit.fk
 ;
-; metal-emit-band — the GPU matvec emitter as recipe, proven three-way: the emitted MSL
-; kernel source is byte-identical across kernels (str_eq against the canonical text), the
-; function name parameterizes cleanly, and the emission is deterministic. The text carries
-; tb-dot's exact right-fold (j counts DOWN) with the multiply and add split through a named
-; temporary so no Metal compiler contraction can change the recipe's op order — the same
-; conformance-by-construction the rust emission rides, declared at fp32 (MSL has no f64).
+; metal-emit-band — the GPU matvec emitter as recipe, proven three-way: ONE emit spine, the
+; precision lanes as format rows (f32/f16/bf16 — MSL float/half/bfloat storage, fp32 accumulator
+; in every lane per format-arith's accumulate-wide-store-lane semantics). Each lane's emitted MSL
+; kernel source is byte-identical across kernels (str_eq against the canonical text), the function
+; name parameterizes cleanly, and the emission is deterministic. Every lane carries tb-dot's exact
+; right-fold (j counts DOWN) with the multiply and add split through a named temporary so no Metal
+; compiler contraction can change the recipe's op order; load and store conversions through the
+; accumulator type are explicit in the text (identities on the f32 lane).
 ;
-; Verdict 7 when the emission lands:
-;   1   the full emitted MSL for form_matvec_f32 equals the canonical text
+; Verdict 31 when the emission lands:
+;   1   the full emitted f32 MSL for form_matvec_f32 equals the canonical text
 ;   2   a different name lands in the same frame (emission is a function, not a constant)
 ;   4   two emissions of the same name are str_eq (deterministic text — the crystallization
 ;       cache's ground: same emission, same cell)
+;   8   the half lane: form_matvec_f16 over "f16" equals the canonical half text
+;  16   the bfloat lane: form_matvec_bf16 over "bf16" equals the canonical bfloat text
 (do
-    (let want "kernel void form_matvec_f32(device const float* w [[buffer(0)]], device const float* x [[buffer(1)]], device float* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const float* row = w + i * cols; float acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; float p = row[j] * x[j]; acc = p + acc; } y[i] = acc; }")
+    (let want "kernel void form_matvec_f32(device const float* w [[buffer(0)]], device const float* x [[buffer(1)]], device float* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const float* row = w + i * cols; float acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; float p = float(row[j]) * float(x[j]); acc = p + acc; } y[i] = float(acc); }")
+    (let want-f16 "kernel void form_matvec_f16(device const half* w [[buffer(0)]], device const half* x [[buffer(1)]], device half* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const half* row = w + i * cols; float acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; float p = float(row[j]) * float(x[j]); acc = p + acc; } y[i] = half(acc); }")
+    (let want-bf16 "kernel void form_matvec_bf16(device const bfloat* w [[buffer(0)]], device const bfloat* x [[buffer(1)]], device bfloat* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const bfloat* row = w + i * cols; float acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; float p = float(row[j]) * float(x[j]); acc = p + acc; } y[i] = bfloat(acc); }")
     (let got (jte-matvec-msl "form_matvec_f32"))
     (let other (jte-matvec-msl "mv2"))
     (let c0 (if (str_eq got want) 1 0))
-    (let c1 (if (str_eq other (str_concat "kernel void " (str_concat "mv2" "(device const float* w [[buffer(0)]], device const float* x [[buffer(1)]], device float* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const float* row = w + i * cols; float acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; float p = row[j] * x[j]; acc = p + acc; } y[i] = acc; }"))) 2 0))
+    (let c1 (if (str_eq other (str_concat "kernel void " (str_concat "mv2" "(device const float* w [[buffer(0)]], device const float* x [[buffer(1)]], device float* y [[buffer(2)]], constant uint& rows [[buffer(3)]], constant uint& cols [[buffer(4)]], uint i [[thread_position_in_grid]]) { if (i >= rows) return; device const float* row = w + i * cols; float acc = 0.0f; uint j = cols; while (j > 0) { j -= 1; float p = float(row[j]) * float(x[j]); acc = p + acc; } y[i] = float(acc); }"))) 2 0))
     (let c2 (if (str_eq (jte-matvec-msl "form_matvec_f32") got) 4 0))
-    (add c0 (add c1 c2)))
+    (let c3 (if (str_eq (jte-matvec-msl-fmt "form_matvec_f16" "f16") want-f16) 8 0))
+    (let c4 (if (str_eq (jte-matvec-msl-fmt "form_matvec_bf16" "bf16") want-bf16) 16 0))
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/scripts/metal_matvec_audit.sh
+++ b/scripts/metal_matvec_audit.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
-# metal_matvec_audit.sh — GPU witness for the Form MSL matvec emitter (jte-matvec-msl in
-# form/form-stdlib/jit-tensor-emit.fk): the kernel's mouth prints the Form-emitted MSL, the
-# host Metal runtime compiles it (mathMode safe — IEEE, no fast-math), one thread per output
-# row dispatches over deterministic input cells, and VALUE PARITY against a CPU fp32
-# right-fold in the recipe's exact op order (j counts DOWN, mul-then-add as two roundings)
-# gates the timing rows — a row only counts when every output row is bit-exact.
+# metal_matvec_audit.sh — GPU witness for the Form MSL matvec emitter (jte-matvec-msl-spine +
+# format rows in form/form-stdlib/jit-tensor-emit.fk): the kernel's mouth prints the Form-emitted
+# MSL per precision lane (f32, f16, bf16), the host Metal runtime compiles it (mathMode safe —
+# IEEE, no fast-math), one thread per output row dispatches over deterministic input cells, and
+# VALUE PARITY against a CPU reference COMPUTED IN THE SAME FORMAT SEMANTICS gates the timing
+# rows — a row only counts when every output row is bit-exact in the lane's own storage format.
 #
-# Carriers: form-kernel-go (the mouth; the band proves the text byte-identical three-way),
-# swiftc + Metal.framework (the driver-organ idiom — allowed host carriers per
-# host-kernel.form host-resource-access); the emitter intelligence lives in the body.
-# fp32 is the lane MSL declares (no f64 in device code); both sides are held to it.
+# The conversion chain per lane (format-arith's cross-precision discipline — the gate is defined
+# BY the format's own semantics, never a tolerance):
+#   inputs   integer-derived n/256, chosen exactly representable in the lane format (f32/f16:
+#            |n|<=500 needs <=9 significand bits; bf16: |n|<=128 needs <=8) — input quantization
+#            is the identity, so the chain starts at the same bits on both sides
+#   load     lane -> fp32   exact (every half/bfloat value is representable in fp32)
+#   mul/add  fp32 right-fold, j DOWN, mul then add as two roundings (the recipe's op order)
+#   store    fp32 -> lane   one round-to-nearest-even (MSL conversions, Swift Float16, and the
+#            bf16 +0x7FFF+lsb fold all carry IEEE's tie rule — format-arith's fq-rne)
+#
+# Carriers: form-kernel-go (the mouth; the band proves each lane's text byte-identical three-way),
+# swiftc + Metal.framework (the driver-organ idiom — allowed host carriers per host-kernel.form
+# host-resource-access); the emitter intelligence lives in the body. MSL bfloat is Metal 3.1+ —
+# the runner checks at runtime and the bf16 lane skips-with-name where the toolchain lacks it.
 #
 # Run:  scripts/metal_matvec_audit.sh [rows cols iters]   (defaults 1280 1280 30)
 set -uo pipefail
@@ -31,61 +41,119 @@ fi
 work="$(mktemp -d "${TMPDIR:-/tmp}/fkmetal.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
 
-# ── 1. Form emits the MSL; the kernel is only the mouth ──────────────────
-cat "$FORMDIR/form-stdlib/jit-tensor-emit.fk" > "$work/driver.fk"
-cat >> "$work/driver.fk" <<'EOF'
-(print "==MSL==")
-(print (jte-matvec-msl "form_matvec_f32"))
-(print "==END==")
-EOF
-(cd "$FORMDIR" && "$GO_BIN" "$work/driver.fk" 2>/dev/null) > "$work/emit.out"
-sed -n '/^==MSL==$/,/^==END==$/p' "$work/emit.out" | sed -e '1d' -e '$d' > "$work/matvec.metal"
-if ! grep -q 'kernel void form_matvec_f32' "$work/matvec.metal"; then
-    echo "FAIL  emission did not produce the MSL kernel — see $work/emit.out"; exit 1
-fi
-echo "emitted MSL: $(wc -c < "$work/matvec.metal" | tr -d ' ') bytes, every byte authored by the Form recipe"
+# ── 1. Form emits the MSL per lane; the kernel is only the mouth ─────────
+emit_lane() {  # $1 = lane (f32|f16|bf16), $2 = function name
+    cat "$FORMDIR/form-stdlib/jit-tensor-emit.fk" > "$work/driver.fk"
+    printf '(print "==MSL==")\n(print (jte-matvec-msl-fmt "%s" "%s"))\n(print "==END==")\n' "$2" "$1" >> "$work/driver.fk"
+    (cd "$FORMDIR" && "$GO_BIN" "$work/driver.fk" 2>/dev/null) > "$work/emit.out"
+    sed -n '/^==MSL==$/,/^==END==$/p' "$work/emit.out" | sed -e '1d' -e '$d' > "$work/matvec_$1.metal"
+    if ! grep -q "kernel void $2" "$work/matvec_$1.metal"; then
+        echo "FAIL  $1 emission did not produce the MSL kernel — see $work/emit.out"; exit 1
+    fi
+    echo "emitted $1 MSL: $(wc -c < "$work/matvec_$1.metal" | tr -d ' ') bytes, every byte authored by the Form recipe"
+}
+emit_lane f32  form_matvec_f32
+emit_lane f16  form_matvec_f16
+emit_lane bf16 form_matvec_bf16
 
 # ── 2. The witness runner — dumb carrier: buffers, dispatch, compare, time ──
 cat > "$work/runner.swift" <<'EOF'
-// metal matvec witness — runtime-compile Form-emitted MSL, parity-gate, time. Carrier only.
+// metal matvec witness — runtime-compile Form-emitted MSL, parity-gate per lane format, time.
+// Carrier only: the CPU reference is the lane's own conversion chain (load exact -> fp32
+// right-fold in the recipe's op order -> one RNE store into the lane format).
 import Metal
 import Foundation
 
 let args = CommandLine.arguments
-let mslPath = args[1], fname = args[2]
-let rows = Int(args[3])!, cols = Int(args[4])!, iters = Int(args[5])!
+let mslPath = args[1], fname = args[2], lane = args[3]
+let rows = Int(args[4])!, cols = Int(args[5])!, iters = Int(args[6])!
 
 let src = try String(contentsOfFile: mslPath, encoding: .utf8)
 guard let dev = MTLCreateSystemDefaultDevice() else { print("SKIP no Metal device"); exit(2) }
 let opts = MTLCompileOptions()
 opts.mathMode = .safe   // IEEE-conformant: no fast-math reassociation/contraction
-let lib = try dev.makeLibrary(source: src, options: opts)
+var lib: MTLLibrary
+do { lib = try dev.makeLibrary(source: src, options: opts) }
+catch {
+    if lane == "bf16" {   // MSL bfloat is Metal 3.1+ — a missing type is a named gate, not a break
+        print("SKIPGATE bfloat lane — this Metal toolchain does not compile MSL bfloat (needs Metal 3.1+)")
+        exit(3)
+    }
+    print("FAIL MSL compile (\(lane)): \(error.localizedDescription)"); exit(1)
+}
 guard let fn = lib.makeFunction(name: fname) else { print("FAIL function \(fname) absent"); exit(1) }
 let pso = try dev.makeComputePipelineState(function: fn)
 
-// deterministic input cells — integer-derived over 256 (exactly representable)
-var w = [Float](repeating: 0, count: rows * cols)
-var x = [Float](repeating: 0, count: cols)
-for i in 0..<rows { for j in 0..<cols {
-    w[i*cols + j] = Float((i*31 + j*17) % 1000 - 500) / 256.0
-}}
-for j in 0..<cols { x[j] = Float((j*13) % 1000 - 500) / 256.0 }
-
-// CPU reference — the recipe's exact right-fold (j DOWN), fp32, mul then add (two roundings)
-var yref = [Float](repeating: 0, count: rows)
-let t0 = DispatchTime.now()
-for i in 0..<rows {
-    var acc: Float = 0.0
-    var j = cols
-    while j > 0 { j -= 1; let p = w[i*cols + j] * x[j]; acc = p + acc }
-    yref[i] = acc
+// bf16 carriers — format-arith's fq-rne tie rule on the fp32 -> bf16 boundary
+func f32ToBf16(_ f: Float) -> UInt16 {
+    let bits = f.bitPattern
+    let lsb = (bits >> 16) & 1
+    return UInt16(truncatingIfNeeded: (bits &+ 0x7FFF &+ lsb) >> 16)   // round half to even
 }
-let cpuMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e6
+func bf16ToF32(_ b: UInt16) -> Float { Float(bitPattern: UInt32(b) << 16) }  // exact widening
+
+// deterministic input cells — integer-derived over 256, exactly representable in the lane
+// format by construction (f32/f16: |n|<=500 fits 9 significand bits; bf16: |n|<=128 fits 8)
+func seedW(_ i: Int, _ j: Int) -> Int { lane == "bf16" ? (i*31 + j*17) % 256 - 128 : (i*31 + j*17) % 1000 - 500 }
+func seedX(_ j: Int) -> Int { lane == "bf16" ? (j*13) % 256 - 128 : (j*13) % 1000 - 500 }
+func val(_ n: Int) -> Float { Float(n) / 256.0 }
+
+// per-lane storage + the CPU reference in the lane's exact conversion chain
+var bw: MTLBuffer!, bx: MTLBuffer!, by: MTLBuffer!
+var refBits = [UInt32](repeating: 0, count: rows)   // lane-format bit patterns, widened
+var refVals = [Float](repeating: 0, count: rows)    // decoded for max_abs_diff sensing
+var cpuMs = 0.0
+
+switch lane {
+case "f32":
+    var w = [Float](repeating: 0, count: rows*cols); var x = [Float](repeating: 0, count: cols)
+    for i in 0..<rows { for j in 0..<cols { w[i*cols+j] = val(seedW(i, j)) } }
+    for j in 0..<cols { x[j] = val(seedX(j)) }
+    let t0 = DispatchTime.now()
+    for i in 0..<rows {
+        var acc: Float = 0.0; var j = cols
+        while j > 0 { j -= 1; let p = w[i*cols+j] * x[j]; acc = p + acc }
+        refBits[i] = acc.bitPattern; refVals[i] = acc
+    }
+    cpuMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e6
+    bw = dev.makeBuffer(bytes: w, length: w.count*4)!
+    bx = dev.makeBuffer(bytes: x, length: x.count*4)!
+    by = dev.makeBuffer(length: rows*4)!
+case "f16":
+    var w = [Float16](repeating: 0, count: rows*cols); var x = [Float16](repeating: 0, count: cols)
+    for i in 0..<rows { for j in 0..<cols { w[i*cols+j] = Float16(val(seedW(i, j))) } }  // exact
+    for j in 0..<cols { x[j] = Float16(val(seedX(j))) }                                  // exact
+    let t0 = DispatchTime.now()
+    for i in 0..<rows {
+        var acc: Float = 0.0; var j = cols
+        while j > 0 { j -= 1; let p = Float(w[i*cols+j]) * Float(x[j]); acc = p + acc }  // load exact
+        let y16 = Float16(acc)                                                           // one RNE store
+        refBits[i] = UInt32(y16.bitPattern); refVals[i] = Float(y16)
+    }
+    cpuMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e6
+    bw = dev.makeBuffer(bytes: w, length: w.count*2)!
+    bx = dev.makeBuffer(bytes: x, length: x.count*2)!
+    by = dev.makeBuffer(length: rows*2)!
+case "bf16":
+    var w = [UInt16](repeating: 0, count: rows*cols); var x = [UInt16](repeating: 0, count: cols)
+    for i in 0..<rows { for j in 0..<cols { w[i*cols+j] = f32ToBf16(val(seedW(i, j))) } }  // exact
+    for j in 0..<cols { x[j] = f32ToBf16(val(seedX(j))) }                                  // exact
+    let t0 = DispatchTime.now()
+    for i in 0..<rows {
+        var acc: Float = 0.0; var j = cols
+        while j > 0 { j -= 1; let p = bf16ToF32(w[i*cols+j]) * bf16ToF32(x[j]); acc = p + acc }
+        let yb = f32ToBf16(acc)                                                            // one RNE store
+        refBits[i] = UInt32(yb); refVals[i] = bf16ToF32(yb)
+    }
+    cpuMs = Double(DispatchTime.now().uptimeNanoseconds - t0.uptimeNanoseconds) / 1e6
+    bw = dev.makeBuffer(bytes: w, length: w.count*2)!
+    bx = dev.makeBuffer(bytes: x, length: x.count*2)!
+    by = dev.makeBuffer(length: rows*2)!
+default:
+    print("FAIL unknown lane \(lane)"); exit(1)
+}
 
 let q = dev.makeCommandQueue()!
-let bw = dev.makeBuffer(bytes: w, length: w.count*4)!
-let bx = dev.makeBuffer(bytes: x, length: x.count*4)!
-let by = dev.makeBuffer(length: rows*4)!
 var ur = UInt32(rows), uc = UInt32(cols)
 
 func dispatchOnce() -> (wall: Double, gpu: Double) {
@@ -108,18 +176,28 @@ func dispatchOnce() -> (wall: Double, gpu: Double) {
 }
 
 _ = dispatchOnce() // warm: pipeline + first-touch
-let ygpu = by.contents().bindMemory(to: Float.self, capacity: rows)
 var exact = 0; var maxAbs: Float = 0
-for i in 0..<rows {
-    if ygpu[i].bitPattern == yref[i].bitPattern { exact += 1 }
-    maxAbs = max(maxAbs, abs(ygpu[i] - yref[i]))
+switch lane {
+case "f32":
+    let yg = by.contents().bindMemory(to: Float.self, capacity: rows)
+    for i in 0..<rows {
+        if yg[i].bitPattern == refBits[i] { exact += 1 }
+        maxAbs = max(maxAbs, abs(yg[i] - refVals[i]))
+    }
+default:
+    let yg = by.contents().bindMemory(to: UInt16.self, capacity: rows)
+    for i in 0..<rows {
+        if UInt32(yg[i]) == refBits[i] { exact += 1 }
+        let g = lane == "f16" ? Float(Float16(bitPattern: yg[i])) : bf16ToF32(yg[i])
+        maxAbs = max(maxAbs, abs(g - refVals[i]))
+    }
 }
 var walls: [Double] = []; var gpus: [Double] = []
 for _ in 0..<iters { let r = dispatchOnce(); walls.append(r.wall); gpus.append(r.gpu) }
 walls.sort(); gpus.sort()
-print("parity_bitexact_rows=\(exact)/\(rows) max_abs_diff=\(maxAbs)")
+print("lane=\(lane) parity_bitexact_rows=\(exact)/\(rows) max_abs_diff=\(maxAbs)")
 print("gpu_wall_ms_median=\(String(format: "%.3f", walls[walls.count/2])) gpu_kernel_ms_median=\(String(format: "%.3f", gpus[gpus.count/2])) iters=\(iters)")
-print("cpu_fp32_rightfold_ms=\(String(format: "%.3f", cpuMs))")
+print("cpu_\(lane)_rightfold_ms=\(String(format: "%.3f", cpuMs))")
 print("device=\(dev.name)")
 if exact != rows { exit(1) }
 EOF
@@ -127,13 +205,24 @@ EOF
 swiftc -O -o "$work/runner" "$work/runner.swift" 2>"$work/swiftc.err" || {
     echo "FAIL  swiftc could not build the witness runner:"; cat "$work/swiftc.err"; exit 1; }
 
-# ── 3. Parity gates the rows ─────────────────────────────────────────────
-echo "witness (${ROWS}x${COLS} fp32 matvec, ${ITERS} timed dispatches after one warm):"
-if ! "$work/runner" "$work/matvec.metal" form_matvec_f32 "$ROWS" "$COLS" "$ITERS" | sed 's/^/  /'; then
-    echo "FAIL  value parity broken — timing rows do not count"; exit 1
-fi
+# ── 3. Parity gates the rows, per lane ───────────────────────────────────
+overall=0
+for lane in f32 f16 bf16; do
+    fname="form_matvec_${lane}"
+    echo
+    echo "witness $lane (${ROWS}x${COLS} matvec, ${ITERS} timed dispatches after one warm):"
+    "$work/runner" "$work/matvec_$lane.metal" "$fname" "$lane" "$ROWS" "$COLS" "$ITERS" | sed 's/^/  /'
+    rc=${PIPESTATUS[0]}
+    if [[ "$rc" == "3" ]]; then
+        echo "  named gate: bf16 lane unavailable on this Metal toolchain — row skipped with its name"
+    elif [[ "$rc" != "0" ]]; then
+        echo "FAIL  $lane value parity broken — timing rows do not count"; overall=1
+    fi
+done
 echo
 echo "conditions: $(uname -m) $(uname -s) $(sw_vers -productVersion 2>/dev/null), Metal runtime compile" \
      "(makeLibrary, mathMode=safe), gpu_wall includes commit+wait, gpu_kernel is the GPU execution" \
-     "window (gpuStartTime..gpuEndTime), cpu row is one thread in the recipe's own fold order"
-echo "ok — parity held and the rows are real; the emitter recipe is form-stdlib/jit-tensor-emit.fk (jte-matvec-msl)"
+     "window (gpuStartTime..gpuEndTime), cpu row is one thread in the lane's own conversion chain" \
+     "(load exact -> fp32 right-fold in the recipe's op order -> one RNE store into the lane format)"
+if [[ "$overall" != "0" ]]; then exit 1; fi
+echo "ok — parity held per lane format and the rows are real; the emitter recipe is form-stdlib/jit-tensor-emit.fk (jte-matvec-msl-spine + format rows)"


### PR DESCRIPTION
## The stone

Round 3 of the Form-OS walk, the bf16/half lanes: the MSL matvec emitter (`jte-matvec-msl`, PR #2842) is now ONE emit spine with **precision as data** — never a copy of the emitter per format.

## What changed

- **`form/form-stdlib/jit-tensor-emit.fk`** — `jte-matvec-msl-spine` (one emitter, `elemty`/`accty` as parameters) + format rows `jte-msl-elem` (f32→`float`, f16→`half`, bf16→`bfloat`) and `jte-msl-acc` (fp32 accumulator in every lane — M1 format-arith's accumulate-wide-store-lane semantics: load exact, mul/add as two fp32 roundings through the named temporary, ONE round-to-nearest-even store into the lane format). `jte-matvec-msl` remains the f32 door over the spine.
- **`form/form-stdlib/tests/metal-emit-band.fk`** — verdict **7 → 31**: each lane's emitted MSL byte-stable three-way, name parameterizes, emission deterministic.
- **`scripts/metal_matvec_audit.sh`** — per-lane live witness: the CPU reference is computed **in the lane's own conversion chain**, parity gated bit-exact in the lane's storage format. Inputs are integer-derived `n/256` chosen exactly representable in each lane format (input quantization is the identity). MSL `bfloat` is Metal 3.1+ — runtime-gated, skip-with-name where absent.
- **`docs/coherence-substrate/form-native-models.form`** — M5 GPU-lane block: f16/bf16 move from named to RUNS; named-open shrinks to the kernel-resident Metal carrier + batching.
- **`docs/system_audit/commit_evidence_2026-06-11_metal_format_lanes.json`** — validated evidence.

## Proof

Band: `metal-emit-band -> 31`, 0 divergent (rust sibling band unchanged → 7).

Live witness (Apple M4 Max, macOS 26.3.1 arm64, `mathMode=safe`, 30 timed dispatches after one warm):

| dim | lane | parity (lane-format bits) | gpu_kernel ms | cpu same-chain ms |
|---|---|---|---|---|
| 1280² | f32 | 1280/1280 bit-exact | 0.417 | 1.217 |
| 1280² | f16 | 1280/1280 bit-exact | 0.305 | 1.133 |
| 1280² | bf16 | 1280/1280 bit-exact | 0.328 | 1.068 |
| 4096² | f32 | 4096/4096 bit-exact | 0.895 | 13.553 (15.1×) |
| 4096² | f16 | 4096/4096 bit-exact | 0.811 | 12.540 (15.5×) |
| 4096² | bf16 | 4096/4096 bit-exact | 0.823 | 12.729 (15.5×) |

The bf16 store-RNE fires on essentially every output row (accumulated fp32 values exceed 8 significand bits), so bit-exact agreement proves the GPU honors the format's round-half-to-even tie rule — format-arith's `fq-rne` — never a tolerance.

## Coordinator note

`linux-as-recipes.form` line ~69 records `metal-emit-band -> 7`; with this PR the verdict is 31 (coordinator-owned doc, left for the gpu-row retune).

🤖 Generated with [Claude Code](https://claude.com/claude-code)