### PR TITLE
tend: the melt-root wall comes down — call args on a walker-managed value stack (bands-on-fourth-arm 11)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -47,7 +47,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 164 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 149 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 151 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-06-11_value_stack_melt_roots.json
+++ b/docs/system_audit/commit_evidence_2026-06-11_value_stack_melt_roots.json
@@ -1,0 +1,122 @@
+{
+  "date": "2026-06-11",
+  "thread_branch": "form-os4/value-stack",
+  "commit_scope": "Call args on a walker-managed value stack (the melt-root wall, down): fk_walk's argument parameter becomes a frame pointer into fk_vs[] — ARG reads fk_vs[fp], CALL/SELF push the evaluated argument and re-enter at the new frame, CONS/NTH park in-flight refs on the same stack — so the copying melt roots AND relocates every live value the walker holds (fk_mlive/fk_mcopy walk fk_vs beside fk_mem). feature-vector, m4e4's honestly-blocked tenth band, crosses onto the fourth arm with the melt firing mid-band. Bands-on-fourth-arm 10 -> 11.",
+  "change_intent": "runtime_feature",
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "m4e5-value-stack-20260611"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "measurement"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "files_owned": [
+    "form/form-stdlib/fourth-walker-emit.fk",
+    "form/form-stdlib/form-flatten.fk",
+    "form/form-stdlib/tests/melt-on-cool-band.fk",
+    "form/form-stdlib/tests/fourth-os-band.fk",
+    "form/form-stdlib/tests/fourth-net-band.fk",
+    "scripts/fourth_kernel_audit.sh",
+    "docs/system_audit/commit_evidence_2026-06-11_value_stack_melt_roots.json"
+  ],
+  "change_files": [
+    "form/form-stdlib/fourth-walker-emit.fk",
+    "form/form-stdlib/form-flatten.fk",
+    "form/form-stdlib/tests/melt-on-cool-band.fk",
+    "form/form-stdlib/tests/fourth-os-band.fk",
+    "form/form-stdlib/tests/fourth-net-band.fk",
+    "scripts/fourth_kernel_audit.sh"
+  ],
+  "evidence_refs": [
+    "docs/coherence-substrate/fourth-kernel.form",
+    "docs/coherence-substrate/bmf-architecture.form",
+    "docs/system_audit/commit_evidence_2026-06-11_m4e4_multiparam_fourth_arm.json",
+    "docs/system_audit/commit_evidence_2026-06-11_melt_on_cool_activation.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/arena-melt.fk form-stdlib/tests/melt-on-cool-band.fk",
+      "cd form && ./validate.sh <preludes> form-stdlib/tests/<band>.fk  # each of the 16 bands whose preludes include fourth-walker-emit.fk, SEPARATE invocations",
+      "bash scripts/fourth_kernel_audit.sh",
+      "python3 scripts/generate_repo_indexes.py",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-11_value_stack_melt_roots.json",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+    ],
+    "notes": "The structural fix m4e4 named: packed args lived in suspended C frames the copying melt could neither root nor relocate. fk_walk(i, a) becomes fk_walk(i, fp) — the argument never rides C; it lives at fk_vs[fp] in a dedicated rooted static region (the fk_mem precedent), capacity a named cell (fkc-vstack-capacity = 65536), breach observable (vs! on stderr, exit 9 — axiom-4). fk_melt() drops its (&hh,&ht) special case: the root set is every fk_vs slot below fk_vsp plus fk_mem, marked once (fk_mlive IS am-live) and rewritten in place (fk_mcopy IS am-melt with forwarding). CONS parks both in-flight operands through the push door across the melt door and stores them back FROM the stack (the melt may have relocated them); NTH parks its ref across the index walk. All three many-family walk variants (many/jit/jitmelt) and all four mains moved together; the single-program lane (no heap, no melt) is byte-identical, so fourth-walker-emit-band's exact text pin and the m4d quine hold unchanged. The flattening rules in form-flatten.fk are UNTOUCHED — only the carrier changed, exactly as the n7-ratchet block predicted. Three honest re-pins where bands assert emission lengths: fourth-os-band 6610->7287 (universal) and 6525->7245 (jit), fourth-net-band 6648->7325 (server). melt-on-cool-band grew 31->63: bit 32 proves the stack discipline in the emitted text (region at the named capacity cell, ARG-on-stack arm, melt rooting and relocating fk_vs, CALL through the push door, both emit lanes). Field warning confirmed again: zsh does not word-split an unquoted scalar — prelude lists for validate.sh must be arrays or literal words, or every band looks divergent.",
+    "measured": {
+      "bands_on_fourth_arm_before": 10,
+      "bands_on_fourth_arm_after": 11,
+      "crossed_band": {
+        "feature-vector": 127
+      },
+      "melt_mid_band_readout": "melt 3687 49 3638 4096 4096 58208 (allocated live dead cap-from cap-to bytes-reclaimed) — allocation crossed the 90% water line mid-call; 49 live cells (packed args included) survived relocation; 58 KB reclaimed; carrier kept",
+      "regression_melts": {
+        "chain_n4200": "melt 3687 3687 0 4096 8192 0 — crowded carrier doubles, answer 4200",
+        "churn_5x1000": "melt 3687 687 3000 4096 4096 48000 — garbage reclaimed, carrier kept, answer 1000"
+      },
+      "emission_lengths": {
+        "universal": 7287,
+        "jit_call_fib": 7245,
+        "server_hi": 7325
+      },
+      "named_remaining": {
+        "adler32": "band/shl_u32/add_u32 figure family + let-in-defn nested do",
+        "str_family": "walker string-pool lane (shared with the m4d full-fixpoint blocker)",
+        "floats": "the value stack is the ground these will stand on"
+      }
+    }
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "CI three-way suite runs on the PR; the full band suite plus kernel builds carry the regression net for the walk-variant and main rewrites."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "form-stdlib changes ride the api image rebuild; the lattice ingests the updated recipes on the post-merge hook."
+  },
+  "phase_gate": {
+    "phase": "m4e5-value-stack",
+    "gate": "every live value the walker holds is visible to the walker — call args on a walker-managed stack the melt roots and relocates; the band the wall blocked crosses UNMODIFIED with the melt firing mid-run, four-way gated",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "floats and strings stand on this ground (the stack is where their values will live); deeper recursion is future-proofed; str_* still needs the walker string-pool lane; adler32 waits on the figure family + nested do"
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "No route behavior changes. The fourth kernel's band ratchet climbs 10 -> 11: feature-vector runs UNMODIFIED on the universal fkw binary with the copying melt firing mid-band, returning the three siblings' own verdict 127.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "melt-on-cool-band proves the stack discipline three-way at 63: the emitted text carries the stack region at the named capacity cell, the ARG-on-stack arm, the melt rooting and relocating fk_vs, and the CALL push door in both emit lanes.",
+      "fourth_kernel_audit.sh section 24: feature-vector's flattened table -> universal fkw -> verdict 127 four-way gated, with the melt stderr readout proving allocation crossed the water line during the band."
+    ],
+    "summary": "validate.sh: melt-on-cool-band 63; all 16 bands whose preludes include fourth-walker-emit.fk at their verdicts (three length pins honestly re-measured); audit end-to-end green with bands-on-fourth-arm at 11 and the melt firing mid-band on the crossing."
+  }
+}

--- a/form/form-stdlib/form-flatten.fk
+++ b/form/form-stdlib/form-flatten.fk
@@ -16,10 +16,12 @@
 ; calls stay direct ARG (no allocation); zero-param packs EMPTY. Scope held
 ; honestly: PURE bands — nonnegative integer literals, defn bodies that see
 ; only their params, top-level lets, one verdict expression. eq/and lowering
-; re-evaluates pure operands; a packed-args list held across a melt-crossing
-; allocation shares m4e2's named suspended-temp gap (band-scale inputs stay
-; far below the water line); str_*, node_*, floats, and nested do are
-; m4e4's remaining family-by-family climb.
+; re-evaluates pure operands. Packed args ride the emitted walker's VALUE
+; STACK (fourth-walker-emit.fk: ARG reads fk_vs[fp], the melt roots and
+; relocates every stack slot), so band-scale allocation melts safely
+; mid-call — feature-vector's crossing is the witness (audit section 24).
+; str_*, node_*, floats, and nested do are the remaining family-by-family
+; climb.
 
 ; ── walker-carried ops as DATA rows (name arity tag) — one generic engine ──
 (defn flt-ops ()

--- a/form/form-stdlib/fourth-walker-emit.fk
+++ b/form/form-stdlib/fourth-walker-emit.fk
@@ -173,15 +173,31 @@
 ; as-is; tail, then head, then cons into the fresh space; forwarding =
 ; same-old-cell -> same-new-cell, the slot face of am-intern's same-
 ; composition-same-cell), the stderr readout IS am-measure at 16 bytes a
-; cell. Named roots at the door: the in-flight cons pair (hh, ht) and the
-; RAM organ (fk_mem) — the two places a no-locals program can hold a cell
-; across an allocating computation. A pointer parked in a suspended outer
-; compute temp instead of RAM is carrier-coordinate use, outside the melt
-; contract (the honest twin of "ports/organs honestly not lowered").
-; Thresholds are DATA from these named cells, never magic in the C.
+; cell. The melt's root set is the VALUE STACK (fk_vs — every live value
+; the walker holds, see below) plus the RAM organ (fk_mem); the melt walks
+; both, marks each slot once, and REWRITES each root in place to its
+; relocated pointer. Thresholds are DATA from these named cells, never
+; magic in the C.
+;
+; ── the walker-managed value stack (the melt-root wall, down) ────────────
+; BMF's stack-not-tokenize discipline (bmf-architecture.form) pointed inward
+; at the emitted walker: call args used to ride suspended C frames — slots
+; the copying melt could neither root nor relocate, so band-scale allocation
+; mid-call went stale (feature-vector's wall, named in m4e4). Now every live
+; value the walker holds is visible to the walker: fk_walk's second
+; parameter is a FRAME POINTER into fk_vs, ARG reads fk_vs[fp], CALL/SELF
+; push the evaluated argument and re-enter at the new frame, and CONS/NTH
+; park their in-flight refs on the same stack across allocating child
+; walks. fk_vs is a dedicated rooted region like fk_mem — static, outside
+; the arena, melt-rooted and melt-relocated like any cells. The capacity is
+; a named cell; a breach is observable (vs! on stderr, exit 9 — axiom-4),
+; and the host C stack exhausts far earlier in honest walks (each walker
+; frame nests many C frames). This is also the ground floats and strings
+; will stand on, and the depth future-proofing for deeper recursion.
 
 (defn fkc-arena-capacity () 4096)
 (defn fkc-melt-water-pct () 90)
+(defn fkc-vstack-capacity () 65536)
 (defn fkc-needs-melt (hp cap) (if (ge (mul hp 100) (mul cap (fkc-melt-water-pct))) 1 0))
 (defn fkc-next-capacity (live cap) (if (gt (mul live 2) cap) (mul cap 2) cap))
 
@@ -193,25 +209,43 @@
 (defn fkc-melt-walk-text ()
     "static long long *fk_fw; static long long *fk_nh; static long long *fk_nt; static long long fk_nhp; static void fk_mw(long long v) { char b[32]; long long n = 0; if (v == 0) { b[0] = 48; n = 1; } while (v > 0) { b[n] = 48 + v % 10; v = v / 10; n = n + 1; } while (n > 0) { n = n - 1; write(2, b + n, 1); } } static void fk_mc(long long c) { char b = c; write(2, &b, 1); } static long long fk_mlive(long long b) { if ((b & 1) == 0) { return 0; } long long p = b >> 1; if (p < 1 || p > fk_hp) { return 0; } if (fk_fw[p] != 0) { return 0; } fk_fw[p] = 0 - 1; return 1 + fk_mlive(fk_ht[p]) + fk_mlive(fk_hh[p]); } static long long fk_mcopy(long long b) { if ((b & 1) == 0) { return b; } long long p = b >> 1; if (p < 1 || p > fk_hp) { return b; } if (fk_fw[p] > 0) { return (fk_fw[p] << 1) | 1; } long long t2 = fk_mcopy(fk_ht[p]); long long h2 = fk_mcopy(fk_hh[p]); fk_nhp = fk_nhp + 1; fk_nh[fk_nhp] = h2; fk_nt[fk_nhp] = t2; fk_fw[p] = fk_nhp; return (fk_nhp << 1) | 1; } ")
 
+; the melt's root walk: EVERY value-stack slot below fk_vsp plus the RAM
+; organ — mark each reachable cell once (fk_mlive IS am-live), then rewrite
+; each root in place to its relocated pointer (fk_mcopy IS am-melt with
+; forwarding). No value the walker holds can hide from this walk: that is
+; the value stack's whole reason to exist.
 (defn fkc-melt-run-text ()
-    "static void fk_melt(long long *rh, long long *rt) { fk_fw = calloc(fk_hp + 1, 8); if (fk_fw == 0) { return; } long long nlive = fk_mlive(*rt) + fk_mlive(*rh); long long k = 0; while (k < 256) { nlive = nlive + fk_mlive(fk_mem[k]); k = k + 1; } long long ncap = fk_cap; if (nlive * 2 > fk_cap) { ncap = fk_cap * 2; } fk_nh = malloc(ncap * 8); fk_nt = malloc(ncap * 8); if (fk_nh == 0 || fk_nt == 0) { free(fk_nh); free(fk_nt); free(fk_fw); return; } fk_nhp = 0; fk_nh[0] = 1; fk_nt[0] = 1; *rt = fk_mcopy(*rt); *rh = fk_mcopy(*rh); k = 0; while (k < 256) { fk_mem[k] = fk_mcopy(fk_mem[k]); k = k + 1; } fk_mc(109); fk_mc(101); fk_mc(108); fk_mc(116); fk_mc(32); fk_mw(fk_hp); fk_mc(32); fk_mw(fk_nhp); fk_mc(32); fk_mw(fk_hp - fk_nhp); fk_mc(32); fk_mw(fk_cap); fk_mc(32); fk_mw(ncap); fk_mc(32); fk_mw((fk_hp - fk_nhp) * 16); fk_mc(10); free(fk_hh); free(fk_ht); free(fk_fw); fk_hh = fk_nh; fk_ht = fk_nt; fk_hp = fk_nhp; fk_cap = ncap; } ")
+    "static void fk_melt(void) { fk_fw = calloc(fk_hp + 1, 8); if (fk_fw == 0) { return; } long long nlive = 0; long long k = 0; while (k < fk_vsp) { nlive = nlive + fk_mlive(fk_vs[k]); k = k + 1; } k = 0; while (k < 256) { nlive = nlive + fk_mlive(fk_mem[k]); k = k + 1; } long long ncap = fk_cap; if (nlive * 2 > fk_cap) { ncap = fk_cap * 2; } fk_nh = malloc(ncap * 8); fk_nt = malloc(ncap * 8); if (fk_nh == 0 || fk_nt == 0) { free(fk_nh); free(fk_nt); free(fk_fw); return; } fk_nhp = 0; fk_nh[0] = 1; fk_nt[0] = 1; k = 0; while (k < fk_vsp) { fk_vs[k] = fk_mcopy(fk_vs[k]); k = k + 1; } k = 0; while (k < 256) { fk_mem[k] = fk_mcopy(fk_mem[k]); k = k + 1; } fk_mc(109); fk_mc(101); fk_mc(108); fk_mc(116); fk_mc(32); fk_mw(fk_hp); fk_mc(32); fk_mw(fk_nhp); fk_mc(32); fk_mw(fk_hp - fk_nhp); fk_mc(32); fk_mw(fk_cap); fk_mc(32); fk_mw(ncap); fk_mc(32); fk_mw((fk_hp - fk_nhp) * 16); fk_mc(10); free(fk_hh); free(fk_ht); free(fk_fw); fk_hh = fk_nh; fk_ht = fk_nt; fk_hp = fk_nhp; fk_cap = ncap; } ")
+
+; the push door: capacity from the named cell; a breach writes vs! and
+; exits 9 — observable (axiom-4), never silent corruption. Pops are plain
+; fk_vsp decrements at each site (balance is the walker's own discipline).
+(defn fkc-vp-text ()
+    (str_concat "extern void _exit(int); static void fk_vp(long long v) { if (fk_vsp >= "
+    (str_concat (int_to_str (fkc-vstack-capacity))
+                ") { fk_mc(118); fk_mc(115); fk_mc(33); fk_mc(10); _exit(9); } fk_vs[fk_vsp] = v; fk_vsp = fk_vsp + 1; } ")))
 
 (defn fkc-melt-text ()
     (str_concat (fkc-arena-init-text)
-    (str_concat (fkc-melt-walk-text) (fkc-melt-run-text))))
+    (str_concat (fkc-melt-walk-text)
+    (str_concat (fkc-melt-run-text) (fkc-vp-text)))))
 
 ; the door at CONS: lazy carrier birth, then the high-water decision
 ; (the same algebra as fkc-needs-melt, pct spliced from the cell), then
-; the hard boundary made OBSERVABLE — a refused allocation answers the
-; null sentinel instead of silently wrapping (axiom-4: breach observable).
+; the hard boundary made OBSERVABLE — a refused allocation pops its two
+; stack-parked operands and answers the null sentinel instead of silently
+; wrapping (axiom-4: breach observable). The in-flight pair rides fk_vs,
+; so the melt sees it as roots like everything else.
 (defn fkc-melt-door-text ()
     (str_concat "if (fk_cap == 0) { fk_arena(); } if (fk_hp * 100 >= fk_cap * "
     (str_concat (int_to_str (fkc-melt-water-pct))
-                ") { fk_melt(&hh, &ht); } if (fk_hp + 1 >= fk_cap) { return 1; } ")))
+                ") { fk_melt(); } if (fk_hp + 1 >= fk_cap) { fk_vsp = fk_vsp - 2; return 1; } ")))
 
 (defn fkc-arena-decl-text ()
-    (str_concat "static long long fk_arms[24]; static long long fk_mem[256]; static char fk_src[262144]; static long long *fk_hh; static long long *fk_ht; static long long fk_hp; static long long fk_cap; extern long long time(long long *); extern unsigned int arc4random(void); extern void *malloc(unsigned long); extern void *calloc(unsigned long, unsigned long); extern void free(void *); extern long long write(long long, const void *, unsigned long); "
-                (fkc-melt-text)))
+    (str_concat "static long long fk_arms[24]; static long long fk_mem[256]; static char fk_src[262144]; static long long *fk_hh; static long long *fk_ht; static long long fk_hp; static long long fk_cap; static long long fk_vs["
+    (str_concat (int_to_str (fkc-vstack-capacity))
+    (str_concat "]; static long long fk_vsp; extern long long time(long long *); extern unsigned int arc4random(void); extern void *malloc(unsigned long); extern void *calloc(unsigned long, unsigned long); extern void free(void *); extern long long write(long long, const void *, unsigned long); "
+                (fkc-melt-text)))))
 
 (defn fkc-decl-many-text (rows roots)
     (str_concat (fkc-arena-decl-text)
@@ -224,17 +258,22 @@
     (str_concat "][4] = { "
     (str_concat (fkc-rows-text rows) " }; "))))))))))
 
+; the shared arms (8..23) under the frame-pointer discipline: fp indexes
+; fk_vs (never a value in C), CALL pushes its evaluated argument and
+; re-enters at the new frame, CONS parks both in-flight operands on the
+; stack across the door (the melt may relocate them; the store reads them
+; back FROM the stack), and NTH parks its ref across the index walk.
 (defn fkc-arms-many-text ()
-    (str_concat " if (t == 8) { return fk_node[fk_walk(fk_node[i][1], a) >> 1][fk_walk(fk_node[i][2], a) >> 1] << 1; } if (t == 9) { putchar((int)(fk_walk(fk_node[i][1], a) >> 1)); return 0; } if (t == 10) { return ((fk_walk(fk_node[i][1], a) >> 1) / (fk_walk(fk_node[i][2], a) >> 1)) << 1; } if (t == 11) { return ((fk_walk(fk_node[i][1], a) >> 1) % (fk_walk(fk_node[i][2], a) >> 1)) << 1; } if (t == 12) { return fk_walk(fk_fn[fk_node[i][1]], fk_walk(fk_node[i][2], a)); } if (t == 13) { long long mi = fk_walk(fk_node[i][1], a) >> 1; long long mv = fk_walk(fk_node[i][2], a); fk_mem[mi & 255] = mv; return mv; } if (t == 14) { return fk_mem[(fk_walk(fk_node[i][1], a) >> 1) & 255]; } if (t == 15) { return time(0) << 1; } if (t == 16) { return ((long long)arc4random()) << 1; } if (t == 17) { return ((long long)fk_src[(fk_walk(fk_node[i][1], a) >> 1) & 262143]) << 1; } if (t == 18) { return 1; } if (t == 19) { long long hh = fk_walk(fk_node[i][1], a); long long ht = fk_walk(fk_node[i][2], a); "
+    (str_concat " if (t == 8) { return fk_node[fk_walk(fk_node[i][1], fp) >> 1][fk_walk(fk_node[i][2], fp) >> 1] << 1; } if (t == 9) { putchar((int)(fk_walk(fk_node[i][1], fp) >> 1)); return 0; } if (t == 10) { return ((fk_walk(fk_node[i][1], fp) >> 1) / (fk_walk(fk_node[i][2], fp) >> 1)) << 1; } if (t == 11) { return ((fk_walk(fk_node[i][1], fp) >> 1) % (fk_walk(fk_node[i][2], fp) >> 1)) << 1; } if (t == 12) { long long v12 = fk_walk(fk_node[i][2], fp); fk_vp(v12); long long r12 = fk_walk(fk_fn[fk_node[i][1]], fk_vsp - 1); fk_vsp = fk_vsp - 1; return r12; } if (t == 13) { long long mi = fk_walk(fk_node[i][1], fp) >> 1; long long mv = fk_walk(fk_node[i][2], fp); fk_mem[mi & 255] = mv; return mv; } if (t == 14) { return fk_mem[(fk_walk(fk_node[i][1], fp) >> 1) & 255]; } if (t == 15) { return time(0) << 1; } if (t == 16) { return ((long long)arc4random()) << 1; } if (t == 17) { return ((long long)fk_src[(fk_walk(fk_node[i][1], fp) >> 1) & 262143]) << 1; } if (t == 18) { return 1; } if (t == 19) { long long h19 = fk_walk(fk_node[i][1], fp); fk_vp(h19); long long t19 = fk_walk(fk_node[i][2], fp); fk_vp(t19); "
     (str_concat (fkc-melt-door-text)
-                "fk_hp = fk_hp + 1; fk_hh[fk_hp] = hh; fk_ht[fk_hp] = ht; return (fk_hp << 1) | 1; } if (t == 20) { long long p = fk_walk(fk_node[i][1], a) >> 1; if (p < 1 || p > fk_hp) { return 1; } return fk_hh[p]; } if (t == 21) { long long p = fk_walk(fk_node[i][1], a) >> 1; if (p < 1 || p > fk_hp) { return 1; } return fk_ht[p]; } if (t == 22) { long long p = fk_walk(fk_node[i][1], a) >> 1; long long n = 0; while (p >= 1 && p <= fk_hp) { n = n + 1; p = fk_ht[p] >> 1; } return n << 1; } if (t == 23) { long long p = fk_walk(fk_node[i][1], a) >> 1; long long k = fk_walk(fk_node[i][2], a) >> 1; while (p >= 1 && p <= fk_hp && k > 0) { p = fk_ht[p] >> 1; k = k - 1; } if (p < 1 || p > fk_hp) { return 1; } return fk_hh[p]; } return 0; } ")))
+                "fk_hp = fk_hp + 1; fk_hh[fk_hp] = fk_vs[fk_vsp - 2]; fk_ht[fk_hp] = fk_vs[fk_vsp - 1]; fk_vsp = fk_vsp - 2; return (fk_hp << 1) | 1; } if (t == 20) { long long p = fk_walk(fk_node[i][1], fp) >> 1; if (p < 1 || p > fk_hp) { return 1; } return fk_hh[p]; } if (t == 21) { long long p = fk_walk(fk_node[i][1], fp) >> 1; if (p < 1 || p > fk_hp) { return 1; } return fk_ht[p]; } if (t == 22) { long long p = fk_walk(fk_node[i][1], fp) >> 1; long long n = 0; while (p >= 1 && p <= fk_hp) { n = n + 1; p = fk_ht[p] >> 1; } return n << 1; } if (t == 23) { long long x23 = fk_walk(fk_node[i][1], fp); fk_vp(x23); long long k23 = fk_walk(fk_node[i][2], fp) >> 1; fk_vsp = fk_vsp - 1; long long p = fk_vs[fk_vsp] >> 1; while (p >= 1 && p <= fk_hp && k23 > 0) { p = fk_ht[p] >> 1; k23 = k23 - 1; } if (p < 1 || p > fk_hp) { return 1; } return fk_hh[p]; } return 0; } ")))
 
 (defn fkc-walk-many-text ()
-    (str_concat "static long long fk_walk(long long i, long long a) { long long t = fk_node[i][0]; fk_arms[t] = fk_arms[t] + 1; if (t == 1) { return fk_node[i][1] << 1; } if (t == 2) { return a; } if (t == 3) { return fk_walk(fk_node[i][1], a) + fk_walk(fk_node[i][2], a); } if (t == 4) { return fk_walk(fk_node[i][1], a) - fk_walk(fk_node[i][2], a); } if (t == 5) { if (fk_walk(fk_node[i][1], a) <= fk_walk(fk_node[i][2], a)) { return 2; } return 0; } if (t == 6) { if (fk_walk(fk_node[i][1], a) == 0) { return fk_walk(fk_node[i][3], a); } return fk_walk(fk_node[i][2], a); } if (t == 7) { return fk_walk(fk_fn[0], fk_walk(fk_node[i][1], a)); }"
+    (str_concat "static long long fk_walk(long long i, long long fp) { long long t = fk_node[i][0]; fk_arms[t] = fk_arms[t] + 1; if (t == 1) { return fk_node[i][1] << 1; } if (t == 2) { return fk_vs[fp]; } if (t == 3) { return fk_walk(fk_node[i][1], fp) + fk_walk(fk_node[i][2], fp); } if (t == 4) { return fk_walk(fk_node[i][1], fp) - fk_walk(fk_node[i][2], fp); } if (t == 5) { if (fk_walk(fk_node[i][1], fp) <= fk_walk(fk_node[i][2], fp)) { return 2; } return 0; } if (t == 6) { if (fk_walk(fk_node[i][1], fp) == 0) { return fk_walk(fk_node[i][3], fp); } return fk_walk(fk_node[i][2], fp); } if (t == 7) { long long v7 = fk_walk(fk_node[i][1], fp); fk_vp(v7); long long r7 = fk_walk(fk_fn[0], fk_vsp - 1); fk_vsp = fk_vsp - 1; return r7; }"
                 (fkc-arms-many-text)))
 
 (defn fkc-main-many-text ()
-    "extern int atoi(const char *); int main(int argc, char **argv) { long long a = 0; if (argc > 1) { a = atoi(argv[1]) << 1; } fk_pv(fk_walk(fk_fn[0], a)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } return 0; }")
+    "extern int atoi(const char *); int main(int argc, char **argv) { long long a = 0; if (argc > 1) { a = atoi(argv[1]) << 1; } fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } return 0; }")
 
 (defn fkc-emit-many2 (flat)
     (str_concat (fkc-pr-text)
@@ -253,7 +292,7 @@
 ; The kernel-resource lifecycle is the constant main (the organ); the body
 ; the program serves is Form. Port is argv[1] (default 8080).
 (defn fkc-server-main-text ()
-    "extern int socket(int,int,int); extern int bind(int,const void*,unsigned int); extern int listen(int,int); extern long accept(int,void*,void*); extern int close(int); extern int dup2(int,int); extern int fflush(void*); extern int fork(void); extern void _exit(int); extern int setsockopt(int,int,int,const void*,unsigned int); extern long read(int,void*,unsigned long); extern int shutdown(int,int); extern int atoi(const char *); static char fk_rq[8192]; struct fk_sa { unsigned char len; unsigned char fam; unsigned char p[2]; unsigned int addr; unsigned char z[8]; }; int main(int argc, char **argv) { long long port = 8080; if (argc > 1) { port = atoi(argv[1]); } int sfd = socket(2, 1, 0); int yes = 1; setsockopt(sfd, 65535, 4, &yes, 4); struct fk_sa a; a.len = 16; a.fam = 2; a.p[0] = (port >> 8) & 255; a.p[1] = port & 255; a.addr = 0; for (int z = 0; z < 8; z = z + 1) { a.z[z] = 0; } if (bind(sfd, &a, 16) < 0) { return 1; } listen(sfd, 16); while (1) { long cfd = accept(sfd, 0, 0); if (cfd < 0) { continue; } if (fork() == 0) { read((int)cfd, fk_rq, 8192); dup2((int)cfd, 1); fk_walk(fk_fn[0], 0); fflush(0); shutdown((int)cfd, 2); _exit(0); } close((int)cfd); } return 0; }")
+    "extern int socket(int,int,int); extern int bind(int,const void*,unsigned int); extern int listen(int,int); extern long accept(int,void*,void*); extern int close(int); extern int dup2(int,int); extern int fflush(void*); extern int fork(void); extern void _exit(int); extern int setsockopt(int,int,int,const void*,unsigned int); extern long read(int,void*,unsigned long); extern int shutdown(int,int); extern int atoi(const char *); static char fk_rq[8192]; struct fk_sa { unsigned char len; unsigned char fam; unsigned char p[2]; unsigned int addr; unsigned char z[8]; }; int main(int argc, char **argv) { long long port = 8080; if (argc > 1) { port = atoi(argv[1]); } int sfd = socket(2, 1, 0); int yes = 1; setsockopt(sfd, 65535, 4, &yes, 4); struct fk_sa a; a.len = 16; a.fam = 2; a.p[0] = (port >> 8) & 255; a.p[1] = port & 255; a.addr = 0; for (int z = 0; z < 8; z = z + 1) { a.z[z] = 0; } if (bind(sfd, &a, 16) < 0) { return 1; } listen(sfd, 16); while (1) { long cfd = accept(sfd, 0, 0); if (cfd < 0) { continue; } if (fork() == 0) { read((int)cfd, fk_rq, 8192); dup2((int)cfd, 1); fk_vs[0] = 0; fk_vsp = 1; fk_walk(fk_fn[0], 0); fflush(0); shutdown((int)cfd, 2); _exit(0); } close((int)cfd); } return 0; }")
 
 (defn fkc-emit-server2 (flat)
     (str_concat (fkc-pr-text)
@@ -282,7 +321,7 @@
 ; captured bytes land in fk_src (the same buffer the universal loader fills),
 ; so op 17 BUF and the streaming cursor read a LIVE subprocess.
 (defn fkc-driver-main-text ()
-    "extern int pipe(int *); extern int fork(void); extern int dup2(int,int); extern int close(int); extern long read(int,void*,unsigned long); extern int execvp(const char*, char* const*); extern void _exit(int); extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fds[2]; if (pipe(fds) < 0) { return 2; } int pid = fork(); if (pid == 0) { dup2(fds[1], 1); close(fds[0]); close(fds[1]); execvp(argv[1], &argv[1]); _exit(127); } close(fds[1]); long total = 0; long g; while ((g = read(fds[0], fk_src + total, 262143 - total)) > 0) { total = total + g; } fk_src[total] = 0; close(fds[0]); long long a = 0; fk_pv(fk_walk(fk_fn[0], a)); return 0; }")
+    "extern int pipe(int *); extern int fork(void); extern int dup2(int,int); extern int close(int); extern long read(int,void*,unsigned long); extern int execvp(const char*, char* const*); extern void _exit(int); extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fds[2]; if (pipe(fds) < 0) { return 2; } int pid = fork(); if (pid == 0) { dup2(fds[1], 1); close(fds[0]); close(fds[1]); execvp(argv[1], &argv[1]); _exit(127); } close(fds[1]); long total = 0; long g; while ((g = read(fds[0], fk_src + total, 262143 - total)) > 0) { total = total + g; } fk_src[total] = 0; close(fds[0]); fk_vs[0] = 0; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); return 0; }")
 
 (defn fkc-emit-driver2 (flat)
     (str_concat (fkc-pr-text)
@@ -338,7 +377,7 @@
                 "static long long fk_fn[64]; static long long fk_node[4096][4]; static char fk_buf[262144]; static long long fk_pos; extern int open(const char *, int); extern long long read(int, char *, unsigned long); static long long fk_next() { while (fk_buf[fk_pos] != 0) { if (fk_buf[fk_pos] >= 48) { if (fk_buf[fk_pos] <= 57) { break; } } fk_pos = fk_pos + 1; } long long v = 0; while (fk_buf[fk_pos] >= 48 && fk_buf[fk_pos] <= 57) { v = v * 10 + (fk_buf[fk_pos] - 48); fk_pos = fk_pos + 1; } return v; } "))
 
 (defn fkc-main-universal-text ()
-    "extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; long long nf = fk_next(); long long k = 0; while (k < nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long a = 0; if (argc > 2) { a = atoi(argv[2]) << 1; } if (argc > 3) { int sfd = open(argv[3], 0); if (sfd >= 0) { long long sg = read(sfd, fk_src, 262143); if (sg >= 0) { fk_src[sg] = 0; } } } fk_pv(fk_walk(fk_fn[0], a)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } return 0; }")
+    "extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; long long nf = fk_next(); long long k = 0; while (k < nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long a = 0; if (argc > 2) { a = atoi(argv[2]) << 1; } if (argc > 3) { int sfd = open(argv[3], 0); if (sfd >= 0) { long long sg = read(sfd, fk_src, 262143); if (sg >= 0) { fk_src[sg] = 0; } } } fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } return 0; }")
 
 (defn fkc-emit-universal ()
     (str_concat (fkc-pr-text)
@@ -376,13 +415,13 @@
         (str_concat "fk_nat_tab[" (str_concat (int_to_str k) (str_concat "] = fk_nat" (str_concat (int_to_str k) (str_concat "; " (fkc-jit-fills (add k 1) nf))))))))
 
 (defn fkc-walk-jit-text ()
-    (str_concat "static long long fk_walk(long long i, long long a) { long long t = fk_node[i][0]; fk_arms[t] = fk_arms[t] + 1; if (t == 1) { return fk_node[i][1] << 1; } if (t == 2) { return a; } if (t == 3) { return fk_walk(fk_node[i][1], a) + fk_walk(fk_node[i][2], a); } if (t == 4) { return fk_walk(fk_node[i][1], a) - fk_walk(fk_node[i][2], a); } if (t == 5) { if (fk_walk(fk_node[i][1], a) <= fk_walk(fk_node[i][2], a)) { return 2; } return 0; } if (t == 6) { if (fk_walk(fk_node[i][1], a) == 0) { return fk_walk(fk_node[i][3], a); } return fk_walk(fk_node[i][2], a); } if (t == 7) { long long v7 = fk_walk(fk_node[i][1], a); fk_heat[0] = fk_heat[0] + 1; if (fk_heat[0] > fk_hot) { fk_njit = fk_njit + 1; return fk_nat_tab[0](v7); } return fk_walk(fk_fn[0], v7); } if (t == 12) { long long f12 = fk_node[i][1]; long long v12 = fk_walk(fk_node[i][2], a); fk_heat[f12] = fk_heat[f12] + 1; if (fk_heat[f12] > fk_hot) { fk_njit = fk_njit + 1; return fk_nat_tab[f12](v12); } return fk_walk(fk_fn[f12], v12); }"
+    (str_concat "static long long fk_walk(long long i, long long fp) { long long t = fk_node[i][0]; fk_arms[t] = fk_arms[t] + 1; if (t == 1) { return fk_node[i][1] << 1; } if (t == 2) { return fk_vs[fp]; } if (t == 3) { return fk_walk(fk_node[i][1], fp) + fk_walk(fk_node[i][2], fp); } if (t == 4) { return fk_walk(fk_node[i][1], fp) - fk_walk(fk_node[i][2], fp); } if (t == 5) { if (fk_walk(fk_node[i][1], fp) <= fk_walk(fk_node[i][2], fp)) { return 2; } return 0; } if (t == 6) { if (fk_walk(fk_node[i][1], fp) == 0) { return fk_walk(fk_node[i][3], fp); } return fk_walk(fk_node[i][2], fp); } if (t == 7) { long long v7 = fk_walk(fk_node[i][1], fp); fk_heat[0] = fk_heat[0] + 1; if (fk_heat[0] > fk_hot) { fk_njit = fk_njit + 1; return fk_nat_tab[0](v7); } fk_vp(v7); long long r7 = fk_walk(fk_fn[0], fk_vsp - 1); fk_vsp = fk_vsp - 1; return r7; } if (t == 12) { long long f12 = fk_node[i][1]; long long v12 = fk_walk(fk_node[i][2], fp); fk_heat[f12] = fk_heat[f12] + 1; if (fk_heat[f12] > fk_hot) { fk_njit = fk_njit + 1; return fk_nat_tab[f12](v12); } fk_vp(v12); long long r12 = fk_walk(fk_fn[f12], fk_vsp - 1); fk_vsp = fk_vsp - 1; return r12; }"
                 (fkc-arms-many-text)))
 
 (defn fkc-main-jit-text (nf)
     (str_concat "extern int atoi(const char *); int main(int argc, char **argv) { long long a = 0; if (argc > 1) { a = atoi(argv[1]) << 1; } fk_hot = 1000000000000; if (argc > 2) { fk_hot = atoi(argv[2]); } "
     (str_concat (fkc-jit-fills 0 nf)
-                "fk_pv(fk_walk(fk_fn[0], a)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } fk_pr(fk_njit); return 0; }")))
+                "fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } fk_pr(fk_njit); return 0; }")))
 
 (defn fkc-emit-jit2 (fns flat)
     (str_concat (fkc-pr-text)
@@ -502,7 +541,7 @@
     (str_concat (fkc-jm-mark-text 102) "} } } } ")))))
 
 (defn fkc-walk-jitmelt-text ()
-    (str_concat "static long long fk_walk(long long i, long long a) { long long t = fk_node[i][0]; fk_arms[t] = fk_arms[t] + 1; if (t == 1) { return fk_node[i][1] << 1; } if (t == 2) { return a; } if (t == 3) { return fk_walk(fk_node[i][1], a) + fk_walk(fk_node[i][2], a); } if (t == 4) { return fk_walk(fk_node[i][1], a) - fk_walk(fk_node[i][2], a); } if (t == 5) { if (fk_walk(fk_node[i][1], a) <= fk_walk(fk_node[i][2], a)) { return 2; } return 0; } if (t == 6) { if (fk_walk(fk_node[i][1], a) == 0) { return fk_walk(fk_node[i][3], a); } return fk_walk(fk_node[i][2], a); } if (t == 7) { long long v7 = fk_walk(fk_node[i][1], a); fk_jd(0); if (fk_ice[0] == 1) { fk_njit = fk_njit + 1; return fk_nat_tab[0](v7); } return fk_walk(fk_fn[0], v7); } if (t == 12) { long long f12 = fk_node[i][1]; long long v12 = fk_walk(fk_node[i][2], a); fk_jd(f12); if (fk_ice[f12] == 1) { fk_njit = fk_njit + 1; return fk_nat_tab[f12](v12); } return fk_walk(fk_fn[f12], v12); }"
+    (str_concat "static long long fk_walk(long long i, long long fp) { long long t = fk_node[i][0]; fk_arms[t] = fk_arms[t] + 1; if (t == 1) { return fk_node[i][1] << 1; } if (t == 2) { return fk_vs[fp]; } if (t == 3) { return fk_walk(fk_node[i][1], fp) + fk_walk(fk_node[i][2], fp); } if (t == 4) { return fk_walk(fk_node[i][1], fp) - fk_walk(fk_node[i][2], fp); } if (t == 5) { if (fk_walk(fk_node[i][1], fp) <= fk_walk(fk_node[i][2], fp)) { return 2; } return 0; } if (t == 6) { if (fk_walk(fk_node[i][1], fp) == 0) { return fk_walk(fk_node[i][3], fp); } return fk_walk(fk_node[i][2], fp); } if (t == 7) { long long v7 = fk_walk(fk_node[i][1], fp); fk_jd(0); if (fk_ice[0] == 1) { fk_njit = fk_njit + 1; return fk_nat_tab[0](v7); } fk_vp(v7); long long r7 = fk_walk(fk_fn[0], fk_vsp - 1); fk_vsp = fk_vsp - 1; return r7; } if (t == 12) { long long f12 = fk_node[i][1]; long long v12 = fk_walk(fk_node[i][2], fp); fk_jd(f12); if (fk_ice[f12] == 1) { fk_njit = fk_njit + 1; return fk_nat_tab[f12](v12); } fk_vp(v12); long long r12 = fk_walk(fk_fn[f12], fk_vsp - 1); fk_vsp = fk_vsp - 1; return r12; }"
                 (fkc-arms-many-text)))
 
 (defn fkc-can-fills (can k)
@@ -519,7 +558,7 @@
     (str_concat "extern int atoi(const char *); int main(int argc, char **argv) { long long a = 0; if (argc > 1) { a = atoi(argv[1]) << 1; } fk_hot = 1000000000000; if (argc > 2) { fk_hot = atoi(argv[2]); } "
     (str_concat (fkc-jit-fills 0 (len fns))
     (str_concat (fkc-can-fills (fkc-can-list fns) 0)
-    (str_concat "fk_pv(fk_walk(fk_fn[0], a)); fk_pr(fk_njit); fk_pr(fk_nmelt); fk_pr(fk_nfreeze); long long f = 0; while (f < "
+    (str_concat "fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); fk_pr(fk_njit); fk_pr(fk_nmelt); fk_pr(fk_nfreeze); long long f = 0; while (f < "
     (str_concat (int_to_str (len fns))
                 ") { fk_pr(fk_heat[f]); fk_pr(fk_ice[f]); f = f + 1; } return 0; }"))))))
 

--- a/form/form-stdlib/tests/fourth-net-band.fk
+++ b/form/form-stdlib/tests/fourth-net-band.fk
@@ -12,8 +12,9 @@
 ;       PUTC chained by ADD-sequencing over a LIT 0 base
 ;   2   the server emission carries the net organ externs — socket(2,1,0),
 ;       fork(), accept(sfd ... — found by str_find
-;   4   the server emission is 6648 bytes for the "hi" responder (the arena
-;       rides with its melt door) and deterministic (same fns -> same text)
+;   4   the server emission is 7325 bytes for the "hi" responder (the arena
+;       rides with its melt door and the walker-managed value stack) and
+;       deterministic (same fns -> same text)
 ;   8   a different responder string gives a different emission (the body the
 ;       net main serves is the program, parameterized)
 (do
@@ -25,7 +26,7 @@
                 (if (ge (str_find srv "fork()" 0) 0)
                     (if (ge (str_find srv "accept(sfd" 0) 0) 2 0) 0) 0))
 
-    (let c2 (if (eq (str_len srv) 6648)
+    (let c2 (if (eq (str_len srv) 7325)
                 (if (str_eq srv (fkc-emit-server (list resp))) 4 0) 0))
 
     (let c3 (if (str_eq srv (fkc-emit-server (list (fkresp "yo")))) 0 8))

--- a/form/form-stdlib/tests/fourth-os-band.fk
+++ b/form/form-stdlib/tests/fourth-os-band.fk
@@ -11,25 +11,26 @@
 ; Verdict 15 when the OS face holds:
 ;   1   the table FILE is canonical — ADD(LIT 40, LIT 2) serializes to
 ;       1 2 3 1 40 0 0 1 2 0 0 3 0 1 0 (function count, roots, row count, rows)
-;   2   the universal walker's full emission is 6610 bytes and deterministic —
+;   2   the universal walker's full emission is 7287 bytes and deterministic —
 ;       program-independent constant tissue: loader, organ arms, the BMF
-;       cursor's eye (op 17 BUF), and the m4e2 arena with its melt door
-;       (ops 18..23 + fk_arena/fk_mlive/fk_mcopy/fk_melt, melt-on-cool-band)
+;       cursor's eye (op 17 BUF), the m4e2 arena with its melt door
+;       (ops 18..23 + fk_arena/fk_mlive/fk_mcopy/fk_melt, melt-on-cool-band),
+;       and the walker-managed value stack (fk_vs — args melt-rooted)
 ;   4   the native lowering is faithful text — ADD(LIT 1, ARG) lowers to
-;       (2 + a): literals lower ENCODED (ints even, refs odd — the tagged ABI) — and the jit emission for CALL-fib is 6525 bytes
+;       (2 + a): literals lower ENCODED (ints even, refs odd — the tagged ABI) — and the jit emission for CALL-fib is 7245 bytes
 ;   8   the organ program (RAM roundtrip + clock + entropy, mask 7) flattens
 ;       to its 23 rows with tags 13..16 present in the table
 (do
     (let c0 (if (str_eq (fkc-table-file (list (fk-add (fk-lit 40) (fk-lit 2)))) "1 2 3 1 40 0 0 1 2 0 0 3 0 1 0") 1 0))
 
-    (let c1 (if (eq (str_len (fkc-emit-universal)) 6610)
+    (let c1 (if (eq (str_len (fkc-emit-universal)) 7287)
                 (if (str_eq (fkc-emit-universal) (fkc-emit-universal)) 2 0) 0))
 
     (let fibc (fk-if (fk-le (fk-arg) (fk-lit 1)) (fk-arg)
                      (fk-add (fk-call 0 (fk-sub (fk-arg) (fk-lit 1)))
                              (fk-call 0 (fk-sub (fk-arg) (fk-lit 2))))))
     (let c2 (if (str_eq (fkc-nat-expr (fk-add (fk-lit 1) (fk-arg))) "(2 + a)")
-                (if (eq (str_len (fkc-emit-jit (list fibc))) 6525) 4 0) 0))
+                (if (eq (str_len (fkc-emit-jit (list fibc))) 7245) 4 0) 0))
 
     (let organ (fk-add (fk-if (fk-sub (fk-set (fk-lit 7) (fk-lit 42)) (fk-get (fk-lit 7))) (fk-lit 0) (fk-lit 1))
                (fk-add (fk-if (fk-le (fk-time) (fk-lit 0)) (fk-lit 0) (fk-lit 2))

--- a/form/form-stdlib/tests/melt-on-cool-band.fk
+++ b/form/form-stdlib/tests/melt-on-cool-band.fk
@@ -7,7 +7,7 @@
 ; spliced door — measured live in scripts/fourth_kernel_audit.sh: the round-1
 ; deaths (n=4096 -> 0, n=4200 -> 104) now answer 4096 and 4200.
 ;
-; Verdict 31 when the activation holds:
+; Verdict 63 when the activation holds:
 ;   1   the named cells tie to round 1: capacity = am-sibling-capacity + 1,
 ;       and the water decision flips exactly at the line (3686 no, 3687 yes)
 ;   2   the growth decision: a crowded melt doubles (3687 live -> 8192), a
@@ -20,6 +20,14 @@
 ;   16  the recipe lane runs the same fire-then-quiet cycle in miniature:
 ;       churn 4x16 crosses a 64-cell water (fires), melts to 4 live, and
 ;       the door is quiet at the next capacity
+;   32  the walker-managed VALUE STACK (the melt-root wall, down): the
+;       region is declared at the named capacity cell, ARG reads the frame
+;       slot (fk_vs[fp] — args never ride suspended C frames), the melt
+;       walk ROOTS every stack slot (fk_mlive over fk_vs) and RELOCATES it
+;       in place (fk_vs[k] = fk_mcopy(...)), and CALL parks its evaluated
+;       argument through the push door (fk_vp) before re-entry — so
+;       band-scale allocation can melt mid-call safely (feature-vector's
+;       crossing, audit section 24)
 (do
     (let c0 (if (eq (fkc-arena-capacity) (add (am-sibling-capacity) 1))
                 (if (eq (fkc-needs-melt 3686 4096) 0)
@@ -31,7 +39,7 @@
 
     (let uni (fkc-emit-universal))
     (let c2 (if (ge (str_find uni (fkc-melt-door-text) 0) 0)
-                (if (ge (str_find uni "fk_melt(&hh, &ht)" 0) 0)
+                (if (ge (str_find uni "fk_melt()" 0) 0)
                     (if (ge (str_find uni "fk_hp = fk_hp + 1" 0) 0) 4 0) 0) 0))
 
     (let many (fkc-emit-many (list (fk-lit 5))))
@@ -46,4 +54,11 @@
                 (if (eq (am-hp (nth wm 0)) 4)
                     (if (eq (fkc-needs-melt (am-hp (nth wm 0)) (fkc-next-capacity (am-hp (nth wm 0)) 64)) 0) 16 0) 0) 0))
 
-    (add c0 (add c1 (add c2 (add c3 c4)))))
+    (let c5 (if (ge (str_find uni (str_concat "static long long fk_vs[" (int_to_str (fkc-vstack-capacity))) 0) 0)
+                (if (ge (str_find uni "if (t == 2) { return fk_vs[fp]; }" 0) 0)
+                    (if (ge (str_find uni "fk_mlive(fk_vs[k])" 0) 0)
+                        (if (ge (str_find uni "fk_vs[k] = fk_mcopy(fk_vs[k])" 0) 0)
+                            (if (ge (str_find uni "fk_vp(v12)" 0) 0)
+                                (if (ge (str_find many "fk_vp(v12)" 0) 0) 32 0) 0) 0) 0) 0) 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 149
+**Total files**: 151
 
 | File | Purpose |
 |---|---|
@@ -50,6 +50,7 @@
 | [export_lineage.py](export_lineage.py) | Export the graph's presence lineage into a durable JSON manifest. |
 | [export_vision_image_prompts.py](export_vision_image_prompts.py) | Export persistent prompt records for Living Collective vision images. |
 | [external_proof_demo.py](external_proof_demo.py) | External proof demo — exercises the Coherence Network public API from outside the repo. |
+| [fatal_http_all_kernels_probe.py](fatal_http_all_kernels_probe.py) | Probe fatal HTTP replies across the current four kernel carriers. |
 | [federation_peer_poll.py](federation_peer_poll.py) | federation_peer_poll — fire one peer-poll cycle from the command line. |
 | [fill_missing_spec_sections.py](fill_missing_spec_sections.py) | Heal pre-existing spec body gaps the validator surfaces. |
 | [form_cli.py](form_cli.py) | form_cli.py — Form-native CLI: generate, execute, convert. |
@@ -154,6 +155,7 @@
 | [viewport_audit.py](viewport_audit.py) | Audit a list of URLs at desktop (1440x900) and mobile (390x844) widths. |
 | [wander.py](wander.py) | Launch a wandering sense into the field. |
 | [wellness_check.py](wellness_check.py) | Wellness check — a gentle sensing of the body. |
+| [whisper_block0_carrier.py](whisper_block0_carrier.py) | scripts/whisper_block0_carrier.py — M6 carrier: load safetensors, slice, quantize, and run reference forward pass. |
 | [word_cell_rewriter.py](word_cell_rewriter.py) | word_cell_rewriter — gesture 3 at word-cell granularity. |
 | [worktree_continuity_guard.py](worktree_continuity_guard.py) | Detect stranded changes across sibling worktrees. |
 | [worktree_pr_guard.py](worktree_pr_guard.py) | Worktree PR guard: prevent common CI failures and track PR check failures. |

--- a/scripts/fourth_kernel_audit.sh
+++ b/scripts/fourth_kernel_audit.sh
@@ -769,13 +769,11 @@ echo
 # Nine more REAL stdlib bands (unmodified source from disk) flatten onto the
 # walker's table and run on the SAME universal binary; each verdict is gated
 # four-way against the three walking siblings' own front door (validate.sh,
-# the nine invocations in parallel). feature-vector is the honest tenth: its
-# flatten lands and fits the loader, but its band-scale allocation crosses
-# the arena's water line and the copying melt cannot see packed args held in
-# suspended C frames (m4e2's named suspended-temp gap) — it stays off the
-# ratchet until call arguments ride a walker-managed value stack instead of
-# C locals. adler32 (the original multi-param candidate) still waits on the
-# band/shl_u32/add_u32 figure family and let-in-defn — named, not bent.
+# the nine invocations in parallel). feature-vector flattens here and CROSSES
+# in section 24: call arguments ride the walker-managed value stack, so its
+# band-scale allocation melts safely mid-call. adler32 (the original
+# multi-param candidate) still waits on the band/shl_u32/add_u32 figure
+# family and let-in-defn — named, not bent.
 mp_mods=(cooldown alert-gate value-execution anomaly-band body-state field-fusion histogram-peak model-retire signal-derivative)
 mp_exps=(63 127 7 127 127 127 127 63 127)
 cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/fourth-walker.fk" \
@@ -819,10 +817,9 @@ fv_rows="$(wc -w < "$work/t-mp-feature-vector.txt")"
 if [[ "$fv_rows" -lt 10 ]]; then
     echo "FAIL  the feature-vector flatten itself regressed"; exit 1
 fi
-echo "  feature-vector     flattens ($fv_rows table words, fits the loader) — held OFF the ratchet:"
-echo "                     band-scale allocation crosses the melt water line and packed args in"
-echo "                     suspended C frames are outside the copying melt's root set (m4e2 gap)"
-echo "  bands-on-fourth-arm: $((mp_pass + 1)) (learning-trend + $mp_pass multi-param bands, four-way gated)"
+echo "  feature-vector     flattens ($fv_rows table words, fits the loader) — crosses in section 24"
+echo "                     (its band-scale allocation melts mid-call on the value stack)"
+echo "  bands-on-fourth-arm so far: $((mp_pass + 1)) (learning-trend + $mp_pass multi-param bands, four-way gated)"
 
 echo
 # ── 23. live delivery priority — multiple offers pending in ONE window; WHICH ──
@@ -880,6 +877,36 @@ if [[ "$p1_ack" == "$p3_ack" ]]; then
     echo "FAIL  the two policy rows agreed — the row was not the variable"; exit 1
 fi
 echo "  one policy discipline, afferent and efferent: the rows are scheduler.fk's (band: tests/afferent-priority-band.fk -> 1023)"
+
+echo
+# ── 24. the melt-root wall, down — feature-vector crosses on the value stack ──
+# m4e4 named the wall precisely: packed args lived in suspended C frames the
+# copying melt could not root, and feature-vector's band-scale allocation
+# crosses the arena's 90% water line MID-CALL — the refs went stale where the
+# melt could not see them. Call arguments now ride fk_vs[], a walker-managed
+# value stack (fourth-walker-emit.fk: ARG reads fk_vs[fp]; CALL/SELF push the
+# evaluated argument; CONS/NTH park in-flight refs) that the melt roots AND
+# relocates like any cells (melt-on-cool-band -> 63). The same flattened
+# table from section 22 runs UNMODIFIED on the SAME universal binary, the
+# melt fires mid-band (the stderr readout is the witness), and the verdict
+# is gated four-way against validate.sh's own three-walker answer.
+fv_three="$(cd "$FORMDIR" && ./validate.sh form-stdlib/core.fk form-stdlib/feature-vector.fk form-stdlib/tests/feature-vector-band.fk 2>/dev/null | sed -n 's/.*→ //p' | head -1)"
+fv_fkw="$("$work/fkwu" "$work/t-mp-feature-vector.txt" 0 2>"$work/fv-melt.txt" | head -1)"
+echo "the melt-root wall, down — feature-vector on the fourth arm, melt firing mid-band:"
+echo "  three-walker verdict (validate.sh) = $fv_three   fkw = $fv_fkw   (expect 127)"
+echo "  melt readout mid-band (allocated live dead cap-from cap-to bytes-reclaimed):"
+sed 's/^/    /' "$work/fv-melt.txt"
+if [[ -z "$fv_three" || "$fv_three" != "$fv_fkw" || "$fv_fkw" != "127" ]]; then
+    echo "FAIL  feature-vector did not cross — the fourth arm disagrees with the siblings"; exit 1
+fi
+if ! grep -q '^melt ' "$work/fv-melt.txt"; then
+    echo "FAIL  no melt fired during the band — this run did not witness the wall coming down"; exit 1
+fi
+awk -v pct=90 '/^melt /{ok=($2 * 100 >= $5 * pct)}END{exit ok?0:1}' "$work/fv-melt.txt" \
+    || { echo "FAIL  the melt readout does not show allocation at the water line"; exit 1; }
+echo "  allocation crossed the water line mid-call and the packed args survived relocation —"
+echo "  every live value the walker holds is a melt-visible root (the BMF stack discipline, inward)"
+echo "  bands-on-fourth-arm: 11 (learning-trend + 9 multi-param + feature-vector, four-way gated)"
 
 echo
 echo "conditions: $(uname -m) $(uname -s), clang -O2, full-process invocations (startup included)"


### PR DESCRIPTION
## The stone

Round 4, fourth-kernel lane: **call args on a walker-managed value stack** — the structural fix the n7-ratchet block named for the melt-root wall.

m4e4's packed-args rule hit a precise wall: packed args lived in suspended C frames the copying melt could neither root nor relocate, so feature-vector's band-scale allocation (crossing the arena's 90% water line mid-call) went stale. This is the BMF stack-not-tokenize discipline (`bmf-architecture.form`) pointed inward at the emitted walker.

## What changed

- **`form/form-stdlib/fourth-walker-emit.fk`** — `fk_walk`'s argument parameter becomes a frame pointer into `fk_vs[]`: ARG reads `fk_vs[fp]`, CALL/SELF push the evaluated argument and re-enter at the new frame, CONS/NTH park in-flight refs on the same stack. `fk_melt()` drops its `(&hh,&ht)` special case — the root set is every stack slot plus `fk_mem`, marked once (`fk_mlive` IS am-live) and **rewritten in place** (`fk_mcopy` IS am-melt with forwarding). The region is dedicated and rooted (the `fk_mem` precedent); capacity is a named cell (`fkc-vstack-capacity` = 65536); breach is observable (`vs!` on stderr, exit 9 — axiom-4). All three many-family walk variants (many/jit/jitmelt) and all four mains moved together; the single-program lane (no heap, no melt) is byte-identical, so the m4d quine and the exact-text band pins hold unchanged.
- **`form/form-stdlib/form-flatten.fk`** — flattening rules UNTOUCHED (only the carrier changed, as predicted); header re-tuned to what IS.
- **Bands** — `melt-on-cool-band` 31 → 63 (bit 32 proves the stack discipline in the emitted text: region at the named cell, ARG-on-stack arm, melt rooting + relocating `fk_vs`, the push door in both emit lanes). Three honest length re-pins: `fourth-os-band` 6610→7287 / 6525→7245, `fourth-net-band` 6648→7325.
- **`scripts/fourth_kernel_audit.sh`** — section 24: feature-vector crosses, melt firing mid-band, four-way gated.

## Witnessed

Audit §24 (full audit end-to-end, exit 0, zero FAILs):

```
the melt-root wall, down — feature-vector on the fourth arm, melt firing mid-band:
  three-walker verdict (validate.sh) = 127   fkw = 127   (expect 127)
  melt readout mid-band (allocated live dead cap-from cap-to bytes-reclaimed):
    melt 3687 49 3638 4096 4096 58208
  bands-on-fourth-arm: 11 (learning-trend + 9 multi-param + feature-vector, four-way gated)
```

Allocation crossed the water line mid-call; 49 live cells — packed args included — survived relocation; 58 KB reclaimed. §19/§20/§21/§22 all at their prior verdicts (chain 4200 doubles the carrier; churn reclaims 3000 dead; jit flip njit=26; hot-swap cycle f→m→f intact).

Three-way proof (separate invocations each): melt-on-cool-band → 63; all 16 bands whose preludes include `fourth-walker-emit.fk` at their verdicts (15/15/15/15/15/15/15/15/31/63/15/127/63/1023 + os 15 + net 15).

Evidence: `docs/system_audit/commit_evidence_2026-06-11_value_stack_melt_roots.json`

## North star

Every live value the walker holds is visible to the walker. This is the ground floats and strings stand on next, and the depth future-proofing for deeper recursion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)