### PR TITLE
tend: the SELF-JIT's gas-ice cycle closes both ways — heat falls, ice melts, re-crystallization is earned

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-11_melt_hot_swap.json
+++ b/docs/system_audit/commit_evidence_2026-06-11_melt_hot_swap.json
@@ -1,0 +1,96 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "form-os3/melt-hot-swap",
+  "commit_scope": "Close the SELF-JIT's gas-ice cycle BOTH ways (round 3 of the Form-OS arc; round 2 = melt-on-cool's arena face, PR #2846). The shipped half let heat only rise: dispatch flips to native past the hot line. This face makes heat FALL and ice MELT: every fkc-decay-quantum (256) dispatches is one epoch and every heat halves (fkc-heat-decay over fkc-decay-divisor); a crystallized native melts back to the walking path when its decayed heat falls below the melt line (fkc-melt-line = hot * fkc-melt-line-pct / 100, the same cell algebra as fkc-melt-water-pct); and re-crystallization is champion-challenger gated — after a melt the native is a challenger again and re-earns ice only by winning fkc-cc-earn-epochs (2) CONSECUTIVE epochs above the hot line. fkc-earn-step/fkc-re-earned ARE cc-promote? specialized to that history (champion = walking path, always correct; margin 0 => every trial won => consecutive wins), proven against champion-challenger.fk itself in the band. One honesty gate joins: lowerability is TRANSITIVE (fkc-can-list, greatest fixpoint over the function table) so a pure function calling a port/organ function never crystallizes (fk_can[] in the emitted C) and a melt can never strand a wrong native. All policy is recipe cells; the emitted C fragments (fkc-jm-*-text) splice those cells, so the band asserts the binary's text IS the recipes' algebra.",
+  "files_owned": [
+    "form/form-stdlib/fourth-walker-emit.fk",
+    "form/form-stdlib/tests/melt-hot-swap-band.fk",
+    "scripts/fourth_kernel_audit.sh",
+    "docs/system_audit/commit_evidence_2026-06-11_melt_hot_swap.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/champion-challenger.fk form-stdlib/tests/melt-hot-swap-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/arena-melt.fk form-stdlib/tests/melt-on-cool-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/tests/fourth-os-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/tests/fourth-walker-emit-band.fk",
+      "bash scripts/fourth_kernel_audit.sh",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-11_melt_hot_swap.json",
+      "python3 scripts/generate_repo_indexes.py"
+    ],
+    "notes": "melt-hot-swap-band verdict 31 with 0 divergent across Go/Rust/TS (cells cohere; melt boundary exact at 24/25 with hot=50; champion-challenger tie proven against cc-promote? itself; transitive lowerability incl. mutual pure recursion staying eligible and impurity poisoning a call edge; emission carries the spliced cell algebra). Neighbor bands hold unchanged: melt-on-cool-band 31, fourth-os-band 15, fourth-walker-emit-band 15, all three-way. Audit section 21 measured rows (arm64 Darwin, clang -O2, one binary, deterministic dispatch counts): hotfn crystallizes at heat 51 (hot line 50, jf 2 51); three idle epochs halve 88 -> 44 -> 22 and it MELTS at heat 22 (melt line 25, jm 2 22); scenario 0's single post-melt call WALKS — final heat 31 = 11 + 20 walked dispatches (a native dispatch would read 12), final ice state 2 (melted gas), value 8610 = walk-only 8610; scenario 1 re-heats and the native RE-EARNS ice after 2 consecutive winning epochs (jf 2 293), final ice state 1, freezes=2 melts=1 njit=62, value 16800 = walk-only 16800 — parity held at every phase, the crossing order asserted as crystallize -> melt -> re-earn.",
+    "environment": "arm64 Darwin, clang -O2, Go/Rust/TS kernels via form/validate.sh"
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote CI three-way validation pending until the branch is pushed and the PR opens."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Recipes, band, audit, and evidence only; no route or service behavior changes. No deploy required beyond normal main rollout."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Local three-way proof and live-binary cycle witness are green; push, PR, and the coordinator's retune of fourth-kernel.form's SELF-JIT block (the hot-swap-free face now closed both ways at the policy level; true runtime codegen for foreign tables remains the named open) follow.",
+    "remaining": [
+      "coordinator retune of fourth-kernel.form SELF-JIT block after all five round-3 siblings merge"
+    ]
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "melt-hot-swap-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "form-os-map"
+      ]
+    },
+    {
+      "contributor_id": "contributor:claude-fable-5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "proof"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "change_intent": "runtime_feature",
+  "change_files": [
+    "form/form-stdlib/fourth-walker-emit.fk",
+    "form/form-stdlib/tests/melt-hot-swap-band.fk",
+    "scripts/fourth_kernel_audit.sh"
+  ],
+  "evidence_refs": [
+    "Three-way band proof: melt-hot-swap-band verdict 31, 0 divergent (Go/Rust/TS) — policy cells cohere (decay halves and reaches zero, melt line at hot=50 is 25, cooling clock and earn window positive); melt boundary exact (heat 24 melts, 25 holds, fresh-frozen 51 never melts at its own crossing); champion-challenger tie proven against cc-promote? itself (a window of won epoch-trials promotes by BOTH doors, one cold epoch breaks both — the consecutive gate IS margin-0 promotion); lowerability transitive (pure self-recursion lowers, port/organ never, impurity poisons a call edge, mutual pure recursion even/odd stays eligible); emission carries the spliced cell algebra (decay, melt line, earn gate, cooling clock, dispatch door, honesty gate).",
+    "Live emitted-sibling cycle (fkc-emit-jitmelt via clang, scripts/fourth_kernel_audit.sh section 21, deterministic dispatch counts): crystallize at heat 51 (jf 2 51, hot line 50); three idle epochs halve 88 -> 44 -> 22 and the native MELTS at heat 22 (jm 2 22, melt line 25); the single post-melt call WALKS — final heat 31 = 11 + 20 walked dispatches where a native dispatch would read 12, final ice state 2 (melted gas); re-heat re-EARNS ice after 2 consecutive winning epochs (jf 2 293), final ice state 1, freezes=2 melts=1 njit=62.",
+    "Parity held at every phase: scenario 0 value 8610 == walk-only 8610; scenario 1 value 16800 == walk-only 16800; crossing order asserted crystallize -> melt -> re-earn (fmf).",
+    "Neighbor bands unchanged: melt-on-cool-band 31, fourth-os-band 15, fourth-walker-emit-band 15, all three-way 0 divergent."
+  ],
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "No route behavior changes. The emitted sibling family gains a new emit lane (fkc-emit-jitmelt) where the SELF-JIT cycle runs both directions: heat decays per epoch, a cooled crystallized native melts back to the walking path, and re-crystallization is champion-challenger gated by consecutive winning epochs. The shipped fkc-emit-jit lane is untouched (its rise-only flip and the fib28 cold/hot witness stay byte-identical); existing emission-pinning bands hold unchanged.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "melt-hot-swap-band proves the policy cells, the melt boundary, the cc-promote? tie, transitive lowerability, and the spliced emission, three-way at 31 with 0 divergent.",
+      "Audit lane end-to-end: section 21 drives one binary through crystallize -> melt -> re-earn with parity at every phase, while every earlier audit section (parity rows, quine, CALL, grammar binaries, universal, JIT flip, net 200, driver, m4e3, afferent witness, n7 band ratchet, melt-on-cool) stays green."
+    ],
+    "summary": "validate.sh new band verdict 31 three-way 0 divergent; live emitted-binary gas-ice cycle measured both ways: jf 2 51 -> jm 2 22 -> jf 2 293, parity 8610/16800 held, ice re-earned never declared."
+  }
+}

--- a/form/form-stdlib/fourth-walker-emit.fk
+++ b/form/form-stdlib/fourth-walker-emit.fk
@@ -395,6 +395,147 @@
 
 (defn fkc-emit-jit (fns) (fkc-emit-jit2 fns (fkc-flatten-many fns)))
 
+; ── melt-hot-swap — the gas-ice cycle closed BOTH ways (the SELF-JIT's cool face) ──
+; The block above ships the rise: heat per function, dispatch flips native past
+; the hot line. This face is the fall. Every fkc-decay-quantum dispatches is one
+; EPOCH and every heat divides by fkc-decay-divisor (halving — the simplest
+; honest decay: recent heat dominates, old heat fades geometrically). A
+; crystallized native MELTS back to the walking path when its decayed heat
+; falls below the melt line (fkc-melt-line — a percentage of the hot line, the
+; same cell algebra as fkc-melt-water-pct: no magic in the C). And
+; re-crystallization is champion-challenger gated: after a melt the native is a
+; CHALLENGER again — the walking path is the champion (always correct; it IS
+; the semantics) — and ice is re-EARNED by winning fkc-cc-earn-epochs
+; CONSECUTIVE epochs, an epoch won when measured heat stays above the hot line.
+; fkc-cc-trial names each epoch as a champion-challenger trial; fkc-earn-step /
+; fkc-re-earned are cc-promote? specialized to that history (champion always 1,
+; margin 0 => every trial in the window won => consecutive wins) — the tie is
+; proven against champion-challenger.fk itself in tests/melt-hot-swap-band.fk.
+; One honesty gate joins the cycle: only functions whose cell trees stay in the
+; pure-compute family (tags 1-7, 12) — TRANSITIVELY, through every callee —
+; are lowerable (fkc-can-list, greatest fixpoint so mutual pure recursion
+; stays native-eligible); a function touching ports/organs walks forever
+; (fk_can[] in the emitted C), so a melt can never strand a wrong native.
+
+(defn fkc-decay-quantum ()  256)  ; dispatches per epoch — the cooling clock
+(defn fkc-decay-divisor ()  2)    ; heat halves each epoch
+(defn fkc-melt-line-pct ()  50)   ; ice melts when heat < hot * pct / 100
+(defn fkc-cc-earn-epochs () 2)    ; consecutive winning epochs to re-earn ice
+
+(defn fkc-heat-decay (h)    (div h (fkc-decay-divisor)))
+(defn fkc-melt-line (hot)   (div (mul hot (fkc-melt-line-pct)) 100))
+(defn fkc-melts-now (h hot) (if (gt (fkc-melt-line hot) h) 1 0))
+(defn fkc-cc-trial (h hot)  (list 1 (if (gt h hot) 1 0)))
+(defn fkc-earn-step (earn won) (if (eq won 1) (add earn 1) 0))
+(defn fkc-re-earned (earn)  (if (ge earn (fkc-cc-earn-epochs)) 1 0))
+
+; transitive lowerability — a function may crystallize only if its own cells
+; AND every callee's are pure-compute. Greatest fixpoint: start all-1, apply
+; len+1 times so impurity propagates through any call chain.
+(defn fkc-lower-ok (n can)
+    (if (eq (fk-tag n) 1) 1
+    (if (eq (fk-tag n) 2) 1
+    (if (eq (fk-tag n) 7) (if (eq (nth can 0) 1) (fkc-lower-ok (fk-body n) can) 0)
+    (if (eq (fk-tag n) 12) (if (eq (nth can (ms-value (ms-child (fk-body n) 0))) 1)
+                               (fkc-lower-ok (ms-child (fk-body n) 1) can) 0)
+    (if (eq (fk-tag n) 6) (if (eq (fkc-lower-ok (ms-child (fk-body n) 0) can) 1)
+                              (fkc-low-if2 n can) 0)
+    (if (eq (fk-tag n) 3) (fkc-low-bin n can)
+    (if (eq (fk-tag n) 4) (fkc-low-bin n can)
+    (if (eq (fk-tag n) 5) (fkc-low-bin n can)
+        0)))))))))
+(defn fkc-low-bin (n can)
+    (if (eq (fkc-lower-ok (ms-child (fk-body n) 0) can) 1)
+        (fkc-lower-ok (ms-child (fk-body n) 1) can) 0))
+(defn fkc-low-if2 (n can)
+    (if (eq (fkc-lower-ok (ms-child (ms-child (fk-body n) 1) 0) can) 1)
+        (fkc-lower-ok (ms-child (ms-child (fk-body n) 1) 1) can) 0))
+(defn fkc-can-map (rest can)
+    (if (eq (len rest) 0) (empty)
+        (cons (fkc-lower-ok (head rest) can) (fkc-can-map (tail rest) can))))
+(defn fkc-can-iter (fns can m)
+    (if (eq m 0) can (fkc-can-iter fns (fkc-can-map fns can) (sub m 1))))
+(defn fkc-ones (m) (if (eq m 0) (empty) (cons 1 (fkc-ones (sub m 1)))))
+(defn fkc-can-list (fns) (fkc-can-iter fns (fkc-ones (len fns)) (add (len fns) 1)))
+
+; the C fragments the cycle is emitted from — each splices its policy cell, so
+; the band can assert the binary's text IS the recipes' algebra
+(defn fkc-jm-decay-text ()
+    (str_concat "fk_heat[f] = fk_heat[f] / " (str_concat (int_to_str (fkc-decay-divisor)) "; ")))
+(defn fkc-jm-melt-cond-text ()
+    (str_concat "fk_heat[f] < fk_hot * " (str_concat (int_to_str (fkc-melt-line-pct)) " / 100")))
+(defn fkc-jm-earn-cond-text ()
+    (str_concat "fk_earn[f] >= " (int_to_str (fkc-cc-earn-epochs))))
+(defn fkc-jm-tick-cond-text ()
+    (str_concat "fk_tick >= " (int_to_str (fkc-decay-quantum))))
+; boundary-crossing readout on stderr (the satsang door): jf = crystallize, jm = melt
+(defn fkc-jm-mark-text (c)
+    (str_concat "fk_mc(106); fk_mc("
+    (str_concat (int_to_str c)
+                "); fk_mc(32); fk_mw(f); fk_mc(32); fk_mw(fk_heat[f]); fk_mc(10); ")))
+
+(defn fkc-jitmelt-decl-text ()
+    "static long long fk_heat[64]; static long long fk_ice[64]; static long long fk_earn[64]; static long long fk_can[64]; static long long fk_tick; static long long fk_hot; static long long fk_njit; static long long fk_nmelt; static long long fk_nfreeze; static long long (*fk_nat_tab[64])(long long); ")
+
+; the epoch: ice states walk 0 gas -> 1 ice -> 2 melted-gas; a melted native
+; re-earns ice only through the consecutive-win gate; then every heat decays
+(defn fkc-epoch-text (nf)
+    (str_concat "static void fk_epoch(void) { long long f = 0; while (f < "
+    (str_concat (int_to_str nf)
+    (str_concat ") { if (fk_ice[f] == 2) { if (fk_heat[f] > fk_hot) { fk_earn[f] = fk_earn[f] + 1; } else { fk_earn[f] = 0; } if ("
+    (str_concat (fkc-jm-earn-cond-text)
+    (str_concat ") { fk_ice[f] = 1; fk_nfreeze = fk_nfreeze + 1; "
+    (str_concat (fkc-jm-mark-text 102)
+    (str_concat "} } if (fk_ice[f] == 1) { if ("
+    (str_concat (fkc-jm-melt-cond-text)
+    (str_concat ") { fk_ice[f] = 2; fk_earn[f] = 0; fk_nmelt = fk_nmelt + 1; "
+    (str_concat (fkc-jm-mark-text 109)
+    (str_concat "} } "
+    (str_concat (fkc-jm-decay-text) "f = f + 1; } } ")))))))))))))
+
+; the dispatch door: tick the cooling clock, count the heat, and first
+; crystallization (gas that was never ice) flips on raw heat — the shipped rise
+(defn fkc-jd-text ()
+    (str_concat "static void fk_jd(long long f) { fk_tick = fk_tick + 1; if ("
+    (str_concat (fkc-jm-tick-cond-text)
+    (str_concat ") { fk_tick = 0; fk_epoch(); } fk_heat[f] = fk_heat[f] + 1; if (fk_ice[f] == 0) { if (fk_can[f] == 1) { if (fk_heat[f] > fk_hot) { fk_ice[f] = 1; fk_nfreeze = fk_nfreeze + 1; "
+    (str_concat (fkc-jm-mark-text 102) "} } } } ")))))
+
+(defn fkc-walk-jitmelt-text ()
+    (str_concat "static long long fk_walk(long long i, long long a) { long long t = fk_node[i][0]; fk_arms[t] = fk_arms[t] + 1; if (t == 1) { return fk_node[i][1] << 1; } if (t == 2) { return a; } if (t == 3) { return fk_walk(fk_node[i][1], a) + fk_walk(fk_node[i][2], a); } if (t == 4) { return fk_walk(fk_node[i][1], a) - fk_walk(fk_node[i][2], a); } if (t == 5) { if (fk_walk(fk_node[i][1], a) <= fk_walk(fk_node[i][2], a)) { return 2; } return 0; } if (t == 6) { if (fk_walk(fk_node[i][1], a) == 0) { return fk_walk(fk_node[i][3], a); } return fk_walk(fk_node[i][2], a); } if (t == 7) { long long v7 = fk_walk(fk_node[i][1], a); fk_jd(0); if (fk_ice[0] == 1) { fk_njit = fk_njit + 1; return fk_nat_tab[0](v7); } return fk_walk(fk_fn[0], v7); } if (t == 12) { long long f12 = fk_node[i][1]; long long v12 = fk_walk(fk_node[i][2], a); fk_jd(f12); if (fk_ice[f12] == 1) { fk_njit = fk_njit + 1; return fk_nat_tab[f12](v12); } return fk_walk(fk_fn[f12], v12); }"
+                (fkc-arms-many-text)))
+
+(defn fkc-can-fills (can k)
+    (if (eq (len can) 0) " "
+        (str_concat "fk_can["
+        (str_concat (int_to_str k)
+        (str_concat "] = "
+        (str_concat (int_to_str (head can))
+        (str_concat "; " (fkc-can-fills (tail can) (add k 1)))))))))
+
+; probe: value, njit, nmelt, nfreeze, then (heat, ice) per function — the
+; thermodynamic state is the readout, born observable like every sibling
+(defn fkc-main-jitmelt-text (fns)
+    (str_concat "extern int atoi(const char *); int main(int argc, char **argv) { long long a = 0; if (argc > 1) { a = atoi(argv[1]) << 1; } fk_hot = 1000000000000; if (argc > 2) { fk_hot = atoi(argv[2]); } "
+    (str_concat (fkc-jit-fills 0 (len fns))
+    (str_concat (fkc-can-fills (fkc-can-list fns) 0)
+    (str_concat "fk_pv(fk_walk(fk_fn[0], a)); fk_pr(fk_njit); fk_pr(fk_nmelt); fk_pr(fk_nfreeze); long long f = 0; while (f < "
+    (str_concat (int_to_str (len fns))
+                ") { fk_pr(fk_heat[f]); fk_pr(fk_ice[f]); f = f + 1; } return 0; }"))))))
+
+(defn fkc-emit-jitmelt2 (fns flat)
+    (str_concat (fkc-pr-text)
+    (str_concat (fkc-decl-many-text (nth flat 0) (nth flat 1))
+    (str_concat (fkc-jitmelt-decl-text)
+    (str_concat (fkc-jit-protos 0 (len fns))
+    (str_concat (fkc-jit-bodies fns 0)
+    (str_concat (fkc-epoch-text (len fns))
+    (str_concat (fkc-jd-text)
+    (str_concat (fkc-walk-jitmelt-text)
+                (fkc-main-jitmelt-text fns))))))))))
+
+(defn fkc-emit-jitmelt (fns) (fkc-emit-jitmelt2 fns (fkc-flatten-many fns)))
+
 ; band helper — does any row carry the given tag? (organ ops in the table)
 (defn fkd-has-tag (rows t)
     (if (eq (len rows) 0) 0

--- a/form/form-stdlib/tests/melt-hot-swap-band.fk
+++ b/form/form-stdlib/tests/melt-hot-swap-band.fk
@@ -1,0 +1,72 @@
+; preludes: form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/champion-challenger.fk
+;
+; melt-hot-swap-band — the SELF-JIT's gas-ice cycle closed BOTH ways, proven
+; three-way. The shipped half flips dispatch to native when measured heat
+; crosses the hot line; this band proves the cool face: heat decays per epoch
+; (fkc-heat-decay over fkc-decay-divisor), ice melts back to the walking path
+; below the melt line (fkc-melts-now over fkc-melt-line-pct), and
+; re-crystallization is champion-challenger gated — fkc-earn-step/fkc-re-earned
+; ARE cc-promote? specialized to the epoch-trial history (champion = walking
+; path, always correct; margin 0), proven against champion-challenger.fk
+; itself. The live binary face is measured in scripts/fourth_kernel_audit.sh
+; section 21: crystallize -> melt -> re-earn, parity held at every phase.
+;
+; Verdict 31 when the cycle holds:
+;   1   the policy cells cohere: decay halves and reaches zero (a heat can
+;       fully cool), the melt line at hot=50 is 25, the cooling clock and the
+;       earn window are positive
+;   2   the melt boundary is exact: heat 24 melts, 25 holds, and a
+;       fresh-frozen heat (51) never melts at its own crossing
+;   4   the champion-challenger tie: a window of won epoch-trials promotes by
+;       BOTH doors (cc-promote? and the earn chain); one cold epoch breaks
+;       both (the consecutive gate IS margin-0 promotion); the trial shape
+;       carries champion-always-1, challenger-by-measured-heat
+;   8   lowerability is transitive: pure self-recursion lowers, a port/organ
+;       function never does, purity poisons through a call edge, and mutual
+;       pure recursion (even/odd) stays native-eligible — the fixpoint holds
+;   16  the emission carries the cycle FROM the cells: decay, melt line,
+;       earn gate, and cooling clock land in the C as the same spliced
+;       algebra; the dispatch door and the honesty gate are present
+(do
+    (let c0 (if (eq (fkc-heat-decay 88) 44)
+                (if (eq (fkc-heat-decay 1) 0)
+                    (if (eq (fkc-melt-line 50) 25)
+                        (if (gt (fkc-decay-quantum) 0)
+                            (if (gt (fkc-cc-earn-epochs) 0) 1 0) 0) 0) 0) 0))
+
+    (let c1 (if (eq (fkc-melts-now 24 50) 1)
+                (if (eq (fkc-melts-now 25 50) 0)
+                    (if (eq (fkc-melts-now 51 50) 0) 2 0) 0) 0))
+
+    (let hwin (list (fkc-cc-trial 60 50) (fkc-cc-trial 70 50)))
+    (let hcold (list (fkc-cc-trial 60 50) (fkc-cc-trial 10 50)))
+    (let c2 (if (eq (cc-promote? hwin (fkc-cc-earn-epochs) 0) 1)
+                (if (eq (fkc-re-earned (fkc-earn-step (fkc-earn-step 0 1) 1)) 1)
+                    (if (eq (cc-promote? hcold (fkc-cc-earn-epochs) 0) 0)
+                        (if (eq (fkc-re-earned (fkc-earn-step (fkc-earn-step 0 1) 0)) 0)
+                            (if (eq (cc-champ (fkc-cc-trial 10 50)) 1)
+                                (if (eq (cc-chall (fkc-cc-trial 10 50)) 0)
+                                    (if (eq (cc-chall (fkc-cc-trial 60 50)) 1) 4 0) 0) 0) 0) 0) 0) 0))
+
+    (let fib1 (fk-if (fk-le (fk-arg) (fk-lit 1)) (fk-arg)
+                     (fk-add (fk-call 0 (fk-sub (fk-arg) (fk-lit 1)))
+                             (fk-call 0 (fk-sub (fk-arg) (fk-lit 2))))))
+    (let ramf (fk-get (fk-lit 3)))
+    (let callsimpure (fk-call 1 (fk-lit 1)))
+    (let evenf (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 1) (fk-call 1 (fk-sub (fk-arg) (fk-lit 1)))))
+    (let oddf  (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0) (fk-call 0 (fk-sub (fk-arg) (fk-lit 1)))))
+    (let c3 (if (eq (nth (fkc-can-list (list fib1)) 0) 1)
+                (if (eq (nth (fkc-can-list (list callsimpure ramf)) 0) 0)
+                    (if (eq (nth (fkc-can-list (list callsimpure ramf)) 1) 0)
+                        (if (eq (nth (fkc-can-list (list evenf oddf)) 0) 1)
+                            (if (eq (nth (fkc-can-list (list evenf oddf)) 1) 1) 8 0) 0) 0) 0) 0))
+
+    (let jm (fkc-emit-jitmelt (list fib1)))
+    (let c4 (if (ge (str_find jm (fkc-jm-decay-text) 0) 0)
+                (if (ge (str_find jm (fkc-jm-melt-cond-text) 0) 0)
+                    (if (ge (str_find jm (fkc-jm-earn-cond-text) 0) 0)
+                        (if (ge (str_find jm (fkc-jm-tick-cond-text) 0) 0)
+                            (if (ge (str_find jm "fk_jd(f12)" 0) 0)
+                                (if (ge (str_find jm "fk_can[0] = 1; " 0) 0) 16 0) 0) 0) 0) 0) 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/scripts/fourth_kernel_audit.sh
+++ b/scripts/fourth_kernel_audit.sh
@@ -698,5 +698,69 @@ awk '/^melt /{ok=($4>0 && $6==4096)}END{exit ok?0:1}' "$work/mechurn.txt" || { e
 echo "  the melt the recipes prove is the melt the binary DOES — live sets cross the boundary, garbage returns"
 
 echo
+# ── 21. melt-hot-swap — the SELF-JIT's gas-ice cycle closes BOTH ways ─────
+# Section 8-10 ships the rise (heat per function; dispatch flips native past
+# the hot line). This face: heat DECAYS (halve per 256-dispatch epoch), a
+# crystallized native MELTS back to walking when its decayed heat falls below
+# the melt line (50% of hot), and re-crystallization is champion-challenger
+# gated — 2 CONSECUTIVE epochs above the hot line re-earn ice (the walking
+# path is the champion, always correct; one hot spike is not enough). All
+# policy is recipe cells (fkc-decay-quantum/divisor, fkc-melt-line-pct,
+# fkc-cc-earn-epochs); the C is emitted from them. One binary, two scenarios
+# by arg: 0 = drive hot -> idle epochs -> ONE more call (must WALK: ice fell);
+# 1 = drive hot -> idle epochs -> re-heat (must RE-EARN: ice returns).
+cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/fourth-walker.fk" \
+    "$FORMDIR/form-stdlib/fourth-walker-emit.fk" > "$work/jm-driver.fk"
+cat >> "$work/jm-driver.fk" <<'EOF'
+(let tri   (fk-if (fk-le (fk-arg) (fk-lit 1)) (fk-arg) (fk-add (fk-arg) (fk-call 2 (fk-sub (fk-arg) (fk-lit 1))))))
+(let loopA (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0) (fk-add (fk-call 2 (fk-lit 20)) (fk-call 1 (fk-sub (fk-arg) (fk-lit 1))))))
+(let loopB (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0) (fk-add (fk-sub (fk-set (fk-lit 9) (fk-arg)) (fk-arg)) (fk-call 3 (fk-sub (fk-arg) (fk-lit 1))))))
+(let driver (fk-if (fk-arg)
+                   (fk-add (fk-call 1 (fk-lit 40)) (fk-add (fk-call 3 (fk-lit 800)) (fk-call 1 (fk-lit 40))))
+                   (fk-add (fk-call 1 (fk-lit 40)) (fk-add (fk-call 3 (fk-lit 800)) (fk-call 2 (fk-lit 20))))))
+(print "==JMC==")
+(print (fkc-emit-jitmelt (list driver loopA tri loopB)))
+(print "==END==")
+EOF
+(cd "$FORMDIR" && "$GO_BIN" "$work/jm-driver.fk" 2>/dev/null) > "$work/jm.out"
+sed -n '/^==JMC==$/,/^==END==$/p' "$work/jm.out" | sed -e '1d' -e '$d' > "$work/fkjm.c"
+"$CLANG" -O2 -o "$work/fkjm" "$work/fkjm.c"
+jm0_walk="$("$work/fkjm" 0 | head -1)"
+jm1_walk="$("$work/fkjm" 1 | head -1)"
+"$work/fkjm" 0 50 > "$work/jm-a.out" 2> "$work/jm-a.err"
+"$work/fkjm" 1 50 > "$work/jm-b.out" 2> "$work/jm-b.err"
+vA="$(sed -n 1p "$work/jm-a.out")"; meltA="$(sed -n 3p "$work/jm-a.out")"; frzA="$(sed -n 4p "$work/jm-a.out")"
+heatA2="$(sed -n 9p "$work/jm-a.out")"; iceA2="$(sed -n 10p "$work/jm-a.out")"
+vB="$(sed -n 1p "$work/jm-b.out")"; njitB="$(sed -n 2p "$work/jm-b.out")"; meltB="$(sed -n 3p "$work/jm-b.out")"; frzB="$(sed -n 4p "$work/jm-b.out")"
+heatB2="$(sed -n 9p "$work/jm-b.out")"; iceB2="$(sed -n 10p "$work/jm-b.out")"
+echo "melt-hot-swap (heat rises per dispatch, halves per epoch; ice melts below the line; re-ice is EARNED):"
+echo "  scenario 0 (hot->cool->one call): value=$vA (walk $jm0_walk)  freezes=$frzA melts=$meltA  hotfn end: heat=$heatA2 ice=$iceA2 (2=melted gas)"
+echo "  scenario 1 (hot->cool->re-heat):  value=$vB (walk $jm1_walk)  freezes=$frzB melts=$meltB njit=$njitB  hotfn end: heat=$heatB2 ice=$iceB2 (1=ice)"
+echo "  hotfn (fn 2) boundary crossings (jf=crystallize@heat, jm=melt@heat):"
+grep '^j[fm] 2 ' "$work/jm-b.err" | sed 's/^/    /'
+if [[ "$vA" != "8610" || "$jm0_walk" != "8610" || "$vB" != "16800" || "$jm1_walk" != "16800" ]]; then
+    echo "FAIL  melt-hot-swap parity broken across the cycle"; exit 1
+fi
+if [[ "$frzA" != "1" || "$meltA" != "1" || "$iceA2" != "2" ]]; then
+    echo "FAIL  the cooled native did not melt back to gas"; exit 1
+fi
+if (( heatA2 <= 12 )); then
+    echo "FAIL  the post-melt call did not WALK (heat shows a native dispatch, not 20 walked ones)"; exit 1
+fi
+if [[ "$frzB" != "2" || "$meltB" != "1" || "$iceB2" != "1" || "$njitB" == "0" ]]; then
+    echo "FAIL  re-heat did not re-earn ice through the champion-challenger gate"; exit 1
+fi
+seq2="$(grep '^j[fm] 2 ' "$work/jm-b.err" | awk '{printf "%s", substr($1,2,1)}')"
+if [[ "$seq2" != "fmf" ]]; then
+    echo "FAIL  hotfn's phase order is not crystallize -> melt -> re-earn (got: $seq2)"; exit 1
+fi
+jf1="$(grep '^jf 2 ' "$work/jm-b.err" | sed -n 1p | awk '{print $3}')"
+jmh="$(grep '^jm 2 ' "$work/jm-b.err" | awk '{print $3}')"
+if (( jf1 <= 50 )) || (( jmh >= 25 )); then
+    echo "FAIL  heat at the boundary crossings disagrees with the policy cells (jf=$jf1 jm=$jmh)"; exit 1
+fi
+echo "  the cycle closed both ways: measured heat froze it, measured cool melted it, ice re-EARNED — never declared"
+
+echo
 echo "conditions: $(uname -m) $(uname -s), clang -O2, full-process invocations (startup included)"
 echo "ok — parity held and the rows are real; the spec is docs/coherence-substrate/fourth-kernel.form"


### PR DESCRIPTION
Round 3 of the Form-OS walk — the melt's hot-swap-free face. fourth-kernel.form's SELF-JIT block named this open: "melting a cooled crystallized native, champion-challenger gated — heat counters still only rise". This closes it at the policy level: the full thermodynamic cycle, gas (walking) ⇄ ice (native), driven by MEASURED heat in both directions, every threshold a recipe cell.

## The cool face

- **Heat decays**: every `fkc-decay-quantum` (256) dispatches is one epoch; every heat halves (`fkc-heat-decay` over `fkc-decay-divisor`) — recent heat dominates, old heat fades geometrically.
- **Ice melts**: a crystallized native returns to the walking path when its decayed heat falls below the melt line (`fkc-melt-line` = hot × `fkc-melt-line-pct` / 100 — the same cell algebra as `fkc-melt-water-pct`; no magic in the C).
- **Re-ice is earned**: after a melt the native is a champion-challenger CHALLENGER again (the walking path is the champion — it IS the semantics, always correct) and re-crystallizes only by winning `fkc-cc-earn-epochs` (2) CONSECUTIVE epochs above the hot line. `fkc-earn-step`/`fkc-re-earned` ARE `cc-promote?` specialized to that history (margin 0 ⇒ every trial won ⇒ consecutive wins) — the tie is proven against `champion-challenger.fk` itself in the band.
- **Honesty gate**: lowerability is TRANSITIVE (`fkc-can-list`, greatest fixpoint over the function table) — a pure function calling a port/organ function never crystallizes (`fk_can[]`), so a melt can never strand a wrong native. Mutual pure recursion (even/odd) stays native-eligible.

All policy is recipe cells; the emitted C fragments (`fkc-jm-*-text`) splice those cells, so the band asserts the binary's text IS the recipes' algebra. The shipped `fkc-emit-jit` lane is untouched; emission-pinning neighbor bands hold unchanged.

## Proof

- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/champion-challenger.fk form-stdlib/tests/melt-hot-swap-band.fk` → **31, 0 divergent** (Go/Rust/TS)
- Neighbors re-validated: melt-on-cool-band → 31, fourth-os-band → 15, fourth-walker-emit-band → 15, all three-way
- Live witness (audit **section 21**, one binary, deterministic dispatch counts):
  - crystallize at heat **51** (`jf 2 51`, hot line 50)
  - three idle epochs halve 88 → 44 → 22; **MELT at heat 22** (`jm 2 22`, melt line 25)
  - the single post-melt call **WALKS**: final heat 31 = 11 + 20 walked dispatches (a native dispatch would read 12); final ice state 2 (melted gas)
  - re-heat **re-EARNS** ice after 2 consecutive winning epochs (`jf 2 293`); final ice state 1; freezes=2 melts=1 njit=62
  - parity held at every phase: scenario 0 → 8610 == walk-only 8610; scenario 1 → 16800 == walk-only 16800; crossing order asserted crystallize → melt → re-earn

Evidence: `docs/system_audit/commit_evidence_2026-06-11_melt_hot_swap.json` (validator-green).

Named open that stays open: true runtime codegen for FOREIGN loaded tables (the universal binary re-emitting through the toolchain port — the full crystallization wire). This PR closes the policy cycle; the coordinator retunes fourth-kernel.form's SELF-JIT block after all five round-3 siblings merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)