### PR TITLE
tend: the second carrier — a rustc cdylib installs as a named callable in the Rust kernel's own table at runtime

### DIFF
--- a/docs/coherence-substrate/install-leaf.form
+++ b/docs/coherence-substrate/install-leaf.form
@@ -25,8 +25,9 @@
     (derived-from core-axioms.form)                   # axioms 3, 4, 5 do all the work
     (protocol    form-stdlib/install-leaf.fk)         # the shape, pure recipe tissue
     (proven-by   form-stdlib/tests/install-leaf-band.fk)  # -> 9, three-way (Go/Rust/TS)
-    (carrier     form-kernel-go jit_install)          # the native lane that RUNS today
-    (witnessed-by form/scripts/jit-install-leaf-test.sh)) # -> 10, live .so install
+    (carrier     form-kernel-go jit_install           # plugin.Open lane, RUNS today
+                 form-kernel-rust jit_install)        # libloading lane, RUNS today
+    (witnessed-by form/scripts/jit-install-leaf-test.sh)) # -> 10 + 10, live .so installs on both
 
   # ── The composition — three axioms, no new machinery ─────────────────
   (composition
@@ -63,7 +64,7 @@
     (call-installed        name -> the-realized-value-or-honest-absence)
     (names-are-query-keys  one-artifact-may-bind-under-many-names — the leaves carry ONE identity))
 
-  # ── The native carrier (Go kernel, RUNS today) ────────────────────────
+  # ── The first native carrier (Go kernel, RUNS today) ──────────────────
   # jit_install closure-name installed-name expected-arity:
   #   1. resolve the closure in the caller's env (no closure -> nothing)
   #   2. refuse a name already callable (natives/env-natives, incl. leaves
@@ -81,21 +82,40 @@
   #   5. ack the body NodeID — the capability handle a caller can hold
   #      but not forge (axiom-3)
   (carrier-go
-    (native        jit_install)                       # env-aware; registry lane 0 (sibling-gap)
+    (native        jit_install)                       # env-aware; registry lane 0 (sibling-gap: ts)
     (introspection installed_leaf?)                   # 1 only for leaves the surface grew at runtime
     (observe       observe/go/jit/install install-refused installed-dispatch installed-guard-miss)
     (witness       form/scripts/jit-install-leaf-test.sh -> 10))
 
-  # ── Open carriers — named, not built speculatively ────────────────────
+  # ── The second native carrier (Rust kernel, RUNS today) ───────────────
+  # Same offer/refusal semantics, only the dlopen mechanics per-host:
+  #   3. ensure the artifact: the main.rs jit lane (recipe -> Rust source
+  #      -> rustc --crate-type=cdylib -> libloading), content-addressed
+  #      plugin cache reused — same body NodeID, same .so
+  #   4. bind the leaf in the kernel's installed-leaves table — Rust's
+  #      NativeFn is a captureless fn pointer, so the grown surface IS a
+  #      kernel-held table consulted at FNCALL dispatch by name: the
+  #      table the protocol names is literally the carrier's data
+  #      structure. The leaf answers the i64 ABI lane it carries; a call
+  #      outside it (floats, wrong arity) acknowledges nothing.
+  # Steps 1, 2, 5 are identical to the Go carrier — the protocol is the
+  # protocol.
+  (carrier-rust
+    (native        jit_install)                       # env-aware; registry lane 0 (sibling-gap: ts)
+    (introspection installed_leaf? jit-stats)         # jit-stats reports "installed" rows: body NodeID + installed name
+    (mechanics     rustc-cdylib libloading installed-leaves-table-at-fncall-dispatch)
+    (witness       form/scripts/jit-install-leaf-test.sh -> 10))
+
+  # ── Open carrier — named, not built speculatively ─────────────────────
   # The PROTOCOL is proven on all three kernels by the band; the native
-  # carrier runs on Go (the kernel that already dlopens). Rust and TS
-  # native lanes are open stones on the same path: Rust would carry
-  # libloading/dlopen over an emitted cdylib; TS would carry a worker or
-  # WASM module. Each lands as the same offer -> bind -> call-by-name
-  # shape; nothing about the protocol changes.
+  # carrier runs on Go (plugin.Open) and Rust (libloading over an emitted
+  # cdylib) — parity by construction, the protocol identical, only the
+  # dlopen mechanics per-host. The TS native lane is the open stone on
+  # the same path: a worker or WASM module. It lands as the same
+  # offer -> bind -> call-by-name shape; nothing about the protocol
+  # changes.
   (open-carriers
-    (rust dlopen-over-emitted-cdylib)
-    (ts   wasm-or-worker-module))
+    (ts wasm-or-worker-module))
 
   (invariant
     (grows-by-offer-never-by-recompile  the-binary-is-untouched; the-table-is-the-surface)
@@ -112,6 +132,7 @@
 #   cd form && ./validate.sh form-stdlib/core.fk form-stdlib/channel.fk \
 #     form-stdlib/install-leaf.fk form-stdlib/tests/install-leaf-band.fk   # -> 9
 #
-#   # the native carrier, live (jit a function, install it under a new
-#   # name, call it BY NAME, parity vs the recipe walk, refusals honest):
-#   ./form/scripts/jit-install-leaf-test.sh                               # -> 10
+#   # the native carriers, live (jit a function, install it under a new
+#   # name, call it BY NAME, parity vs the recipe walk, refusals honest;
+#   # one section per carrier, each toolchain-gated):
+#   ./form/scripts/jit-install-leaf-test.sh         # go -> 10, rust -> 10

--- a/docs/coherence-substrate/primitive-registry.form
+++ b/docs/coherence-substrate/primitive-registry.form
@@ -77,11 +77,11 @@
                      str_line_at str_ascii_prefix
                      framebuffer-observe-start framebuffer-observe-stop
                      framebuffer-observe-active?
-                     jit_install installed_leaf?   # install-leaf.form carrier
                      # rust-gap:
                      framebuffer-counts framebuffer-event-rows
                      # ts-gap:
-                     value_str value_kind value-kind str_to_float jit_compiled?))
+                     value_str value_kind value-kind str_to_float jit_compiled?
+                     jit_install installed_leaf?))  # install-leaf.form carriers: go + rust live
 
   # ── how this feeds the fourth kernel ────────────────────────────────
   # M2 (native BMF compiler) and M4 (the emitted walker) prove themselves

--- a/docs/system_audit/commit_evidence_2026-06-11_install_leaf_rust_carrier.json
+++ b/docs/system_audit/commit_evidence_2026-06-11_install_leaf_rust_carrier.json
@@ -1,0 +1,113 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "form-os3/install-rust",
+  "commit_scope": "The SECOND native carrier of install-as-named-callable-leaf lands on the Rust kernel: jit_install compiles the named closure through the existing main.rs jit lane (recipe -> Rust source -> rustc --crate-type=cdylib -> libloading, content-addressed plugin cache reused) and binds the artifact in the kernel's own installed-leaves table AT RUNTIME — a subsequent call BY NAME, a name no closure serves, dispatches into the loaded .so at FNCALL. The protocol (form-stdlib/install-leaf.fk, proven three-way) is untouched: the ack is the artifact's body NodeID on bind, 0 on collision (first-bind-wins against natives, env-natives, and earlier leaves) or interface mismatch (expected arity is not the closure's own), nothing when there is no closure to install. Rust's NativeFn is a captureless fn pointer, so the grown surface IS a kernel-held table consulted at dispatch — the table the protocol names is literally the carrier's data structure. The leaf answers the i64 ABI lane it carries; a call outside it (floats, wrong arity) acknowledges nothing — axiom-4's observable boundary. installed_leaf? distinguishes runtime-grown leaves from build-time natives; jit-stats reports 'installed' rows (body NodeID + installed name) so the grown table is readable from Form. Parity by construction with the Go carrier: the protocol identical, only the dlopen mechanics per-host. The TS native carrier stays named open (wasm/worker), not built speculatively.",
+  "files_owned": [
+    "form/form-kernel-rust/src/main.rs",
+    "form/scripts/jit-install-leaf-test.sh",
+    "form/form-stdlib/install-leaf.fk",
+    "form/form-stdlib/primitive-registry.fk",
+    "docs/coherence-substrate/install-leaf.form",
+    "docs/coherence-substrate/primitive-registry.form",
+    "docs/system_audit/commit_evidence_2026-06-11_install_leaf_rust_carrier.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/channel.fk form-stdlib/install-leaf.fk form-stdlib/tests/install-leaf-band.fk",
+      "cd form && ./validate.sh form-stdlib/primitive-registry.fk form-stdlib/tests/primitive-registry-band.fk",
+      "./form/scripts/jit-install-leaf-test.sh",
+      "cd form/form-kernel-rust && cargo test --release",
+      "python3 form/scripts/validate_primitive_registry.py",
+      "python3 scripts/generate_repo_indexes.py",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-11_install_leaf_rust_carrier.json"
+    ],
+    "summary": "install-leaf-band verdict 9, 0 divergent (the protocol band stays green — no protocol change). Witness now runs one section per carrier: go verdict 10 PASS (int + float lanes), rust verdict 10 PASS — jit_install compiled (defn il-probe (a b) (add (mul a b) 7)) through rustc to a cdylib, libloading mapped it, and the artifact bound as 'il-probe-native' in the kernel's installed-leaves table at runtime; (il-probe-native 6 7) = 49 = the recipe walk; a float call acknowledges nothing (outside the i64 ABI the leaf carries); rebind refused, build-time-native collision refused, arity-3 offer refused with nothing landing, absent closure acked nothing, a 3-arg call to the 2-arity leaf acked nothing. primitive-registry-band 63, 0 divergent — no lane flips (ts still gapped), spec lines retuned to name the two live carriers. cargo test --release: 51 passed, 0 failed. validate_primitive_registry.py: no failures, pins steady at 199/162/37.",
+    "observed_delta": {
+      "bands": "install-leaf-band 9 — 0 divergent (unchanged); primitive-registry-band 63 — 0 divergent (no pin changes, spec text only)",
+      "witness": "form/scripts/jit-install-leaf-test.sh -> go verdict 10 PASS + rust verdict 10 PASS (live cdylib install via libloading, call-by-name, i64 parity, interface-boundary silence, three refusal shapes)",
+      "kernel_surface": "form-kernel-rust gains jit_install (env-aware, witness category) and installed_leaf? (compare); Kernel.installed_leaves holds runtime-grown leaves (Arc-shared artifacts, worker-clone safe); FNCALL dispatch answers installed names after build-time natives, before closure lookup; jit-stats gains 'installed' rows",
+      "ledger_row": "linux-as-recipes (loadable-modules) install-as-named-callable-leaf — two native carriers live (go plugin.Open, rust libloading); ts named open; row retune stays with the coordinator"
+    },
+    "known_limitations": [
+      {
+        "limitation": "The Rust leaf answers the i64 ABI lane only — the interface the rustc-cdylib lane carries today. Go's leaf additionally answers float and Value ABI lanes. A call outside the Rust leaf's lane acknowledges nothing (honest, observable), so sibling value-parity holds where the lane exists and refusal-parity holds where it does not.",
+        "follow_up": "Widen the Rust JIT ABI (f64 / tagged-value lanes) when a hot recipe asks for it; the install protocol does not change."
+      },
+      {
+        "limitation": "The TS native carrier stays a named open stone (wasm/worker module) — a different loading shape, not built speculatively.",
+        "follow_up": "Build it when an ask needs it; the offer -> bind -> call-by-name shape is fixed by the band."
+      },
+      {
+        "limitation": "Rust has no per-event observe ledger like Go's observe/go/jit/install family; the grown table is introspectable via installed_leaf? and jit-stats 'installed' rows instead.",
+        "follow_up": "If sibling observe parity becomes a proof target, lift the observe shape into a shared Form teaching first."
+      }
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "summary": "PR gates run the three-way bands; sibling kernels keep the verdict honest."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "form-kernel-rust rides the kernel rebuild; no route changes."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "No route changes. The Rust kernel's callable surface can grow at runtime by offer — same protocol, same refusals, same node ack as the Go carrier; parity by construction.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "jit-install-leaf-test.sh rust section: jit (rustc cdylib + libloading) -> install -> call-by-name -> i64 parity vs the recipe walk -> float-call boundary silence -> rebind/native-collision/arity refusals -> absent-cell nothing -> wrong-arity silence.",
+      "install-leaf-band three-way regression: the protocol band stays 9 with 0 divergent."
+    ],
+    "summary": "validate.sh 9 + 63, all 0 divergent; witness go 10 + rust 10 PASS; cargo test 51/51."
+  },
+  "phase_gate": {
+    "phase": "form-os3-install-rust",
+    "gate": "the second native carrier witnessed live on the Rust kernel with the protocol band still green three-way; ledger retune stays with the coordinator",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "coordinator retunes the loadable-modules row (two carriers live, ts named); ts carrier when asked; ABI widening when a hot recipe asks"
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "form-core-kernel-conformance"
+  ],
+  "task_ids": [
+    "form-os3-install-rust-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "form-os-map"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "evidence_refs": [
+    "docs/coherence-substrate/install-leaf.form",
+    "docs/coherence-substrate/linux-as-recipes.form",
+    "docs/coherence-substrate/core-axioms.form",
+    "docs/system_audit/commit_evidence_2026-06-11_install_leaf.json"
+  ],
+  "change_intent": "runtime_feature",
+  "change_files": [
+    "docs/coherence-substrate/install-leaf.form",
+    "docs/coherence-substrate/primitive-registry.form",
+    "docs/system_audit/commit_evidence_2026-06-11_install_leaf_rust_carrier.json",
+    "form/form-kernel-rust/src/main.rs",
+    "form/form-stdlib/install-leaf.fk",
+    "form/form-stdlib/primitive-registry.fk",
+    "form/scripts/jit-install-leaf-test.sh"
+  ]
+}

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -1162,6 +1162,14 @@ pub(crate) struct Kernel {
     // counter — the only cost is the warm-up.
     jit_hits: HashMap<NodeID, u32>,
     jit_failed: HashSet<NodeID>,
+    // installed_leaves — installed-name → leaf for callables bound into the
+    // kernel's own table AT RUNTIME by jit_install (the
+    // install-as-named-callable-leaf protocol: form-stdlib/install-leaf.fk,
+    // proven three-way by tests/install-leaf-band.fk). NativeFn is a plain
+    // fn pointer (no captures), so the leaf's loaded artifact lives here and
+    // FNCALL dispatch consults this table by name — the table IS the grown
+    // surface. First-bind-wins: jit_install refuses a name already callable.
+    installed_leaves: HashMap<NameID, InstalledLeaf>,
     // Content-addressed maps — the kernel's O(1) dispatch tables, keyed by the
     // NodeID (content-address) of the key. A switch (status→phrase, name→handler,
     // shape→route) becomes a direct NodeID lookup instead of a scan: two
@@ -1545,6 +1553,7 @@ impl Kernel {
             jit_compiled: HashMap::new(),
             jit_hits: HashMap::new(),
             jit_failed: HashSet::new(),
+            installed_leaves: HashMap::new(),
             maps: HashMap::new(),
             next_map: 0,
             switch_tables: HashMap::new(),
@@ -1954,6 +1963,9 @@ impl Kernel {
             // its own hot paths).
             jit_hits: HashMap::new(),
             jit_failed: self.jit_failed.clone(),
+            // Arc clones — installed leaves stay callable in workers; the
+            // table is shared surface, not per-worker state.
+            installed_leaves: self.installed_leaves.clone(),
             // Dispatch tables are content (built at load); each worker carries
             // its own copy so routing needs no lock.
             maps: self.maps.clone(),
@@ -2140,6 +2152,21 @@ impl Drop for JitCompiled {
         // though the on-disk file is gone. Best-effort: ignore errors.
         let _ = fs::remove_dir_all(&self._temp_dir);
     }
+}
+
+// InstalledLeaf — one binding the callable surface grew at runtime via
+// jit_install (install-as-named-callable-leaf; protocol:
+// form-stdlib/install-leaf.fk, proven three-way by
+// tests/install-leaf-band.fk). Carries the loaded artifact (Arc-shared
+// with jit_compiled — same content-addressed body, same .so; the
+// interface it answers is jc.arity over the i64 ABI) and the body NodeID
+// whose content-address is the ack a caller holds but cannot forge
+// (axiom-3). The table never rebinds — first-bind-wins is enforced at
+// jit_install, so a leaf, once bound, is the name's only answer.
+#[derive(Clone, Debug)]
+struct InstalledLeaf {
+    jc: Arc<JitCompiled>,
+    body: NodeID,
 }
 
 // Maximum arity the JIT supports — bounded so dispatch can be a static
@@ -4406,6 +4433,83 @@ impl Kernel {
             k.jit_compiled.insert(cl.body, Arc::new(jc));
             Value::Int(1)
         });
+        // jit_install closure-name-str installed-name-str expected-arity →
+        //   the install-as-named-callable-leaf protocol
+        //   (form-stdlib/install-leaf.fk, proven three-way by
+        //   tests/install-leaf-band.fk) carried onto the Rust JIT lane:
+        //   rustc --crate-type=cdylib → libloading, the artifact bound under
+        //   a NEW name in the kernel's own table at runtime — the surface
+        //   grows by offer, never by recompile. The ack follows axiom-5:
+        //     node — the artifact's body NodeID (content-addressed,
+        //            unforgeable) on bind
+        //     0    — refusal: name collision (first-bind-wins), interface
+        //            mismatch (expected arity is not the closure's own), or
+        //            no artifact (the recipe is outside the JIT subset /
+        //            rustc absent) — the table is untouched either way
+        //     nothing — there is no closure to install (honest absence)
+        self.register_env_native("jit_install", cat_witness(), |k, a, env, args| {
+            if args.len() != 3 {
+                return Value::Null;
+            }
+            let closure_name = args[0].as_str().to_string();
+            let installed_name = args[1].as_str().to_string();
+            let expected_arity = args[2].as_int();
+            let closure_id = k.intern_string(&closure_name).inst;
+            let cl = match a.lookup(env, closure_id) {
+                Some(Value::Closure(c)) => c,
+                // nothing — there is no cell to install
+                _ => return Value::Null,
+            };
+            let installed_id = k.intern_string(&installed_name).inst;
+            if k.natives.contains_key(&installed_id)
+                || k.env_natives.contains_key(&installed_id)
+                || k.installed_leaves.contains_key(&installed_id)
+            {
+                // name collision — first-bind-wins, the table never rebinds
+                return Value::Int(0);
+            }
+            if expected_arity != cl.params.len() as i64 {
+                // interface mismatch — the artifact cannot be bound through
+                // an interface it does not carry
+                return Value::Int(0);
+            }
+            // Ensure the artifact: reuse the content-addressed plugin cache
+            // (same body NodeID, same .so) or compile through the jit lane.
+            let jc = match k.jit_compiled.get(&cl.body).cloned() {
+                Some(j) => j,
+                None => {
+                    let compiled = emit_rust_source(k, cl.name, &cl.params, cl.body)
+                        .and_then(|src| compile_rust_cdylib(&src, cl.params.len()));
+                    match compiled {
+                        Some(j) => {
+                            let arc = Arc::new(j);
+                            k.jit_compiled.insert(cl.body, arc.clone());
+                            arc
+                        }
+                        None => {
+                            // no artifact — the recipe still walks under its
+                            // own name; nothing installs
+                            k.jit_failed.insert(cl.body);
+                            return Value::Int(0);
+                        }
+                    }
+                }
+            };
+            k.installed_leaves
+                .insert(installed_id, InstalledLeaf { jc, body: cl.body });
+            // the node ack: the artifact's content-addressed identity
+            Value::Nid(cl.body)
+        });
+        // installed_leaf? name-str → 1 if the name is a callable the surface
+        // grew at runtime via jit_install, else 0 (build-time natives answer 0).
+        self.register_native("installed_leaf?", cat_compare(RCMP_EQ), |k, _, args| {
+            let id = k.intern_string(args[0].as_str()).inst;
+            if k.installed_leaves.contains_key(&id) {
+                Value::Int(1)
+            } else {
+                Value::Int(0)
+            }
+        });
         // jit_aliased? form-name-str → 1 if a JIT alias is currently bound
         // for this name, else 0. Lets Form code introspect dispatch routing.
         self.register_native("jit_aliased?", cat_compare(RCMP_EQ), |k, _, args| {
@@ -4460,6 +4564,22 @@ impl Kernel {
                     format!("{}.{}.{}.{}", body.pkg, body.level, body.ty, body.inst),
                     1,
                     String::new(),
+                ));
+            }
+            // Installed leaves — callables the surface grew at runtime via
+            // jit_install; detail carries the installed name so the grown
+            // table is readable from Form (sibling of Go's observe lane).
+            let installed: Vec<(NameID, NodeID)> = k
+                .installed_leaves
+                .iter()
+                .map(|(name, leaf)| (*name, leaf.body))
+                .collect();
+            for (name, body) in installed {
+                rows.push((
+                    "installed".to_string(),
+                    format!("{}.{}.{}.{}", body.pkg, body.level, body.ty, body.inst),
+                    0,
+                    k.name_str(name).to_string(),
                 ));
             }
             rows.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
@@ -6806,6 +6926,30 @@ fn walk_inner(k: &mut Kernel, a: &mut Arena, n: NodeID, env: FrameId) -> Value {
                             t.record_native(&native_name);
                         }
                         return (ne.func)(k, a, &args);
+                    }
+                }
+                // Installed leaf — a callable the surface grew at runtime via
+                // jit_install (install-as-named-callable-leaf,
+                // form-stdlib/install-leaf.fk). The leaf only answers the
+                // interface it offered: a call outside it (wrong arity, value
+                // shapes the i64 ABI doesn't carry) acknowledges nothing —
+                // honest absence, never a fabricated value (axiom-4: the name
+                // is the boundary; reaching past it is observable as null).
+                let leaf_opt = k.installed_leaves.get(&name).cloned();
+                if let Some(leaf) = leaf_opt {
+                    if a.lookup(env, name).is_none() {
+                        let mut args = Vec::with_capacity(kids.len() - 1);
+                        for arg in &kids[1..] {
+                            args.push(walk(k, a, *arg, env));
+                        }
+                        let leaf_name = k.name_str(name).to_string();
+                        if let Some(t) = &mut k.trace {
+                            t.record_native(&leaf_name);
+                        }
+                        // Arc held through the call — the Library can't be
+                        // dropped mid-call (same contract as the closure jit
+                        // fast path below).
+                        return jit_dispatch(&leaf.jc, &args).unwrap_or(Value::Null);
                     }
                 }
                 // Closure lookup uses the ORIGINAL function-name (not the JIT-

--- a/form/form-stdlib/install-leaf.fk
+++ b/form/form-stdlib/install-leaf.fk
@@ -38,10 +38,11 @@
 ;   INSTALLED-LEAF   (name, artifact)   — one binding in the table
 ;
 ; Proven by tests/install-leaf-band.fk (three-way). The native carrier —
-; a jitted .so installed into the Go kernel's own native table at runtime
-; — is jit_install in form-kernel-go (witness:
-; form/scripts/jit-install-leaf-test.sh); Rust/TS native carriers are
-; open; the PROTOCOL is what this file proves on all three.
+; a jitted .so installed into the kernel's own callable table at runtime
+; — is jit_install in form-kernel-go (plugin.Open) and form-kernel-rust
+; (rustc cdylib + libloading), both witnessed by
+; form/scripts/jit-install-leaf-test.sh; the TS native carrier is open
+; (wasm/worker); the PROTOCOL is what this file proves on all three.
 
 ;; --- Blueprints ------------------------------------------------------
 (let INSTALL-IFACE    (bp "INSTALL-IFACE"))

--- a/form/form-stdlib/primitive-registry.fk
+++ b/form/form-stdlib/primitive-registry.fk
@@ -346,9 +346,9 @@
             (defn pv-jit-emit-c () (if (str_eq (jit_emit_c "pv-jit-absent-name") "") 1 0)) 1 1)
         (prim "jit_compile_value" "witness" "toolchain: Value-ABI JIT on the go carrier (-1 unbound there); siblings answer constant 0"
             (defn pv-jit-compile-value () (add (jit_compile_value "pv-jit-absent-name") 1)) 0 0)
-        (prim "jit_install" "witness" "sibling-gap: installs a jitted artifact as a NAMED callable in the kernel's own native table at runtime (install-leaf.fk carrier); ack node=body-NodeID, 0 on collision/interface refusal, nothing when no closure"
+        (prim "jit_install" "witness" "sibling-gap (ts): installs a jitted artifact as a NAMED callable in the kernel's own native table at runtime (install-leaf.fk carrier; go plugin.Open and rust libloading carriers live, witnessed by form/scripts/jit-install-leaf-test.sh); ack node=body-NodeID, 0 on collision/interface refusal, nothing when no closure"
             (defn pv-jit-install () (if (str_eq (value_kind (jit_install "pv-jit-absent-name" "pv-jit-install-leaf" 1)) "null") 1 0)) 1 0)
-        (prim "installed_leaf?" "compare" "sibling-gap: 1 when the name is a callable the surface grew at runtime via jit_install, else 0"
+        (prim "installed_leaf?" "compare" "sibling-gap (ts): 1 when the name is a callable the surface grew at runtime via jit_install, else 0 (go and rust carriers live)"
             (defn pv-installed-leaf? () (installed_leaf? "pv-il-absent-name")) 0 0)
         (prim "jit_aliased?" "compare" "1 when a jit alias is bound for the name, else 0"
             (defn pv-jit-aliased? () (add (jit_aliased? "pv-ali-absent")

--- a/form/scripts/jit-install-leaf-test.sh
+++ b/form/scripts/jit-install-leaf-test.sh
@@ -1,36 +1,40 @@
 #!/usr/bin/env bash
 #
-# jit-install-leaf-test.sh - live witness that the Go kernel's JIT lane
-# installs a compiled artifact as a NAMED callable at runtime
+# jit-install-leaf-test.sh - live witness that a kernel's JIT lane installs
+# a compiled artifact as a NAMED callable at runtime
 # (install-as-named-callable-leaf; protocol: form-stdlib/install-leaf.fk,
 # proven three-way by tests/install-leaf-band.fk — this script witnesses
-# the native carrier: recipe -> .so -> kernel's own native table -> call
-# by name -> value parity vs the recipe walk).
+# the native carriers: recipe -> .so -> the kernel's own table -> call by
+# name -> value parity vs the recipe walk -> refusals honest).
 #
-# Requires the host Go toolchain (the JIT lane invokes
-# `go build -buildmode=plugin`); exits SKIP when absent — the protocol
+# Two native carriers run today, one section each:
+#   go   - jit.go: go build -buildmode=plugin -> plugin.Open; the leaf
+#          answers int, float, and Value ABI lanes
+#   rust - main.rs: rustc --crate-type=cdylib -> libloading; the leaf
+#          answers the i64 ABI lane — a call outside the carried
+#          interface (floats, wrong arity) acknowledges nothing
+# Each section exits SKIP when its host toolchain is absent — the protocol
 # band still proves the shape on all three kernels without it.
 set -euo pipefail
 
 FORMDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$FORMDIR"
 
-if ! command -v go >/dev/null 2>&1; then
-  echo "SKIP: host go toolchain not found - the JIT install carrier needs it." >&2
-  exit 0
-fi
-
-GO_BIN="form-kernel-go/bin-go"
-if [[ ! -x "$GO_BIN" ]] || find form-kernel-go -name '*.go' -newer "$GO_BIN" -print -quit | grep -q .; then
-  echo "building go kernel..." >&2
-  (cd form-kernel-go && go build -o bin-go .)
-fi
-
 DRIVER="$(mktemp "${TMPDIR:-/tmp}/jit-install-leaf.XXXXXX.fk")"
 cleanup() { rm -f "$DRIVER"; }
 trap cleanup EXIT
 
-cat > "$DRIVER" <<'FK'
+FAIL=0
+
+# --- go carrier --------------------------------------------------------
+if command -v go >/dev/null 2>&1; then
+  GO_BIN="form-kernel-go/bin-go"
+  if [[ ! -x "$GO_BIN" ]] || find form-kernel-go -name '*.go' -newer "$GO_BIN" -print -quit | grep -q .; then
+    echo "building go kernel..." >&2
+    (cd form-kernel-go && go build -o bin-go .)
+  fi
+
+  cat > "$DRIVER" <<'FK'
 (do
     ;; a small pure capability — the recipe stays canonical truth
     (defn il-probe (a b) (add (mul a b) 7))
@@ -71,12 +75,78 @@ cat > "$DRIVER" <<'FK'
     (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 c9))))))))))
 FK
 
-OUT="$("$GO_BIN" "$DRIVER" 2>&1 | tail -1)"
-echo "verdict: $OUT"
-if [[ "$OUT" == "10" ]]; then
-  echo "jit install leaf: PASS - a jitted artifact installed as a named callable in the kernel's own table at runtime; call-by-name reached it with value parity (int + float lanes); collision, interface mismatch, and absent-cell offers refused honestly."
-  exit 0
+  OUT="$("$GO_BIN" "$DRIVER" 2>&1 | tail -1)"
+  echo "go verdict: $OUT"
+  if [[ "$OUT" == "10" ]]; then
+    echo "go jit install leaf: PASS - a jitted artifact installed as a named callable in the kernel's own table at runtime; call-by-name reached it with value parity (int + float lanes); collision, interface mismatch, and absent-cell offers refused honestly."
+  else
+    echo "go jit install leaf: FAIL - expected verdict 10." >&2
+    FAIL=1
+  fi
 else
-  echo "jit install leaf: FAIL - expected verdict 10." >&2
-  exit 1
+  echo "SKIP go: host go toolchain not found - the Go JIT install carrier needs it." >&2
 fi
+
+# --- rust carrier ------------------------------------------------------
+if command -v rustc >/dev/null 2>&1 && command -v cargo >/dev/null 2>&1; then
+  RS_BIN="form-kernel-rust/target/release/form-kernel-rust"
+  if [[ ! -x "$RS_BIN" || "form-kernel-rust/src/main.rs" -nt "$RS_BIN" ]]; then
+    echo "building rust kernel..." >&2
+    (cd form-kernel-rust && cargo build --release --quiet)
+  fi
+
+  cat > "$DRIVER" <<'FK'
+(do
+    ;; a small pure capability — the recipe stays canonical truth
+    (defn il-probe (a b) (add (mul a b) 7))
+    (let walk-value (il-probe 6 7))
+
+    ;; the install offer: jit the closure (rustc -> cdylib -> libloading),
+    ;; bind the artifact under a NEW name in the kernel's own table —
+    ;; ack is the body NodeID
+    (let ack (jit_install "il-probe" "il-probe-native" 2))
+    (let c0 (if (str_eq (value_kind ack) "node_id") 1 0))
+    (let c1 (if (eq (installed_leaf? "il-probe-native") 1) 1 0))
+
+    ;; a call BY NAME reaches the artifact: no closure binding exists
+    ;; under this name — only the installed leaf can answer it
+    (let c2 (if (eq (il-probe-native 6 7) walk-value) 1 0))
+
+    ;; the rust ABI carries i64 only — a float call is outside the
+    ;; interface the leaf offered and acknowledges nothing (axiom-4:
+    ;; the boundary is observable, never a fabricated value)
+    (let c3 (if (str_eq (value_kind (il-probe-native 2.5 4.0)) "null") 1 0))
+
+    ;; collision: the bound name refuses a rebind (first-bind-wins)
+    (let c4 (if (eq (jit_install "il-probe" "il-probe-native" 2) 0) 1 0))
+
+    ;; collision with a build-time native refuses the same way
+    (let c5 (if (eq (jit_install "il-probe" "str_len" 2) 0) 1 0))
+
+    ;; interface mismatch: arity 3 is not the closure's own — refused,
+    ;; and nothing landed in the table
+    (let c6 (if (eq (jit_install "il-probe" "il-probe-native-3" 3) 0) 1 0))
+    (let c7 (if (eq (installed_leaf? "il-probe-native-3") 0) 1 0))
+
+    ;; no cell to install acknowledges nothing
+    (let c8 (if (str_eq (value_kind (jit_install "no-such-fn" "x-leaf" 1)) "null") 1 0))
+
+    ;; a call outside the offered interface acknowledges nothing
+    (let c9 (if (str_eq (value_kind (il-probe-native 1 2 3)) "null") 1 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 c9))))))))))
+FK
+
+  OUT="$("$RS_BIN" "$DRIVER" 2>&1 | tail -1)"
+  echo "rust verdict: $OUT"
+  if [[ "$OUT" == "10" ]]; then
+    echo "rust jit install leaf: PASS - a rustc-built cdylib installed as a named callable in the kernel's own table at runtime via libloading; call-by-name reached it with value parity vs the recipe walk; collision, interface mismatch, absent-cell, and outside-interface calls refused honestly."
+  else
+    echo "rust jit install leaf: FAIL - expected verdict 10." >&2
+    FAIL=1
+  fi
+else
+  echo "SKIP rust: host rust toolchain not found - the Rust JIT install carrier needs it." >&2
+fi
+
+exit "$FAIL"


### PR DESCRIPTION
## What grows

The install-as-named-callable-leaf protocol (`form-stdlib/install-leaf.fk`, proven three-way by `tests/install-leaf-band.fk` → 9) gains its **second native carrier**: the Rust kernel. `jit_install` compiles the named closure through the existing main.rs jit lane (recipe → Rust source → `rustc --crate-type=cdylib` → libloading, content-addressed plugin cache reused) and binds the artifact in the kernel's own installed-leaves table **at runtime** — a call BY NAME, a name no closure serves, dispatches into the loaded .so at FNCALL.

Same offer/refusal semantics as the Go carrier (#2844), only the dlopen mechanics per-host:
- **node ack** — the artifact's body NodeID (content-addressed, unforgeable, axiom-3)
- **0** — collision (first-bind-wins against natives, env-natives, and earlier leaves) or interface mismatch (expected arity is not the closure's own)
- **nothing** — no closure to install

Rust's `NativeFn` is a captureless fn pointer, so the grown surface IS a kernel-held table consulted at dispatch — the table the protocol names is literally the carrier's data structure. The leaf answers the i64 ABI lane it carries; a call outside it (floats, wrong arity) acknowledges nothing — axiom-4's observable boundary. `installed_leaf?` answers 1 only for runtime-grown leaves; `jit-stats` reports `installed` rows (body NodeID + installed name) so the grown table is readable from Form.

No new dependencies — libloading and the rustc-cdylib lane were already in the kernel.

## Proof

- `./validate.sh core.fk channel.fk install-leaf.fk tests/install-leaf-band.fk` → **9**, 0 divergent (protocol band unchanged)
- `./validate.sh primitive-registry.fk tests/primitive-registry-band.fk` → **63**, 0 divergent (no lane flips — ts still gapped; spec lines name the two live carriers)
- `./form/scripts/jit-install-leaf-test.sh` → **go verdict 10 PASS + rust verdict 10 PASS** (one section per carrier, each toolchain-gated)
- `cargo test --release` → 51 passed, 0 failed
- `validate_primitive_registry.py` → no failures, pins steady 199/162/37

## Docs

`docs/coherence-substrate/install-leaf.form`: the Rust carrier moves from named-open to witnessed (carrier-rust block); **TS stays a named open stone (wasm/worker), not built speculatively**. `primitive-registry.form`: the two natives move from go-only to the ts-gap group. Evidence: `docs/system_audit/commit_evidence_2026-06-11_install_leaf_rust_carrier.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)