### PR TITLE
tend: validate.sh loses its three taxes — 75x per band; suite now compute-bound

### DIFF
--- a/form/form-kernel-ts/src/bench.ts
+++ b/form/form-kernel-ts/src/bench.ts
@@ -229,6 +229,6 @@ export function runBench(): void {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === `file://${process.argv[1]}` && import.meta.url.includes("bench")) {
   runBench();
 }

--- a/form/form-kernel-ts/src/numeric-bench.ts
+++ b/form/form-kernel-ts/src/numeric-bench.ts
@@ -357,6 +357,6 @@ export function runNumericBench(): void {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === `file://${process.argv[1]}` && import.meta.url.includes("numeric-bench")) {
   runNumericBench();
 }

--- a/form/validate.sh
+++ b/form/validate.sh
@@ -50,13 +50,35 @@ build_rs() {
     fi
 }
 
+build_ts() {
+    # Bundle the TS kernel once (esbuild, cached by source mtimes) so each band
+    # runs via plain `node` (~60ms) instead of npx tsx (~1.5s). With 455 bands
+    # that is the difference between seconds and 11+ minutes of startup tax.
+    local bundle="$TS_DIR/dist/main.mjs"
+    local stale=0
+    if [[ ! -f "$bundle" ]]; then stale=1; else
+        local f
+        for f in "$TS_DIR"/src/*.ts; do
+            [[ "$f" -nt "$bundle" ]] && { stale=1; break; }
+        done
+    fi
+    if [[ "$stale" == "1" ]]; then
+        echo "  bundling ts kernel..." >&2
+        npx --yes esbuild "$TS_DIR/src/main.ts" --bundle --platform=node             --format=esm --outfile="$bundle" --log-level=warning >&2 || rm -f "$bundle"
+    fi
+}
+
 build_go &
 build_rs &
+build_ts &
 wait
 
 run_ts() {
+    local bundle="$TS_DIR/dist/main.mjs"
     local loader="$PWD/$TS_DIR/node_modules/tsx/dist/loader.mjs"
-    if [[ -x "$TS_DIR/node_modules/.bin/tsx" ]]; then
+    if [[ -f "$bundle" ]]; then
+        node --stack_size="$HOST_STACK_KB" "$bundle" "$@"
+    elif [[ -x "$TS_DIR/node_modules/.bin/tsx" ]]; then
         node --stack_size="$HOST_STACK_KB" --import "$loader" "$TS_DIR/src/main.ts" "$@"
     else
         npx --yes tsx --stack_size="$HOST_STACK_KB" "$TS_DIR/src/main.ts" "$@"
@@ -74,18 +96,38 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Source-compiled preludes are cached by CONTENT (file + compiler chain): the
+# same unchanged core.fk compiles once, not once per band. Without this cache
+# every validate invocation re-ran the full BML source-compiler (~12s) on
+# identical input — 455 bands paid ~90 serial minutes for the same artifact.
+SOURCE_CACHE_DIR="form-stdlib/.cache/source-compiled"
+mkdir -p "$SOURCE_CACHE_DIR"
+compiler_stamp=""
+compiler_chain=("form-stdlib/form-ontology-loader.fk" "form-stdlib/line-grammar.fk" "form-stdlib/bmf-core.fk" "form-stdlib/bmf-grammar.fk" "form-stdlib/bml.fk" "form-stdlib/bml-source.fk" "form-stdlib/source-compiler.fk")
+compiler_stamp="$(cat "${compiler_chain[@]}" "$GO_BIN" 2>/dev/null | shasum | cut -c1-16)"
+
 prepared_args=()
 prepare_sources() {
     prepared_args=()
-    local src out safe driver
+    local src out safe driver key cached
     for src in "$@"; do
         if grep -Eq '^[[:space:]]*section \[' "$src"; then
-            safe="${src//\//__}"
-            out="$source_compile_dir/$safe"
-            driver="$source_compile_dir/compile-${safe}.fk"
-            printf '(do (form-source-compile-file "%s" "%s"))\n' "$src" "$out" > "$driver"
-            "$GO_BIN" "form-stdlib/form-ontology-loader.fk" "form-stdlib/line-grammar.fk" "form-stdlib/bmf-core.fk" "form-stdlib/bmf-grammar.fk" "form-stdlib/bml.fk" "form-stdlib/bml-source.fk" "form-stdlib/source-compiler.fk" "$driver" >/dev/null
-            prepared_args+=("$out")
+            key="$(cat "$src" | shasum | cut -c1-16)-$compiler_stamp"
+            cached="$SOURCE_CACHE_DIR/$key.fk"
+            if [[ ! -s "$cached" ]]; then
+                safe="${src//\//__}"
+                out="$source_compile_dir/$safe"
+                driver="$source_compile_dir/compile-${safe}.fk"
+                printf '(do (form-source-compile-file "%s" "%s"))\n' "$src" "$out" > "$driver"
+                "$GO_BIN" "${compiler_chain[@]}" "$driver" >/dev/null
+                if [[ -s "$out" ]]; then
+                    mv -f "$out" "$cached" 2>/dev/null || cp "$out" "$cached"
+                else
+                    prepared_args+=("$src")
+                    continue
+                fi
+            fi
+            prepared_args+=("$cached")
         else
             prepared_args+=("$src")
         fi
@@ -116,11 +158,18 @@ fi
 # prelude + test file). Every kernel receives the same file list.
 run_siblings() {
     local label="$1"; shift
-    local go_out rs_out ts_out
+    local go_out rs_out ts_out legs
     prepare_sources "$@"
-    go_out=$("$GO_BIN" "${prepared_args[@]}" 2>&1 || true)
-    rs_out=$("$RS_BIN" "${prepared_args[@]}" 2>&1 || true)
-    ts_out=$(run_ts "${prepared_args[@]}" 2>&1 || true)
+    # The three kernels run CONCURRENTLY: a band's wall time is max(leg), not
+    # sum — on compiler-heavy bands the Go+Rust legs ride inside the TS leg's
+    # shadow for free. Outputs stay byte-compared exactly as before.
+    legs="$(mktemp -d "${TMPDIR:-/tmp}/form-legs.XXXXXX")"
+    ( "$GO_BIN" "${prepared_args[@]}" > "$legs/go" 2>&1 || true ) &
+    ( "$RS_BIN" "${prepared_args[@]}" > "$legs/rs" 2>&1 || true ) &
+    ( run_ts "${prepared_args[@]}" > "$legs/ts" 2>&1 || true ) &
+    wait
+    go_out=$(cat "$legs/go"); rs_out=$(cat "$legs/rs"); ts_out=$(cat "$legs/ts")
+    rm -rf "$legs"
     if [[ "$go_out" == "$rs_out" && "$go_out" == "$ts_out" ]]; then
         printf "  ✓  %-30s  → %s\n" "$label" "$go_out"
         ok=$((ok + 1))


### PR DESCRIPTION
The 50x test-time complaint, measured to its roots and removed — no semantic change (verdicts byte-compared exactly as before):

1. **TS startup tax**: `npx tsx` cost **1.47s per invocation** (455 bands = 11+ min of startup). The TS kernel now bundles once via esbuild (cached by source mtimes) and runs with plain `node`: **0.06s (24x)**. The bench is-main guards gain a filename clause (inside a bundle, `import.meta.url === argv[1]` is true for every module).
2. **The recompile tax (the big one)**: every sectioned prelude (core.fk!) re-ran the full BML source-compiler (~12s) per band — ~90 serial minutes of identical work across the suite. Compiled sources are now cached by content (file hash + compiler-chain hash), atomic for shard concurrency. **Warm single band: 14.19s → 0.19s (75x)**.
3. **Serial legs**: the three kernels run concurrently per band — wall = max(leg), not sum.

**Numbers**: 10-band slice 88.9s → **3.5s**; full 455-band suite (12 shards, cold): **20.2 min**, now genuinely compute-bound — a fat tail of ~12 compiler-family bands at 200–310s each (13,345 band-seconds). The <5 min budget needs those bands to **load the proven bml-compiler .fkb image** instead of rebuilding the compiler per band — follow-up dispatched. Two pre-existing shard failures flagged (unbound prelude functions on both old and new TS paths — runner prelude-header issue, not this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)