### PR TITLE
tend: multi-param crosses onto the fourth arm — packed args, bands-on-fourth-arm 1 -> 10

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-11_m4e4_multiparam_fourth_arm.json
+++ b/docs/system_audit/commit_evidence_2026-06-11_m4e4_multiparam_fourth_arm.json
@@ -1,0 +1,115 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "form-os3/m4e4-multiparam",
+  "commit_scope": "m4e4 multi-param family (n7-ratchet): packed-args flattening rule in form-flatten.fk — an N-arg call right-folds its arguments into a CONS chain on the arena, the callee binds each param as NTH(ARG, i). A pure flattening lift: zero new walker tags, the emitted C unchanged. Nine more REAL stdlib bands (cooldown, alert-gate, value-execution, anomaly-band, body-state, field-fusion, histogram-peak, model-retire, signal-derivative — unmodified source from disk) run on the universal fkw binary and return the three walkers' own validate.sh verdicts. Bands-on-fourth-arm 1 -> 10.",
+  "change_intent": "runtime_feature",
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "m4e4-multiparam-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "measurement"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "files_owned": [
+    "form/form-stdlib/form-flatten.fk",
+    "form/form-stdlib/fourth-walker.fk",
+    "form/form-stdlib/tests/form-flatten-band.fk",
+    "scripts/fourth_kernel_audit.sh",
+    "docs/system_audit/commit_evidence_2026-06-11_m4e4_multiparam_fourth_arm.json"
+  ],
+  "change_files": [
+    "form/form-stdlib/form-flatten.fk",
+    "form/form-stdlib/fourth-walker.fk",
+    "form/form-stdlib/tests/form-flatten-band.fk",
+    "scripts/fourth_kernel_audit.sh"
+  ],
+  "evidence_refs": [
+    "docs/coherence-substrate/fourth-kernel.form",
+    "docs/system_audit/commit_evidence_2026-06-11_m4e3_first_click_fourth_arm.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/form-parse.fk form-stdlib/form-flatten.fk form-stdlib/tests/form-flatten-band.fk",
+      "cd form && ./validate.sh <preludes> form-stdlib/tests/<band>.fk  # all 16 bands whose preludes include fourth-walker.fk, in parallel",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/<module>.fk form-stdlib/tests/<module>-band.fk  # the nine crossing bands, three-way",
+      "bash scripts/fourth_kernel_audit.sh",
+      "python3 scripts/generate_repo_indexes.py",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-11_m4e4_multiparam_fourth_arm.json",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+    ],
+    "notes": "form-flatten-band 15 -> 127 three-way: add3(7,11,13)=31 proves the 3-param pack, accsum((5 6 7),0)=18 proves a recursive 2-param fn carrying packed args across re-entry with list walking (the recipe-side walker's new arena arms 18..23 prove by VALUE), and the REAL cooldown module+band flatten and walk by value to the siblings' 63. All 16 bands whose preludes include the touched fourth-walker.fk stayed at their prior verdicts (15/63/31). The op-profile ranking over the band corpus (single-prelude, integer-pure, no nested do) found ten zero-blocker multi-param candidates; nine run four-way clean on fkw: cooldown 63, alert-gate 127, value-execution 7, anomaly-band 127, body-state 127, field-fusion 127, histogram-peak 127, model-retire 63, signal-derivative 127 — each equal to its validate.sh three-walker verdict. feature-vector is the honest tenth: it flattens and fits the loader, but its band-scale allocation crosses the arena's 90% water line and the copying melt cannot see packed args held in suspended C frames (m4e2's named suspended-temp gap), so it stays off the ratchet until call arguments ride a walker-managed value stack. adler32 (the originally rejected multi-param candidate) still waits on the band/shl_u32/add_u32 figure family and let-in-defn nested do — named, not bent. `params` as a leading defn parameter name is a kernel grammar keyword; the flattener carries the list as `ps`.",
+    "measured": {
+      "bands_on_fourth_arm_before": 1,
+      "bands_on_fourth_arm_after": 10,
+      "crossed_bands": {
+        "cooldown": 63,
+        "alert-gate": 127,
+        "value-execution": 7,
+        "anomaly-band": 127,
+        "body-state": 127,
+        "field-fusion": 127,
+        "histogram-peak": 127,
+        "model-retire": 63,
+        "signal-derivative": 127
+      },
+      "named_blocked": {
+        "feature-vector": "melt suspended-temp gap (packed args in C frames are not melt roots; ~14k cells allocated vs 4096 arena)",
+        "adler32": "band/shl_u32/add_u32 ops absent from the walker tag set; let-in-defn nested do",
+        "str_family": "string values need a walker string-pool lane (also the m4d full-fixpoint blocker) — named for the next hands"
+      }
+    }
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "CI three-way suite runs on the PR; the 459-band suite plus kernel builds carry the regression net for the fkm-walk arena arms and the flt-call/flt-defn rework."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "form-stdlib changes ride the api image rebuild; the lattice ingests the updated form-flatten.fk on the post-merge hook."
+  },
+  "phase_gate": {
+    "phase": "m4e4-multiparam-family",
+    "gate": "multi-param functions cross onto the fourth arm via packed args (a pure flattening rule over the existing op set); the crossed bands run UNMODIFIED and four-way gated; the flattener growth proven three-way as recipe tissue",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "str_* family needs a walker string-pool lane (shared with the m4d full-fixpoint blocker); nested do / let-in-defn unlocks adler32-shaped bands together with the band/shl_u32/add_u32 figure family; feature-vector-scale allocation wants call arguments on a walker-managed value stack so the copying melt sees them as roots"
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "No route behavior changes. The fourth kernel's band ratchet climbs 1 -> 10: multi-param stdlib bands flatten through packed args onto the unchanged walker op set and the universal fkw binary returns the three siblings' own verdicts, four-way gated in audit section 22.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "form-flatten-band proves the packed-args family three-way at 127: add3(7,11,13)=31, recursive accsum((5 6 7),0)=18 through the recipe-side arena arms, and the REAL cooldown band by value at the siblings' 63.",
+      "fourth_kernel_audit.sh section 22: flatten nine multi-param bands -> table files -> universal fkw -> verdicts gated on equality with validate.sh's three-walker verdict per band, plus the feature-vector flatten-only structural gate."
+    ],
+    "summary": "validate.sh: form-flatten-band 127; all 16 fourth-walker-prelude bands at their prior verdicts; the nine crossing bands each 1 ok 0 divergent with fkw matching; audit end-to-end green with bands-on-fourth-arm at 10."
+  }
+}

--- a/form/form-stdlib/form-flatten.fk
+++ b/form/form-stdlib/form-flatten.fk
@@ -9,11 +9,17 @@
 ; band through the fs port: the fourth arm's band ratchet.
 ;
 ; Builds on form-parse.fk (the expression stone: a cursor over the source
-; string, no tokenizer — the BMF discipline). Scope held honestly: PURE bands
-; — nonnegative integer literals, single-param defns whose body sees only its
-; param, top-level lets, one verdict expression. eq/and lowering re-evaluates
-; pure operands; str_*, node_*, floats, nested do, and multi-param defns are
-; m4e4's family-by-family climb.
+; string, no tokenizer — the BMF discipline). Multi-param defns ride PACKED
+; ARGS (m4e4): an N-arg call right-folds its arguments into a CONS chain on
+; the arena, the callee's params bind as NTH(ARG, i) by position — a pure
+; flattening rule over the existing op set, no new walker tags. Single-param
+; calls stay direct ARG (no allocation); zero-param packs EMPTY. Scope held
+; honestly: PURE bands — nonnegative integer literals, defn bodies that see
+; only their params, top-level lets, one verdict expression. eq/and lowering
+; re-evaluates pure operands; a packed-args list held across a melt-crossing
+; allocation shares m4e2's named suspended-temp gap (band-scale inputs stay
+; far below the water line); str_*, node_*, floats, and nested do are
+; m4e4's remaining family-by-family climb.
 
 ; ── walker-carried ops as DATA rows (name arity tag) — one generic engine ──
 (defn flt-ops ()
@@ -87,9 +93,25 @@
 (defn flt-bin (row s ae fns env) (flt-bin2 row s (nth ae 0) (flt-expr s (nth ae 1) fns env)))
 (defn flt-bin2 (row s a be) (list (flt-mkop row a (nth be 0)) (fp-close s (nth be 1))))
 
-(defn flt-call (fname s pos fns env) (flt-call2 (flt-assoc fname fns) s (flt-expr s pos fns env)))
-(defn flt-call2 (row s ae) (list (flt-call3 row (nth ae 0)) (fp-close s (nth ae 1))))
-(defn flt-call3 (row arg) (if (eq (len row) 0) (fk-lit 0) (fk-call (nth row 1) arg)))
+; ── user function calls: every argument until ')' parses, then the row's
+;    arity picks the carrier — arity 1 rides ARG direct (no allocation),
+;    any other arity right-folds the args into a CONS pack the callee
+;    unpacks by NTH position (multi-param-via-packed-args, m4e4) ──────────
+(defn flt-args (s pos fns env)
+    (if (eq (fp-at s (fp-skip s pos)) 41) (list (list) (add (fp-skip s pos) 1))
+        (flt-args2 s (flt-expr s pos fns env) fns env)))
+(defn flt-args2 (s ae fns env) (flt-args3 (nth ae 0) (flt-args s (nth ae 1) fns env)))
+(defn flt-args3 (a re) (list (cons a (nth re 0)) (nth re 1)))
+
+(defn flt-pack (args arity) (if (eq arity 1) (head args) (flt-pack2 args)))
+(defn flt-pack2 (args)
+    (if (eq (len args) 0) (fk-empty)
+        (fk-cons (head args) (flt-pack2 (tail args)))))
+
+(defn flt-call (fname s pos fns env) (flt-call2 (flt-assoc fname fns) (flt-args s pos fns env)))
+(defn flt-call2 (row ae) (list (flt-call3 row (nth ae 0)) (nth ae 1)))
+(defn flt-call3 (row args)
+    (if (eq (len row) 0) (fk-lit 0) (fk-call (nth row 1) (flt-pack args (nth row 2)))))
 
 (defn flt-if (s pos fns env) (flt-if-c s (flt-expr s pos fns env) fns env))
 (defn flt-if-c (s ce fns env) (flt-if-t s (nth ce 0) (flt-expr s (nth ce 1) fns env) fns env))
@@ -116,18 +138,36 @@
         (flt-main s (flt-expr s pos fns env) fns rbodies env))))))
 (defn flt-main (s ee fns rbodies env) (flt-items s (nth ee 1) fns rbodies env (nth ee 0)))
 
-; (defn name (param) body) — pos arrives at the form's '('
+; (defn name (p0 p1 ...) body) — pos arrives at the form's '('. The param
+; LIST reads whole first so the function row carries (name index arity)
+; BEFORE the body parses — self-recursion sees its own arity and packs.
+; The body env binds each param by position: arity 1 is ARG itself, any
+; other arity is NTH(ARG, i) into the packed CONS chain.
+(defn flt-params (s pos)
+    (if (eq (fp-at s (fp-skip s pos)) 41) (list (list) (add (fp-skip s pos) 1))
+        (flt-params2 s (fp-skip s pos))))
+(defn flt-params2 (s pos) (flt-params3 (flt-word s pos) (flt-params s (fp-sym-end s pos))))
+(defn flt-params3 (w re) (list (cons w (nth re 0)) (nth re 1)))
+
+; (`params` itself is a defn-grammar keyword, so the list rides as `ps`)
+(defn flt-penv (ps n i)
+    (if (eq (len ps) 0) (list)
+        (cons (list (head ps)
+                    (if (eq n 1) (fk-arg) (fk-nth (fk-arg) (fk-lit i))))
+              (flt-penv (tail ps) n (add i 1)))))
+
 (defn flt-defn (s pos fns rbodies env main)
     (flt-defn-n s (fp-skip s (fp-sym-end s (fp-skip s (add pos 1)))) fns rbodies env main))
 (defn flt-defn-n (s pos fns rbodies env main)
     (flt-defn-p (flt-word s pos) s (fp-sym-end s pos) fns rbodies env main))
 (defn flt-defn-p (name s pos fns rbodies env main)
-    (flt-defn-p2 name s (fp-skip s (add (fp-skip s pos) 1)) fns rbodies env main))
-(defn flt-defn-p2 (name s pos fns rbodies env main)
-    (flt-defn-b (flt-word s pos) s (add (fp-skip s (fp-sym-end s pos)) 1)
-                (cons (list name (add (len fns) 1)) fns) rbodies env main))
-(defn flt-defn-b (param s pos fns rbodies env main)
-    (flt-defn-done s (flt-expr s pos fns (list (list param (fk-arg)))) fns rbodies env main))
+    (flt-defn-p2 name s (flt-params s (add (fp-skip s pos) 1)) fns rbodies env main))
+(defn flt-defn-p2 (name s pe fns rbodies env main)
+    (flt-defn-b s (nth pe 1)
+                (cons (list name (add (len fns) 1) (len (nth pe 0))) fns)
+                (flt-penv (nth pe 0) (len (nth pe 0)) 0) rbodies env main))
+(defn flt-defn-b (s pos fns benv rbodies env main)
+    (flt-defn-done s (flt-expr s pos fns benv) fns rbodies env main))
 (defn flt-defn-done (s be fns rbodies env main)
     (flt-items s (fp-close s (nth be 1)) fns (cons (nth be 0) rbodies) env main))
 

--- a/form/form-stdlib/fourth-walker.fk
+++ b/form/form-stdlib/fourth-walker.fk
@@ -69,7 +69,18 @@
     (if (eq (fk-tag node) 7) (fkm-walk fns (nth fns 0) (fkm-walk fns (fk-body node) arg))
     (if (eq (fk-tag node) 12) (fkm-walk fns (nth fns (ms-value (ms-child (fk-body node) 0)))
                                             (fkm-walk fns (ms-child (fk-body node) 1) arg))
-        0)))))))))
+    ; list arms 18..23 — the arena family on the RECIPE side: lists are the
+    ; host kernel's own lists, so a packed-args program (m4e4 multi-param)
+    ; proves by VALUE three-way before the emitted arena carries it
+    (if (eq (fk-tag node) 18) (list)
+    (if (eq (fk-tag node) 19) (cons (fkm-walk fns (ms-child (fk-body node) 0) arg)
+                                    (fkm-walk fns (ms-child (fk-body node) 1) arg))
+    (if (eq (fk-tag node) 20) (head (fkm-walk fns (fk-body node) arg))
+    (if (eq (fk-tag node) 21) (tail (fkm-walk fns (fk-body node) arg))
+    (if (eq (fk-tag node) 22) (len (fkm-walk fns (fk-body node) arg))
+    (if (eq (fk-tag node) 23) (nth (fkm-walk fns (ms-child (fk-body node) 0) arg)
+                                   (fkm-walk fns (ms-child (fk-body node) 1) arg))
+        0)))))))))))))))
 
 (defn fkm-run (fns arg) (fkm-walk fns (nth fns 0) arg))
 

--- a/form/form-stdlib/tests/form-flatten-band.fk
+++ b/form/form-stdlib/tests/form-flatten-band.fk
@@ -8,7 +8,7 @@
 ; in scripts/fourth_kernel_audit.sh — the fourth arm, where the heap ops
 ; live). Same cells, both walkers; content-addressing carries the identity.
 ;
-; Verdict 15 when the flattener holds:
+; Verdict 127 when the flattener holds:
 ;   1   the lowerings carry values — gt strict at the tie (gt 4 4 -> 0,
 ;       the learning-trend boundary), ge admits it, eq lands, and gates
 ;   2   defn/let/CALL — a mini band with a function, a let, and a verdict
@@ -18,6 +18,15 @@
 ;       function table
 ;   8   the flattened table FITS the universal fkw binary — more than 100
 ;       real rows, under the loader's 4096-row capacity
+;   16  multi-param via packed args (m4e4) — a 3-param function's call
+;       right-folds its arguments into a CONS pack and the body reads
+;       them back by NTH position: add3(7,11,13) walks to 31
+;   32  a RECURSIVE 2-param function carries packed args across its own
+;       re-entry while walking a list: accsum((5 6 7), 0) walks to 18
+;       (the recipe-side walker's arena arms 18..23 prove by value)
+;   64  the REAL cooldown module + band (multi-param throughout: 2- and
+;       3-param defns, let-bound call arguments, unmodified from disk)
+;       flatten and walk BY VALUE to the siblings' own verdict 63
 (do
     (let c0 (if (and (and (eq (fkm-run (flt-src-fns "(do (gt 5 2))") 0) 1)
                           (eq (fkm-run (flt-src-fns "(do (gt 4 4))") 0) 0))
@@ -32,4 +41,8 @@
     (let c2 (if (eq (len real) 6) 4 0))
     (let rows (nth (fkc-flatten-many real) 0))
     (let c3 (if (and (gt (len rows) 100) (gt 4096 (len rows))) 8 0))
-    (add c0 (add c1 (add c2 c3))))
+    (let c4 (if (eq (fkm-run (flt-src-fns "(do (defn add3 (a b c) (add a (add b c))) (add3 7 11 13))") 0) 31) 16 0))
+    (let c5 (if (eq (fkm-run (flt-src-fns "(do (defn accsum (xs acc) (if (eq (len xs) 0) acc (accsum (tail xs) (add acc (head xs))))) (accsum (list 5 6 7) 0))") 0) 18) 32 0))
+    (let c6 (if (eq (fkm-run (flt-band-fns (read_file "form-stdlib/cooldown.fk")
+                                           (read_file "form-stdlib/tests/cooldown-band.fk")) 0) 63) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/scripts/fourth_kernel_audit.sh
+++ b/scripts/fourth_kernel_audit.sh
@@ -762,5 +762,68 @@ fi
 echo "  the cycle closed both ways: measured heat froze it, measured cool melted it, ice re-EARNED — never declared"
 
 echo
+# ── 22. m4e4 — multi-param bands on the fourth arm: the ratchet climbs 1 -> 10 ──
+# form-flatten.fk's packed-args rule (an N-arg call right-folds its arguments
+# into a CONS chain on the arena; the callee binds each param as NTH(ARG, i))
+# is a pure flattening lift — ZERO new walker tags, the emitted C unchanged.
+# Nine more REAL stdlib bands (unmodified source from disk) flatten onto the
+# walker's table and run on the SAME universal binary; each verdict is gated
+# four-way against the three walking siblings' own front door (validate.sh,
+# the nine invocations in parallel). feature-vector is the honest tenth: its
+# flatten lands and fits the loader, but its band-scale allocation crosses
+# the arena's water line and the copying melt cannot see packed args held in
+# suspended C frames (m4e2's named suspended-temp gap) — it stays off the
+# ratchet until call arguments ride a walker-managed value stack instead of
+# C locals. adler32 (the original multi-param candidate) still waits on the
+# band/shl_u32/add_u32 figure family and let-in-defn — named, not bent.
+mp_mods=(cooldown alert-gate value-execution anomaly-band body-state field-fusion histogram-peak model-retire signal-derivative)
+mp_exps=(63 127 7 127 127 127 127 63 127)
+cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/fourth-walker.fk" \
+    "$FORMDIR/form-stdlib/fourth-walker-emit.fk" "$FORMDIR/form-stdlib/form-parse.fk" \
+    "$FORMDIR/form-stdlib/form-flatten.fk" > "$work/mp-driver.fk"
+for m in "${mp_mods[@]}" feature-vector; do
+    cat >> "$work/mp-driver.fk" <<EOF
+(print "==MP-$m==")
+(print (fkc-table-file (flt-band-fns (read_file "form-stdlib/$m.fk") (read_file "form-stdlib/tests/$m-band.fk"))))
+EOF
+done
+echo '(print "==MP-END==")' >> "$work/mp-driver.fk"
+(cd "$FORMDIR" && "$GO_BIN" "$work/mp-driver.fk" 2>/dev/null) > "$work/mp.out"
+prev=""
+while IFS= read -r line; do
+    if [[ "$line" == ==MP-*== ]]; then
+        prev="${line#==MP-}"; prev="${prev%==}"
+        : > "$work/t-mp-$prev.txt"
+    elif [[ -n "$prev" ]]; then
+        printf '%s\n' "$line" >> "$work/t-mp-$prev.txt"
+    fi
+done < "$work/mp.out"
+for m in "${mp_mods[@]}"; do
+    (cd "$FORMDIR" && ./validate.sh form-stdlib/core.fk "form-stdlib/$m.fk" "form-stdlib/tests/$m-band.fk" 2>/dev/null \
+        | sed -n 's/.*→ //p' | head -1 > "$work/vw-$m.txt") &
+done
+wait
+echo "m4e4 multi-param bands on the fourth arm (packed args, flattened by form-flatten.fk):"
+mp_pass=0
+for k in "${!mp_mods[@]}"; do
+    m="${mp_mods[$k]}"; exp="${mp_exps[$k]}"
+    three_way="$(cat "$work/vw-$m.txt")"
+    fkw_v="$("$work/fkwu" "$work/t-mp-$m.txt" 0 2>/dev/null | head -1)"
+    printf "  %-18s three-walker (validate.sh) = %-4s fkw = %-4s (expect %s)\n" "$m" "$three_way" "$fkw_v" "$exp"
+    if [[ -z "$three_way" || "$three_way" != "$fkw_v" || "$fkw_v" != "$exp" ]]; then
+        echo "FAIL  the fourth arm disagrees with the siblings on $m"; exit 1
+    fi
+    mp_pass=$((mp_pass + 1))
+done
+fv_rows="$(wc -w < "$work/t-mp-feature-vector.txt")"
+if [[ "$fv_rows" -lt 10 ]]; then
+    echo "FAIL  the feature-vector flatten itself regressed"; exit 1
+fi
+echo "  feature-vector     flattens ($fv_rows table words, fits the loader) — held OFF the ratchet:"
+echo "                     band-scale allocation crosses the melt water line and packed args in"
+echo "                     suspended C frames are outside the copying melt's root set (m4e2 gap)"
+echo "  bands-on-fourth-arm: $((mp_pass + 1)) (learning-trend + $mp_pass multi-param bands, four-way gated)"
+
+echo
 echo "conditions: $(uname -m) $(uname -s), clang -O2, full-process invocations (startup included)"
 echo "ok — parity held and the rows are real; the spec is docs/coherence-substrate/fourth-kernel.form"


### PR DESCRIPTION
## m4e4's keystone family: multi-param via packed args

fourth-kernel.form's n7-ratchet named the next families; multi-param was the keystone (adler32 was rejected as the first band precisely for needing it). This stone lands it **as a pure flattening rule** — the mechanism the m4e3 scoping named (`multi-param-via-packed-args`), chosen over walker op growth after reading how args ride today:

- **Call site** (`form-flatten.fk`): an N-arg call right-folds its arguments into a CONS chain on the arena (`flt-args` / `flt-pack`); arity-1 calls stay direct ARG (no allocation); the function row grows to `(name index arity)`, registered before the body parses so self-recursion packs correctly.
- **Callee**: each param binds as `NTH(ARG, i)` by position (`flt-penv`). Zero new walker tags; **the emitted C is unchanged** — `fkc-flat` and the arena arms already carry CONS/NTH totally.
- **Recipe side** (`fourth-walker.fk`): `fkm-walk` gains the additive arena arms 18..23 (lists as the host kernel's own lists), so packed-args programs prove by VALUE three-way before the emitted arena carries them.

## Measured: bands-on-fourth-arm 1 -> 10

The mechanical op-profile ranking over the band corpus (single-prelude, integer-pure, no nested do) found ten zero-blocker multi-param candidates. Nine cross, UNMODIFIED, four-way gated in audit **section 22** (fkw verdict == the three walkers' own validate.sh verdict, the nine invocations in parallel):

| band | verdict (3-way == fkw) |
|---|---|
| cooldown | 63 |
| alert-gate | 127 |
| value-execution | 7 |
| anomaly-band | 127 |
| body-state | 127 |
| field-fusion | 127 |
| histogram-peak | 127 |
| model-retire | 63 |
| signal-derivative | 127 |

n7's learning-trend click stays green (127 four-way). `form-flatten-band` climbs 15 -> 127 three-way: the 3-param pack (add3 = 31), a recursive 2-param list fold through the new recipe-side arms (accsum = 18), and the REAL cooldown band by value (63). All 16 bands whose preludes include `fourth-walker.fk` hold their prior verdicts.

## Named, not bent

- **feature-vector** (the honest tenth): flattens and fits the loader, but band-scale allocation crosses the arena's water line and the copying melt cannot see packed args held in suspended C frames (m4e2's named suspended-temp gap). Off the ratchet until call arguments ride a walker-managed value stack.
- **adler32**: still waits on the `band`/`shl_u32`/`add_u32` figure family and let-in-defn nested `do` — multi-param alone was not its blocker.
- **str_***: wants the walker string-pool lane it shares with the m4d full-fixpoint blocker — named for the next hands, not started.

Evidence: `docs/system_audit/commit_evidence_2026-06-11_m4e4_multiparam_fourth_arm.json`. Audit end-to-end green (exit 0), arm64 Darwin, clang -O2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)