### PR TITLE
tend: the third ring closes — the Form-OS maps retune to round 3

### DIFF
--- a/docs/coherence-substrate/afferent-offer.form
+++ b/docs/coherence-substrate/afferent-offer.form
@@ -136,9 +136,19 @@
 # (TIME + tail countdown), not minted. Proven: tests/afferent-live-band.fk
 # -> 63 three-way; witnessed: fourth_kernel_audit.sh section 18.
 #
-# Next stones when an ask needs them (named, not built ahead of need):
-# delivery priority as data (POSIX number-order, IRQ priority — a
-# policy cell over the same engine; the live carrier lowers a single
-# pending offer today, so multi-offer time-ordering lands exactly
-# there); the scheduler row, which is this engine's efferent twin
-# (offer-the-compute-organ-to-competing-recipes).
+# Delivery priority is closed — and it closed as the scheduler's OWN
+# rows read backward: POSIX number-order IS sched-fifo's row data
+# (least-wins over the ordinal key, read over signal numbers); IRQ
+# priority IS sched-priority's row data (greatest-wins over urgency,
+# read over levels) — proven row-for-row (afferent-priority.fk,
+# tests/afferent-priority-band.fk -> 1023 three-way) and witnessed
+# live (audit section 23: the same two-offer pending set delivers in
+# opposite orders under the two rows, on the real clock). The mask/
+# window rules stay sovereign before any ranking; one chooser
+# discipline now reads both directions, afferent and efferent.
+#
+# Next stone when an ask needs it (named, not built ahead of need):
+# preemption — a higher-priority offer arriving MID-wait does not yet
+# displace the composed winner; the re-decide-on-arrival stone lands
+# where sched-step and the live poll loop compose (one re-verdict per
+# poll tick rather than per wait).

--- a/docs/coherence-substrate/fourth-kernel.form
+++ b/docs/coherence-substrate/fourth-kernel.form
@@ -351,9 +351,23 @@
                            onto IF/LE; lists 1:1 onto arena tags); fkw answers
                            127 = the three walkers' own validate.sh verdict,
                            gated four-way in the audit (n7 section);
-                           bands-on-fourth-arm 0 -> 1, measured; next families
-                           are m4e4 exactly as scoped (str_*/node_*/floats/
-                           multi-param), each lifting more of the 424)
+                           bands-on-fourth-arm 0 -> 1, measured; m4e4
+                           multi-param [SHIPPED]: packed args as a PURE
+                           flattening rule (an N-arg call right-folds its
+                           args into a CONS chain; the callee binds params
+                           as NTH(ARG,i); zero new walker tags, emitted C
+                           unchanged) — nine more bands crossed UNMODIFIED,
+                           bands-on-fourth-arm 1 -> 10, each four-way gated
+                           (audit section 22; tests/form-flatten-band.fk ->
+                           127); remaining families named with their walls:
+                           str_* (needs the walker string-pool lane, shared
+                           with the m4d fixpoint blocker), figure-ops
+                           (band/shl_u32/add_u32 + nested-do unlock the
+                           checksum bands), floats; and the melt-root wall —
+                           packed args live in suspended C frames the
+                           copying melt cannot root (feature-vector blocked
+                           there), the structural fix is call args on a
+                           walker-managed value stack)
           (n8-assembly     [SHIPPED] otool -tvV on the emitted walker in the
                            audit shows real ARM64 (stp/ldr/adrp/lsl) — the
                            whole arc visible: Form recipe -> emitted C ->
@@ -432,12 +446,24 @@
                      the round-1 deaths survive (n=4096 -> 4096 was 0,
                      n=4200 -> 4200 was 104), growth and reclaim faces both
                      witnessed in the audit (section 20), proven three-way
-                     (tests/melt-on-cool-band.fk -> 31). Open, named: the
-                     hot-swap-free face (melting a cooled crystallized
-                     native, champion-challenger gated — heat counters still
-                     only rise), and true runtime codegen for FOREIGN loaded
-                     tables (the universal binary re-emitting through the
-                     toolchain port — the full crystallization wire))
+                     (tests/melt-on-cool-band.fk -> 31). hot-swap face
+                     [SHIPPED]: the gas-ice cycle closes BOTH ways — heat
+                     DECAYS (halve per 256-dispatch epoch; decay quantum,
+                     divisor, melt-line pct, earn window all recipe cells),
+                     a cooled native melts back to walking at the melt line
+                     (50% of hot), and re-crystallization is champion-
+                     challenger gated (fkc-earn-step/fkc-re-earned are
+                     cc-promote? specialized to epoch-trials — ice earned,
+                     never declared, no boundary flip-flop); a transitive
+                     lowerability fixpoint (fk_can) joined as the honesty
+                     gate so a melt can never strand a wrong native;
+                     witnessed audit section 21 (freeze at 51 -> 3 idle
+                     epochs halve 88->44->22 -> melt at 22 -> re-earn after
+                     2 winning epochs), proven three-way
+                     (tests/melt-hot-swap-band.fk -> 31). Open, named: true
+                     runtime codegen for FOREIGN loaded tables (the
+                     universal binary re-emitting through the toolchain
+                     port — the full crystallization wire))
 
         (organs-physical  one physical proof per host resource through the
                      fourth sibling, band tests/fourth-os-band.fk -> 15:

--- a/docs/coherence-substrate/linux-as-recipes.form
+++ b/docs/coherence-substrate/linux-as-recipes.form
@@ -27,7 +27,10 @@
                             compute organ; the POLICY is a pure data row (key-field, least-wins, floor,
                             requeue) in ONE chooser engine — fifo/round-robin/priority/fitness are four
                             rows, never four branches; recognition-router's max-over-a-floor choosing is
-                            now a row of this engine (tests/scheduler-band.fk -> 511 three-way))
+                            now a row of this engine (tests/scheduler-band.fk -> 511 three-way); THE
+                            ROWS READ BOTH DIRECTIONS: afferent delivery priority is these same rows —
+                            fifo's data over signal numbers, priority's data over IRQ levels
+                            (afferent-priority.fk, tests/afferent-priority-band.fk -> 1023))
     (signals          RUNS  afferent-offer.fk — ao-alarm makes a timer armed for tick T a standing
                             unsolicited offer on the ALRM line, so SIGALRM-fires and wait-times-out are
                             one structure (timeout==nothing IS the SIGALRM shape, checked at the window
@@ -36,7 +39,10 @@
                             (tests/afferent-offer-band.fk -> 511 three-way); LIVE: afferent-live.fk
                             lowers ao-wait's verdict onto op 15 TIME — the armed timer's tick arrives on
                             the host clock, the empty window yields nothing only after real elapsed time
-                            (tests/afferent-live-band.fk -> 63; audit section 18)))
+                            (tests/afferent-live-band.fk -> 63; audit section 18); multi-offer
+                            delivery order is a scheduler policy row over the deliverable set — masked
+                            and out-of-window rules stay sovereign before any ranking
+                            (afferent-priority.fk -> 1023; audit section 23)))
 
   # ── Memory ──────────────────────────────────────────────────────────
   (memory
@@ -66,12 +72,13 @@
                             carrier-swappable; host-resource-access admits any host driver/OS API)
     (entropy          RUNS  op 16 RND — /dev/urandom's shape (two draws differ, witnessed))
     (clock            RUNS  op 15 TIME — the host clock organ, real epoch (afferent scalar))
-    (gpu              RUNS  the native emitter lane: jte-matvec-msl (jit-tensor-emit.fk) emits the Metal
-                            matvec from the same tensor cells as the C path, MSL byte-stable three-way
-                            (tests/metal-emit-band.fk -> 7); LIVE on M4 Max: bit-exact value parity on
-                            every output row vs the CPU fp32 right-fold, 13.2x kernel-window at 4096^2
+    (gpu              RUNS  the native emitter lane, precision as DATA: one MSL spine (jte-matvec-msl-spine,
+                            jit-tensor-emit.fk) with f32/f16/bf16 as format rows, byte-stable three-way
+                            (tests/metal-emit-band.fk -> 31); LIVE on M4 Max: every lane bit-exact by its
+                            format's OWN semantics (format-arith's RNE chain, accumulate-in-fp32 as data),
+                            15.5x kernel-window at 4096^2 on the 16-bit lanes
                             (scripts/metal_matvec_audit.sh); ollama/Metal still ride the driver organ;
-                            kernel-resident carrier + bf16/half lanes named open)
+                            kernel-resident carrier + batching named open)
     (audio-video-hmi  RUNS-via-host mic/speaker/camera via the OS API; n4 TTS (say) + STT (whisper) witnessed))
 
   # ── Networking ──────────────────────────────────────────────────────
@@ -109,8 +116,10 @@
                             recompile; collisions and interface mismatches refuse honestly; the node ack
                             is the artifact's content NodeID (insmod composed from axiom-3+5, never
                             ported) — protocol install-leaf.fk (tests/install-leaf-band.fk -> 9
-                            three-way), Go carrier witnessed live (jit_install); Rust/TS carriers named
-                            open in install-leaf.form)
+                            three-way), TWO carriers witnessed live — Go (plugin.Open; int+float+Value
+                            ABI lanes) and Rust (rustc cdylib + libloading; i64 ABI, refusal-parity
+                            where a lane is absent: the leaf acks nothing rather than fabricating);
+                            TS (wasm/worker) named open in install-leaf.form)
     (dynamic-linking  RUNS-via-host dlopen/clang are allowed carriers; the recipe is the linked unit)
     (interrupts       RUNS  afferent-offer.fk — the SAME ao-wait engine as signals, readings as data:
                             ao-irq latches a device payload on an IRQ line; a masked or silent line
@@ -139,11 +148,14 @@
              and now scheduler policy, signals, interrupts, gc/melt (measured), offers-in-flight
              concurrency, boot-from-axioms: every subsystem row, as fourth-kernel binaries or Form
              recipes with three-way proof bands")
-    (named  "the deepenings that opened as the last four closed: Rust/TS install carriers (the protocol
-             already proven three-way); the melt's hot-swap-free face (cooled natives re-melting,
-             champion-challenger gated); m4e4's families lifting more bands onto the fourth arm
-             (str_*/node_*/floats/multi-param); kernel-resident Metal carrier + bf16/half lanes;
-             delivery priority as a policy cell over the afferent engine — each named where it lives")
+    (named  "the ring that opened as the last five closed: the TS install carrier (wasm/worker — Go and
+             Rust are live); m4e4's remaining families (str_* needs the walker string-pool lane shared
+             with the m4d fixpoint blocker; figure-ops band/shl_u32/add_u32 + nested-do unlock the
+             checksum bands; floats); call args on a walker-managed value stack (packed args live in
+             suspended C frames the copying melt cannot root — the wall feature-vector hit); preemption
+             (a higher-priority offer arriving MID-wait re-deciding the composed winner — one re-verdict
+             per poll tick where sched-step and the live loop compose); kernel-resident Metal carrier +
+             batching; the crystallization wire (runtime codegen for FOREIGN loaded tables)")
     (verdict "every high-level Linux subsystem RUNS (or RUNS-by-construction) as Form recipes with
               three-way proof, and the four named deepenings of the first walk now RUN too — live
               clock, surviving boundary, growing kernel table, native GPU lane; what stays NAMED is


### PR DESCRIPTION
Round 3 closed five stones, each proven before landing:

- **melt hot-swap face** — #2870: the gas-ice cycle closes both ways; decay/melt-line/earn-window as recipe cells; ice re-earned via champion-challenger (band → 31, audit §21)
- **m4e4 multi-param** — #2868: packed args as a pure flattening rule, zero new walker tags; **bands-on-fourth-arm 1 → 10**, all four-way gated (band → 127, audit §22)
- **Rust install carrier** — #2864: rustc cdylib + libloading; the kernel's table grows at runtime on a second native carrier (witness verdict 10; protocol band stays 9)
- **Metal format lanes** — #2862: f32/f16/bf16 as data rows on one MSL spine, every lane bit-exact by its format's own RNE semantics, 15.5× at 4096² (band → 31)
- **delivery priority** — #2869: the scheduler's policy rows read both directions — POSIX order IS the fifo row, IRQ priority IS the priority row, row-for-row (band → 1023, audit §23)

This PR retunes the three maps and names the next ring where each stone lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)