### PR TITLE
tend: the crystallization wire — a foreign table runs hot and the binary re-emits itself native through the toolchain port

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-11_crystallization_wire.json
+++ b/docs/system_audit/commit_evidence_2026-06-11_crystallization_wire.json
@@ -1,0 +1,101 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "form-os4/crystallization-wire",
+  "commit_scope": "Close m4e-jit's last named open: true runtime codegen for FOREIGN loaded tables (round 4 of the Form-OS arc, the fourth kernel's own install-leaf). The universal walker could load any node-table file through the fs port but only WALK it - native alternatives existed solely for functions baked at its own emit time. The crystallization wire makes the running binary grow native capability from any program it is given: fkc-emit-uwire emits a universal binary that CARRIES THE LOWERER (fk_lo - fkc-nat-expr's per-tag algebra emitted as C that reads the loaded rows at runtime), and when a foreign function's measured heat crosses the hot line the binary emits C source FROM THE LOADED CELLS, drives clang through the driver organ (fork/exec - the toolchain port, an allowed host carrier under allow-presence + measure-health), dlopens the artifact, and flips dispatch. Round-3's thermodynamics apply unchanged: the SAME epoch body (fkc-epoch-body-text, the round-3 epoch refactored to take its bound as text so one body serves baked counts and the runtime fk_nf - no parallel policy), the SAME policy cells (decay quantum/divisor, melt line, earn window), so a foreign native melts on cool and re-earns ice without recompiling (the dlopen handle persists; one clang invocation per table). Honesty gates: lowerability is the SAME transitive fixpoint (fkc-can-list's walk emitted as fk_ok/fk_canc, computed at LOAD time over foreign rows) so ports/organs refuse before any heat counts; a toolchain refusal (no clang, failed dlopen/dlsym) marks the function unlowerable for the run, observable on stderr (jr), never retried into a storm, never a wrong native. Every byte the binary emits at runtime descends from cells: the phrase table is Form strings compiled to char codes (fkc-phrase), the expression shapes are fkc-nat-expr's, the decision shape is named cells (fkc-wire-fires/-ice/-can-after) the band proves.",
+  "files_owned": [
+    "form/form-stdlib/fourth-walker-emit.fk",
+    "form/form-stdlib/tests/crystallization-wire-band.fk",
+    "scripts/fourth_kernel_audit.sh",
+    "docs/system_audit/commit_evidence_2026-06-11_crystallization_wire.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/tests/crystallization-wire-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/champion-challenger.fk form-stdlib/tests/melt-hot-swap-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/arena-melt.fk form-stdlib/tests/melt-on-cool-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/tests/fourth-os-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/tests/fourth-walker-emit-band.fk",
+      "bash scripts/fourth_kernel_audit.sh",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-11_crystallization_wire.json",
+      "python3 scripts/generate_repo_indexes.py"
+    ],
+    "notes": "crystallization-wire-band verdict 31 with 0 divergent across Go/Rust/TS (the firing cell honors the can gate and the hot line; the verdict cells land ice on toolchain-ok and drop can to 0 on toolchain refusal; the load-time fixpoint on the audit's foreign family refuses the driver and the SET-touching cooler while the loop and pure odd-sum stay eligible; the emission carries the cooling clock, the wire door, the fixpoint call, the clang phrase compiled from fkc-wire-clang, and the dlopen carrier; the carried lowerer IS fkc-nat-expr's algebra - LIT doubles into tagged space, IF emits else-then order, the epoch body runs over the RUNTIME function count). All thirteen neighbor bands that prelude fourth-walker-emit.fk re-proven green after the epoch-bound refactor. Audit section 27 measured the live wire (arm64 Darwin, clang -O2, deterministic dispatch counts): a FOREIGN table (odd-sum n^2, built in the audit, never seen by any emitter) loads, fn 2 crosses the hot line at heat 51, the binary emits 218 bytes of C from the loaded cells, drives one clang invocation, dlopens, dispatch flips (jw 2 51 -> jf 2 51, njit=38 native dispatches); 800 cooling dispatches on the refused organ function tick three epochs, heat halves to 22 and the foreign native MELTS (jm 2 22, final ice state 2); parity 16400 walked == 16400 wired; fn 3 (RAM organ) ends heat 370 ice 0 can 0 - hot but refused by the fixpoint, the wire never fires for it. fn 4 (figure-op row, BXOR tag 36 - a tag family outside fk_lo's pure-compute set) is refused at LOAD (can 0): new tag families walk on the universal arm, they never crystallize wrongly. Re-proven on the post-rebase tree carrying the value-stack walker (#2878), the string-pool lane (#2881), and the figure-ops family (#2880): the uwire main rides the fk_walk(i,fp) frame-pointer convention with args on fk_vs and loads the table's string section like the universal sibling; all measured dispatch counts unchanged.",
+    "environment": "arm64 Darwin, clang -O2, Go/Rust/TS kernels via form/validate.sh"
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Remote CI three-way validation pending until the branch is pushed and the PR opens."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Recipes, band, audit, and evidence only; no route or service behavior changes. No deploy required beyond normal main rollout."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Local three-way proof and live-wire witness are green; push and PR follow. The coordinator's m4e-jit retune (the crystallization wire closed for the pure-compute family) lands after the round-4 siblings merge.",
+    "remaining": [
+      "coordinator retune of fourth-kernel.form m4e-jit block after round-4 siblings merge",
+      "category coverage beyond the pure-compute family (tags 1-7, 12): organ/arena/string ops stay walk-only by the honesty gate until their native shapes are authored"
+    ]
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "crystallization-wire-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "contributor:seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "form-os-map"
+      ]
+    },
+    {
+      "contributor_id": "contributor:claude-fable-5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "proof"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "change_intent": "runtime_feature",
+  "change_files": [
+    "form/form-stdlib/fourth-walker-emit.fk",
+    "form/form-stdlib/tests/crystallization-wire-band.fk",
+    "scripts/fourth_kernel_audit.sh",
+    "scripts/INDEX.md",
+    "MANIFEST.md"
+  ],
+  "evidence_refs": [
+    "Three-way band proof: crystallization-wire-band verdict 31, 0 divergent (Go/Rust/TS) - firing cell (can AND heat past the hot line), verdict cells (toolchain ok -> ice + can kept; toolchain refused -> no ice + can dropped; no attempt leaves can untouched), load-time fixpoint on the foreign family (driver and SET-cooler refuse, loop and odd-sum eligible), emission carries the wire from the cells (cooling clock, wire door, fk_canc, clang phrase, dlopen), the carried lowerer is fkc-nat-expr's algebra over rows.",
+    "Live wire (fkc-emit-uwire via clang, scripts/fourth_kernel_audit.sh section 27, deterministic dispatch counts): a foreign table no emitter ever lowered loads through the fs port; fn 2 (odd-sum) crosses at heat 51; the RUNNING BINARY emits C from the loaded cells, drives ONE clang invocation through the driver organ, dlopens, and dispatch flips (jw 2 51 -> jf 2 51, njit=38); three idle epochs on the refused cooler halve the heat and the foreign native MELTS at 22 (jm 2 22, ice state 2 in the probe).",
+    "Parity held across the wire: walk-only value 16400 == wired value 16400 (nwire 0 vs 1); phase order asserted toolchain -> crystallize -> melt (wfm).",
+    "Honest refusal measured: fn 3 touches the RAM organ, accumulates heat 370 (far past the hot line 50), and ends ice 0 can 0 - the load-time fixpoint refused it before any heat counted; the runtime-emitted source (218 bytes) contains only the can-true family (fk_n1, fk_n2).",
+    "Neighbor bands unchanged after the epoch-bound refactor: melt-hot-swap-band 31, melt-on-cool-band 31, arena-melt-band 63, fourth-os-band 15, fourth-walker-emit-band 15, form-flatten-band 127, afferent-live-band 63, afferent-priority-band 1023, fourth-{call,driver,fixpoint,heap,match,model,net}-band 15, all three-way 0 divergent."
+  ],
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "No route behavior changes. The emitted sibling family gains a new emit lane (fkc-emit-uwire): a universal binary with no baked program and no baked natives that grows its own native capability at runtime from any loaded table - emit C from loaded cells, drive clang through the toolchain port, dlopen, flip dispatch, melt on cool under round-3's unchanged policy cells. Existing emit lanes (fkc-emit-universal, fkc-emit-jit, fkc-emit-jitmelt) are byte-identical; emission-pinning bands hold unchanged.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "crystallization-wire-band proves the wire's decision shape (what crystallizes, what refuses), the load-time fixpoint on the foreign family, and the cell-spliced emission, three-way at 31 with 0 divergent.",
+      "Audit lane end-to-end: section 27 loads a foreign table, drives one function hot, witnesses emit -> clang -> dlopen -> dispatch flip with parity, then cool -> melt; every earlier audit section (parity rows, quine, CALL, grammar binaries, universal, JIT flip, net 200, driver, m4e3, afferent witness, n7+m4e4 band ratchet, melt-on-cool, melt-hot-swap, live priority) stays green."
+    ],
+    "summary": "validate.sh new band verdict 31 three-way 0 divergent; live foreign-table gas-ice cycle measured end-to-end: jw 2 51 -> jf 2 51 -> jm 2 22, parity 16400/16400, one clang invocation, organ function refused at heat 370."
+  }
+}

--- a/form/form-stdlib/fourth-walker-emit.fk
+++ b/form/form-stdlib/fourth-walker-emit.fk
@@ -593,10 +593,13 @@
     "static long long fk_heat[64]; static long long fk_ice[64]; static long long fk_earn[64]; static long long fk_can[64]; static long long fk_tick; static long long fk_hot; static long long fk_njit; static long long fk_nmelt; static long long fk_nfreeze; static long long (*fk_nat_tab[64])(long long); ")
 
 ; the epoch: ice states walk 0 gas -> 1 ice -> 2 melted-gas; a melted native
-; re-earns ice only through the consecutive-win gate; then every heat decays
-(defn fkc-epoch-text (nf)
+; re-earns ice only through the consecutive-win gate; then every heat decays.
+; The bound is TEXT so the same body serves a baked count (a literal) and the
+; universal wire's runtime count (fk_nf) — one epoch, never two.
+(defn fkc-epoch-text (nf) (fkc-epoch-body-text (int_to_str nf)))
+(defn fkc-epoch-body-text (bound)
     (str_concat "static void fk_epoch(void) { long long f = 0; while (f < "
-    (str_concat (int_to_str nf)
+    (str_concat bound
     (str_concat ") { if (fk_ice[f] == 2) { if (fk_heat[f] > fk_hot) { fk_earn[f] = fk_earn[f] + 1; } else { fk_earn[f] = 0; } if ("
     (str_concat (fkc-jm-earn-cond-text)
     (str_concat ") { fk_ice[f] = 1; fk_nfreeze = fk_nfreeze + 1; "
@@ -662,3 +665,124 @@
         (if (eq (nth (head rows) 0) 1)
             (if (eq (nth (head rows) 1) v) 1 (fkd-has-lit (tail rows) v))
             (fkd-has-lit (tail rows) v))))
+
+; ── the crystallization wire — runtime codegen for FOREIGN loaded tables ──
+; The SELF-JIT above bakes native alternatives at EMIT time: fkc-nat-expr
+; lowers the cells the emitter saw. A FOREIGN table — loaded through the fs
+; port by the universal walker, never seen by any emitter — could only walk.
+; This wire closes the loop: the universal binary CARRIES THE LOWERER (fk_lo —
+; fkc-nat-expr's per-tag algebra emitted as C that reads the loaded rows), and
+; when a foreign function runs hot it emits C source FROM THE LOADED CELLS,
+; drives clang through the driver organ (fork/exec — the toolchain port, an
+; allowed host carrier like say/whisper/ollama), dlopens the artifact, and
+; flips dispatch — the full gas-to-ice cycle for programs that arrived after
+; birth. Round-3's thermodynamics apply unchanged: the SAME epoch body
+; (fkc-epoch-body-text over fk_nf), the SAME policy cells (decay quantum and
+; divisor, melt line, earn window), so a foreign native melts on cool and
+; re-earns ice through the champion-challenger gate without recompiling (the
+; dlopen handle persists; one clang invocation per table). Honesty gates:
+; lowerability is the SAME transitive fixpoint (fkc-can-list's walk emitted
+; as fk_ok/fk_canc over the rows, computed at LOAD time), so ports and organs
+; refuse before any heat counts; and a toolchain refusal (no clang, failed
+; dlopen/dlsym) marks the function unlowerable for the run — observable on
+; stderr (jr), never retried into a storm, never a wrong native.
+; Every byte the binary emits at runtime descends from these cells: the
+; phrase table is Form strings compiled to char codes (fkc-phrase), the
+; expression shapes are fkc-nat-expr's, the decision shape is named below.
+
+; the wire's decision cells — the band proves these ARE the emitted door
+(defn fkc-wire-fires (canf heat hot) (if (eq canf 1) (if (gt heat hot) 1 0) 0))
+(defn fkc-wire-ice (fires ok) (if (eq fires 1) (if (eq ok 1) 1 0) 0))
+(defn fkc-wire-can-after (fires ok canf) (if (eq fires 1) (if (eq ok 1) canf 0) canf))
+
+; the toolchain port's host organ and the condensation path, named as cells
+(defn fkc-wire-clang () "clang")
+(defn fkc-wire-tmp () "/tmp/fk-wire-")
+
+; a Form string compiled to a C char array — the runtime emitter's phrases
+; stay authored HERE, the C only carries their codes
+(defn fkc-ccodes (s i)
+    (if (eq i (str_len s)) "0"
+        (str_concat (int_to_str (ord (char_at s i)))
+                    (str_concat "," (fkc-ccodes s (add i 1))))))
+(defn fkc-phrase (name s)
+    (str_concat "static const char "
+    (str_concat name
+    (str_concat "[] = {"
+    (str_concat (fkc-ccodes s 0) "}; ")))))
+
+(defn fkc-wire-phrases-text ()
+    (str_concat (fkc-phrase "fk_p1" "long long fk_n")
+    (str_concat (fkc-phrase "fk_p2" "(long long a);")
+    (str_concat (fkc-phrase "fk_p3" "(long long a){return ")
+    (str_concat (fkc-phrase "fk_p4" ";}")
+    (str_concat (fkc-phrase "fk_p5" "fk_n")
+    (str_concat (fkc-phrase "fk_p6" (fkc-wire-tmp))
+    (str_concat (fkc-phrase "fk_p7" ".c")
+    (str_concat (fkc-phrase "fk_p8" ".so")
+    (str_concat (fkc-phrase "fk_p9" "")
+    (str_concat (fkc-phrase "fk_pc" (fkc-wire-clang))
+    (str_concat (fkc-phrase "fk_po" "-O2")
+    (str_concat (fkc-phrase "fk_ps" "-shared")
+    (str_concat (fkc-phrase "fk_pf" "-fPIC")
+                (fkc-phrase "fk_pd" "-o")))))))))))))))
+
+(defn fkc-wire-decl-text ()
+    "static long long fk_nf; static long long fk_nwire; static void *fk_dlh; static char fk_cs[65536]; static long long fk_cn; static char fk_fc[64]; static char fk_fs[64]; static char fk_sy[32]; extern int close(int); extern int creat(const char *, int); extern int fork(void); extern int execvp(const char *, char * const *); extern int waitpid(int, int *, int); extern int getpid(void); extern void _exit(int); extern void *dlopen(const char *, int); extern void *dlsym(void *, const char *); ")
+
+; text builders: append char/decimal/phrase into the source buffer; fk_mkp
+; shapes a name or path as prefix-number-suffix (the only naming the wire does)
+(defn fkc-rt-append-text ()
+    "static void fk_ca(long long c) { fk_cs[fk_cn] = (char)c; fk_cn = fk_cn + 1; } static void fk_cd(long long v) { char b[32]; long long n = 0; if (v == 0) { b[0] = 48; n = 1; } while (v > 0) { b[n] = 48 + v % 10; v = v / 10; n = n + 1; } while (n > 0) { n = n - 1; fk_ca(b[n]); } } static void fk_cp(const char *p) { while (*p) { fk_ca(*p); p = p + 1; } } static void fk_mkp(char *b, const char *pre, long long v, const char *suf) { long long n = 0; while (*pre) { b[n] = *pre; n = n + 1; pre = pre + 1; } char d[32]; long long m = 0; if (v == 0) { d[0] = 48; m = 1; } while (v > 0) { d[m] = 48 + v % 10; v = v / 10; m = m + 1; } while (m > 0) { m = m - 1; b[n] = d[m]; n = n + 1; } while (*suf) { b[n] = *suf; n = n + 1; suf = suf + 1; } b[n] = 0; } ")
+
+; the lowerability fixpoint over LOADED rows — fkc-lower-ok/fkc-can-list's
+; walk, reading the table: tags 1-7 and 12 lower; everything else refuses;
+; impurity poisons transitively through call edges (nf+1 simultaneous passes)
+(defn fkc-rt-can-text ()
+    "static long long fk_ok(long long i) { long long t = fk_node[i][0]; if (t == 1) { return 1; } if (t == 2) { return 1; } if (t == 3) { if (fk_ok(fk_node[i][1]) == 0) { return 0; } return fk_ok(fk_node[i][2]); } if (t == 4) { if (fk_ok(fk_node[i][1]) == 0) { return 0; } return fk_ok(fk_node[i][2]); } if (t == 5) { if (fk_ok(fk_node[i][1]) == 0) { return 0; } return fk_ok(fk_node[i][2]); } if (t == 6) { if (fk_ok(fk_node[i][1]) == 0) { return 0; } if (fk_ok(fk_node[i][2]) == 0) { return 0; } return fk_ok(fk_node[i][3]); } if (t == 7) { if (fk_can[0] == 0) { return 0; } return fk_ok(fk_node[i][1]); } if (t == 12) { if (fk_can[fk_node[i][1]] == 0) { return 0; } return fk_ok(fk_node[i][2]); } return 0; } static void fk_canc(void) { long long k = 0; while (k < fk_nf) { fk_can[k] = 1; k = k + 1; } long long m = 0; while (m <= fk_nf) { long long nx[64]; k = 0; while (k < fk_nf) { nx[k] = fk_ok(fk_fn[k]); k = k + 1; } k = 0; while (k < fk_nf) { fk_can[k] = nx[k]; k = k + 1; } m = m + 1; } } ")
+
+; the lowerer the binary carries: fkc-nat-expr's per-tag shapes, reading the
+; loaded rows — LIT doubles into tagged space, LE answers 2/0, IF emits the
+; else-then order, SELF and CALL recurse through fk_n<idx> in the same .so
+(defn fkc-rt-lower-text ()
+    "static void fk_lo(long long i) { long long t = fk_node[i][0]; if (t == 1) { fk_cd(fk_node[i][1] + fk_node[i][1]); } if (t == 2) { fk_ca(97); } if (t == 3) { fk_ca(40); fk_lo(fk_node[i][1]); fk_ca(43); fk_lo(fk_node[i][2]); fk_ca(41); } if (t == 4) { fk_ca(40); fk_lo(fk_node[i][1]); fk_ca(45); fk_lo(fk_node[i][2]); fk_ca(41); } if (t == 5) { fk_ca(40); fk_lo(fk_node[i][1]); fk_ca(60); fk_ca(61); fk_lo(fk_node[i][2]); fk_ca(63); fk_ca(50); fk_ca(58); fk_ca(48); fk_ca(41); } if (t == 6) { fk_ca(40); fk_lo(fk_node[i][1]); fk_ca(61); fk_ca(61); fk_ca(48); fk_ca(63); fk_lo(fk_node[i][3]); fk_ca(58); fk_lo(fk_node[i][2]); fk_ca(41); } if (t == 7) { fk_cp(fk_p5); fk_cd(0); fk_ca(40); fk_lo(fk_node[i][1]); fk_ca(41); } if (t == 12) { fk_cp(fk_p5); fk_cd(fk_node[i][1]); fk_ca(40); fk_lo(fk_node[i][2]); fk_ca(41); } } ")
+
+; the wire itself: one source for the WHOLE can-true family (the fixpoint
+; guarantees every callee is in it), one clang drive, one dlopen handle for
+; the run; each hot function dlsyms its own symbol when its heat crosses
+(defn fkc-wire-text ()
+    (str_concat "static long long fk_wire(long long f) { fk_nwire = fk_nwire + 1; "
+    (str_concat (fkc-jm-mark-text 119)
+                "if (fk_dlh == 0) { fk_cn = 0; long long k = 0; while (k < fk_nf) { if (fk_can[k] == 1) { fk_cp(fk_p1); fk_cd(k); fk_cp(fk_p2); } k = k + 1; } k = 0; while (k < fk_nf) { if (fk_can[k] == 1) { fk_cp(fk_p1); fk_cd(k); fk_cp(fk_p3); fk_lo(fk_fn[k]); fk_cp(fk_p4); } k = k + 1; } long long pid = getpid(); fk_mkp(fk_fc, fk_p6, pid, fk_p7); fk_mkp(fk_fs, fk_p6, pid, fk_p8); int fd = creat(fk_fc, 420); if (fd < 0) { return 0; } write(fd, fk_cs, fk_cn); close(fd); int cp = fork(); if (cp == 0) { char *av[8]; av[0] = (char *)fk_pc; av[1] = (char *)fk_po; av[2] = (char *)fk_ps; av[3] = (char *)fk_pf; av[4] = (char *)fk_pd; av[5] = fk_fs; av[6] = fk_fc; av[7] = 0; execvp(av[0], av); _exit(127); } int st = 1; waitpid(cp, &st, 0); if (st != 0) { return 0; } fk_dlh = dlopen(fk_fs, 2); if (fk_dlh == 0) { return 0; } } fk_mkp(fk_sy, fk_p5, f, fk_p9); void *sp = dlsym(fk_dlh, fk_sy); if (sp == 0) { return 0; } fk_nat_tab[f] = (long long (*)(long long))sp; return 1; } ")))
+
+; the dispatch door with the wire in the freeze arm: fkc-wire-fires decides
+; (can AND heat past the hot line), fkc-wire-ice/-can-after land the verdict —
+; success flips dispatch (jf), a toolchain refusal marks can=0 honestly (jr)
+(defn fkc-jd-wire-text ()
+    (str_concat "static void fk_jd(long long f) { fk_tick = fk_tick + 1; if ("
+    (str_concat (fkc-jm-tick-cond-text)
+    (str_concat ") { fk_tick = 0; fk_epoch(); } fk_heat[f] = fk_heat[f] + 1; if (fk_ice[f] == 0) { if (fk_can[f] == 1) { if (fk_heat[f] > fk_hot) { if (fk_wire(f) == 1) { fk_ice[f] = 1; fk_nfreeze = fk_nfreeze + 1; "
+    (str_concat (fkc-jm-mark-text 102)
+    (str_concat "} else { fk_can[f] = 0; "
+    (str_concat (fkc-jm-mark-text 114)
+                "} } } } } ")))))))
+
+; probe: value, njit, nmelt, nfreeze, nwire, then (heat, ice, can) per loaded
+; function — the foreign thermodynamic state born observable like every sibling
+(defn fkc-main-uwire-text ()
+    "extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; fk_nf = fk_next(); long long k = 0; while (k < fk_nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long ns = fk_next(); long long si = 0; while (si < ns) { long long sl = fk_next(); fk_so[fk_sp] = fk_sbp; fk_sl[fk_sp] = sl; long long bj = 0; while (bj < sl) { fk_sb[fk_sbp] = (char)fk_next(); fk_sbp = fk_sbp + 1; bj = bj + 1; } fk_sp = fk_sp + 1; si = si + 1; } long long a = 0; if (argc > 2) { a = atoi(argv[2]) << 1; } fk_hot = 1000000000000; if (argc > 3) { fk_hot = atoi(argv[3]); } fk_canc(); fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); fk_pr(fk_njit); fk_pr(fk_nmelt); fk_pr(fk_nfreeze); fk_pr(fk_nwire); long long f = 0; while (f < fk_nf) { fk_pr(fk_heat[f]); fk_pr(fk_ice[f]); fk_pr(fk_can[f]); f = f + 1; } return 0; }")
+
+(defn fkc-emit-uwire ()
+    (str_concat (fkc-pr-text)
+    (str_concat (fkc-decl-universal-text)
+    (str_concat (fkc-jitmelt-decl-text)
+    (str_concat (fkc-wire-decl-text)
+    (str_concat (fkc-wire-phrases-text)
+    (str_concat (fkc-rt-append-text)
+    (str_concat (fkc-rt-can-text)
+    (str_concat (fkc-rt-lower-text)
+    (str_concat (fkc-wire-text)
+    (str_concat (fkc-epoch-body-text "fk_nf")
+    (str_concat (fkc-jd-wire-text)
+    (str_concat (fkc-walk-jitmelt-text)
+                (fkc-main-uwire-text))))))))))))))

--- a/form/form-stdlib/tests/crystallization-wire-band.fk
+++ b/form/form-stdlib/tests/crystallization-wire-band.fk
@@ -1,0 +1,66 @@
+; preludes: form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk
+;
+; crystallization-wire-band — the m4e-jit wire's decision shape, proven
+; three-way: WHAT crystallizes at runtime (a transitively lowerable foreign
+; function whose measured heat crossed the hot line, when the toolchain
+; answered) and WHAT refuses (ports/organs by the fixpoint before any heat
+; counts; a toolchain refusal marks the function unlowerable for the run —
+; observable, never retried into a storm, never a wrong native). The live
+; binary face is measured in scripts/fourth_kernel_audit.sh section 27: a
+; foreign table the emitter never saw runs hot, the binary emits C FROM THE
+; LOADED CELLS, drives clang through the driver organ, dlopens, dispatch
+; flips, parity holds, and round-3's cycle melts it on cool.
+;
+; Verdict 31 when the wire's decision shape holds:
+;   1   the firing cell: lowerable AND past the hot line fires; at the line
+;       or unlowerable never fires
+;   2   the verdict cells: toolchain ok -> ice, can kept; toolchain refused
+;       -> no ice AND can drops to 0; no attempt leaves can untouched
+;   4   the load-time fixpoint on the section-27 foreign family: the driver
+;       (reaches the RAM organ through fn 3) and the cooler (SET) refuse;
+;       the loop and the pure odd-sum crystallize — impurity poisons
+;       transitively, purity survives the call edge
+;   8   the emission carries the wire FROM the cells: the cooling clock,
+;       the wire door in the freeze arm, the load-time fixpoint call, the
+;       clang phrase compiled from fkc-wire-clang, and the dlopen carrier
+;       all land in the universal binary's text
+;   16  the lowerer the binary carries IS fkc-nat-expr's algebra over rows:
+;       LIT doubles into tagged space, IF emits the else-then order, and
+;       the epoch body runs over the RUNTIME function count
+(do
+    (let c0 (if (eq (fkc-wire-fires 1 51 50) 1)
+                (if (eq (fkc-wire-fires 1 50 50) 0)
+                    (if (eq (fkc-wire-fires 0 999 50) 0) 1 0) 0) 0))
+
+    (let c1 (if (eq (fkc-wire-ice 1 1) 1)
+                (if (eq (fkc-wire-ice 1 0) 0)
+                    (if (eq (fkc-wire-can-after 1 1 1) 1)
+                        (if (eq (fkc-wire-can-after 1 0 1) 0)
+                            (if (eq (fkc-wire-can-after 0 1 1) 1) 2 0) 0) 0) 0) 0))
+
+    (let oddsum (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0)
+                       (fk-add (fk-sub (fk-add (fk-arg) (fk-arg)) (fk-lit 1))
+                               (fk-call 2 (fk-sub (fk-arg) (fk-lit 1))))))
+    (let loopA (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0)
+                      (fk-add (fk-call 2 (fk-lit 20)) (fk-call 1 (fk-sub (fk-arg) (fk-lit 1))))))
+    (let cool  (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0)
+                      (fk-add (fk-sub (fk-set (fk-lit 9) (fk-arg)) (fk-arg)) (fk-call 3 (fk-sub (fk-arg) (fk-lit 1))))))
+    (let driver (fk-add (fk-call 1 (fk-lit 40)) (fk-add (fk-call 3 (fk-lit 800)) (fk-call 2 (fk-lit 20)))))
+    (let can27 (fkc-can-list (list driver loopA oddsum cool)))
+    (let c2 (if (eq (nth can27 0) 0)
+                (if (eq (nth can27 1) 1)
+                    (if (eq (nth can27 2) 1)
+                        (if (eq (nth can27 3) 0) 4 0) 0) 0) 0))
+
+    (let uw (fkc-emit-uwire))
+    (let c3 (if (ge (str_find uw (fkc-jm-tick-cond-text) 0) 0)
+                (if (ge (str_find uw "if (fk_wire(f) == 1)" 0) 0)
+                    (if (ge (str_find uw "fk_canc(); " 0) 0)
+                        (if (ge (str_find uw (fkc-phrase "fk_pc" (fkc-wire-clang)) 0) 0)
+                            (if (ge (str_find uw "fk_dlh = dlopen(fk_fs, 2)" 0) 0) 8 0) 0) 0) 0) 0))
+
+    (let c4 (if (ge (str_find uw "fk_cd(fk_node[i][1] + fk_node[i][1])" 0) 0)
+                (if (ge (str_find uw "fk_lo(fk_node[i][3]); fk_ca(58); fk_lo(fk_node[i][2])" 0) 0)
+                    (if (ge (str_find uw "while (f < fk_nf) { if (fk_ice[f] == 2)" 0) 0) 16 0) 0) 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/scripts/fourth_kernel_audit.sh
+++ b/scripts/fourth_kernel_audit.sh
@@ -1041,5 +1041,87 @@ echo "                     wants let-as-binding (the value-stack lane), not re-e
 echo "  bands-on-fourth-arm: $((11 + sp_pass + fig_pass)) (learning-trend + 9 multi-param + feature-vector + $sp_pass string-pool + $fig_pass checksum-family bands, four-way gated)"
 
 echo
+# ── 27. the crystallization wire — runtime codegen for a FOREIGN loaded table ──
+# The universal walker's natives were baked at ITS OWN emit time; this binary
+# (fkc-emit-uwire) is emitted ONCE with no baked program and no baked natives.
+# The audit then builds a FOREIGN table from a program no emitter ever lowered
+# (odd-sum: n^2 by summed odds), loads it through the fs port, drives one
+# function hot — and the RUNNING BINARY emits C source FROM THE LOADED CELLS
+# (fk_lo, fkc-nat-expr's algebra over rows), drives clang through the driver
+# organ (the toolchain port), dlopens the artifact, and flips dispatch.
+# Round-3's cycle applies unchanged: idle epochs decay the heat and the
+# foreign native melts back to gas at the melt line. The cooler (fn 3, RAM
+# organ) is refused by the SAME transitive fixpoint, computed at LOAD time —
+# its heat climbs past the line and the wire never fires for it. A fifth
+# function carries a figure-op row (BXOR, tag 36) — outside fk_lo's pure-
+# compute family — and the SAME fixpoint refuses it at load (can=0): new
+# tag families walk on the universal arm, they never crystallize wrongly.
+cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/fourth-walker.fk" \
+    "$FORMDIR/form-stdlib/fourth-walker-emit.fk" > "$work/uw-driver.fk"
+cat >> "$work/uw-driver.fk" <<'EOF'
+(let oddsum (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0)
+                   (fk-add (fk-sub (fk-add (fk-arg) (fk-arg)) (fk-lit 1))
+                           (fk-call 2 (fk-sub (fk-arg) (fk-lit 1))))))
+(let loopA (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0)
+                  (fk-add (fk-call 2 (fk-lit 20)) (fk-call 1 (fk-sub (fk-arg) (fk-lit 1))))))
+(let cool  (fk-if (fk-le (fk-arg) (fk-lit 0)) (fk-lit 0)
+                  (fk-add (fk-sub (fk-set (fk-lit 9) (fk-arg)) (fk-arg)) (fk-call 3 (fk-sub (fk-arg) (fk-lit 1))))))
+(let driver (fk-add (fk-call 1 (fk-lit 40)) (fk-add (fk-call 3 (fk-lit 800)) (fk-call 2 (fk-lit 20)))))
+(let fig (fk-bxor (fk-arg) (fk-lit 5)))
+(print "==UW==")
+(print (fkc-emit-uwire))
+(print "==TF==")
+(print (fkc-table-file (list driver loopA oddsum cool fig)))
+(print "==END==")
+EOF
+(cd "$FORMDIR" && "$GO_BIN" "$work/uw-driver.fk" 2>/dev/null) > "$work/uw.out"
+sed -n '/^==UW==$/,/^==TF==$/p' "$work/uw.out" | sed -e '1d' -e '$d' > "$work/uw.c"
+sed -n '/^==TF==$/,/^==END==$/p' "$work/uw.out" | sed -e '1d' -e '$d' > "$work/t-foreign.txt"
+"$CLANG" -O2 -o "$work/fkuw" "$work/uw.c"
+uw_cold_out="$("$work/fkuw" "$work/t-foreign.txt" 0 2>/dev/null)"
+uw_cold="$(printf '%s\n' "$uw_cold_out" | sed -n 1p)"
+uw_cold_wire="$(printf '%s\n' "$uw_cold_out" | sed -n 5p)"
+"$work/fkuw" "$work/t-foreign.txt" 0 50 > "$work/uw-hot.out" 2> "$work/uw-hot.err"
+uw_hot="$(sed -n 1p "$work/uw-hot.out")"; uw_njit="$(sed -n 2p "$work/uw-hot.out")"
+uw_nmelt="$(sed -n 3p "$work/uw-hot.out")"; uw_nfrz="$(sed -n 4p "$work/uw-hot.out")"
+uw_nwire="$(sed -n 5p "$work/uw-hot.out")"
+uw_ice2="$(sed -n 13p "$work/uw-hot.out")"; uw_can2="$(sed -n 14p "$work/uw-hot.out")"
+uw_heat3="$(sed -n 15p "$work/uw-hot.out")"; uw_ice3="$(sed -n 16p "$work/uw-hot.out")"; uw_can3="$(sed -n 17p "$work/uw-hot.out")"
+uw_ice4="$(sed -n 19p "$work/uw-hot.out")"; uw_can4="$(sed -n 20p "$work/uw-hot.out")"
+rm -f /tmp/fk-wire-*.c /tmp/fk-wire-*.so
+echo "the crystallization wire (a FOREIGN table runs hot; the binary re-emits itself native at runtime):"
+echo "  walk-only: value=$uw_cold nwire=$uw_cold_wire   wired (hot 50): value=$uw_hot njit=$uw_njit freezes=$uw_nfrz melts=$uw_nmelt clang-drives=$uw_nwire"
+echo "  hot fn (2, odd-sum) boundary crossings (jw=toolchain fires, jf=crystallize, jm=melt):"
+grep '^j[wfmr] ' "$work/uw-hot.err" | sed 's/^/    /'
+echo "  readout: fn2 ice=$uw_ice2 can=$uw_can2 (melted gas after cool)   fn3 heat=$uw_heat3 ice=$uw_ice3 can=$uw_can3 (RAM organ: hot but REFUSED by the fixpoint)"
+echo "           fn4 ice=$uw_ice4 can=$uw_can4 (figure-op row, tag 36: outside fk_lo's family, REFUSED at load)"
+if [[ "$uw_cold" != "16400" || "$uw_hot" != "16400" ]]; then
+    echo "FAIL  foreign-table parity broken across the wire"; exit 1
+fi
+if [[ "$uw_cold_wire" != "0" || "$uw_nwire" != "1" || "$uw_nfrz" != "1" || "$uw_nmelt" != "1" || "$uw_njit" == "0" ]]; then
+    echo "FAIL  the wire did not fire exactly once on heat (or dispatch never went native)"; exit 1
+fi
+uw_seq="$(grep '^j[wfm] 2 ' "$work/uw-hot.err" | awk '{printf "%s", substr($1,2,1)}')"
+if [[ "$uw_seq" != "wfm" ]]; then
+    echo "FAIL  the wire's phase order is not toolchain -> crystallize -> melt (got: $uw_seq)"; exit 1
+fi
+uw_jf="$(grep '^jf 2 ' "$work/uw-hot.err" | awk '{print $3}')"
+uw_jm="$(grep '^jm 2 ' "$work/uw-hot.err" | awk '{print $3}')"
+if (( uw_jf <= 50 )) || (( uw_jm >= 25 )); then
+    echo "FAIL  wire boundary heats disagree with the policy cells (jf=$uw_jf jm=$uw_jm)"; exit 1
+fi
+if [[ "$uw_ice2" != "2" || "$uw_can2" != "1" ]]; then
+    echo "FAIL  the foreign native did not melt back to gas on cool"; exit 1
+fi
+if [[ "$uw_ice3" != "0" || "$uw_can3" != "0" ]] || (( uw_heat3 <= 50 )); then
+    echo "FAIL  the organ-touching function was not refused by the load-time fixpoint"; exit 1
+fi
+if [[ "$uw_ice4" != "0" || "$uw_can4" != "0" ]]; then
+    echo "FAIL  the figure-op function was not refused by the load-time fixpoint"; exit 1
+fi
+echo "  the loop is closed: load foreign cells -> heat -> emit C from the cells -> clang -> dlopen -> flip -> cool -> melt"
+echo "  (band: tests/crystallization-wire-band.fk -> 31; one clang invocation per table, the dlopen handle persists for re-earn)"
+
+echo
 echo "conditions: $(uname -m) $(uname -s), clang -O2, full-process invocations (startup included)"
 echo "ok — parity held and the rows are real; the spec is docs/coherence-substrate/fourth-kernel.form"


### PR DESCRIPTION
## The stone (round 4, m4e-jit's last open)

The universal walker loads node-table FILES through the fs port and walks them — but its SELF-JIT had native alternatives only for functions baked at ITS OWN emit time. A FOREIGN table, loaded at runtime, could only walk. This PR closes the wire: **when a foreign function runs hot, the running binary re-emits a native alternative FROM THE LOADED CELLS through the toolchain port, dlopens it, and dispatch flips** — the full gas-to-ice cycle for tables that arrived after birth.

## The wire

- **`fkc-emit-uwire`** (form/form-stdlib/fourth-walker-emit.fk) — a universal binary with no baked program and no baked natives that CARRIES THE LOWERER: `fk_lo` is fkc-nat-expr's per-tag algebra emitted as C that reads the loaded rows at runtime (LIT doubles into tagged space, LE answers 2/0, IF in else-then order, SELF/CALL through `fk_n<idx>` in the same .so).
- **Toolchain port** = the driver organ pointed at clang: fork/exec, one invocation per table, `dlopen` handle persists so post-melt re-earn never recompiles.
- **Honesty gates reused, not minted**: the SAME transitive lowerability fixpoint (fkc-can-list's walk as `fk_ok`/`fk_canc`, computed at LOAD time over foreign rows) refuses ports/organs before any heat counts; a toolchain refusal marks `can=0`, observable on stderr (`jr`), never retried, never a wrong native.
- **Round-3 thermodynamics unchanged**: one epoch body (`fkc-epoch-body-text`, the bound now text so a baked literal and the runtime `fk_nf` share one cell), same policy cells (decay quantum/divisor, melt line, earn window). Foreign natives melt on cool and re-earn ice identically.
- Every runtime-emitted byte descends from cells: the phrase table is Form strings compiled to char codes (`fkc-phrase`); the decision shape is named cells (`fkc-wire-fires`/`-ice`/`-can-after`) the band proves.

## Witness (audit § 27)

```
walk-only: value=16400 nwire=0   wired (hot 50): value=16400 njit=38 freezes=1 melts=1 clang-drives=1
  jw 2 51    <- the toolchain fires at heat 51
  jf 2 51    <- crystallize: dlopen'd native installed, dispatch flips
  jm 2 22    <- three cooling epochs halve the heat; the foreign native melts
readout: fn2 ice=2 can=1 (melted gas)   fn3 heat=370 ice=0 can=0 (RAM organ: hot but REFUSED)
```

The 218 bytes of C the binary emitted at runtime carry only the can-true family — lowered from cells no emitter ever saw.

## Proof

- `tests/crystallization-wire-band.fk` → **31 three-way** (what crystallizes, what refuses; the emission carries the wire from the cells)
- All thirteen bands that prelude fourth-walker-emit.fk re-proven green after the epoch-bound refactor (melt-hot-swap 31, melt-on-cool 31, arena-melt 63, form-flatten 127, afferent-live 63, afferent-priority 1023, fourth-os/emit/call/driver/fixpoint/heap/match/model/net 15)
- `scripts/fourth_kernel_audit.sh` green end-to-end, exit 0
- Evidence: docs/system_audit/commit_evidence_2026-06-11_crystallization_wire.json

## Open, named

Category coverage: the wire crystallizes the pure-compute family (tags 1-7, 12) — the same family fkc-nat-expr establishes. Organ/arena/string ops stay walk-only by the honesty gate until their native shapes are authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)