### PR TITLE
tend: align go fatal HTTP response across kernels

### DIFF
--- a/docs/system_audit/commit_evidence_20260611_all_kernel_fatal_http_parity.json
+++ b/docs/system_audit/commit_evidence_20260611_all_kernel_fatal_http_parity.json
@@ -1,0 +1,97 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "codex/all-kernel-fatal-http-20260611",
+  "commit_scope": "Extend Go kernel HTTP native handler panic recovery to the same fatal response contract as Rust, and add a four-carrier HTTP proof covering Rust, Go, TypeScript JIT, and the Form-emitted fourth HTTP organ.",
+  "files_owned": [
+    "form/form-kernel-go/main.go",
+    "form/form-kernel-go/server.go",
+    "form/form-kernel-go/server_test.go",
+    "scripts/fatal_http_all_kernels_probe.py"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form/form-kernel-go && go test ./... -run TestNativeHandlerFatalResponseNamesKindTraceAndWorkerContinues -count=1",
+      "python3 scripts/fatal_http_all_kernels_probe.py",
+      "cd form/form-kernel-go && go test ./...",
+      "cd form/form-kernel-rust && cargo test --quiet crash_diagnostics_tests -- --nocapture",
+      "python3 -m py_compile scripts/fatal_http_all_kernels_probe.py",
+      "git diff --check"
+    ],
+    "notes": "Focused Go fatal response regression passed. The four-carrier probe returned real HTTP 500 replies for Rust serve and Go serve, a TS kernel+compileNode JIT HTTP wrapper with X-Form-JIT-Compile: 1, and the Form-emitted fourth HTTP binary's current static fatal responder. The Rust and Go rows also proved /ok answered after /boom on the same server. Full Go package tests passed in 214.828s."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "Hostinger Auto Deploy on main after merge"
+    ],
+    "notes": "Deploy proof should confirm kernel-router startup and public API canaries remain healthy after Go fatal-response hardening."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed; PR CI and deploy proof remain pending."
+  },
+  "idea_ids": [
+    "pipeline-reliability",
+    "native-api-lane",
+    "form-native-front-door"
+  ],
+  "spec_ids": [
+    "pulse-silence-boundary-repair",
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "all-kernel-fatal-http-parity-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5-codex"
+  },
+  "evidence_refs": [
+    "form/form-kernel-go/server.go#goServeWorker.serve",
+    "form/form-kernel-go/main.go#diagnoseKernelPanic",
+    "form/form-kernel-go/main.go#writeKernelCrashTraceWithContext",
+    "scripts/fatal_http_all_kernels_probe.py"
+  ],
+  "change_files": [
+    "form/form-kernel-go/main.go",
+    "form/form-kernel-go/server.go",
+    "form/form-kernel-go/server_test.go",
+    "scripts/fatal_http_all_kernels_probe.py",
+    "docs/system_audit/commit_evidence_20260611_all_kernel_fatal_http_parity.json"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Selected Go native handler panics now return HTTP 500 fatal responses with X-Form-Router: native-kernel-error, X-Form-Fatal-Kind, X-Form-Crash-Trace, a diagnosis body, and a JSON trace with source/request/route operation; the worker remains usable after the fatal response.",
+    "public_endpoints": [
+      "local://form-kernel-rust/serve/boom",
+      "local://form-kernel-go/serve/boom",
+      "local://form-kernel-ts/jit-wrapper/boom",
+      "local://fourth-kernel/emitted-http/boom"
+    ],
+    "test_flows": [
+      "Trigger a defined local /boom route and inspect the HTTP 500 fatal response fields.",
+      "Verify a healthy /ok route still answers after /boom for Rust and Go listeners.",
+      "Exercise the TS kernel through compileNode JIT under an HTTP wrapper and return the same fatal response envelope.",
+      "Compile the fourth-kernel HTTP responder binary and show its current static fatal response, naming the remaining dynamic API-host gap."
+    ]
+  }
+}

--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -4988,6 +4988,86 @@ func kernelSourceLineCount(src string) int {
 	return strings.Count(src, "\n") + 1
 }
 
+type kernelCrashDiagnosis struct {
+	fatalKind       string
+	likelyRootCause string
+	avoidance       string
+}
+
+func diagnoseKernelPanic(message string) kernelCrashDiagnosis {
+	lower := strings.ToLower(message)
+	switch {
+	case strings.Contains(lower, "as_str") ||
+		strings.Contains(lower, "argstr") ||
+		strings.Contains(lower, "expected string") ||
+		strings.Contains(lower, "string"):
+		return kernelCrashDiagnosis{
+			fatalKind:       "type_contract_violation",
+			likelyRootCause: "a Form/native recipe passed a non-string value to a string-only primitive",
+			avoidance:       "guard with value_kind/value-kind, convert with value_str, or use null-safe JSON constructors before calling string primitives",
+		}
+	case strings.Contains(lower, "as_int") ||
+		strings.Contains(lower, "argint") ||
+		strings.Contains(lower, "expected int") ||
+		strings.Contains(lower, "wrong primitive kind"):
+		return kernelCrashDiagnosis{
+			fatalKind:       "type_contract_violation",
+			likelyRootCause: "a Form/native recipe passed a value with the wrong primitive kind to a typed host boundary",
+			avoidance:       "validate the value kind before the native call, or route through an explicit conversion recipe",
+		}
+	case strings.Contains(lower, "unbound"):
+		return kernelCrashDiagnosis{
+			fatalKind:       "name_resolution_error",
+			likelyRootCause: "a recipe or route manifest referenced a name that was not bound in the loaded source/prelude set",
+			avoidance:       "run the route/source check gate and include the defining prelude before serving the manifest",
+		}
+	case strings.Contains(lower, "arity") ||
+		strings.Contains(lower, "wants") ||
+		strings.Contains(lower, "argument"):
+		return kernelCrashDiagnosis{
+			fatalKind:       "arity_contract_violation",
+			likelyRootCause: "a closure or native was called with a different argument count than its declaration accepts",
+			avoidance:       "align the call site with the function signature or add an adapter recipe at the boundary",
+		}
+	case strings.Contains(lower, "bounds") ||
+		strings.Contains(lower, "range") ||
+		strings.Contains(lower, "index"):
+		return kernelCrashDiagnosis{
+			fatalKind:       "bounds_violation",
+			likelyRootCause: "a recipe indexed outside the observed collection/string bounds",
+			avoidance:       "check length/bounds before indexing or use a boundary-aware recipe that returns an explicit error value",
+		}
+	case strings.Contains(lower, "source-compile") ||
+		strings.Contains(lower, "parse error"):
+		return kernelCrashDiagnosis{
+			fatalKind:       "source_compile_failure",
+			likelyRootCause: "source text could not be lowered into a valid Form recipe before execution",
+			avoidance:       "run the source compiler/check command and repair the reported source coordinate before serving",
+		}
+	default:
+		return kernelCrashDiagnosis{
+			fatalKind:       "kernel_panic",
+			likelyRootCause: "the kernel crossed an unchecked host-language panic boundary",
+			avoidance:       "inspect the trace stack and source excerpt, then move the failing boundary into a checked fatal/error return",
+		}
+	}
+}
+
+func kernelFatalHTTPBody(message string, diagnosis kernelCrashDiagnosis, tracePath string) string {
+	trace := tracePath
+	if trace == "" {
+		trace = "trace unavailable"
+	}
+	return fmt.Sprintf(
+		"fatal[%s]: %s\nlikely_root_cause: %s\navoidance: %s\ntrace: %s\n",
+		diagnosis.fatalKind,
+		message,
+		diagnosis.likelyRootCause,
+		diagnosis.avoidance,
+		trace,
+	)
+}
+
 func kernelModeFromArgs(args []string) string {
 	if len(args) == 0 {
 		return "startup"
@@ -5013,6 +5093,10 @@ func kernelModeFromArgs(args []string) string {
 }
 
 func writeKernelCrashTrace(args []string, src string, recovered any) string {
+	return writeKernelCrashTraceWithContext(args, src, recovered, "", "")
+}
+
+func writeKernelCrashTraceWithContext(args []string, src string, recovered any, sourceLabel string, operation string) string {
 	dir := filepath.Join(".cache", "form-kernel-go")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		dir = os.TempDir()
@@ -5025,12 +5109,20 @@ func writeKernelCrashTrace(args []string, src string, recovered any) string {
 	if tailStart < 0 {
 		tailStart = 0
 	}
+	message := fmt.Sprint(recovered)
+	diagnosis := diagnoseKernelPanic(message)
 	report := map[string]any{
 		"when_utc":          time.Now().UTC().Format(time.RFC3339Nano),
 		"pid":               os.Getpid(),
 		"mode":              kernelModeFromArgs(args),
 		"args":              args,
-		"panic":             fmt.Sprint(recovered),
+		"fatal_kind":        diagnosis.fatalKind,
+		"fatal_message":     message,
+		"panic":             message,
+		"likely_root_cause": diagnosis.likelyRootCause,
+		"avoidance":         diagnosis.avoidance,
+		"source_label":      sourceLabel,
+		"operation":         operation,
 		"source_bytes":      len(src),
 		"source_line_count": kernelSourceLineCount(src),
 		"source_head":       kernelSourceExcerpt(src, 2000),

--- a/form/form-kernel-go/server.go
+++ b/form/form-kernel-go/server.go
@@ -39,7 +39,10 @@ const (
 	headerNativePath     = "X-Form-Native-Invitation-Selected-Path"
 	headerNativeDecline  = "X-Form-Native-Invitation-Decline-Signal"
 	headerNativeFallback = "X-Form-Native-Invitation-Decline-Header"
+	headerFatalKind      = "X-Form-Fatal-Kind"
+	headerCrashTrace     = "X-Form-Crash-Trace"
 	routeHowNative       = "native-kernel-go"
+	routeHowNativeError  = "native-kernel-error"
 	routeHowFanout       = "fanout-python"
 	nativeInviteValue    = "offered"
 	nativeInviteState    = "native-invitation-offered"
@@ -1511,9 +1514,38 @@ func (p *goServeProgram) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (wkr *goServeWorker) serve(w http.ResponseWriter, r *http.Request) {
+	var activeRoute *goRoute
 	defer func() {
 		if recovered := recover(); recovered != nil {
-			http.Error(w, fmt.Sprintf("native handler panic: %v\n", recovered), http.StatusInternalServerError)
+			message := fmt.Sprint(recovered)
+			diagnosis := diagnoseKernelPanic(message)
+			source, sourceLabel := wkr.crashSource()
+			where := "route:unknown request:" + r.URL.EscapedPath()
+			if activeRoute != nil {
+				where = nativeRouteWhere(activeRoute, r)
+			}
+			operation := fmt.Sprintf("request=%s %s %s", r.Method, r.URL.RequestURI(), where)
+			tracePath := writeKernelCrashTraceWithContext(
+				[]string{"serve", r.Method, r.URL.RequestURI()},
+				source,
+				recovered,
+				sourceLabel,
+				operation,
+			)
+			setRouteDecisionHeaders(
+				w.Header(),
+				routeHowNativeError,
+				where,
+				routeDecisionWho(r),
+				routeDecisionWhen(),
+			)
+			w.Header().Set(headerFatalKind, sanitizeDecisionHeader(diagnosis.fatalKind))
+			if tracePath != "" {
+				w.Header().Set(headerCrashTrace, sanitizeDecisionHeader(tracePath))
+			}
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(kernelFatalHTTPBody(message, diagnosis, tracePath)))
 		}
 	}()
 	route := wkr.match(r)
@@ -1525,6 +1557,7 @@ func (wkr *goServeWorker) serve(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	activeRoute = route
 	requestValue, err := requestValue(route, r)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("native request read failed: %v\n", err), http.StatusBadRequest)
@@ -1559,6 +1592,19 @@ func (wkr *goServeWorker) serve(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(status)
 	_, _ = w.Write([]byte(body))
 	wkr.k.substrateGC([]Value{result}, wkr.env)
+}
+
+func (wkr *goServeWorker) crashSource() (string, string) {
+	if wkr == nil || wkr.program == nil {
+		return "", "form-kernel-go serve"
+	}
+	if wkr.program.source != "" {
+		return wkr.program.source, "go serve source manifest"
+	}
+	if len(wkr.program.artifact) > 0 {
+		return fmt.Sprintf("<compiled route artifact: %d bytes>", len(wkr.program.artifact)), "go serve compiled route artifact"
+	}
+	return "", "go serve route manifest"
 }
 
 func (wkr *goServeWorker) fanout(w http.ResponseWriter, r *http.Request) {

--- a/form/form-kernel-go/server_test.go
+++ b/form/form-kernel-go/server_test.go
@@ -256,6 +256,76 @@ func TestHealthRouteNativeOperationalShape(t *testing.T) {
 	}
 }
 
+func TestNativeHandlerFatalResponseNamesKindTraceAndWorkerContinues(t *testing.T) {
+	source := `
+(defn route_boom (q) (form_error "as_str: Null"))
+(defn route_ok (q) "ok")
+(let routes (list
+  (list "/boom" route_boom)
+  (list "/ok" route_ok)))
+`
+	worker, err := buildGoServeWorker(&goServeProgram{source: source})
+	if err != nil {
+		t.Fatalf("buildGoServeWorker: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://native.example.test/boom", nil)
+	rec := httptest.NewRecorder()
+	worker.serve(rec, req)
+	res := rec.Result()
+	defer res.Body.Close()
+	gotBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("fatal status = %d body=%s", res.StatusCode, string(gotBody))
+	}
+	if got := res.Header.Get("X-Form-Router"); got != "native-kernel-error" {
+		t.Fatalf("fatal router = %q, want native-kernel-error", got)
+	}
+	if got := res.Header.Get("X-Form-Fatal-Kind"); got != "type_contract_violation" {
+		t.Fatalf("fatal kind = %q", got)
+	}
+	tracePath := res.Header.Get("X-Form-Crash-Trace")
+	if tracePath == "" {
+		t.Fatal("missing X-Form-Crash-Trace")
+	}
+	defer os.Remove(tracePath)
+	if !strings.Contains(string(gotBody), "fatal[type_contract_violation]: as_str: Null") {
+		t.Fatalf("fatal body missing diagnosis: %s", string(gotBody))
+	}
+	if !strings.Contains(string(gotBody), "trace: "+tracePath) {
+		t.Fatalf("fatal body missing trace path: %s", string(gotBody))
+	}
+	traceBody, err := os.ReadFile(tracePath)
+	if err != nil {
+		t.Fatalf("read trace %s: %v", tracePath, err)
+	}
+	for _, want := range []string{
+		`"fatal_kind": "type_contract_violation"`,
+		`"source_label": "go serve source manifest"`,
+		`"operation": "request=GET /boom route:`,
+	} {
+		if !strings.Contains(string(traceBody), want) {
+			t.Fatalf("trace body missing %s: %s", want, string(traceBody))
+		}
+	}
+
+	okReq := httptest.NewRequest(http.MethodGet, "http://native.example.test/ok", nil)
+	okRec := httptest.NewRecorder()
+	worker.serve(okRec, okReq)
+	okRes := okRec.Result()
+	defer okRes.Body.Close()
+	okBody, err := io.ReadAll(okRes.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if okRes.StatusCode != http.StatusOK || string(okBody) != "ok" {
+		t.Fatalf("worker did not continue: status=%d body=%s", okRes.StatusCode, string(okBody))
+	}
+}
+
 func TestCompileSourceSectionNativeReturnsRecipe(t *testing.T) {
 	k := NewKernel()
 	expr := `(compile_source_section "form.bml" "add(20, 22);" "test/runtime.bml")`

--- a/scripts/fatal_http_all_kernels_probe.py
+++ b/scripts/fatal_http_all_kernels_probe.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Probe fatal HTTP replies across the current four kernel carriers.
+
+The first two rows use the real persistent HTTP front doors:
+  - form-kernel-rust serve
+  - form-kernel-go serve
+
+The TypeScript row uses the TS kernel + JS JIT under a tiny HTTP harness because
+the TS carrier does not yet ship a persistent route-listener CLI. The fourth row
+uses the Form-emitted server binary lane; today that net organ serves a static
+program response, so the probe writes the trace file before emitting the fatal
+response. Both limitations are printed in the row notes instead of hidden.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+FORM = ROOT / "form"
+RUST_BIN = FORM / "form-kernel-rust" / "target" / "release" / "form-kernel-rust"
+GO_BIN = FORM / "form-kernel-go" / "bin-go"
+
+
+@dataclass
+class ProbeResult:
+    name: str
+    command: list[str]
+    reply: str
+    note: str
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def wait_port(port: int, proc: subprocess.Popen[bytes], timeout: float = 10.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            err = proc.stderr.read().decode("utf-8", "replace") if proc.stderr else ""
+            raise RuntimeError(f"server exited before listen: {err}")
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.03)
+    raise TimeoutError(f"listener did not open on 127.0.0.1:{port}")
+
+
+def raw_get(port: int, path: str = "/boom") -> str:
+    req = (
+        f"GET {path} HTTP/1.1\r\n"
+        "Host: 127.0.0.1\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+    ).encode("ascii")
+    with socket.create_connection(("127.0.0.1", port), timeout=5.0) as s:
+        s.sendall(req)
+        chunks: list[bytes] = []
+        while True:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    return b"".join(chunks).decode("utf-8", "replace")
+
+
+def terminate(proc: subprocess.Popen[bytes]) -> None:
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=3)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=3)
+
+
+def build_binaries() -> None:
+    subprocess.run(["cargo", "build", "--release", "--quiet"], cwd=FORM / "form-kernel-rust", check=True)
+    subprocess.run(["go", "build", "-o", "bin-go", "."], cwd=FORM / "form-kernel-go", check=True)
+
+
+ROUTES_SOURCE = """
+(defn route_boom (q) (form_error "as_str: Null"))
+(defn route_ok (q) "ok")
+(let routes (list
+  (list "/boom" route_boom)
+  (list "/ok" route_ok)))
+"""
+
+
+def probe_rust(work: Path) -> ProbeResult:
+    port = free_port()
+    routes = work / "rust-routes.fk"
+    routes.write_text(ROUTES_SOURCE, encoding="utf-8")
+    cmd = [str(RUST_BIN), "serve", "--port", str(port), "--workers", "1", "--routes", str(routes)]
+    proc = subprocess.Popen(cmd, cwd=FORM, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    try:
+        wait_port(port, proc)
+        reply = raw_get(port)
+        ok_reply = raw_get(port, "/ok")
+        if "HTTP/1.1 200 OK" not in ok_reply or "\r\n\r\nok" not in ok_reply:
+            raise RuntimeError(f"rust worker did not continue after fatal:\n{ok_reply}")
+        return ProbeResult(
+            "rust-serve",
+            cmd,
+            reply,
+            "real form-kernel-rust serve route; /ok answered after /boom",
+        )
+    finally:
+        terminate(proc)
+
+
+def probe_go(work: Path) -> ProbeResult:
+    port = free_port()
+    routes = work / "go-routes.fk"
+    routes.write_text(ROUTES_SOURCE, encoding="utf-8")
+    cmd = [str(GO_BIN), "serve", "--port", str(port), str(routes)]
+    proc = subprocess.Popen(cmd, cwd=FORM, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    try:
+        wait_port(port, proc)
+        reply = raw_get(port)
+        ok_reply = raw_get(port, "/ok")
+        if "200 OK" not in ok_reply or "\r\n\r\nok" not in ok_reply:
+            raise RuntimeError(f"go worker did not continue after fatal:\n{ok_reply}")
+        return ProbeResult(
+            "go-serve",
+            cmd,
+            reply,
+            "real form-kernel-go serve route; /ok answered after /boom",
+        )
+    finally:
+        terminate(proc)
+
+
+def probe_ts_jit(work: Path) -> ProbeResult:
+    port = free_port()
+    server = work / "ts-fatal-server.ts"
+    kernel = json.dumps(str(FORM / "form-kernel-ts" / "src" / "kernel.ts"))
+    reader = json.dumps(str(FORM / "form-kernel-ts" / "src" / "reader.ts"))
+    compiler = json.dumps(str(FORM / "form-kernel-ts" / "src" / "compiler.ts"))
+    trace_dir = json.dumps(str(ROOT / ".cache" / "form-kernel-ts"))
+    server.write_text(
+        f"""
+import http from "node:http";
+import {{ mkdirSync, writeFileSync }} from "node:fs";
+import {{ join }} from "node:path";
+import {{ Frame, Kernel, shutdownSocketWorker, walk }} from {kernel};
+import {{ readAll }} from {reader};
+import {{ compileNode }} from {compiler};
+
+const port = Number(process.argv[2]);
+const traceDir = {trace_dir};
+
+function diagnose(message: string) {{
+  if (message.includes("as_str") || message.toLowerCase().includes("string")) {{
+    return {{
+      fatal_kind: "type_contract_violation",
+      likely_root_cause: "a Form/native recipe passed a non-string value to a string-only primitive",
+      avoidance: "guard with value_kind/value-kind, convert with value_str, or use null-safe JSON constructors before calling string primitives",
+    }};
+  }}
+  return {{
+    fatal_kind: "kernel_panic",
+    likely_root_cause: "the kernel crossed an unchecked host-language panic boundary",
+    avoidance: "inspect the trace stack and source excerpt, then move the failing boundary into a checked fatal/error return",
+  }};
+}}
+
+function writeTrace(message: string, stack: string | undefined, source: string) {{
+  mkdirSync(traceDir, {{ recursive: true }});
+  const path = join(traceDir, `crash-${{new Date().toISOString().replace(/[:.]/g, "")}}-${{process.pid}}.json`);
+  const d = diagnose(message);
+  writeFileSync(path, JSON.stringify({{
+    when_utc: new Date().toISOString(),
+    mode: "ts-jit-http-proof",
+    fatal_kind: d.fatal_kind,
+    fatal_message: message,
+    likely_root_cause: d.likely_root_cause,
+    avoidance: d.avoidance,
+    source_label: "ts jit proof source",
+    operation: "request=GET /boom route=/boom handler=route_boom jit_compile=1",
+    source_head: source.slice(0, 2000),
+    js_stack: stack ?? null,
+  }}, null, 2) + "\\n");
+  return path;
+}}
+
+function fatalBody(message: string, d: ReturnType<typeof diagnose>, trace: string) {{
+  return `fatal[${{d.fatal_kind}}]: ${{message}}\\nlikely_root_cause: ${{d.likely_root_cause}}\\navoidance: ${{d.avoidance}}\\ntrace: ${{trace}}\\n`;
+}}
+
+function runBoom() {{
+  const source = `(do
+    (defn route_boom (q) (form_error "as_str: Null"))
+    (let _jit (jit_compile "route_boom"))
+    (route_boom (list)))`;
+  const k = new Kernel();
+  k.jitCompileHook = compileNode;
+  const frame = new Frame(null);
+  const root = readAll(k, source);
+  try {{
+    walk(k, root, frame);
+  }} catch (err) {{
+    const message = err instanceof Error ? err.message : String(err);
+    const stack = err instanceof Error ? err.stack : undefined;
+    const d = diagnose(message);
+    const trace = writeTrace(message, stack, source);
+    return {{ ok: false, message, diagnosis: d, trace }};
+  }}
+  return {{ ok: true }};
+}}
+
+const server = http.createServer((req, res) => {{
+  if (req.url === "/ok") {{
+    res.statusCode = 200;
+    res.setHeader("X-Form-Router", "native-kernel-ts-jit");
+    res.end("ok");
+    return;
+  }}
+  const result = runBoom();
+  if (result.ok) {{
+    res.statusCode = 200;
+    res.end("unexpected ok");
+    return;
+  }}
+  res.statusCode = 500;
+  res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  res.setHeader("Connection", "close");
+  res.setHeader("X-Form-Router", "native-kernel-error");
+  res.setHeader("X-Form-Fatal-Kind", result.diagnosis.fatal_kind);
+  res.setHeader("X-Form-Crash-Trace", result.trace);
+  res.setHeader("X-Form-JIT-Compile", "1");
+  res.end(fatalBody(result.message, result.diagnosis, result.trace));
+}});
+
+server.listen(port, "127.0.0.1", () => {{
+  process.stderr.write(`ts fatal proof listening on ${{port}}\\n`);
+}});
+
+process.on("SIGTERM", () => {{
+  server.close(() => {{
+    shutdownSocketWorker();
+    process.exit(0);
+  }});
+}});
+""",
+        encoding="utf-8",
+    )
+    cmd = ["npx", "--yes", "tsx", str(server), str(port)]
+    proc = subprocess.Popen(cmd, cwd=FORM / "form-kernel-ts", stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    try:
+        wait_port(port, proc)
+        reply = raw_get(port)
+        ok_reply = raw_get(port, "/ok")
+        if "200 OK" not in ok_reply or "\r\n\r\nok" not in ok_reply:
+            raise RuntimeError(f"ts proof server did not continue after fatal:\n{ok_reply}")
+        return ProbeResult(
+            "typescript-jit-http-wrapper",
+            cmd,
+            reply,
+            "TS kernel has no serve CLI yet; this wraps Kernel+compileNode JIT in HTTP and proves fatal envelope",
+        )
+    finally:
+        terminate(proc)
+
+
+def probe_fourth(work: Path) -> ProbeResult:
+    if shutil.which("clang") is None:
+        raise RuntimeError("clang is required for fourth-kernel HTTP proof")
+    trace_dir = ROOT / ".cache" / "fourth-kernel"
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    trace_path = trace_dir / f"crash-{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}-{os.getpid()}.json"
+    trace_path.write_text(
+        json.dumps(
+            {
+                "when_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "mode": "fourth-kernel-static-http-proof",
+                "fatal_kind": "kernel_panic",
+                "fatal_message": "fourth-kernel fatal proof responder",
+                "likely_root_cause": "the fourth HTTP organ is a static responder today; dynamic route panic capture is still the next API-host slice",
+                "avoidance": "move request-line parsing, route dispatch, and fatal capture into the fourth-kernel API host before counting it as dynamic route parity",
+                "source_label": "fourth-walker-emit.fk fkc-emit-server",
+                "operation": "request=GET /boom static fatal responder",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    response = (
+        "HTTP/1.0 500 Internal Server Error\r\n"
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "Connection: close\r\n"
+        "X-Form-Router: fourth-kernel-error\r\n"
+        "X-Form-Fatal-Kind: kernel_panic\r\n"
+        f"X-Form-Crash-Trace: {trace_path}\r\n"
+        "\r\n"
+        "fatal[kernel_panic]: fourth-kernel fatal proof responder\n"
+        "likely_root_cause: the fourth HTTP organ is a static responder today; dynamic route panic capture is still the next API-host slice\n"
+        "avoidance: move request-line parsing, route dispatch, and fatal capture into the fourth-kernel API host before counting it as dynamic route parity\n"
+        f"trace: {trace_path}\n"
+    )
+    driver = work / "fourth-server-driver.fk"
+    driver.write_text(
+        (FORM / "form-stdlib" / "minimal-surface.fk").read_text(encoding="utf-8")
+        + (FORM / "form-stdlib" / "fourth-walker.fk").read_text(encoding="utf-8")
+        + (FORM / "form-stdlib" / "fourth-walker-emit.fk").read_text(encoding="utf-8")
+        + "\n"
+        + f'(let resp (fkresp {sexp_string(response)}))\n'
+        + '(print "==SRV==")\n'
+        + '(print (fkc-emit-server (list resp)))\n'
+        + '(print "==END==")\n',
+        encoding="utf-8",
+    )
+    emit = subprocess.run([str(GO_BIN), str(driver)], cwd=FORM, check=True, capture_output=True, text=True)
+    c_path = work / "fourth-api.c"
+    in_block = False
+    lines: list[str] = []
+    for line in emit.stdout.splitlines():
+        if line == "==SRV==":
+            in_block = True
+            continue
+        if line == "==END==":
+            break
+        if in_block:
+            lines.append(line)
+    c_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    bin_path = work / "fourth-api"
+    subprocess.run(["clang", "-O2", "-o", str(bin_path), str(c_path)], check=True)
+    port = free_port()
+    cmd = [str(bin_path), str(port)]
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    try:
+        wait_port(port, proc)
+        reply = raw_get(port)
+        return ProbeResult(
+            "fourth-kernel-emitted-http",
+            cmd,
+            reply,
+            "Form-emitted HTTP binary; static fatal responder until fourth API-host routing lands",
+        )
+    finally:
+        terminate(proc)
+
+
+def sexp_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def compact_reply(reply: str) -> str:
+    head, sep, body = reply.partition("\r\n\r\n")
+    interesting = []
+    for line in head.splitlines():
+        lower = line.lower()
+        if (
+            line.startswith("HTTP/")
+            or lower.startswith("x-form-router:")
+            or lower.startswith("x-form-fatal-kind:")
+            or lower.startswith("x-form-crash-trace:")
+            or lower.startswith("x-form-jit-compile:")
+            or lower.startswith("content-type:")
+            or lower.startswith("connection:")
+        ):
+            interesting.append(line)
+    return "\n".join(interesting) + (sep.replace("\r\n", "\n") if sep else "\n\n") + body
+
+
+def main() -> int:
+    build_binaries()
+    results: list[ProbeResult] = []
+    with tempfile.TemporaryDirectory(prefix="fatal-http-kernels-") as tmp:
+        work = Path(tmp)
+        for probe in (probe_rust, probe_go, probe_ts_jit, probe_fourth):
+            results.append(probe(work))
+    print("fatal HTTP replies across kernel carriers")
+    for result in results:
+        print(f"\n## {result.name}")
+        print("note:", result.note)
+        print("command:", " ".join(result.command))
+        print(compact_reply(result.reply).rstrip())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Extends Go kernel native-handler panic recovery to return structured HTTP 500 fatal responses with X-Form-Fatal-Kind and X-Form-Crash-Trace.
- Adds JSON trace context for Go serve failures: fatal kind, root cause, avoidance, source label, and request/route operation.
- Adds scripts/fatal_http_all_kernels_probe.py to show real HTTP replies from Rust serve, Go serve, a TS kernel+compileNode JIT HTTP wrapper, and the current fourth-kernel emitted HTTP responder.

## Proof
- cd form/form-kernel-go && go test ./... -run TestNativeHandlerFatalResponseNamesKindTraceAndWorkerContinues -count=1
- python3 scripts/fatal_http_all_kernels_probe.py
- cd form/form-kernel-go && go test ./...
- cd form/form-kernel-rust && cargo test --quiet crash_diagnostics_tests -- --nocapture
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260611_all_kernel_fatal_http_parity.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict

## Notes
- Rust and Go rows are real persistent kernel HTTP listeners and prove /ok answers after /boom.
- TypeScript has no serve CLI yet, so the proof wraps Kernel+compileNode JIT in HTTP and marks X-Form-JIT-Compile: 1.
- The fourth HTTP organ is currently a Form-emitted static responder; dynamic request parsing/route panic capture remains the fourth API-host gap.
