### PR TITLE
tend: --changed mode — a change validates its own bands in seconds (13 bands, ~12s, was 90 min)

### DIFF
--- a/form/form-kernel-ts/src/bench.ts
+++ b/form/form-kernel-ts/src/bench.ts
@@ -229,6 +229,6 @@ export function runBench(): void {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === `file://${process.argv[1]}` && import.meta.url.includes("bench")) {
   runBench();
 }

--- a/form/form-kernel-ts/src/numeric-bench.ts
+++ b/form/form-kernel-ts/src/numeric-bench.ts
@@ -357,6 +357,6 @@ export function runNumericBench(): void {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === `file://${process.argv[1]}` && import.meta.url.includes("numeric-bench")) {
   runNumericBench();
 }

--- a/form/validate.sh
+++ b/form/validate.sh
@@ -50,13 +50,35 @@ build_rs() {
     fi
 }
 
+build_ts() {
+    # Bundle the TS kernel once (esbuild, cached by source mtimes) so each band
+    # runs via plain `node` (~60ms) instead of npx tsx (~1.5s). With 455 bands
+    # that is the difference between seconds and 11+ minutes of startup tax.
+    local bundle="$TS_DIR/dist/main.mjs"
+    local stale=0
+    if [[ ! -f "$bundle" ]]; then stale=1; else
+        local f
+        for f in "$TS_DIR"/src/*.ts; do
+            [[ "$f" -nt "$bundle" ]] && { stale=1; break; }
+        done
+    fi
+    if [[ "$stale" == "1" ]]; then
+        echo "  bundling ts kernel..." >&2
+        npx --yes esbuild "$TS_DIR/src/main.ts" --bundle --platform=node             --format=esm --outfile="$bundle" --log-level=warning >&2 || rm -f "$bundle"
+    fi
+}
+
 build_go &
 build_rs &
+build_ts &
 wait
 
 run_ts() {
+    local bundle="$TS_DIR/dist/main.mjs"
     local loader="$PWD/$TS_DIR/node_modules/tsx/dist/loader.mjs"
-    if [[ -x "$TS_DIR/node_modules/.bin/tsx" ]]; then
+    if [[ -f "$bundle" ]]; then
+        node --stack_size="$HOST_STACK_KB" "$bundle" "$@"
+    elif [[ -x "$TS_DIR/node_modules/.bin/tsx" ]]; then
         node --stack_size="$HOST_STACK_KB" --import "$loader" "$TS_DIR/src/main.ts" "$@"
     else
         npx --yes tsx --stack_size="$HOST_STACK_KB" "$TS_DIR/src/main.ts" "$@"
@@ -74,18 +96,38 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Source-compiled preludes are cached by CONTENT (file + compiler chain): the
+# same unchanged core.fk compiles once, not once per band. Without this cache
+# every validate invocation re-ran the full BML source-compiler (~12s) on
+# identical input — 455 bands paid ~90 serial minutes for the same artifact.
+SOURCE_CACHE_DIR="form-stdlib/.cache/source-compiled"
+mkdir -p "$SOURCE_CACHE_DIR"
+compiler_stamp=""
+compiler_chain=("form-stdlib/form-ontology-loader.fk" "form-stdlib/line-grammar.fk" "form-stdlib/bmf-core.fk" "form-stdlib/bmf-grammar.fk" "form-stdlib/bml.fk" "form-stdlib/bml-source.fk" "form-stdlib/source-compiler.fk")
+compiler_stamp="$(cat "${compiler_chain[@]}" "$GO_BIN" 2>/dev/null | shasum | cut -c1-16)"
+
 prepared_args=()
 prepare_sources() {
     prepared_args=()
-    local src out safe driver
+    local src out safe driver key cached
     for src in "$@"; do
         if grep -Eq '^[[:space:]]*section \[' "$src"; then
-            safe="${src//\//__}"
-            out="$source_compile_dir/$safe"
-            driver="$source_compile_dir/compile-${safe}.fk"
-            printf '(do (form-source-compile-file "%s" "%s"))\n' "$src" "$out" > "$driver"
-            "$GO_BIN" "form-stdlib/form-ontology-loader.fk" "form-stdlib/line-grammar.fk" "form-stdlib/bmf-core.fk" "form-stdlib/bmf-grammar.fk" "form-stdlib/bml.fk" "form-stdlib/bml-source.fk" "form-stdlib/source-compiler.fk" "$driver" >/dev/null
-            prepared_args+=("$out")
+            key="$(cat "$src" | shasum | cut -c1-16)-$compiler_stamp"
+            cached="$SOURCE_CACHE_DIR/$key.fk"
+            if [[ ! -s "$cached" ]]; then
+                safe="${src//\//__}"
+                out="$source_compile_dir/$safe"
+                driver="$source_compile_dir/compile-${safe}.fk"
+                printf '(do (form-source-compile-file "%s" "%s"))\n' "$src" "$out" > "$driver"
+                "$GO_BIN" "${compiler_chain[@]}" "$driver" >/dev/null
+                if [[ -s "$out" ]]; then
+                    mv -f "$out" "$cached" 2>/dev/null || cp "$out" "$cached"
+                else
+                    prepared_args+=("$src")
+                    continue
+                fi
+            fi
+            prepared_args+=("$cached")
         else
             prepared_args+=("$src")
         fi
@@ -116,11 +158,18 @@ fi
 # prelude + test file). Every kernel receives the same file list.
 run_siblings() {
     local label="$1"; shift
-    local go_out rs_out ts_out
+    local go_out rs_out ts_out legs
     prepare_sources "$@"
-    go_out=$("$GO_BIN" "${prepared_args[@]}" 2>&1 || true)
-    rs_out=$("$RS_BIN" "${prepared_args[@]}" 2>&1 || true)
-    ts_out=$(run_ts "${prepared_args[@]}" 2>&1 || true)
+    # The three kernels run CONCURRENTLY: a band's wall time is max(leg), not
+    # sum — on compiler-heavy bands the Go+Rust legs ride inside the TS leg's
+    # shadow for free. Outputs stay byte-compared exactly as before.
+    legs="$(mktemp -d "${TMPDIR:-/tmp}/form-legs.XXXXXX")"
+    ( "$GO_BIN" "${prepared_args[@]}" > "$legs/go" 2>&1 || true ) &
+    ( "$RS_BIN" "${prepared_args[@]}" > "$legs/rs" 2>&1 || true ) &
+    ( run_ts "${prepared_args[@]}" > "$legs/ts" 2>&1 || true ) &
+    wait
+    go_out=$(cat "$legs/go"); rs_out=$(cat "$legs/rs"); ts_out=$(cat "$legs/ts")
+    rm -rf "$legs"
     if [[ "$go_out" == "$rs_out" && "$go_out" == "$ts_out" ]]; then
         printf "  ✓  %-30s  → %s\n" "$label" "$go_out"
         ok=$((ok + 1))

--- a/scripts/form_validate_shards.py
+++ b/scripts/form_validate_shards.py
@@ -91,6 +91,50 @@ def _enumerate_default_workloads() -> list[Workload]:
     return workloads
 
 
+KERNEL_SEMANTIC_PREFIXES = (
+    "form/form-kernel-go/",
+    "form/form-kernel-rust/",
+    "form/form-kernel-ts/",
+    "form/validate.sh",
+    "scripts/form_validate_shards.py",
+)
+
+
+def _changed_paths(ref: str) -> set[str]:
+    """Repo-relative paths changed vs ref, plus working-tree edits and new files."""
+    import subprocess
+
+    paths: set[str] = set()
+    for cmd in (
+        ["git", "diff", "--name-only", f"{ref}...HEAD"],
+        ["git", "diff", "--name-only"],
+        ["git", "ls-files", "--others", "--exclude-standard", "form/"],
+    ):
+        out = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
+        paths.update(p.strip() for p in out.stdout.splitlines() if p.strip())
+    return paths
+
+
+def _select_changed(workloads: list[Workload], ref: str) -> list[Workload] | None:
+    """Bands affected by the change set, derived from declared prelude edges.
+
+    Returns None when kernel/runner semantics changed — the honest answer is
+    then the FULL suite, because every band's meaning may have moved.
+    """
+    changed = _changed_paths(ref)
+    if any(p.startswith(KERNEL_SEMANTIC_PREFIXES) or p in KERNEL_SEMANTIC_PREFIXES for p in changed):
+        return None
+    form_changed = {p.removeprefix("form/") for p in changed if p.startswith("form/")}
+    if not form_changed:
+        return []
+    selected = []
+    for w in workloads:
+        deps = set(w.args)
+        if deps & form_changed:
+            selected.append(w)
+    return selected
+
+
 def _filter_workloads(
     workloads: list[Workload],
     include_regex: str | None,
@@ -197,6 +241,17 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help=f"parallel shard count after the warm shard (default: {default_jobs})",
     )
     parser.add_argument(
+        "--changed",
+        nargs="?",
+        const="origin/main",
+        metavar="REF",
+        help=(
+            "run only bands whose declared prelude chain (or the band itself) "
+            "changed vs REF (default origin/main), incl. working-tree edits; "
+            "kernel/runner changes honestly select the FULL suite"
+        ),
+    )
+    parser.add_argument(
         "--regex",
         "--include-regex",
         dest="include_regex",
@@ -264,6 +319,13 @@ def run(argv: list[str]) -> int:
     except re.error as exc:
         print(f"invalid regex: {exc}", file=sys.stderr)
         return 2
+
+    if args.changed:
+        narrowed = _select_changed(workloads, args.changed)
+        if narrowed is None:
+            print("form-validate-shards: kernel/runner semantics changed — full suite selected")
+        else:
+            workloads = narrowed
 
     _print_selection(workloads, args.binary, args.jobs)
     if not workloads:


### PR DESCRIPTION
Urs: *we don't want to wait 90 mins for a change.* Selection is now DATA: every band's `; preludes:` header IS the dependency graph, so changed-file → affected-bands is a set intersection over declared edges. **Witnessed: one recipe edit (fourth-walker-emit.fk) → 13 bands selected → ~12s real run** (each warm band 0.19s after #2867). core.fk edits select everything through the same rule; kernel/runner changes honestly select the FULL suite (semantics may have moved everywhere). Usage: `scripts/form_validate_shards.py --changed [REF]` (default origin/main, includes working-tree edits + new band files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)