### PR TITLE
tend: the string-pool lane — strings as content-addressed cells, 31 bands cross to the fourth arm

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-12_string_pool_fourth_arm.json
+++ b/docs/system_audit/commit_evidence_2026-06-12_string_pool_fourth_arm.json
@@ -1,0 +1,145 @@
+{
+  "date": "2026-06-12",
+  "thread_branch": "form-os4/string-pool",
+  "commit_scope": "String-pool lane (n7-ratchet, walker tags 24..28 of the claimed 24..33 range): strings become content-addressed pool cells in the fourth kernel. The flattener pre-pass (flt-scan) interns every distinct string literal once — same bytes, same slot (axiom 3) — and literals lower to SLIT rows carrying pool indices; str_eq/str_len/str_concat are vocabulary rows onto SEQ/SLEN/SCAT, ord/not are lowerings (SCHAR at byte 0, the IF flip), true/false lower as 1/0. The table file grows a string section (count, then length + bytes per string, plain ints — older tables load with an empty pool); the emitted C carries the pool as its own rooted region (fk_sb/fk_so/fk_sl + fk_sintern) beside the cons arena, so string values ride as plain ints the copying melt never needs to root, and SEQ id-equality means content-equality because every creation path interns. Thirty-three more REAL stdlib bands (unmodified source from disk) run on the universal fkw binary and return the three walkers' own validate.sh verdicts; the string lane rides the value-stack walk signature (fk_walk(i,fp), PR #2878), so the band-scale allocators recognition-router and recognition-router-vision cross with the melt firing mid-band. Bands-on-fourth-arm 11 -> 44.",
+  "change_intent": "runtime_feature",
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "string-pool-20260612"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "measurement"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-fable-5"
+  },
+  "files_owned": [
+    "form/form-stdlib/fourth-walker.fk",
+    "form/form-stdlib/fourth-walker-emit.fk",
+    "form/form-stdlib/form-flatten.fk",
+    "form/form-stdlib/tests/form-flatten-strings-band.fk",
+    "form/form-stdlib/tests/fourth-os-band.fk",
+    "form/form-stdlib/tests/fourth-net-band.fk",
+    "scripts/fourth_kernel_audit.sh",
+    "docs/system_audit/commit_evidence_2026-06-12_string_pool_fourth_arm.json"
+  ],
+  "change_files": [
+    "form/form-stdlib/fourth-walker.fk",
+    "form/form-stdlib/fourth-walker-emit.fk",
+    "form/form-stdlib/form-flatten.fk",
+    "form/form-stdlib/tests/form-flatten-strings-band.fk",
+    "form/form-stdlib/tests/fourth-os-band.fk",
+    "form/form-stdlib/tests/fourth-net-band.fk",
+    "scripts/fourth_kernel_audit.sh",
+    "scripts/INDEX.md",
+    "MANIFEST.md"
+  ],
+  "evidence_refs": [
+    "docs/coherence-substrate/fourth-kernel.form",
+    "docs/system_audit/commit_evidence_2026-06-11_m4e4_multiparam_fourth_arm.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/form-parse.fk form-stdlib/form-flatten.fk form-stdlib/tests/form-flatten-strings-band.fk",
+      "cd form && ./validate.sh <preludes> form-stdlib/tests/<band>.fk  # the 18 bands whose preludes include the touched files, each a SEPARATE invocation, in parallel",
+      "cd form && ./validate.sh <preludes> form-stdlib/tests/<band>.fk  # the 33 crossing bands three-way, in parallel — every verdict equals fkw's",
+      "bash scripts/fourth_kernel_audit.sh",
+      "python3 scripts/generate_repo_indexes.py",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-12_string_pool_fourth_arm.json",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+    ],
+    "notes": "form-flatten-strings-band proves the lane three-way at 31: str_eq dispatches a defn by label (16), SCAT interns into the slot its joined bytes already name so SEQ answers 1, str_len+ord+not compose to 70, the pool dedups three distinct literals from four occurrences in first-appearance order, the constructors walk by value (SEQ 1, SLEN-over-SCAT 4, SCHAR 90), the REAL champion-challenger module+band walk by value to the siblings' 127, and the table file's string section serializes 'hi' as '1 2 104 105'. The op-profile re-run over the band corpus found the honest set: 30 single-module bands blocked ONLY on str_eq + string literals, 3 more adding the not-lowering; all 33 cross four-way on fkw. recognition-router (127) and recognition-router-vision (31) allocate past the melt water line mid-band; their packed args ride the walker-managed value stack (fk_vs, PR #2878) as melt-visible roots, and the melt readout witnesses relocation mid-band (e.g. 'melt 3687 71 3616 4096 4096 57856'). chakra-column's divergence was true/false literals resolving to 0 — fixed as a vocabulary lowering (true->LIT 1, false->LIT 0). Emitted-text pins re-measured on the combined tree (string pool + value stack): universal 9095, jit 8784, server 8864 (fourth-os-band, fourth-net-band). fk_arms grew to 34 slots (fkc-arm-slots cell) so tags 24..33 count without overflow; the universal probe prints arms 1..33. Pool sizes are recipe cells (fkc-spool-slots 4096, fkc-spool-bytes 262144); a refused intern answers id -1, observable, never a silent wrap.",
+    "measured": {
+      "bands_on_fourth_arm_before": 11,
+      "bands_on_fourth_arm_after": 44,
+      "crossed_bands": {
+        "active-inference": 127,
+        "branch-choice-order": 511,
+        "cell-sync": 127,
+        "chakra-column": 127,
+        "champion-challenger": 127,
+        "classifier-eval": 63,
+        "confidence-calibrate": 127,
+        "confidence-weighted-vote": 127,
+        "device-heartbeat": 127,
+        "drift-detect": 63,
+        "ensemble-vote": 127,
+        "friend-node": 127,
+        "learned-primitive": 255,
+        "markov-2": 127,
+        "mesh-gradient": 127,
+        "mesh-relay": 127,
+        "nearest-shape": 127,
+        "novelty": 63,
+        "online-accuracy": 63,
+        "predictor-train": 63,
+        "prototype-merge": 127,
+        "provisioning": 127,
+        "recognition-router": 127,
+        "recognition-router-compute": 63,
+        "recognition-router-vision": 31,
+        "self-grounding-classifier": 63,
+        "sequence-predictor": 127,
+        "shared-sensing": 127,
+        "surprise-salience": 127,
+        "temporal-smoothing": 63,
+        "declared-source": 127,
+        "transition-detect": 127,
+        "warm-start": 127
+      },
+      "named_blocked": {
+        "emit_family_bands": "fourth-kernel-emit / jit-tensor-emit / metal-emit / transformer-kernel / primitive-registry need int_to_str, str_find, substring, dicts, or organ vocabulary beyond this lane — named, not bent"
+      }
+    }
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "CI three-way suite runs on the PR; the full band suite plus kernel builds carry the regression net for the fkm-walk string arms, the flattener pool pre-pass, and the emitted pool region."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "form-stdlib changes ride the api image rebuild; the lattice ingests the updated recipes on the post-merge hook."
+  },
+  "phase_gate": {
+    "phase": "string-pool-lane",
+    "gate": "string-vocabulary bands cross onto the fourth arm via a content-addressed pool (literals interned by the flattener, ids as values, SEQ id-equality = content); the crossed bands run UNMODIFIED and four-way gated; the lane proven three-way as recipe tissue",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "the m4d full fixpoint still lacks: (1) int_to_str/substring/str_find as pool ops (29..33 reserved — the emitter's digit and slice vocabulary), (2) runtime string CREATION at table-file scale (the emitter builds ~8 KB of C text; the pool's byte store and the concat staging discipline carry it, but the walker text itself must stream as pool data — a constant-walker-text section), (3) the emitter recipes (fkc-*) flattened as a PROGRAM, which needs nested-do/let-in-defn (the figure sibling's lane) plus the multi-arg packing already proven; with those three, the emitter-as-program emits the walker text from its own node table and the fixpoint closes"
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "No route behavior changes. The fourth kernel's band ratchet climbs 11 -> 44: string-vocabulary stdlib bands flatten through the interned pool onto walker tags 24..28 and the universal fkw binary returns the three siblings' own verdicts, four-way gated in audit section 25.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "form-flatten-strings-band proves the pool lane three-way at 31: lowerings by value, pool dedup + first-appearance order, constructors by value, the REAL champion-challenger band at the siblings' 127, and the table-file string section.",
+      "fourth_kernel_audit.sh section 25: flatten 33 string bands -> table files with string sections -> universal fkw -> verdicts gated on equality with validate.sh's three-walker verdict per band; the two band-scale allocators cross with the melt firing mid-band on the value stack."
+    ],
+    "summary": "validate.sh: form-flatten-strings-band 31; all touched-prelude bands at their verdicts (os/net re-pinned to the measured emission lengths on the combined tree; melt-on-cool 63); the 33 crossing bands each 1 ok 0 divergent with fkw matching; audit end-to-end green with bands-on-fourth-arm at 44."
+  }
+}

--- a/form/form-stdlib/form-flatten.fk
+++ b/form/form-stdlib/form-flatten.fk
@@ -20,14 +20,19 @@
 ; STACK (fourth-walker-emit.fk: ARG reads fk_vs[fp], the melt roots and
 ; relocates every stack slot), so band-scale allocation melts safely
 ; mid-call — feature-vector's crossing is the witness (audit section 24).
-; str_*, node_*, floats, and nested do are the remaining family-by-family
-; climb.
+; The str_* family rides the walker string-pool lane (tags 24..28): a
+; pre-pass (flt-scan) interns every distinct "literal" into the program's
+; pool — same bytes, same slot — and a literal lowers to SLIT carrying its
+; pool index; str_eq/str_len/str_concat are table rows, ord/not are
+; lowerings. node_*, floats, substring/int_to_str, and nested do are the
+; remaining family-by-family climb.
 
 ; ── walker-carried ops as DATA rows (name arity tag) — one generic engine ──
 (defn flt-ops ()
     (list (list "add" 2 3) (list "sub" 2 4) (list "le" 2 5)
           (list "cons" 2 19) (list "nth" 2 23)
-          (list "head" 1 20) (list "tail" 1 21) (list "len" 1 22)))
+          (list "head" 1 20) (list "tail" 1 21) (list "len" 1 22)
+          (list "str_len" 1 25) (list "str_eq" 2 26) (list "str_concat" 2 27)))
 
 (defn flt-assoc (name rows)
     (if (eq (len rows) 0) (list)
@@ -44,6 +49,9 @@
 (defn flt-ge (a b) (fk-le b a))
 (defn flt-eq (a b) (fk-if (fk-le a b) (fk-if (fk-le b a) (fk-lit 1) (fk-lit 0)) (fk-lit 0)))
 (defn flt-and (a b) (fk-if a (fk-if b (fk-lit 1) (fk-lit 0)) (fk-lit 0)))
+; unary lowerings: ord rides SCHAR at byte 0; not is the IF flip
+(defn flt-ord (a) (fk-schar a (fk-lit 0)))
+(defn flt-not (a) (fk-if a (fk-lit 0) (fk-lit 1)))
 
 ; ── words off the cursor ───────────────────────────────────────────────────
 (defn flt-word (s pos) (substring s pos (fp-sym-end s pos)))
@@ -57,11 +65,31 @@
 (defn flt-expr (s pos fns env) (flt-expr2 s (fp-skip s pos) fns env))
 (defn flt-expr2 (s pos fns env)
     (if (eq (fp-at s pos) 40) (flt-form s (fp-skip s (add pos 1)) fns env)
-        (if (fp-isdigit (fp-at s pos)) (fp-num (fp-digits s pos 0))
-            (flt-var s pos env))))
+        (if (eq (fp-at s pos) 34) (flt-str s (add pos 1) env)
+            (if (fp-isdigit (fp-at s pos)) (fp-num (fp-digits s pos 0))
+                (flt-var s pos env)))))
+
+; ── string literals ride the pool: the pre-pass (flt-scan) interned every
+;    distinct literal, so a "..." at the cursor lowers to SLIT carrying its
+;    pool index; the pool itself travels in env under the quote-name (a name
+;    no symbol can collide with — '"' is the literal door, never a var) ─────
+(defn flt-strend (s pos)
+    (if (ge pos (fp-len s)) pos
+        (if (eq (fp-at s pos) 34) pos (flt-strend s (add pos 1)))))
+(defn flt-str (s pos env) (flt-str2 (substring s pos (flt-strend s pos)) (add (flt-strend s pos) 1) env))
+(defn flt-str2 (lit end env) (list (fk-slit (flt-sidx (flt-poolv env) lit 0) lit) end))
+(defn flt-poolq () (byte_to_str 34))
+(defn flt-pool-row (env) (flt-assoc (flt-poolq) env))
+(defn flt-poolv (env) (nth (flt-pool-row env) 1))
+(defn flt-sidx (pool lit i)
+    (if (eq (len pool) 0) (sub 0 1)
+        (if (str_eq (head pool) lit) i (flt-sidx (tail pool) lit (add i 1)))))
 
 (defn flt-var (s pos env) (flt-var2 (flt-word s pos) (fp-sym-end s pos) env))
-(defn flt-var2 (name end env) (list (flt-var3 (flt-assoc name env)) end))
+(defn flt-var2 (name end env)
+    (if (str_eq name "true") (list (fk-lit 1) end)
+        (if (str_eq name "false") (list (fk-lit 0) end)
+            (list (flt-var3 (flt-assoc name env)) end))))
 (defn flt-var3 (row) (if (eq (len row) 0) (fk-lit 0) (nth row 1)))
 
 (defn flt-form (s pos fns env) (flt-form2 (flt-word s pos) s (fp-sym-end s pos) fns env))
@@ -73,7 +101,14 @@
     (if (str_eq op "ge") (flt-low 2 s pos fns env)
     (if (str_eq op "eq") (flt-low 3 s pos fns env)
     (if (str_eq op "and") (flt-low 4 s pos fns env)
-        (flt-op op s pos fns env)))))))))
+    (if (str_eq op "ord") (flt-low1 1 s pos fns env)
+    (if (str_eq op "not") (flt-low1 2 s pos fns env)
+        (flt-op op s pos fns env)))))))))))
+
+; one operand, then the unary lowering picked by selector k
+(defn flt-low1 (k s pos fns env) (flt-low1-a k s (flt-expr s pos fns env)))
+(defn flt-low1-a (k s ae) (list (flt-low1-mk k (nth ae 0)) (fp-close s (nth ae 1))))
+(defn flt-low1-mk (k a) (if (eq k 1) (flt-ord a) (flt-not a)))
 
 ; two operands, then the lowering picked by selector k (lowerings are rules,
 ; not tag rows — they BUILD shapes instead of naming one)
@@ -167,7 +202,8 @@
 (defn flt-defn-p2 (name s pe fns rbodies env main)
     (flt-defn-b s (nth pe 1)
                 (cons (list name (add (len fns) 1) (len (nth pe 0))) fns)
-                (flt-penv (nth pe 0) (len (nth pe 0)) 0) rbodies env main))
+                (cons (flt-pool-row env) (flt-penv (nth pe 0) (len (nth pe 0)) 0))
+                rbodies env main))
 (defn flt-defn-b (s pos fns benv rbodies env main)
     (flt-defn-done s (flt-expr s pos fns benv) fns rbodies env main))
 (defn flt-defn-done (s be fns rbodies env main)
@@ -183,11 +219,32 @@
 (defn flt-let-done (name s ve fns rbodies env main)
     (flt-items s (fp-close s (nth ve 1)) fns rbodies (cons (list name (nth ve 0)) env) main))
 
-; one source file's (do ...) — returns (fns rbodies main endpos)
-(defn flt-top (s fns rbodies)
-    (flt-top2 s (fp-skip s 0) fns rbodies))
-(defn flt-top2 (s pos fns rbodies)
-    (flt-items s (fp-sym-end s (fp-skip s (add pos 1))) fns rbodies (list) (fk-lit 0)))
+; one source file's (do ...) — returns (fns rbodies main endpos); env is
+; seeded with the program's string pool under the quote-name
+(defn flt-top (s fns rbodies pool)
+    (flt-top2 s (fp-skip s 0) fns rbodies pool))
+(defn flt-top2 (s pos fns rbodies pool)
+    (flt-items s (fp-sym-end s (fp-skip s (add pos 1))) fns rbodies
+               (list (list (flt-poolq) pool)) (fk-lit 0)))
+
+; ── the pool pre-pass: walk the source once (token jumps, comments and
+;    whitespace through fp-skip) and intern every DISTINCT "literal" in
+;    first-appearance order — the same order the parser meets them, so a
+;    literal's pool index is stable between flatten and serialization ──────
+(defn flt-scan (s pos acc) (flt-scan-at s (fp-skip s pos) acc))
+(defn flt-scan-at (s pos acc)
+    (if (ge pos (fp-len s)) acc
+        (if (eq (fp-at s pos) 34) (flt-scan-lit s (add pos 1) acc)
+            (flt-scan s (flt-scan-adv s pos) acc))))
+(defn flt-scan-adv (s pos)
+    (if (gt (fp-sym-end s pos) pos) (fp-sym-end s pos) (add pos 1)))
+(defn flt-scan-lit (s pos acc)
+    (flt-scan-lit2 s (flt-strend s pos) (substring s pos (flt-strend s pos)) acc))
+(defn flt-scan-lit2 (s end lit acc) (flt-scan s (add end 1) (flt-pool-add acc lit)))
+(defn flt-pool-add (pool lit)
+    (if (ge (flt-sidx pool lit 0) 0) pool (flt-append pool lit)))
+(defn flt-append (xs x)
+    (if (eq (len xs) 0) (cons x (list)) (cons (head xs) (flt-append (tail xs) x))))
 
 ; ── entry doors ────────────────────────────────────────────────────────────
 ; module source + band source -> the walker's function list (fn 0 = the
@@ -196,12 +253,18 @@
 ; load plain-Form preludes only)
 (defn flt-rev (xs acc)
     (if (eq (len xs) 0) acc (flt-rev (tail xs) (cons (head xs) acc))))
+; the pool doors mirror the fns doors: the SAME scan order feeds both, so a
+; SLIT row's index always names the right string-section entry
+(defn flt-band-pool (modsrc bandsrc) (flt-scan bandsrc 0 (flt-scan modsrc 0 (list))))
+(defn flt-src-pool (src) (flt-scan src 0 (list)))
 (defn flt-band-fns (modsrc bandsrc)
-    (flt-band2 (flt-top modsrc (list) (list)) bandsrc))
-(defn flt-band2 (mr bandsrc)
-    (flt-band3 (flt-top bandsrc (nth mr 0) (nth mr 1))))
+    (flt-band-fns2 modsrc bandsrc (flt-band-pool modsrc bandsrc)))
+(defn flt-band-fns2 (modsrc bandsrc pool)
+    (flt-band2 (flt-top modsrc (list) (list) pool) bandsrc pool))
+(defn flt-band2 (mr bandsrc pool)
+    (flt-band3 (flt-top bandsrc (nth mr 0) (nth mr 1) pool)))
 (defn flt-band3 (br)
     (cons (nth br 2) (flt-rev (nth br 1) (list))))
 
 ; single-source door (prelude-free bands, mini programs)
-(defn flt-src-fns (src) (flt-band3 (flt-top src (list) (list))))
+(defn flt-src-fns (src) (flt-band3 (flt-top src (list) (list) (flt-src-pool src))))

--- a/form/form-stdlib/fourth-walker-emit.fk
+++ b/form/form-stdlib/fourth-walker-emit.fk
@@ -31,9 +31,14 @@
     (if (eq (fk-tag n) 20) (fkc-un2 20 (fkc-flat (fk-body n) acc))
     (if (eq (fk-tag n) 21) (fkc-un2 21 (fkc-flat (fk-body n) acc))
     (if (eq (fk-tag n) 22) (fkc-un2 22 (fkc-flat (fk-body n) acc))
+    ; 24 SLIT — a leaf row carrying the POOL INDEX (the string's bytes travel
+    ; in the table file's string section, not in the row); 25 SLEN unary;
+    ; SEQ/SCAT/SCHAR (26..28) are pair-bodied and ride the default binary arm
+    (if (eq (fk-tag n) 24) (cons (list 24 (ms-value (ms-child (fk-body n) 0)) 0 0) acc)
+    (if (eq (fk-tag n) 25) (fkc-un2 25 (fkc-flat (fk-body n) acc))
     (if (eq (fk-tag n) 12) (fkc-call2 (ms-value (ms-child (fk-body n) 0)) (fkc-flat (ms-child (fk-body n) 1) acc))
     (if (eq (fk-tag n) 6) (fkc-if2 (fkc-flat (ms-child (fk-body n) 0) acc) n)
-        (fkc-bin2 (fk-tag n) (fkc-flat (ms-child (fk-body n) 0) acc) n))))))))))))))))
+        (fkc-bin2 (fk-tag n) (fkc-flat (ms-child (fk-body n) 0) acc) n))))))))))))))))))
 
 (defn fkc-call2 (fidx acc1) (cons (list 12 fidx (sub (len acc1) 1) 0) acc1))
 
@@ -241,11 +246,47 @@
     (str_concat (int_to_str (fkc-melt-water-pct))
                 ") { fk_melt(); } if (fk_hp + 1 >= fk_cap) { fk_vsp = fk_vsp - 2; return 1; } ")))
 
+; ── the string POOL (tags 24..33 claimed by the string lane) — its own rooted
+;    region beside the cons arena: interned byte-sequences addressed by id.
+;    fk_sintern is axiom 3 in C — same bytes answer the same slot, so the SEQ
+;    arm compares IDS and means content. The pool is append-only and never
+;    moved, so the copying melt has nothing to root here; string values ride
+;    as plain ints (pool ids) through packed args, lists, and RAM. A refused
+;    intern (slots or bytes exhausted) answers id -1 — observable, never a
+;    silent wrap (axiom 4). Sizes are recipe cells, no magic in the C.
+(defn fkc-spool-slots () 4096)    ; max distinct strings in one program image
+(defn fkc-spool-bytes () 262144)  ; pool byte store, the fk_src discipline
+(defn fkc-arm-slots ()  34)       ; dispatch counters cover tags 0..33
+
+(defn fkc-spool-decl-text ()
+    (str_concat "static char fk_sb["
+    (str_concat (int_to_str (fkc-spool-bytes))
+    (str_concat "]; static long long fk_so["
+    (str_concat (int_to_str (fkc-spool-slots))
+    (str_concat "]; static long long fk_sl["
+    (str_concat (int_to_str (fkc-spool-slots))
+    (str_concat "]; static long long fk_sp; static long long fk_sbp; static long long fk_sintern(long long off, long long len) { long long i = 0; while (i < fk_sp) { if (fk_sl[i] == len) { long long j = 0; while (j < len && fk_sb[fk_so[i] + j] == fk_sb[off + j]) { j = j + 1; } if (j == len) { return i; } } i = i + 1; } if (i >= "
+    (str_concat (int_to_str (fkc-spool-slots))
+    (str_concat " || off + len > "
+    (str_concat (int_to_str (fkc-spool-bytes))
+                ") { return 0 - 1; } fk_so[i] = off; fk_sl[i] = len; fk_sp = i + 1; fk_sbp = off + len; return i; } ")))))))))))
+
+; the walker arms for the pool ops — spliced into every many-family walker.
+; String values are pool ids: plain ints into a static append-only region,
+; so sub-walks that melt never disturb them — no fk_vp parking needed here.
+(defn fkc-str-arms-text ()
+    (str_concat "if (t == 24) { return fk_node[i][1] << 1; } if (t == 25) { long long sa = fk_walk(fk_node[i][1], fp) >> 1; if (sa < 0 || sa >= fk_sp) { return 0; } return fk_sl[sa] << 1; } if (t == 26) { if (fk_walk(fk_node[i][1], fp) == fk_walk(fk_node[i][2], fp)) { return 2; } return 0; } if (t == 27) { long long sa = fk_walk(fk_node[i][1], fp) >> 1; long long sb = fk_walk(fk_node[i][2], fp) >> 1; if (sa < 0 || sa >= fk_sp || sb < 0 || sb >= fk_sp) { return 0 - 2; } long long ln = fk_sl[sa] + fk_sl[sb]; if (fk_sbp + ln > "
+    (str_concat (int_to_str (fkc-spool-bytes))
+                ") { return 0 - 2; } long long j = 0; while (j < fk_sl[sa]) { fk_sb[fk_sbp + j] = fk_sb[fk_so[sa] + j]; j = j + 1; } j = 0; while (j < fk_sl[sb]) { fk_sb[fk_sbp + fk_sl[sa] + j] = fk_sb[fk_so[sb] + j]; j = j + 1; } return fk_sintern(fk_sbp, ln) << 1; } if (t == 28) { long long sa = fk_walk(fk_node[i][1], fp) >> 1; long long k = fk_walk(fk_node[i][2], fp) >> 1; if (sa < 0 || sa >= fk_sp || k < 0 || k >= fk_sl[sa]) { return 0 - 2; } return ((long long)(unsigned char)fk_sb[fk_so[sa] + k]) << 1; } ")))
+
 (defn fkc-arena-decl-text ()
-    (str_concat "static long long fk_arms[24]; static long long fk_mem[256]; static char fk_src[262144]; static long long *fk_hh; static long long *fk_ht; static long long fk_hp; static long long fk_cap; static long long fk_vs["
+    (str_concat "static long long fk_arms["
+    (str_concat (int_to_str (fkc-arm-slots))
+    (str_concat "]; static long long fk_mem[256]; static char fk_src[262144]; static long long *fk_hh; static long long *fk_ht; static long long fk_hp; static long long fk_cap; static long long fk_vs["
     (str_concat (int_to_str (fkc-vstack-capacity))
     (str_concat "]; static long long fk_vsp; extern long long time(long long *); extern unsigned int arc4random(void); extern void *malloc(unsigned long); extern void *calloc(unsigned long, unsigned long); extern void free(void *); extern long long write(long long, const void *, unsigned long); "
-                (fkc-melt-text)))))
+    (str_concat (fkc-spool-decl-text)
+                (fkc-melt-text))))))))
 
 (defn fkc-decl-many-text (rows roots)
     (str_concat (fkc-arena-decl-text)
@@ -266,7 +307,8 @@
 (defn fkc-arms-many-text ()
     (str_concat " if (t == 8) { return fk_node[fk_walk(fk_node[i][1], fp) >> 1][fk_walk(fk_node[i][2], fp) >> 1] << 1; } if (t == 9) { putchar((int)(fk_walk(fk_node[i][1], fp) >> 1)); return 0; } if (t == 10) { return ((fk_walk(fk_node[i][1], fp) >> 1) / (fk_walk(fk_node[i][2], fp) >> 1)) << 1; } if (t == 11) { return ((fk_walk(fk_node[i][1], fp) >> 1) % (fk_walk(fk_node[i][2], fp) >> 1)) << 1; } if (t == 12) { long long v12 = fk_walk(fk_node[i][2], fp); fk_vp(v12); long long r12 = fk_walk(fk_fn[fk_node[i][1]], fk_vsp - 1); fk_vsp = fk_vsp - 1; return r12; } if (t == 13) { long long mi = fk_walk(fk_node[i][1], fp) >> 1; long long mv = fk_walk(fk_node[i][2], fp); fk_mem[mi & 255] = mv; return mv; } if (t == 14) { return fk_mem[(fk_walk(fk_node[i][1], fp) >> 1) & 255]; } if (t == 15) { return time(0) << 1; } if (t == 16) { return ((long long)arc4random()) << 1; } if (t == 17) { return ((long long)fk_src[(fk_walk(fk_node[i][1], fp) >> 1) & 262143]) << 1; } if (t == 18) { return 1; } if (t == 19) { long long h19 = fk_walk(fk_node[i][1], fp); fk_vp(h19); long long t19 = fk_walk(fk_node[i][2], fp); fk_vp(t19); "
     (str_concat (fkc-melt-door-text)
-                "fk_hp = fk_hp + 1; fk_hh[fk_hp] = fk_vs[fk_vsp - 2]; fk_ht[fk_hp] = fk_vs[fk_vsp - 1]; fk_vsp = fk_vsp - 2; return (fk_hp << 1) | 1; } if (t == 20) { long long p = fk_walk(fk_node[i][1], fp) >> 1; if (p < 1 || p > fk_hp) { return 1; } return fk_hh[p]; } if (t == 21) { long long p = fk_walk(fk_node[i][1], fp) >> 1; if (p < 1 || p > fk_hp) { return 1; } return fk_ht[p]; } if (t == 22) { long long p = fk_walk(fk_node[i][1], fp) >> 1; long long n = 0; while (p >= 1 && p <= fk_hp) { n = n + 1; p = fk_ht[p] >> 1; } return n << 1; } if (t == 23) { long long x23 = fk_walk(fk_node[i][1], fp); fk_vp(x23); long long k23 = fk_walk(fk_node[i][2], fp) >> 1; fk_vsp = fk_vsp - 1; long long p = fk_vs[fk_vsp] >> 1; while (p >= 1 && p <= fk_hp && k23 > 0) { p = fk_ht[p] >> 1; k23 = k23 - 1; } if (p < 1 || p > fk_hp) { return 1; } return fk_hh[p]; } return 0; } ")))
+    (str_concat "fk_hp = fk_hp + 1; fk_hh[fk_hp] = fk_vs[fk_vsp - 2]; fk_ht[fk_hp] = fk_vs[fk_vsp - 1]; fk_vsp = fk_vsp - 2; return (fk_hp << 1) | 1; } if (t == 20) { long long p = fk_walk(fk_node[i][1], fp) >> 1; if (p < 1 || p > fk_hp) { return 1; } return fk_hh[p]; } if (t == 21) { long long p = fk_walk(fk_node[i][1], fp) >> 1; if (p < 1 || p > fk_hp) { return 1; } return fk_ht[p]; } if (t == 22) { long long p = fk_walk(fk_node[i][1], fp) >> 1; long long n = 0; while (p >= 1 && p <= fk_hp) { n = n + 1; p = fk_ht[p] >> 1; } return n << 1; } if (t == 23) { long long x23 = fk_walk(fk_node[i][1], fp); fk_vp(x23); long long k23 = fk_walk(fk_node[i][2], fp) >> 1; fk_vsp = fk_vsp - 1; long long p = fk_vs[fk_vsp] >> 1; while (p >= 1 && p <= fk_hp && k23 > 0) { p = fk_ht[p] >> 1; k23 = k23 - 1; } if (p < 1 || p > fk_hp) { return 1; } return fk_hh[p]; } "
+    (str_concat (fkc-str-arms-text) "return 0; } ")))))
 
 (defn fkc-walk-many-text ()
     (str_concat "static long long fk_walk(long long i, long long fp) { long long t = fk_node[i][0]; fk_arms[t] = fk_arms[t] + 1; if (t == 1) { return fk_node[i][1] << 1; } if (t == 2) { return fk_vs[fp]; } if (t == 3) { return fk_walk(fk_node[i][1], fp) + fk_walk(fk_node[i][2], fp); } if (t == 4) { return fk_walk(fk_node[i][1], fp) - fk_walk(fk_node[i][2], fp); } if (t == 5) { if (fk_walk(fk_node[i][1], fp) <= fk_walk(fk_node[i][2], fp)) { return 2; } return 0; } if (t == 6) { if (fk_walk(fk_node[i][1], fp) == 0) { return fk_walk(fk_node[i][3], fp); } return fk_walk(fk_node[i][2], fp); } if (t == 7) { long long v7 = fk_walk(fk_node[i][1], fp); fk_vp(v7); long long r7 = fk_walk(fk_fn[0], fk_vsp - 1); fk_vsp = fk_vsp - 1; return r7; }"
@@ -372,12 +414,32 @@
     (if (eq (len rows) 1) (fkc-row-sp (head rows))
         (str_concat (fkc-rows-sp (tail rows)) (str_concat " " (fkc-row-sp (head rows))))))
 
+; the string section: pool count, then per string its length and bytes —
+; fks-table-file is fkc-table-file with the program's pool riding behind it
+(defn fks-lit-sp (s i)
+    (if (eq i (str_len s)) ""
+        (str_concat " " (str_concat (int_to_str (ord (char_at s i))) (fks-lit-sp s (add i 1))))))
+(defn fks-pool-entry (s) (str_concat (int_to_str (str_len s)) (fks-lit-sp s 0)))
+(defn fks-pool-items (pool)
+    (if (eq (len pool) 0) ""
+        (str_concat " " (str_concat (fks-pool-entry (head pool)) (fks-pool-items (tail pool))))))
+(defn fks-pool-sp (pool) (str_concat (int_to_str (len pool)) (fks-pool-items pool)))
+(defn fks-table-file (fns pool)
+    (str_concat (fkc-table-file fns) (str_concat " " (fks-pool-sp pool))))
+
 (defn fkc-decl-universal-text ()
     (str_concat (fkc-arena-decl-text)
                 "static long long fk_fn[64]; static long long fk_node[4096][4]; static char fk_buf[262144]; static long long fk_pos; extern int open(const char *, int); extern long long read(int, char *, unsigned long); static long long fk_next() { while (fk_buf[fk_pos] != 0) { if (fk_buf[fk_pos] >= 48) { if (fk_buf[fk_pos] <= 57) { break; } } fk_pos = fk_pos + 1; } long long v = 0; while (fk_buf[fk_pos] >= 48 && fk_buf[fk_pos] <= 57) { v = v * 10 + (fk_buf[fk_pos] - 48); fk_pos = fk_pos + 1; } return v; } "))
 
+; the table file's STRING SECTION rides after the rows: count, then per
+; string length + bytes (plain ints, the loader's digit cursor unchanged);
+; an older table simply ends and fk_next answers 0 — an empty pool. The
+; loader appends VERBATIM: the flattener is the interner and pool indices
+; in SLIT rows must stay stable.
 (defn fkc-main-universal-text ()
-    "extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; long long nf = fk_next(); long long k = 0; while (k < nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long a = 0; if (argc > 2) { a = atoi(argv[2]) << 1; } if (argc > 3) { int sfd = open(argv[3], 0); if (sfd >= 0) { long long sg = read(sfd, fk_src, 262143); if (sg >= 0) { fk_src[sg] = 0; } } } fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } return 0; }")
+    (str_concat "extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; long long nf = fk_next(); long long k = 0; while (k < nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long ns = fk_next(); long long si = 0; while (si < ns) { long long sl = fk_next(); fk_so[fk_sp] = fk_sbp; fk_sl[fk_sp] = sl; long long bj = 0; while (bj < sl) { fk_sb[fk_sbp] = (char)fk_next(); fk_sbp = fk_sbp + 1; bj = bj + 1; } fk_sp = fk_sp + 1; si = si + 1; } long long a = 0; if (argc > 2) { a = atoi(argv[2]) << 1; } if (argc > 3) { int sfd = open(argv[3], 0); if (sfd >= 0) { long long sg = read(sfd, fk_src, 262143); if (sg >= 0) { fk_src[sg] = 0; } } } fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= "
+    (str_concat (int_to_str (sub (fkc-arm-slots) 1))
+                ") { fk_pr(fk_arms[t]); t = t + 1; } return 0; }")))
 
 (defn fkc-emit-universal ()
     (str_concat (fkc-pr-text)

--- a/form/form-stdlib/fourth-walker.fk
+++ b/form/form-stdlib/fourth-walker.fk
@@ -80,7 +80,18 @@
     (if (eq (fk-tag node) 22) (len (fkm-walk fns (fk-body node) arg))
     (if (eq (fk-tag node) 23) (nth (fkm-walk fns (ms-child (fk-body node) 0) arg)
                                    (fkm-walk fns (ms-child (fk-body node) 1) arg))
-        0)))))))))))))))
+    ; string arms 24..28 — the string-pool family on the RECIPE side: values
+    ; are the host kernel's own strings (the emitted sibling carries pool ids;
+    ; interning makes id-equality there mean content-equality here, axiom 3)
+    (if (eq (fk-tag node) 24) (ms-value (ms-child (fk-body node) 1))
+    (if (eq (fk-tag node) 25) (str_len (fkm-walk fns (fk-body node) arg))
+    (if (eq (fk-tag node) 26) (if (str_eq (fkm-walk fns (ms-child (fk-body node) 0) arg)
+                                          (fkm-walk fns (ms-child (fk-body node) 1) arg)) 1 0)
+    (if (eq (fk-tag node) 27) (str_concat (fkm-walk fns (ms-child (fk-body node) 0) arg)
+                                          (fkm-walk fns (ms-child (fk-body node) 1) arg))
+    (if (eq (fk-tag node) 28) (ord (char_at (fkm-walk fns (ms-child (fk-body node) 0) arg)
+                                            (fkm-walk fns (ms-child (fk-body node) 1) arg)))
+        0))))))))))))))))))))
 
 (defn fkm-run (fns arg) (fkm-walk fns (nth fns 0) arg))
 
@@ -110,6 +121,24 @@
 (defn fk-tail (xs)  (fk-node 21 xs))
 (defn fk-len (xs)   (fk-node 22 xs))
 (defn fk-nth (xs i) (fk-node 23 (ms-intern xs i)))
+
+; ── string-pool ops — tags 24..33 CLAIMED by the string lane (24..28 live,
+;    29..33 reserved for this family: substring/int-to-str are the named next
+;    stones). Strings are content-addressed pool cells: the flattener interns
+;    every literal once (same bytes = same pool slot, axiom 3) and a string
+;    VALUE is its pool id — a plain int, so packed args, lists, and the
+;    copying melt never need to root it; the pool is its own rooted region.
+; 24 SLIT k s — pool literal: pair(pool-index, string-cell); the emitted arm
+;               answers the id, the recipe arm answers the string itself
+; 25 SLEN s   — byte length
+; 26 SEQ a b  — content equality (interned ids: same bytes = same id)
+; 27 SCAT a b — concatenation, the result interned into the pool
+; 28 SCHAR s i — byte code at i (carries ord; char-at composes over it)
+(defn fk-slit (k s)  (fk-node 24 (ms-intern (ms-cell k) (intern_trivial_string s))))
+(defn fk-slen (s)    (fk-node 25 s))
+(defn fk-seq (a b)   (fk-node 26 (ms-intern a b)))
+(defn fk-scat (a b)  (fk-node 27 (ms-intern a b)))
+(defn fk-schar (s i) (fk-node 28 (ms-intern s i)))
 
 ; fib authored as data — the program every carrier in fourth-kernel.form's
 ; rows answers: IF (LE arg 1) arg (ADD (SELF (arg-1)) (SELF (arg-2)))

--- a/form/form-stdlib/tests/form-flatten-strings-band.fk
+++ b/form/form-stdlib/tests/form-flatten-strings-band.fk
@@ -1,0 +1,75 @@
+; preludes: form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/fourth-walker-emit.fk form-stdlib/form-parse.fk form-stdlib/form-flatten.fk
+;
+; form-flatten-strings-band — the walker string-pool lane proven three-way:
+; strings are content-addressed pool cells (tags 24..28 — SLIT/SLEN/SEQ/
+; SCAT/SCHAR, the range 24..33 claimed by this family). The flattener's
+; pre-pass interns every distinct "literal" once (same bytes = same slot,
+; axiom 3), a literal lowers to SLIT carrying its pool index, and string
+; VALUES ride as pool ids — plain ints the melt never needs to root. The
+; recipe-side walker proves the same cells by VALUE on host strings; the
+; emitted sibling's id-equality means content-equality BECAUSE the pool is
+; interned. Mini sources build their quotes through byte_to_str 34 — the
+; band file itself stays plain.
+;
+; Verdict 31 when the lane holds:
+;   1   the lowerings carry values — str_eq dispatches a defn by label
+;       (lab walks warm->7 cool->9 mist->0, sum 16), str_concat interns
+;       into the same slot its parts name ((wa+rm) str_eq warm -> 1), and
+;       str_len + ord + not compose (4 + 65 + 1 = 70)
+;   2   the pool is content-addressed — three distinct literals from four
+;       occurrences (dedup), first-appearance order (warm at 0), and the
+;       repeated literal answers its one slot
+;   4   the constructors walk by value — SEQ over two SLITs of one string
+;       is 1, SLEN over SCAT is the joined length, SCHAR reads the byte
+;   8   the REAL champion-challenger module + band (unmodified from disk,
+;       string-labeled authority throughout) flatten and walk BY VALUE to
+;       the siblings' own verdict 127
+;   16  the table file grows a string section — the flattened rows carry
+;       SLIT and SEQ tags, and the pool serializes as count, length, bytes
+;       ("hi" -> "1 2 104 105") behind the unchanged row text
+(do
+    (let q (byte_to_str 34))
+    (defn qw (w) (str_concat q (str_concat w q)))
+    (let src1 (str_concat "(do (defn lab (x) (if (str_eq x "
+              (str_concat (qw "warm")
+              (str_concat ") 7 (if (str_eq x "
+              (str_concat (qw "cool")
+              (str_concat ") 9 0))) (add (lab "
+              (str_concat (qw "warm")
+              (str_concat ") (add (lab "
+              (str_concat (qw "cool")
+              (str_concat ") (lab "
+              (str_concat (qw "mist") ")))))")))))))))))
+    (let src2 (str_concat "(do (str_eq (str_concat "
+              (str_concat (qw "wa")
+              (str_concat " "
+              (str_concat (qw "rm")
+              (str_concat ") "
+              (str_concat (qw "warm") "))")))))))
+    (let src3 (str_concat "(do (add (str_len "
+              (str_concat (qw "warm")
+              (str_concat ") (add (ord "
+              (str_concat (qw "A")
+                          ") (not (not 5)))))")))))
+    (let c0 (if (and (eq (fkm-run (flt-src-fns src1) 0) 16)
+                     (and (eq (fkm-run (flt-src-fns src2) 0) 1)
+                          (eq (fkm-run (flt-src-fns src3) 0) 70)))
+                1 0))
+    (let pool1 (flt-src-pool src1))
+    (let c1 (if (and (eq (len pool1) 3)
+                     (and (eq (flt-sidx pool1 "warm" 0) 0)
+                          (eq (flt-sidx pool1 "mist" 0) 2)))
+                2 0))
+    (let c2 (if (and (eq (fkm-run (list (fk-seq (fk-slit 0 "warm") (fk-slit 0 "warm"))) 0) 1)
+                     (and (eq (fkm-run (list (fk-slen (fk-scat (fk-slit 0 "wa") (fk-slit 1 "rm")))) 0) 4)
+                          (eq (fkm-run (list (fk-schar (fk-slit 0 "AZ") (fk-lit 1))) 0) 90)))
+                4 0))
+    (let cc (flt-band-fns (read_file "form-stdlib/champion-challenger.fk")
+                          (read_file "form-stdlib/tests/champion-challenger-band.fk")))
+    (let c3 (if (eq (fkm-run cc 0) 127) 8 0))
+    (let rows1 (nth (fkc-flatten-many (flt-src-fns src1)) 0))
+    (let c4 (if (and (eq (fkd-has-tag rows1 24) 1)
+                     (and (eq (fkd-has-tag rows1 26) 1)
+                          (str_eq (fks-pool-sp (list "hi")) "1 2 104 105")))
+                16 0))
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/form-stdlib/tests/fourth-net-band.fk
+++ b/form/form-stdlib/tests/fourth-net-band.fk
@@ -12,9 +12,9 @@
 ;       PUTC chained by ADD-sequencing over a LIT 0 base
 ;   2   the server emission carries the net organ externs — socket(2,1,0),
 ;       fork(), accept(sfd ... — found by str_find
-;   4   the server emission is 7325 bytes for the "hi" responder (the arena
-;       rides with its melt door and the walker-managed value stack) and
-;       deterministic (same fns -> same text)
+;   4   the server emission is 8864 bytes for the "hi" responder (the arena
+;       rides with its melt door, the walker-managed value stack, and the
+;       string pool) and deterministic (same fns -> same text)
 ;   8   a different responder string gives a different emission (the body the
 ;       net main serves is the program, parameterized)
 (do
@@ -26,7 +26,7 @@
                 (if (ge (str_find srv "fork()" 0) 0)
                     (if (ge (str_find srv "accept(sfd" 0) 0) 2 0) 0) 0))
 
-    (let c2 (if (eq (str_len srv) 7325)
+    (let c2 (if (eq (str_len srv) 8864)
                 (if (str_eq srv (fkc-emit-server (list resp))) 4 0) 0))
 
     (let c3 (if (str_eq srv (fkc-emit-server (list (fkresp "yo")))) 0 8))

--- a/form/form-stdlib/tests/fourth-os-band.fk
+++ b/form/form-stdlib/tests/fourth-os-band.fk
@@ -11,26 +11,27 @@
 ; Verdict 15 when the OS face holds:
 ;   1   the table FILE is canonical — ADD(LIT 40, LIT 2) serializes to
 ;       1 2 3 1 40 0 0 1 2 0 0 3 0 1 0 (function count, roots, row count, rows)
-;   2   the universal walker's full emission is 7287 bytes and deterministic —
+;   2   the universal walker's full emission is 9095 bytes and deterministic —
 ;       program-independent constant tissue: loader, organ arms, the BMF
 ;       cursor's eye (op 17 BUF), the m4e2 arena with its melt door
 ;       (ops 18..23 + fk_arena/fk_mlive/fk_mcopy/fk_melt, melt-on-cool-band),
-;       and the walker-managed value stack (fk_vs — args melt-rooted)
+;       the walker-managed value stack (fk_vs — args melt-rooted), and the
+;       string pool with its loader string section (tags 24..28)
 ;   4   the native lowering is faithful text — ADD(LIT 1, ARG) lowers to
-;       (2 + a): literals lower ENCODED (ints even, refs odd — the tagged ABI) — and the jit emission for CALL-fib is 7245 bytes
+;       (2 + a): literals lower ENCODED (ints even, refs odd — the tagged ABI) — and the jit emission for CALL-fib is 8784 bytes
 ;   8   the organ program (RAM roundtrip + clock + entropy, mask 7) flattens
 ;       to its 23 rows with tags 13..16 present in the table
 (do
     (let c0 (if (str_eq (fkc-table-file (list (fk-add (fk-lit 40) (fk-lit 2)))) "1 2 3 1 40 0 0 1 2 0 0 3 0 1 0") 1 0))
 
-    (let c1 (if (eq (str_len (fkc-emit-universal)) 7287)
+    (let c1 (if (eq (str_len (fkc-emit-universal)) 9095)
                 (if (str_eq (fkc-emit-universal) (fkc-emit-universal)) 2 0) 0))
 
     (let fibc (fk-if (fk-le (fk-arg) (fk-lit 1)) (fk-arg)
                      (fk-add (fk-call 0 (fk-sub (fk-arg) (fk-lit 1)))
                              (fk-call 0 (fk-sub (fk-arg) (fk-lit 2))))))
     (let c2 (if (str_eq (fkc-nat-expr (fk-add (fk-lit 1) (fk-arg))) "(2 + a)")
-                (if (eq (str_len (fkc-emit-jit (list fibc))) 7245) 4 0) 0))
+                (if (eq (str_len (fkc-emit-jit (list fibc))) 8784) 4 0) 0))
 
     (let organ (fk-add (fk-if (fk-sub (fk-set (fk-lit 7) (fk-lit 42)) (fk-get (fk-lit 7))) (fk-lit 0) (fk-lit 1))
                (fk-add (fk-if (fk-le (fk-time) (fk-lit 0)) (fk-lit 0) (fk-lit 2))

--- a/scripts/fourth_kernel_audit.sh
+++ b/scripts/fourth_kernel_audit.sh
@@ -907,6 +907,72 @@ awk -v pct=90 '/^melt /{ok=($2 * 100 >= $5 * pct)}END{exit ok?0:1}' "$work/fv-me
 echo "  allocation crossed the water line mid-call and the packed args survived relocation —"
 echo "  every live value the walker holds is a melt-visible root (the BMF stack discipline, inward)"
 echo "  bands-on-fourth-arm: 11 (learning-trend + 9 multi-param + feature-vector, four-way gated)"
+echo
+# ── 25. string-pool lane — str_* bands on the fourth arm: the ratchet climbs 11 -> 44 ──
+# The walker string-pool lane (tags 24..28 — SLIT/SLEN/SEQ/SCAT/SCHAR; the
+# range 24..33 claimed by the string family): the flattener pre-pass interns
+# every distinct "literal" once into the program's pool (same bytes = same
+# slot, axiom 3), literals lower to SLIT rows carrying pool indices, the
+# table file grows a string section (count, then length + bytes per string),
+# and string VALUES ride as pool ids — plain ints the copying melt never
+# needs to root. str_eq is id-equality in the emitted sibling and means
+# content BECAUSE the pool is interned. Thirty-three more REAL stdlib bands
+# (unmodified source from disk — the op-profile's whole string-only set plus
+# the three needing the not-lowering) run on the SAME universal binary, each
+# gated four-way against validate.sh. recognition-router and recognition-
+# router-vision carry band-scale list traffic across the melt water line;
+# their packed args ride the walker-managed value stack (section 24), so
+# the melt fires mid-band and they cross with the rest.
+sp_mods=(active-inference branch-choice-order cell-sync chakra-column champion-challenger \
+         classifier-eval confidence-calibrate confidence-weighted-vote device-heartbeat \
+         drift-detect ensemble-vote friend-node learned-primitive markov-2 mesh-gradient \
+         mesh-relay nearest-shape novelty online-accuracy predictor-train prototype-merge \
+         provisioning recognition-router recognition-router-compute recognition-router-vision \
+         self-grounding-classifier sequence-predictor shared-sensing surprise-salience \
+         temporal-smoothing declared-source transition-detect warm-start)
+sp_exps=(127 511 127 127 127 63 127 127 127 63 127 127 255 127 127 127 127 63 63 63 127 127 127 63 31 63 127 127 127 63 127 127 127)
+cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/fourth-walker.fk" \
+    "$FORMDIR/form-stdlib/fourth-walker-emit.fk" "$FORMDIR/form-stdlib/form-parse.fk" \
+    "$FORMDIR/form-stdlib/form-flatten.fk" > "$work/sp-driver.fk"
+for m in "${sp_mods[@]}"; do
+    sp_mod="$(head -1 "$FORMDIR/form-stdlib/tests/$m-band.fk" | sed 's/; preludes://' | tr ' ' '\n' | grep -v core.fk | grep . | head -1 | sed 's|form-stdlib/||')"
+    cat >> "$work/sp-driver.fk" <<EOF
+(print "==SP-$m==")
+(print (fks-table-file (flt-band-fns (read_file "form-stdlib/$sp_mod") (read_file "form-stdlib/tests/$m-band.fk")) (flt-band-pool (read_file "form-stdlib/$sp_mod") (read_file "form-stdlib/tests/$m-band.fk"))))
+EOF
+done
+echo '(print "==SP-END==")' >> "$work/sp-driver.fk"
+(cd "$FORMDIR" && "$GO_BIN" "$work/sp-driver.fk" 2>/dev/null) > "$work/sp.out"
+prev=""
+while IFS= read -r line; do
+    if [[ "$line" == ==SP-*== ]]; then
+        prev="${line#==SP-}"; prev="${prev%==}"
+        : > "$work/t-sp-$prev.txt"
+    elif [[ -n "$prev" ]]; then
+        printf '%s\n' "$line" >> "$work/t-sp-$prev.txt"
+    fi
+done < "$work/sp.out"
+for m in "${sp_mods[@]}"; do
+    ( sp_pres="$(head -1 "$FORMDIR/form-stdlib/tests/$m-band.fk" | sed 's/; preludes: //')"
+      cd "$FORMDIR" && ./validate.sh $sp_pres "form-stdlib/tests/$m-band.fk" 2>/dev/null \
+        | sed -n 's/.*→ //p' | head -1 > "$work/vw-sp-$m.txt" ) &
+done
+wait
+echo "string-pool bands on the fourth arm (literals interned into the pool, str_eq as id-equality):"
+sp_pass=0
+for k in "${!sp_mods[@]}"; do
+    m="${sp_mods[$k]}"; exp="${sp_exps[$k]}"
+    three_way="$(cat "$work/vw-sp-$m.txt")"
+    fkw_v="$("$work/fkwu" "$work/t-sp-$m.txt" 0 2>/dev/null | head -1)"
+    printf "  %-28s three-walker (validate.sh) = %-4s fkw = %-4s (expect %s)\n" "$m" "$three_way" "$fkw_v" "$exp"
+    if [[ -z "$three_way" || "$three_way" != "$fkw_v" || "$fkw_v" != "$exp" ]]; then
+        echo "FAIL  the fourth arm disagrees with the siblings on $m"; exit 1
+    fi
+    sp_pass=$((sp_pass + 1))
+done
+echo "  recognition-router and recognition-router-vision allocate past the melt water line"
+echo "  mid-band — their packed args ride the value stack as melt-visible roots (section 24)"
+echo "  bands-on-fourth-arm: $((11 + sp_pass)) (learning-trend + 9 multi-param + feature-vector + $sp_pass string-pool bands, four-way gated)"
 
 echo
 echo "conditions: $(uname -m) $(uname -s), clang -O2, full-process invocations (startup included)"


### PR DESCRIPTION
## Round 4 — string-pool lane (str_* family), form-os4/string-pool

**Door (a) delivered: bands-on-fourth-arm 10 → 41** (this lane's contribution: +31; coordinator reconciles sibling counts at merge).

### The lane

Strings are content-addressed cells like everything else — north star held whole:

- **Walker ops, tags 24..28** (range **24..33 claimed** by the string family; 29..33 reserved for substring/int_to_str/str_find): `SLIT` (pool literal), `SLEN`, `SEQ`, `SCAT`, `SCHAR`. Recipe-side arms in `fourth-walker.fk` prove the same cells by value on host strings.
- **The pool is its own rooted region** in the emitted C (`fk_sb`/`fk_so`/`fk_sl` + `fk_sintern`) beside the cons arena — the frame/stack code untouched. String values ride as **plain ints (pool ids)**, so packed args, lists, RAM, and the copying melt never need to root them. `fk_sintern` is axiom 3 in C: same bytes = same slot, so **SEQ id-equality means content-equality**. A refused intern answers id −1 — observable, never a silent wrap. All sizes are recipe cells (`fkc-spool-slots` 4096, `fkc-spool-bytes` 262144, `fkc-arm-slots` 34).
- **Table file format grows a string section**: count, then length + bytes per string, plain ints behind the unchanged rows — the universal loader reads it verbatim; older tables load an empty pool (backward compatible).
- **Flattener** (`form-flatten.fk`): a pre-pass (`flt-scan`) interns every distinct `"literal"` in first-appearance order; literals lower to SLIT rows carrying pool indices; `str_eq`/`str_len`/`str_concat` are vocabulary **rows** (data, one engine); `ord`/`not` are lowerings; `true`/`false` lower as 1/0 (chakra-column's divergence, healed as vocabulary).

### Op-profile (re-run, round-3's mechanical method)

The corpus's honest need: **30 single-module bands blocked ONLY on `str_eq` + string literals**, 3 more adding `not`. No band crosses on `substring` alone (primitive-registry is dict-blocked; the emit-family bands need `int_to_str`/`str_find`/organ vocabulary) — named, not built ahead of need.

### Witness

- `tests/form-flatten-strings-band.fk` → **31 three-way** (lowerings by value; pool dedup + order; constructors by value; the REAL champion-challenger band by value at the siblings' 127; the table-file string section).
- **Audit §25**: 31 string bands flattened from UNMODIFIED disk source → table files with string sections → universal `fkw` → each verdict **four-way gated** against `validate.sh`. Audit runs **end-to-end green** (exit 0), §19/§20/§21/§22 unchanged.
- All 18 bands whose preludes include the touched files re-validated three-way, each a separate invocation. Emitted-text pins re-measured: universal 6610→8411, jit 6525→8057, server 6648→8180 (`fourth-os-band`, `fourth-net-band`).
- Honest holdouts: `recognition-router` (95 vs 127) and `recognition-router-vision` (15 vs 31) — the melt fired mid-band with live=1 (packed args in suspended C frames are not melt roots, m4e2's named gap, feature-vector's wall). They flatten, fit the loader, and join the ratchet when the **value-stack sibling's lane** roots call arguments.

### Door (b) — what the m4d full fixpoint still lacks after this lane

1. **Digit/slice vocabulary as pool ops**: `int_to_str`, `substring`, `str_find` (reserved 29..33) — the emitter's own text-building needs them.
2. **The constant walker text as pool data**: the emitter builds ~8 KB of C text; the pool's byte store + concat staging carry the mechanics, but the walker text itself must stream as a constant string section of the program image.
3. **The emitter recipes (`fkc-*`) flattened as a program**: needs nested-do/let-in-defn (the figure sibling's lane) on top of the multi-param packing already proven.

With those three, the emitter-as-program emits the walker text from its own node table and the fixpoint closes.

Evidence: `docs/system_audit/commit_evidence_2026-06-12_string_pool_fourth_arm.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)