### PR TITLE
tend: return fatal response for native handler panics

### DIFF
--- a/docs/system_audit/commit_evidence_20260611_rust_kernel_fatal_http_response.json
+++ b/docs/system_audit/commit_evidence_20260611_rust_kernel_fatal_http_response.json
@@ -1,0 +1,82 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "codex/crash-fatal-http-response-20260611",
+  "commit_scope": "Return a structured HTTP 500 fatal response for recoverable Rust native handler panics instead of an empty reply",
+  "files_owned": [
+    "form/form-kernel-rust/src/main.rs"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form/form-kernel-rust && cargo test --quiet crash_diagnostics_tests -- --nocapture",
+      "cd form/form-kernel-rust && cargo test --quiet",
+      "cd form/form-kernel-rust && cargo build --quiet && target/debug/form-kernel-rust serve --port <free-port> --routes <tmp-crash-routes.fk> --workers 1; curl -D /tmp/form-rust-boom.headers /boom; curl -D /tmp/form-rust-ok.headers /ok"
+    ],
+    "notes": "The synthetic /boom route is a defined local route that intentionally triggers the real type-contract panic class by calling str_concat on Null from _json_get. It is not an undefined-route proof; undefined routes still return local-control 404 or fanout. The corrected one-worker proof returns HTTP/1.1 500 Internal Server Error with X-Form-Router: native-kernel-error, X-Form-Fatal-Kind: type_contract_violation, X-Form-Crash-Trace, and a body starting fatal[type_contract_violation]: as_str: Null. The same one-worker server then serves /ok as HTTP 200 with X-Form-Router: native-kernel. Full Rust kernel tests passed 52/52 in 143.30s."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "Hostinger Auto Deploy on main after merge"
+    ],
+    "notes": "Deploy proof should confirm the kernel-router still starts and public canaries remain healthy after native handler fatal-response hardening."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed; PR CI and deploy proof remain pending."
+  },
+  "idea_ids": [
+    "pipeline-reliability",
+    "native-api-lane",
+    "form-native-front-door"
+  ],
+  "spec_ids": [
+    "pulse-silence-boundary-repair"
+  ],
+  "task_ids": [
+    "rust-kernel-fatal-http-response-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5-codex"
+  },
+  "evidence_refs": [
+    "form/form-kernel-rust/src/main.rs#handle_request",
+    "form/form-kernel-rust/src/main.rs#kernel_fatal_http_body",
+    "form/form-kernel-rust/src/main.rs#kernel_fatal_http_headers"
+  ],
+  "change_files": [
+    "form/form-kernel-rust/src/main.rs",
+    "docs/system_audit/commit_evidence_20260611_rust_kernel_fatal_http_response.json"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "A selected native handler panic should return a proper fatal HTTP 500 with classification and trace path when possible, while preserving the source/stack crash trace and keeping the worker pool alive.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/utils/kernel_status",
+      "https://api.coherencycoin.com/api/health"
+    ],
+    "test_flows": [
+      "Trigger a defined local route whose handler panics on Null-to-string and verify HTTP 500 fatal response fields.",
+      "Verify a healthy route still responds after the fatal response on a one-worker serve process."
+    ]
+  }
+}

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -59,6 +59,7 @@ fn crash_trace_context() -> &'static Mutex<CrashTraceContext> {
 
 thread_local! {
     static THREAD_CRASH_TRACE_CONTEXT: RefCell<Option<CrashTraceContext>> = const { RefCell::new(None) };
+    static THREAD_LAST_CRASH_TRACE_PATH: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
 }
 
 fn source_excerpt_head(src: &str, max_chars: usize) -> String {
@@ -116,6 +117,22 @@ fn current_crash_trace_context() -> CrashTraceContext {
         .lock()
         .map(|guard| guard.clone())
         .unwrap_or_default()
+}
+
+fn clear_thread_last_crash_trace_path() {
+    THREAD_LAST_CRASH_TRACE_PATH.with(|slot| {
+        *slot.borrow_mut() = None;
+    });
+}
+
+fn set_thread_last_crash_trace_path(path: &Path) {
+    THREAD_LAST_CRASH_TRACE_PATH.with(|slot| {
+        *slot.borrow_mut() = Some(path.to_path_buf());
+    });
+}
+
+fn take_thread_last_crash_trace_path() -> Option<PathBuf> {
+    THREAD_LAST_CRASH_TRACE_PATH.with(|slot| slot.borrow_mut().take())
 }
 
 fn diagnose_kernel_panic(message: &str) -> CrashDiagnosis {
@@ -222,10 +239,46 @@ fn write_kernel_crash_trace(message: &str, location: Option<String>) -> Option<P
         }
         let path = dir.join(&filename);
         if fs::write(&path, &payload).is_ok() {
+            set_thread_last_crash_trace_path(&path);
             return Some(path);
         }
     }
     None
+}
+
+fn http_header_safe(value: &str) -> String {
+    value.replace(['\r', '\n'], " ")
+}
+
+fn kernel_fatal_http_body(
+    message: &str,
+    diagnosis: &CrashDiagnosis,
+    trace_path: Option<&Path>,
+) -> String {
+    let trace = trace_path
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "trace unavailable".to_string());
+    format!(
+        "fatal[{}]: {}\nlikely_root_cause: {}\navoidance: {}\ntrace: {}\n",
+        diagnosis.fatal_kind, message, diagnosis.likely_root_cause, diagnosis.avoidance, trace
+    )
+}
+
+fn kernel_fatal_http_headers(
+    diagnosis: &CrashDiagnosis,
+    trace_path: Option<&Path>,
+) -> Vec<(String, String)> {
+    let mut headers = vec![(
+        "X-Form-Fatal-Kind".to_string(),
+        diagnosis.fatal_kind.to_string(),
+    )];
+    if let Some(path) = trace_path {
+        headers.push((
+            "X-Form-Crash-Trace".to_string(),
+            http_header_safe(&path.display().to_string()),
+        ));
+    }
+    headers
 }
 
 // --- Socket natives — L1 physical layer (TCP) ---------------------------
@@ -8860,7 +8913,33 @@ fn handle_request(
             );
             return false; // close — the oversized request was fully read; drop it
         }
-        let result = walk(k, arena, cl.body, call_frame);
+        clear_thread_last_crash_trace_path();
+        let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            walk(k, arena, cl.body, call_frame)
+        })) {
+            Ok(value) => value,
+            Err(payload) => {
+                let msg = panic_payload_message(payload.as_ref());
+                let diagnosis = diagnose_kernel_panic(&msg);
+                let trace_path = take_thread_last_crash_trace_path()
+                    .or_else(|| write_kernel_crash_trace(&msg, None));
+                let body = kernel_fatal_http_body(&msg, &diagnosis, trace_path.as_deref());
+                let headers = kernel_fatal_http_headers(&diagnosis, trace_path.as_deref());
+                record_router_metrics(router_metrics, &path, "native-kernel-error");
+                let _ = stream.write_all(
+                    http_response(
+                        "500 Internal Server Error",
+                        &body,
+                        "native-kernel-error",
+                        false,
+                        "",
+                        &headers,
+                    )
+                    .as_bytes(),
+                );
+                return false;
+            }
+        };
         router = "native-kernel";
         // A native handler can return the first-class KernelHTTPResponse cell:
         //   kh-response(status, list(kh-header(name, value)...), body)
@@ -13792,6 +13871,24 @@ mod crash_diagnostics_tests {
             .contains("non-string"));
         set_thread_crash_trace_context(CrashTraceContext::default());
         let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn fatal_http_response_names_kind_trace_and_avoidance() {
+        let diagnosis = diagnose_kernel_panic("as_str: Null");
+        let trace_path = Path::new(".cache/form-kernel-rust/crash-test.json");
+        let body = kernel_fatal_http_body("as_str: Null", &diagnosis, Some(trace_path));
+        assert!(body.contains("fatal[type_contract_violation]: as_str: Null"));
+        assert!(body.contains("likely_root_cause:"));
+        assert!(body.contains("avoidance:"));
+        assert!(body.contains("trace: .cache/form-kernel-rust/crash-test.json"));
+        let headers = kernel_fatal_http_headers(&diagnosis, Some(trace_path));
+        assert!(headers
+            .iter()
+            .any(|(k, v)| { k == "X-Form-Fatal-Kind" && v == "type_contract_violation" }));
+        assert!(headers.iter().any(|(k, v)| {
+            k == "X-Form-Crash-Trace" && v == ".cache/form-kernel-rust/crash-test.json"
+        }));
     }
 }
 


### PR DESCRIPTION
## Summary
- convert selected Rust native handler panics into structured HTTP 500 fatal responses instead of empty replies
- preserve the existing source/stack crash trace and attach `X-Form-Fatal-Kind` plus `X-Form-Crash-Trace` when available
- keep worker containment: after a fatal handler response, the one-worker proof still serves the next healthy native route
- record evidence clarifying `/boom` is a defined synthetic route, not an undefined-route crash

## Proof
- `cd form/form-kernel-rust && cargo test --quiet crash_diagnostics_tests -- --nocapture`
- `cd form/form-kernel-rust && cargo test --quiet`
- one-worker serve proof: `/boom` returns HTTP 500 with `fatal[type_contract_violation]`, `X-Form-Fatal-Kind`, and `X-Form-Crash-Trace`; `/ok` then returns HTTP 200 with `X-Form-Router: native-kernel`
- `./scripts/test_hostinger_deploy_form_paths.sh`
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`