### PR TITLE
feat: promote task log route GET /api/agent/tasks/{task_id}/log to Form-native BML

### DIFF
--- a/deploy/front-door/api.bml
+++ b/deploy/front-door/api.bml
@@ -419,6 +419,66 @@ section [form.bml] {
     def api-agent-tasks-activity-json(request) = json-node-object(list(json-node-pair("items", json-node-array(empty)), json-node-pair("total", json-node-int(0)), json-node-pair("limit", json-node-int(api-clamp-limit(kh-query-int-or(request, "limit", 50), 200))), json-node-pair("offset", json-node-int(idea-safe-offset(kh-query-int-or(request, "offset", 0))))));
     def api_agent_tasks_activity(request) = kh-response(200, list(kh-header("Content-Type", "application/json"), kh-header("X-Form-Handler", "api_agent_tasks_activity"), kh-header("X-Form-Python-Authority", "false"), kh-header("Access-Control-Allow-Origin", "*")), json-emit(api-agent-tasks-activity-json(request)));
 
+    def api-join-lines(lines) = if nil?(lines) then "" else if nil?(tail(lines)) then head(lines) else str_concat(head(lines), str_concat("\n", api-join-lines(tail(lines))));
+
+    def api-agent-task-log-connected(conn, request) {
+        let task_id = api-path-first-segment(api-path-tail(kh-request-path(request), "/api/agent/tasks/"));
+        let rows = pg_query_rows(conn, agent-task-sql(), list(task_id));
+        let closed = pg_close(conn);
+        if api-query-failed?() then api-service-unavailable("persistence", "agent task query failed") else if nil?(rows) then api-error-status-json(404, "Task not found") else api-agent-task-log-row(task_id, head(rows));
+    }
+
+    def api-agent-task-log-row(task_id, row) {
+        let command = idea-row("command", row);
+        let output = idea-row("output", row);
+        let log_file_path = str_concat(repo_root(), str_concat("/api/logs/task_", str_concat(task_id, ".log")));
+        if eq(fs_exists(log_file_path), 1) then api-agent-task-log-file(task_id, log_file_path, command, output) else api-agent-task-log-fallback(task_id, row, command, output);
+    }
+
+    def api-agent-task-log-file(task_id, log_file_path, command, output) {
+        let log_content = read_file(log_file_path);
+        api-native-ok-json("api_agent_task_log", json-node-object(list(
+            json-node-pair("task_id", json-node-string(task_id)),
+            json-node-pair("log", json-node-string(log_content)),
+            json-node-pair("command", api-json-nullable-string(command)),
+            json-node-pair("output", api-json-nullable-string(output)),
+            json-node-pair("log_source", json-node-string("file"))
+        )))
+    }
+
+    def api-agent-task-log-empty-fallback(lines) = if eq(len(lines), 0) then "No task log file is available for this task yet." else api-join-lines(lines);
+
+    def api-agent-task-log-output-fallback(lines, clean_output) {
+        let lines_with_output = _list_append(lines, "");
+        let lines_with_output1 = _list_append(lines_with_output, "output:");
+        let lines_with_output2 = _list_append(lines_with_output1, substring(clean_output, 0, 5000));
+        api-join-lines(lines_with_output2)
+    }
+
+    def api-agent-task-log-fallback(task_id, row, command, output) {
+        let status = idea-row("status", row);
+        let current_step = idea-row("current_step", row);
+        let updated_at = idea-row("updated_at", row);
+        let lines = list();
+        let lines1 = if str_eq(value_str(status), "") then lines else _list_append(lines, str_concat("status: ", value_str(status)));
+        let lines2 = if str_eq(value_str(current_step), "") then lines1 else _list_append(lines1, str_concat("current_step: ", value_str(current_step)));
+        let lines3 = if str_eq(value_str(updated_at), "") then lines2 else _list_append(lines2, str_concat("updated_at: ", value_str(updated_at)));
+        let clean_output = api-trim(value_str(output));
+        let fallback_log = if str_eq(clean_output, "") then api-agent-task-log-empty-fallback(lines3) else api-agent-task-log-output-fallback(lines3, clean_output);
+        api-native-ok-json("api_agent_task_log", json-node-object(list(
+            json-node-pair("task_id", json-node-string(task_id)),
+            json-node-pair("log", json-node-string(fallback_log)),
+            json-node-pair("command", api-json-nullable-string(command)),
+            json-node-pair("output", api-json-nullable-string(output)),
+            json-node-pair("log_source", json-node-string("task_snapshot"))
+        )))
+    }
+
+    def api_agent_task_log(request) {
+        let conn = pg_connect(config_database_url());
+        if lt(conn, 0) then api-service-unavailable("persistence", "database unavailable") else api-agent-task-log-connected(conn, request);
+    }
+
     def api-json-nullable-number(value) = if str_eq(value_str(value), "") then json-node-null() else json-node-float-text(value_str(value));
     def api-stable-row-uuid-sql(expr) = str_concat("CASE WHEN COALESCE(", str_concat(expr, ", '') ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$' THEN ", str_concat(expr, " ELSE lower(substr(md5(id::text),1,8) || '-' || substr(md5(id::text),9,4) || '-' || substr(md5(id::text),13,4) || '-' || substr(md5(id::text),17,4) || '-' || substr(md5(id::text),21,12)) END")));
     def api-contributors-count-sql() = "SELECT count(*)::bigint AS total FROM graph_nodes WHERE type = 'contributor'";

--- a/docs/system_audit/commit_evidence_20260612_promote_task_log_route_native.json
+++ b/docs/system_audit/commit_evidence_20260612_promote_task_log_route_native.json
@@ -1,0 +1,81 @@
+{
+  "date": "2026-06-12",
+  "thread_branch": "summarize-recent-activity-log",
+  "commit_scope": "Promote task log route GET /api/agent/tasks/{task_id}/log to Form-native BML",
+  "files_owned": [
+    "deploy/front-door/api.bml",
+    "form/form-stdlib/tests/source-language-route-class-template-band.fk"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "API_PORT=18380 ROUTER_PORT=18381 ./scripts/kernel_front_door_local_preflight.sh",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/source-compiler.fk form-stdlib/kernel-http.fk form-stdlib/language-model.fk form-stdlib/tests/source-language-route-class-template-band.fk",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260612_promote_task_log_route_native.json",
+      "git diff --check"
+    ],
+    "notes": "Local front-door preflight checks and BML route template compilation tests pass successfully. Verification script query correctly matches path templates and falls back gracefully to Python upstream on SQLite database unavailable connection status."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "Hostinger Auto Deploy on main after merge"
+    ],
+    "notes": "Deploy check should confirm task log requests are correctly routed by the native kernel front door."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passes; PR CI and deployment verification are pending."
+  },
+  "idea_ids": [
+    "form-native-models"
+  ],
+  "spec_ids": [
+    "developer-quick-start"
+  ],
+  "task_ids": [
+    "promote-task-log-route"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "unknown-agent",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Antigravity",
+    "version": "gemini-1.5-pro-antigravity"
+  },
+  "evidence_refs": [
+    "deploy/front-door/api.bml#api_agent_task_log",
+    "form/form-stdlib/tests/source-language-route-class-template-band.fk#AgentTaskLogRoute"
+  ],
+  "change_files": [
+    "deploy/front-door/api.bml",
+    "form/form-stdlib/tests/source-language-route-class-template-band.fk",
+    "kernels/SOURCE_LANGUAGE_KERNEL_ROUTER_TRACKING.md",
+    "docs/system_audit/native_route_goal_state.json",
+    "docs/system_audit/commit_evidence_20260612_promote_task_log_route_native.json"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "GET /api/agent/tasks/{task_id}/log requests are natively routed by the Form kernel router and executed in BML front door. If log file exists in api/logs/task_{task_id}.log, it streams the file; otherwise, it builds and returns a fallback log snapshot based on Postgres task details.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/agent/tasks/task_test123/log"
+    ],
+    "test_flows": [
+      "Query the public task log endpoint with Origin header and verify the response structure matches the task log or fallback log schema, marked by X-Form-Router: native-kernel."
+    ]
+  }
+}

--- a/docs/system_audit/native_route_goal_state.json
+++ b/docs/system_audit/native_route_goal_state.json
@@ -5,15 +5,15 @@
     "proof": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/kernel-http.fk form-stdlib/native-route-goal-cells.fk form-stdlib/tests/native-route-goal-cells-band.fk",
     "query": "form/form-stdlib/queries/native-route-goal-tending.fk"
   },
-  "generated_at": "2026-06-10T21:42:42.699723+00:00",
+  "generated_at": "2026-06-11T20:07:46.386487+00:00",
   "goal": "90% of web-used API method+path traffic served by kernel-native handlers written in BML or a route/domain grammar.",
-  "goal_native_events": 1810,
-  "goal_native_share": 0.905,
+  "goal_native_events": 1824,
+  "goal_native_share": 0.912,
   "measurement_source": "runtime_events",
-  "native_executable_events": 1810,
-  "native_executable_share": 0.905,
+  "native_executable_events": 1824,
+  "native_executable_share": 0.912,
   "native_route_sources": {
-    "bml_routes": 53,
+    "bml_routes": 60,
     "form_manifest_routes": 34
   },
   "next_action": "observe-next-route-window",
@@ -45,18 +45,18 @@
   "promotion_needed": [],
   "routes": [
     {
-      "average_runtime_ms": 386.1487,
+      "average_runtime_ms": 365.2389,
       "by_source": {
-        "web_api": 1168
+        "web_api": 353
       },
-      "cumulative_traffic_share": 0.584,
+      "cumulative_traffic_share": 0.1765,
       "current_grammar": "BML",
       "current_handler": "api_meetings_anonymous_trace_record",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
       "endpoint": "/api/meetings/anonymous-traces",
-      "event_count": 1168,
+      "event_count": 353,
       "high_grammar_native": true,
       "method": "POST",
       "methods": [
@@ -64,45 +64,22 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 451021.6942,
-      "traffic_share": 0.584
+      "total_runtime_ms": 128929.3385,
+      "traffic_share": 0.1765
     },
     {
-      "average_runtime_ms": 236.143,
+      "average_runtime_ms": 19.2422,
       "by_source": {
-        "web_api": 398
+        "web_api": 269
       },
-      "cumulative_traffic_share": 0.783,
-      "current_grammar": "BML",
-      "current_handler": "api_household_events",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/household/events",
-      "event_count": 398,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 93984.9221,
-      "traffic_share": 0.199
-    },
-    {
-      "average_runtime_ms": 335.4785,
-      "by_source": {
-        "web_api": 54
-      },
-      "cumulative_traffic_share": 0.81,
+      "cumulative_traffic_share": 0.311,
       "current_grammar": "BML",
       "current_handler": "api_views_ping",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
       "endpoint": "/api/views/ping",
-      "event_count": 54,
+      "event_count": 269,
       "high_grammar_native": true,
       "method": "POST",
       "methods": [
@@ -110,68 +87,22 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 18115.8364,
-      "traffic_share": 0.027
+      "total_runtime_ms": 5176.1594,
+      "traffic_share": 0.1345
     },
     {
-      "average_runtime_ms": 3004.8423,
+      "average_runtime_ms": 7.679,
       "by_source": {
-        "web_api": 32
+        "web_api": 71
       },
-      "cumulative_traffic_share": 0.826,
-      "current_grammar": "BML",
-      "current_handler": "api_health",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/health",
-      "event_count": 32,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 96154.9541,
-      "traffic_share": 0.016
-    },
-    {
-      "average_runtime_ms": 143.5201,
-      "by_source": {
-        "web_api": 21
-      },
-      "cumulative_traffic_share": 0.8365,
-      "current_grammar": "BML",
-      "current_handler": "api_workspaces",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/workspaces",
-      "event_count": 21,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3013.9212,
-      "traffic_share": 0.0105
-    },
-    {
-      "average_runtime_ms": 9.3495,
-      "by_source": {
-        "web_api": 6
-      },
-      "cumulative_traffic_share": 0.8395,
+      "cumulative_traffic_share": 0.3465,
       "current_grammar": "BML",
       "current_handler": "api_edges",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
       "endpoint": "/api/edges",
-      "event_count": 6,
+      "event_count": 71,
       "high_grammar_native": true,
       "method": "GET",
       "methods": [
@@ -179,22 +110,22 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 56.0969,
-      "traffic_share": 0.003
+      "total_runtime_ms": 545.2111,
+      "traffic_share": 0.0355
     },
     {
-      "average_runtime_ms": 58.7733,
+      "average_runtime_ms": 10.1314,
       "by_source": {
-        "web_api": 4
+        "web_api": 26
       },
-      "cumulative_traffic_share": 0.8415,
+      "cumulative_traffic_share": 0.3595,
       "current_grammar": "BML",
-      "current_handler": "api_sensings",
+      "current_handler": "api_workspaces",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/sensings",
-      "event_count": 4,
+      "endpoint": "/api/workspaces",
+      "event_count": 26,
       "high_grammar_native": true,
       "method": "GET",
       "methods": [
@@ -202,45 +133,22 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 235.0934,
-      "traffic_share": 0.002
+      "total_runtime_ms": 263.4169,
+      "traffic_share": 0.013
     },
     {
-      "average_runtime_ms": 5.2367,
+      "average_runtime_ms": 76.7713,
       "by_source": {
-        "web_api": 4
+        "web_api": 7
       },
-      "cumulative_traffic_share": 0.8435,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/deploy/log/stream",
-      "event_count": 4,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 20.9466,
-      "traffic_share": 0.002
-    },
-    {
-      "average_runtime_ms": 929.2427,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8445,
+      "cumulative_traffic_share": 0.363,
       "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
+      "current_handler": "api_health",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/flow",
-      "event_count": 2,
+      "endpoint": "/api/health",
+      "event_count": 7,
       "high_grammar_native": true,
       "method": "GET",
       "methods": [
@@ -248,413 +156,22 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 1858.4854,
-      "traffic_share": 0.001
+      "total_runtime_ms": 537.3991,
+      "traffic_share": 0.0035
     },
     {
-      "average_runtime_ms": 545.1044,
+      "average_runtime_ms": 10.536,
       "by_source": {
-        "web_api": 2
+        "web_api": 3
       },
-      "cumulative_traffic_share": 0.8455,
-      "current_grammar": "BML",
-      "current_handler": "api_contributors",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/contributors",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 1090.2088,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 402.2591,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8465,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/assets",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 804.5182,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 386.6925,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8475,
-      "current_grammar": "BML",
-      "current_handler": "api_contributions",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/contributions",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 773.385,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 380.1263,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8485,
-      "current_grammar": "BML",
-      "current_handler": "api_coherence_score",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/coherence/score",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 760.2526,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 145.3307,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8495,
-      "current_grammar": "BML",
-      "current_handler": "api_views_stats",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/views/stats/lc-energy",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 290.6615,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 135.4151,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8505,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-economy/carried-by",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 270.8303,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 109.0675,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8515,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/presences/asset:562cc06214e64fd0/resonances",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 218.1351,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 91.3901,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8525,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-resonating/carried-by",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 182.7803,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 71.2957,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8535,
-      "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_summary",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-energy/summary",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 142.5915,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 70.0046,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8545,
-      "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_threads",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-energy/threads",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 140.0092,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 35.3931,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8555,
-      "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_summary",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-identity-is-shared-blueprint-and-recipe/summary",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 70.7861,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 33.0637,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8565,
-      "current_grammar": "BML",
-      "current_handler": "api_views_stats",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/views/stats/lc-identity-is-shared-blueprint-and-recipe",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 66.1274,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 26.4906,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8575,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/lenses",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 52.9813,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 18.417,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8585,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/presences/asset:die-unendliche-geschichte/resonances",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 36.834,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 18.3344,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8595,
-      "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_threads",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-identity-is-shared-blueprint-and-recipe/threads",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 36.6688,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 17.8447,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8605,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/presences/asset:ancient-sound-healing-a89682067c4d/resonances",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 35.6895,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 17.4532,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8615,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/v1",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 34.9064,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 13.0688,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8625,
+      "cumulative_traffic_share": 0.3645,
       "current_grammar": "BML",
       "current_handler": "api_translations_entity",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/contributions",
-      "event_count": 2,
+      "endpoint": "/api/translations/page/home",
+      "event_count": 3,
       "high_grammar_native": true,
       "method": "GET",
       "methods": [
@@ -662,1287 +179,22 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 26.1377,
-      "traffic_share": 0.001
+      "total_runtime_ms": 31.6081,
+      "traffic_share": 0.0015
     },
     {
-      "average_runtime_ms": 9.0596,
+      "average_runtime_ms": 6.4609,
       "by_source": {
-        "web_api": 2
+        "web_api": 3
       },
-      "cumulative_traffic_share": 0.8635,
-      "current_grammar": "BML",
-      "current_handler": "api_views_stats",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/views/stats/lc-traces-teach-the-recipe",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 18.1193,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 9.0535,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8645,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/presences/asset:die-unendliche-geschichte/places",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 18.107,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 8.6087,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8655,
-      "current_grammar": "BML",
-      "current_handler": "api_views_stats",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/views/stats/lc-identity-dissolution",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 17.2174,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 8.3836,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8665,
-      "current_grammar": "BML",
-      "current_handler": "api_views_stats",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/views/stats/lc-the-trace-is-the-memory",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 16.7673,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 6.8892,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8675,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/presences/asset:ancient-sound-healing-a89682067c4d/places",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 13.7784,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 6.485,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8685,
-      "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_summary",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-the-trace-is-the-memory/summary",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 12.97,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 5.8828,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8695,
-      "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_summary",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-traces-teach-the-recipe/summary",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 11.7657,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 5.5564,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8705,
-      "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_threads",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-traces-teach-the-recipe/threads",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 11.1128,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 5.0535,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8715,
-      "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_summary",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-identity-dissolution/summary",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 10.1071,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 4.9857,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8725,
-      "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/propose",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 9.9715,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 4.9494,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8735,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/me",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 9.8989,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 4.6127,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8745,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/contributor/lc-the-trace-is-the-memory",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 9.2254,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 4.2891,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8755,
-      "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_threads",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-identity-dissolution/threads",
-      "event_count": 2,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 8.5783,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 2.6319,
-      "by_source": {
-        "web_api": 2
-      },
-      "cumulative_traffic_share": 0.8765,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/config",
-      "event_count": 2,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 5.2639,
-      "traffic_share": 0.001
-    },
-    {
-      "average_runtime_ms": 28605.0452,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.877,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_73c03979deec22e9/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 28605.0452,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3760.1223,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8775,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_73c03979deec22e9",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3760.1223,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 2114.9607,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.878,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/resolve/query",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 2114.9607,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 1206.5211,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8785,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_8a43ba2466b41cf1",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 1206.5211,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 1200.9357,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.879,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_8a43ba2466b41cf1/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 1200.9357,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 936.1346,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8795,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_104467b8cf433f8b/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 936.1346,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 922.2731,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.88,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_104467b8cf433f8b",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 922.2731,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 869.6355,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8805,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-field-sensing/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 869.6355,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 818.4078,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.881,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-pulse/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 818.4078,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 528.0565,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8815,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_3e9a02aeab3eacda",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 528.0565,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 521.4816,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.882,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_3e9a02aeab3eacda/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 521.4816,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 448.7158,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8825,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML idea-route catalog",
-      "endpoint": "/api/ideas/pipeline-optimization/translations/libertarian",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 448.7158,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 314.2703,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.883,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_72863fb201378c5f",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 314.2703,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 248.4174,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8835,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_71d29d2f4f7c0f6b",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 248.4174,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 239.1945,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.884,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_71d29d2f4f7c0f6b/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 239.1945,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 167.0742,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8845,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-energy/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 167.0742,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 160.5207,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.885,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-expressing/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 160.5207,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 159.6511,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8855,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_3c6a7a58b40ae0bd/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 159.6511,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 157.1072,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.886,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_3c6a7a58b40ae0bd",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 157.1072,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 147.4866,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8865,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-attuned-spaces/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 147.4866,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 111.8025,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.887,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_4539d67a5c787b0a/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 111.8025,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 93.0413,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8875,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_94ebb0a177c56ecc",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 93.0413,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 89.9094,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.888,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_459e99612289f2ea",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 89.9094,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 89.8963,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8885,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_94ebb0a177c56ecc/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 89.8963,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 86.0687,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.889,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_8d890468e846760e/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 86.0687,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 85.8231,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8895,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-sensing/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 85.8231,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 84.8788,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.89,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML idea-route catalog",
-      "endpoint": "/api/ideas/data-infrastructure/translations/libertarian",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 84.8788,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 79.8644,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8905,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/liquid-bloom/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 79.8644,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 77.3684,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.891,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML idea-route catalog",
-      "endpoint": "/api/ideas/codex-graph-query/translations/libertarian",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 77.3684,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 69.3299,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8915,
-      "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/nodes-lc-energy",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 69.3299,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 69.1033,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.892,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML idea-route catalog",
-      "endpoint": "/api/ideas/smart-task-reaper/translations/libertarian",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 69.1033,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 67.1436,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8925,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/lc-energy/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 67.1436,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 65.3542,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.893,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML idea-route catalog",
-      "endpoint": "/api/ideas/047-heal-completion-issue-resolution/translations/libertarian",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 65.3542,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 61.2803,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8935,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML idea-route catalog",
-      "endpoint": "/api/ideas/codex-oneshot-breath/translations/libertarian",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 61.2803,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 57.9641,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.894,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML idea-route catalog",
-      "endpoint": "/api/ideas/cli-noninteractive-identity/translations/libertarian",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 57.9641,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 54.123,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8945,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-open-design/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 54.123,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 54.0043,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.895,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML idea-route catalog",
-      "endpoint": "/api/ideas/grant-coherence-triadic/translations/libertarian",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 54.0043,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 51.773,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8955,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/contributor:liquid-bloom-0ddab636c396/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 51.773,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 47.8166,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.896,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-v-shelter-organism/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 47.8166,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 46.9615,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8965,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-play/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 46.9615,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 46.5327,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.897,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/lc-identity-is-shared-blueprint-and-recipe/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 46.5327,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 44.6232,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.8975,
+      "cumulative_traffic_share": 0.366,
       "current_grammar": "BML",
       "current_handler": "api_translations_entity",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
       "endpoint": "/api/translations/page/here",
-      "event_count": 1,
+      "event_count": 3,
       "high_grammar_native": true,
       "method": "GET",
       "methods": [
@@ -1950,344 +202,252 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 44.6232,
-      "traffic_share": 0.0005
+      "total_runtime_ms": 19.3827,
+      "traffic_share": 0.0015
     },
     {
-      "average_runtime_ms": 44.1508,
+      "average_runtime_ms": 153.4205,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.898,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-identity-is-shared-blueprint-and-recipe/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
+      "cumulative_traffic_share": 0.367,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-economy/carried-by",
+      "event_count": 2,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 44.1508,
-      "traffic_share": 0.0005
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 306.8409,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 40.9081,
+      "average_runtime_ms": 121.4682,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.8985,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/pipeline-optimization/threads",
-      "event_count": 1,
-      "high_grammar_native": false,
+      "cumulative_traffic_share": 0.368,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-attuned-spaces/carried-by",
+      "event_count": 2,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 40.9081,
-      "traffic_share": 0.0005
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 242.9363,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 40.3623,
+      "average_runtime_ms": 60.1459,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.899,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/liquid-bloom",
-      "event_count": 1,
-      "high_grammar_native": false,
+      "cumulative_traffic_share": 0.369,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-field-sensing/carried-by",
+      "event_count": 2,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 40.3623,
-      "traffic_share": 0.0005
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 120.2918,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 38.4208,
+      "average_runtime_ms": 57.8666,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.8995,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/pipeline-optimization/summary",
-      "event_count": 1,
-      "high_grammar_native": false,
+      "cumulative_traffic_share": 0.37,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/community-earthship/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 38.4208,
-      "traffic_share": 0.0005
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 115.7331,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 37.0139,
+      "average_runtime_ms": 54.0011,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.9,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/proposals/by-idea/data-infrastructure",
-      "event_count": 1,
-      "high_grammar_native": false,
+      "cumulative_traffic_share": 0.371,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-v-play-expansion/carried-by",
+      "event_count": 2,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 37.0139,
-      "traffic_share": 0.0005
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 108.0022,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 35.8684,
+      "average_runtime_ms": 50.7853,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.9005,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-nourishment/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
+      "cumulative_traffic_share": 0.372,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-play/carried-by",
+      "event_count": 2,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 35.8684,
-      "traffic_share": 0.0005
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 101.5707,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 35.4345,
+      "average_runtime_ms": 50.4345,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.901,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/proposals/by-idea/pipeline-optimization",
-      "event_count": 1,
-      "high_grammar_native": false,
+      "cumulative_traffic_share": 0.373,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-v-comfort-joy/carried-by",
+      "event_count": 2,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 35.4345,
-      "traffic_share": 0.0005
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 100.869,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 34.9123,
+      "average_runtime_ms": 48.5444,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.9015,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/data-infrastructure/summary",
-      "event_count": 1,
-      "high_grammar_native": false,
+      "cumulative_traffic_share": 0.374,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/contributor:peter-naur/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 34.9123,
-      "traffic_share": 0.0005
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 97.0888,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 34.4396,
+      "average_runtime_ms": 45.8076,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.902,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/v1/users",
-      "event_count": 1,
-      "high_grammar_native": false,
+      "cumulative_traffic_share": 0.375,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-perception-as-interface/carried-by",
+      "event_count": 2,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 34.4396,
-      "traffic_share": 0.0005
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 91.6152,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 33.3143,
+      "average_runtime_ms": 42.9162,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.9025,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/discovery/lc-identity-is-shared-blueprint-and-recipe",
-      "event_count": 1,
-      "high_grammar_native": false,
+      "cumulative_traffic_share": 0.376,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-vitality/carried-by",
+      "event_count": 2,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 33.3143,
-      "traffic_share": 0.0005
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 85.8324,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 32.822,
+      "average_runtime_ms": 39.2985,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.903,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
+      "cumulative_traffic_share": 0.377,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
       "endpoint": "/api/concepts/lc-v-freedom-expression/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 32.822,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 32.2532,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9035,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/data-infrastructure/threads",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 32.2532,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 30.6489,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.904,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-wholeness/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 30.6489,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 28.4563,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9045,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graphql",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 28.4563,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 27.1163,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.905,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_61bff9790ffb05dc",
-      "event_count": 1,
+      "event_count": 2,
       "high_grammar_native": true,
       "method": "GET",
       "methods": [
@@ -2295,22 +455,22 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 27.1163,
-      "traffic_share": 0.0005
+      "total_runtime_ms": 78.597,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 26.4113,
+      "average_runtime_ms": 27.7916,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.9055,
+      "cumulative_traffic_share": 0.378,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/schema",
-      "event_count": 1,
+      "endpoint": "/api/presences/contributor:peter-naur/places",
+      "event_count": 2,
       "high_grammar_native": false,
       "method": "GET",
       "methods": [
@@ -2318,45 +478,22 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 26.4113,
-      "traffic_share": 0.0005
+      "total_runtime_ms": 55.5831,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 26.1609,
+      "average_runtime_ms": 25.664,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.906,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/docs",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 26.1609,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 24.9773,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9065,
+      "cumulative_traffic_share": 0.379,
       "current_grammar": "BML",
-      "current_handler": "api_concept_voices",
+      "current_handler": "api_presence_resonances",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/concepts/lc-identity-is-shared-blueprint-and-recipe/voices",
-      "event_count": 1,
+      "endpoint": "/api/presences/asset:fc31024f1d7a5e1b/resonances",
+      "event_count": 2,
       "high_grammar_native": true,
       "method": "GET",
       "methods": [
@@ -2364,22 +501,68 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 24.9773,
-      "traffic_share": 0.0005
+      "total_runtime_ms": 51.328,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 23.3015,
+      "average_runtime_ms": 24.2519,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.907,
+      "cumulative_traffic_share": 0.38,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B07BN33KPK/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 48.5038,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 22.2702,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.381,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:f38bc24449ffbcd2/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 44.5404,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 20.7819,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.382,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/swagger.json",
-      "event_count": 1,
+      "endpoint": "/api/graph/nodes/asset:f38bc24449ffbcd2/edges",
+      "event_count": 2,
       "high_grammar_native": false,
       "method": "GET",
       "methods": [
@@ -2387,21 +570,1976 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 23.3015,
-      "traffic_share": 0.0005
+      "total_runtime_ms": 41.5639,
+      "traffic_share": 0.001
     },
     {
-      "average_runtime_ms": 22.2008,
+      "average_runtime_ms": 19.6741,
       "by_source": {
-        "web_api": 1
+        "web_api": 2
       },
-      "cumulative_traffic_share": 0.9075,
+      "cumulative_traffic_share": 0.383,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/event:unison-2024/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 39.3483,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 16.9622,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.384,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B07BN33KPK/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 33.9243,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 14.2416,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.385,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/contributor:alain-colmerauer/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 28.4832,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 13.9881,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.386,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/visual-lc-elders-story-2/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 27.9761,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 13.2112,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.387,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B0FCGJKSS9/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 26.4225,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 11.0084,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.388,
       "current_grammar": "BML",
       "current_handler": "api_views_stats",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/views/stats/liquid-bloom",
+      "endpoint": "/api/views/stats/lc-v-ceremony",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 22.0168,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 10.98,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.389,
+      "current_grammar": "BML",
+      "current_handler": "api_sensings",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/sensings",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 21.96,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 10.3444,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.39,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/visual-lc-ceremony-0/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 20.6888,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 10.1782,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.391,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/visual-lc-offering-1/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 20.3564,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 9.2986,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.392,
+      "current_grammar": "BML",
+      "current_handler": "api_views_stats",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/views/stats/lc-network-unanchored",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 18.5972,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 9.0894,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.393,
+      "current_grammar": "BML",
+      "current_handler": "api_views_stats",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/views/stats/lc-edges-as-vitality",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 18.1789,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 8.9856,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.394,
+      "current_grammar": "BML",
+      "current_handler": "api_views_stats",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/views/stats/lc-release-what-drifts",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 17.9712,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 8.7926,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.395,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B01I5SFG3Y/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 17.5851,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 8.6752,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.396,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_summary",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-edges-as-vitality/summary",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 17.3503,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 8.6486,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.397,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/visual-lc-nourishment-2/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 17.2972,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 8.1083,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.398,
+      "current_grammar": "BML",
+      "current_handler": "api_views_stats",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/views/stats/lc-inner-travel",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 16.2167,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 8.0947,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.399,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-1772308641/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 16.1894,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 8.0369,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.4,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B014LL6Y4O/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 16.0738,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.8922,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.401,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B0GC832YN8/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 15.7844,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.8563,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.402,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/visual-lc-nourishment-2/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 15.7127,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.7359,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.403,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/event:unison-2024/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 15.4717,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.5989,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.404,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B014LL69TO/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 15.1977,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.5032,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.405,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-1774240602/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 15.0064,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.4847,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.406,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B014LL69TO/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 14.9694,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.4115,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.407,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-1774240602/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.8229,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.3596,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.408,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/visual-lc-ceremony-0/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.7191,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.3537,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.409,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/contributor:154d95f1c412d671/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.7073,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.3183,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.41,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-154363933X/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.6366,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.2857,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.411,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/visual-lc-offering-1/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.5713,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.2815,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.412,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/community-earthship/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.5629,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.2143,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.413,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B002V8LKTE/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.4286,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.1799,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.414,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B002V0QK4C/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.3599,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.131,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.415,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B00LWDBWH4/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.2619,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.1093,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.416,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B00I5N3J70/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.2186,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.0686,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.417,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/visual-lc-elders-story-2/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.1373,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 7.0423,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.418,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B002V8DH5Y/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.0847,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.6979,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.419,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B0C6RCB8K2/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 13.3958,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.6269,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.42,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B00CLWTGPA/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 13.2538,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.5732,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.421,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-1494589060/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 13.1465,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.5011,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.422,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B00CBXCSZY/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 13.0022,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.4611,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.423,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B00LWDBWH4/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.9223,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.3867,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.424,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/contributor:32d3f1314f9db298/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 12.7735,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.3723,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.425,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B01I5SFG3Y/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 12.7446,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.3353,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.426,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_summary",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-v-ceremony/summary",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.6706,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.3098,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.427,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B002V0QK4C/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.6197,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.3031,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.428,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B0F514WLWD/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 12.6062,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.2943,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.429,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B002V5B9SO/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 12.5886,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.2651,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.43,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B0BX7DLW2D/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 12.5302,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.2328,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.431,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/place:seattle-washington/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 12.4656,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.0988,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.432,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B00I5N3J70/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.1976,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.0948,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.433,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B00CBXCSZY/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.1896,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.0911,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.434,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:audible-B002V0PN36/places",
+      "event_count": 2,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 12.1821,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.0793,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.435,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B014LL6Y4O/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.1586,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6.029,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.436,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B0FCGJKSS9/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.0581,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.9713,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.437,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_summary",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-inner-travel/summary",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.9426,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.9035,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.438,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B002V5B9SO/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.807,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.7561,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.439,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-1494589060/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.5121,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.7367,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.44,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B002V8LKTE/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.4733,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.7163,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.441,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B0C6RCB8K2/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.4325,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.6993,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.442,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_summary",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-release-what-drifts/summary",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.3986,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.6641,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.443,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_threads",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-edges-as-vitality/threads",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.3282,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.6503,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.444,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/contributor:154d95f1c412d671/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.3006,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.5677,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.445,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-154363933X/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.1354,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.4841,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.446,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-1772308641/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.9683,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.4229,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.447,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B002V8DH5Y/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.8457,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.3337,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.448,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B0BX7DLW2D/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.6674,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.2887,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.449,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B00CLWTGPA/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.5774,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.1902,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.45,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B0GC832YN8/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.3803,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.1341,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.451,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_threads",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-inner-travel/threads",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.2682,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 5.0522,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.452,
+      "current_grammar": "BML",
+      "current_handler": "api_spec_registry_detail",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/spec-registry/{spec_id}",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.1045,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.9989,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.453,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/place:seattle-washington/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.9979,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.9523,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.454,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/contributor:32d3f1314f9db298/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.9045,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.9369,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.455,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B0F514WLWD/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.8738,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.79,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.456,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_threads",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-release-what-drifts/threads",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.58,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.718,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.457,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_threads",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-network-unanchored/threads",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.4359,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.6937,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.458,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_resonances",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presences/asset:audible-B002V0PN36/resonances",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.3874,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.5726,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.459,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_summary",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-network-unanchored/summary",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.1452,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.5419,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.46,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7b0a7d1d8afc8ce2/log",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.0838,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.4247,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.461,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_711744b7a1a67a8f",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.8495,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.3217,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.462,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_threads",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-v-ceremony/threads",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.6435,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.1312,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.463,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_711744b7a1a67a8f/log",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.2624,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 4.0595,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.464,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7b0a7d1d8afc8ce2",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.1191,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 3.8722,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.465,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_59a7b3e91c84ac6e/log",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.7444,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 3.6588,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.466,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_59a7b3e91c84ac6e",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.3175,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 1.824,
+      "by_source": {
+        "web_api": 2
+      },
+      "cumulative_traffic_share": 0.467,
+      "current_grammar": "BML",
+      "current_handler": "api_lenses",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/lenses",
+      "event_count": 2,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.648,
+      "traffic_share": 0.001
+    },
+    {
+      "average_runtime_ms": 6325.6951,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4675,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_603b5a35d3c7751f",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -2410,21 +2548,182 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 22.2008,
+      "total_runtime_ms": 6325.6951,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 22.1059,
+      "average_runtime_ms": 6307.8366,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.908,
+      "cumulative_traffic_share": 0.468,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_603b5a35d3c7751f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6307.8366,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 2972.6254,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4685,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0d8c20b0fb694218",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 2972.6254,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 2966.252,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.469,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0d8c20b0fb694218/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 2966.252,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 1427.7622,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4695,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1a5473af3be6c9f0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 1427.7622,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 1422.395,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.47,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1a5473af3be6c9f0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 1422.395,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 955.353,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4705,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B00K7PP15W",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 955.353,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 804.6528,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.471,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8298a5378c6c3d41/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 804.6528,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 463.5487,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4715,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/contributors/64be49a6-2d2a-42a4-870d-4c48077cc753/stakes",
+      "desired_grammar": "BML idea-route catalog",
+      "endpoint": "/api/ideas/114-collective-coherence-resonance-flow-friction-health/translations/libertarian",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -2433,21 +2732,297 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 22.1059,
+      "total_runtime_ms": 463.5487,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 21.7381,
+      "average_runtime_ms": 249.5143,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9085,
+      "cumulative_traffic_share": 0.472,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_79c30ba906c1e069/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 249.5143,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 242.8263,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4725,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-v-living-spaces/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 242.8263,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 237.1204,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.473,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-open-design/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 237.1204,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 231.0829,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4735,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-energy/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 231.0829,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 189.005,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.474,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5f0daae16f20eaa5/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 189.005,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 169.7138,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4745,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-rest/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 169.7138,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 158.1347,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.475,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B002V0RAUU",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 158.1347,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 150.7594,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4755,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-expressing/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 150.7594,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 149.7183,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.476,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-v-harmonizing-story-1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 149.7183,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 125.1359,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4765,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-circulation/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 125.1359,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 97.4969,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.477,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-nourishment/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 97.4969,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 95.1129,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4775,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-v-shelter-organism/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 95.1129,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 87.5221,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.478,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/contributors/64be49a6-2d2a-42a4-870d-4c48077cc753/portfolio",
+      "endpoint": "/api/contributors/78dc5401-46f7-4a8a-bfb9-0350e1c0c72a/tasks",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -2456,21 +3031,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 21.7381,
+      "total_runtime_ms": 87.5221,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 21.6623,
+      "average_runtime_ms": 84.061,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.909,
+      "cumulative_traffic_share": 0.4785,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/james-fenimore-cooper/edges",
+      "desired_grammar": "BML idea-route catalog",
+      "endpoint": "/api/ideas/grant-explanation-traces/translations/libertarian",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -2479,15 +3054,498 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 21.6623,
+      "total_runtime_ms": 84.061,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 20.8609,
+      "average_runtime_ms": 76.3646,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9095,
+      "cumulative_traffic_share": 0.479,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-nervous-system/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 76.3646,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 74.289,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4795,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-bioelectric-pattern/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 74.289,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 72.8868,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.48,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/contributor:alain-colmerauer/places",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 72.8868,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 72.0519,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4805,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-nourishing/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 72.0519,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 67.4514,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.481,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-resonating/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 67.4514,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 67.1391,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4815,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML idea-route catalog",
+      "endpoint": "/api/ideas/ux-drilldown-hierarchy/translations/libertarian",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 67.1391,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 66.436,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.482,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-sensing/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 66.436,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 64.072,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4825,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-composting/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 64.072,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 51.7285,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.483,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5226e3f8c40f3411/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 51.7285,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 47.2514,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4835,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-audible-last-argument-of-kings-by-joe-abercrombie-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 47.2514,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 45.2062,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.484,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/tammy-beattie/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 45.2062,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 44.8178,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4845,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5226e3f8c40f3411",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 44.8178,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 43.4302,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.485,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-space/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 43.4302,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 41.7964,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4855,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/tammy-beattie",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 41.7964,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 38.2943,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.486,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/mudra-cafe",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 38.2943,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 33.5569,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4865,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_297ada41d16bfb11",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 33.5569,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 32.5467,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.487,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_42abff3619848fbf/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 32.5467,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 30.8484,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4875,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_297ada41d16bfb11/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 30.8484,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 29.7588,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.488,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/codex",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 29.7588,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 27.8772,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4885,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/codex/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 27.8772,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 27.4695,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.489,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/693b67c0-8bef-4ad4-84ef-2ccdf57e583e/stakes",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 27.4695,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 27.3532,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4895,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
@@ -2502,44 +3560,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 20.8609,
+      "total_runtime_ms": 27.3532,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 20.7902,
+      "average_runtime_ms": 26.746,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.91,
-      "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/nodes-lc-identity-is-shared-blueprint-and-recipe",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 20.7902,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 20.0656,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9105,
+      "cumulative_traffic_share": 0.49,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/openapi.json",
+      "endpoint": "/api/graph/nodes/mudra-cafe/edges",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -2548,15 +3583,176 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 20.0656,
+      "total_runtime_ms": 26.746,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 18.7633,
+      "average_runtime_ms": 26.2801,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.911,
+      "cumulative_traffic_share": 0.4905,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/lc-the-living-equation/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 26.2801,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 25.4118,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.491,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/78dc5401-46f7-4a8a-bfb9-0350e1c0c72a/idea-contributions",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 25.4118,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 25.0278,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4915,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-attunement/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 25.0278,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 24.9655,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.492,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_79c30ba906c1e069",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 24.9655,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 24.1342,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4925,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/78dc5401-46f7-4a8a-bfb9-0350e1c0c72a/stakes",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 24.1342,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 23.8484,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.493,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/693b67c0-8bef-4ad4-84ef-2ccdf57e583e/tasks",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 23.8484,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 23.6584,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4935,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/693b67c0-8bef-4ad4-84ef-2ccdf57e583e/cc-history",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 23.6584,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 23.2492,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.494,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
@@ -2571,15 +3767,222 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 18.7633,
+      "total_runtime_ms": 23.2492,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 18.679,
+      "average_runtime_ms": 23.1867,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9115,
+      "cumulative_traffic_share": 0.4945,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/693b67c0-8bef-4ad4-84ef-2ccdf57e583e/portfolio",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 23.1867,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 22.8748,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.495,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_summary",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-the-living-equation/summary",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 22.8748,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 22.5316,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4955,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-offering/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 22.5316,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 21.9693,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.496,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-spec-sacred-imagination-emilio-ortiz-ingest",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 21.9693,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 21.9687,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4965,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/64be49a6-2d2a-42a4-870d-4c48077cc753/stakes",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 21.9687,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 21.8802,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.497,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_130af61132e3a10e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 21.8802,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 21.7991,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4975,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/f06c8b09-e11d-49cb-b30d-44cd58d7410c/idea-contributions",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 21.7991,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 21.6297,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.498,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:goethes-faust/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 21.6297,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 21.508,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.4985,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/visual-lc-ceremony-0/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 21.508,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 21.3428,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.499,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
@@ -2594,343 +3997,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 18.679,
+      "total_runtime_ms": 21.3428,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 17.543,
+      "average_runtime_ms": 21.0727,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.912,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/quark-virtual-dom/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 17.543,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 16.9483,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9125,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_0b1966f0ec660191",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 16.9483,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 16.8916,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.913,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-v-harmonizing/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 16.8916,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 16.2903,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9135,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_tasks",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 16.2903,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 15.5524,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.914,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/asset:562cc06214e64fd0/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 15.5524,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 15.2286,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9145,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/contributor/lc-identity-is-shared-blueprint-and-recipe",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 15.2286,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 14.5386,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.915,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/lc-traces-teach-the-recipe/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 14.5386,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 14.3984,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9155,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-w-spanda/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 14.3984,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 13.944,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.916,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_459e99612289f2ea/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 13.944,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 13.714,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9165,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/quark-virtual-dom",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 13.714,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 13.6747,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.917,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_0b1966f0ec660191/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 13.6747,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 13.3354,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9175,
-      "current_grammar": "BML",
-      "current_handler": "api_concept_voices",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/concepts/lc-the-trace-is-the-memory/voices",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 13.3354,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 11.9559,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.918,
-      "current_grammar": "BML",
-      "current_handler": "api_views_stats",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/views/stats/james-fenimore-cooper",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 11.9559,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 11.919,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9185,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/asset:ancient-sound-healing-a89682067c4d/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 11.919,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 11.5534,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.919,
+      "cumulative_traffic_share": 0.4995,
       "current_grammar": "BML",
       "current_handler": "api_translations_entity",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/substrate-concept-lc-space",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B009GLCXPO",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -2939,21 +4020,67 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 11.5534,
+      "total_runtime_ms": 21.0727,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 10.8531,
+      "average_runtime_ms": 20.7857,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9195,
+      "cumulative_traffic_share": 0.5,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/78dc5401-46f7-4a8a-bfb9-0350e1c0c72a/cc-history",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 20.7857,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 20.7392,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5005,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/64be49a6-2d2a-42a4-870d-4c48077cc753/portfolio",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 20.7392,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 20.7321,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.501,
       "current_grammar": "BML",
-      "current_handler": "api_agent_task",
+      "current_handler": "api_agent_task_log",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_02fabc340cd3ef6c",
+      "endpoint": "/api/agent/tasks/task_27232402bfeb148b/log",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -2962,1050 +4089,15 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 10.8531,
+      "total_runtime_ms": 20.7321,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 10.8197,
+      "average_runtime_ms": 20.6454,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.92,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/proposals/by-idea/smart-task-reaper",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 10.8197,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 10.0915,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9205,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/lc-the-trace-is-the-memory/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 10.0915,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 10.0283,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.921,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/lc-panini-the-first-substrate/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 10.0283,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 9.6596,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9215,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/asset:die-unendliche-geschichte/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 9.6596,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 9.3858,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.922,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/james-fenimore-cooper",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 9.3858,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 9.2814,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9225,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/asset:quark-virtual-dom/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 9.2814,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 9.2625,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.923,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/contributor:james-fenimore-cooper/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 9.2625,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 9.2111,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9235,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/contributor/lc-energy",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 9.2111,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 9.157,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.924,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_28a94ee9c8c9ae28/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 9.157,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 8.9524,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9245,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/smart-task-reaper/summary",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 8.9524,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 8.8928,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.925,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-traces-teach-the-recipe/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 8.8928,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 8.8801,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9255,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_28a94ee9c8c9ae28",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 8.8801,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 8.7391,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.926,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_61bff9790ffb05dc/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 8.7391,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 8.7108,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9265,
-      "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_summary",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-panini-the-first-substrate/summary",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 8.7108,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 8.4654,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.927,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/lc-identity-dissolution/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 8.4654,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 8.3075,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9275,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_979be35b65cabc87",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 8.3075,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 8.2891,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.928,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_036f396e77876608/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 8.2891,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 8.1502,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9285,
-      "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/people-multidisciplinary-association-for-psychedelic-studies-maps-edit",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 8.1502,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.8229,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.929,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_8d890468e846760e",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 7.8229,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.8071,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9295,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/codex-graph-query/summary",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.8071,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.7419,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.93,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_8f43a5d873abd888/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.7419,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.5916,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9305,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_2b325cc1e78fb69a",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 7.5916,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.5814,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.931,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_6b392f2437978914/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.5814,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.5711,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9315,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_6b392f2437978914",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 7.5711,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.4796,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.932,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/discovery/lc-traces-teach-the-recipe",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.4796,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.4241,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9325,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_0337df4443a95ed7/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.4241,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.3979,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.933,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/047-heal-completion-issue-resolution/summary",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.3979,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.2959,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9335,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_7863edc939753105",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 7.2959,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.1559,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.934,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/graph/nodes/contributor:multidisciplinary-association-for-psyche-cf0b1e2b252a/edges",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.1559,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.1034,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9345,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "content/entity grammar",
-      "endpoint": "/api/content-manager",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.1034,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.0873,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.935,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/discovery/lc-identity-dissolution",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.0873,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.0209,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9355,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_72863fb201378c5f/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.0209,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 7.0077,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.936,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/proposals/by-idea/grant-coherence-triadic",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 7.0077,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.9543,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9365,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/proposals/by-idea/codex-oneshot-breath",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 6.9543,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.8259,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.937,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/user",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 6.8259,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.7734,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9375,
-      "current_grammar": "BML",
-      "current_handler": "api_views_stats",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/views/stats/quark-virtual-dom",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 6.7734,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.7627,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.938,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_8f08fa841e96bc68",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 6.7627,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.6972,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9385,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/grant-coherence-triadic/summary",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 6.6972,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.6283,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.939,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_576c1f3214e9a104/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 6.6283,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.6263,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9395,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_4dfbf1ff0818f625/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 6.6263,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.5256,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.94,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_18d2cc4a3983eca5",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 6.5256,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.4349,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9405,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_82e45bf1855af470/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 6.4349,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.3989,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.941,
-      "current_grammar": "BML",
-      "current_handler": "api_views_stats",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/views/stats/lc-panini-the-first-substrate",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 6.3989,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.3792,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9415,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_26ea9a9bf3831c96/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 6.3792,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.3466,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.942,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_294fc905163f02f4/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 6.3466,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 6.224,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9425,
+      "cumulative_traffic_share": 0.5015,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
@@ -4020,21 +4112,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 6.224,
+      "total_runtime_ms": 20.6454,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 6.2198,
+      "average_runtime_ms": 20.5986,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.943,
+      "cumulative_traffic_share": 0.502,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-the-trace-is-the-memory/carried-by",
+      "endpoint": "/api/graph/nodes/asset:audible-B0FCGJKSS9/edges",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -4043,21 +4135,44 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 6.2198,
+      "total_runtime_ms": 20.5986,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 6.2134,
+      "average_runtime_ms": 20.4034,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9435,
+      "cumulative_traffic_share": 0.5025,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/f06c8b09-e11d-49cb-b30d-44cd58d7410c/portfolio",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 20.4034,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 20.3107,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.503,
       "current_grammar": "BML",
-      "current_handler": "api_agent_task",
+      "current_handler": "api_views_stats",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_95116d7f24bc6c60",
+      "endpoint": "/api/views/stats/lc-the-living-equation",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4066,21 +4181,67 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 6.2134,
+      "total_runtime_ms": 20.3107,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 6.0749,
+      "average_runtime_ms": 20.2443,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.944,
+      "cumulative_traffic_share": 0.5035,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/contributors/f06c8b09-e11d-49cb-b30d-44cd58d7410c/tasks",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 20.2443,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 20.0232,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.504,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/proposals/by-idea/114-collective-coherence-resonance-flow-friction-health",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 20.0232,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 19.9634,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5045,
       "current_grammar": "BML",
-      "current_handler": "api_agent_task",
+      "current_handler": "api_agent_task_log",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_03b6260dcffb954f",
+      "endpoint": "/api/agent/tasks/task_78a842fdf49c31fc/log",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4089,21 +4250,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 6.0749,
+      "total_runtime_ms": 19.9634,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.9887,
+      "average_runtime_ms": 19.4889,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9445,
+      "cumulative_traffic_share": 0.505,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/contributor/lc-traces-teach-the-recipe",
+      "endpoint": "/api/contributors/78dc5401-46f7-4a8a-bfb9-0350e1c0c72a/portfolio",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -4112,21 +4273,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 5.9887,
+      "total_runtime_ms": 19.4889,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.9856,
+      "average_runtime_ms": 19.2628,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.945,
+      "cumulative_traffic_share": 0.5055,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/show",
+      "endpoint": "/api/contributors/693b67c0-8bef-4ad4-84ef-2ccdf57e583e/idea-contributions",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -4135,44 +4296,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 5.9856,
+      "total_runtime_ms": 19.2628,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.969,
+      "average_runtime_ms": 18.857,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9455,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_03b6260dcffb954f/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 5.969,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 5.866,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.946,
+      "cumulative_traffic_share": 0.506,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_44ab1528729ca8af",
+      "endpoint": "/api/agent/tasks/task_10e28ccace232dc9",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4181,21 +4319,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 5.866,
+      "total_runtime_ms": 18.857,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.7954,
+      "average_runtime_ms": 18.2407,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9465,
+      "cumulative_traffic_share": 0.5065,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/private",
+      "endpoint": "/api/contributors/f06c8b09-e11d-49cb-b30d-44cd58d7410c/cc-history",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -4204,21 +4342,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 5.7954,
+      "total_runtime_ms": 18.2407,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.6908,
+      "average_runtime_ms": 17.9408,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.947,
+      "cumulative_traffic_share": 0.507,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/presences/asset:562cc06214e64fd0/places",
+      "endpoint": "/api/contributors/f06c8b09-e11d-49cb-b30d-44cd58d7410c/stakes",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -4227,21 +4365,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 5.6908,
+      "total_runtime_ms": 17.9408,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.5914,
+      "average_runtime_ms": 17.8037,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9475,
+      "cumulative_traffic_share": 0.5075,
       "current_grammar": "BML",
-      "current_handler": "api_agent_task",
+      "current_handler": "api_agent_task_log",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_82e45bf1855af470",
+      "endpoint": "/api/agent/tasks/task_0e2cba7bbb0736e3/log",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4250,67 +4388,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 5.5914,
+      "total_runtime_ms": 17.8037,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.5418,
+      "average_runtime_ms": 17.6095,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.948,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-identity-dissolution/carried-by",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 5.5418,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 5.4966,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9485,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_979be35b65cabc87/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 5.4966,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 5.3174,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.949,
+      "cumulative_traffic_share": 0.508,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_294fc905163f02f4",
+      "endpoint": "/api/agent/tasks/task_e8b77f876134d847",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4319,21 +4411,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 5.3174,
+      "total_runtime_ms": 17.6095,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.2252,
+      "average_runtime_ms": 17.3694,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9495,
+      "cumulative_traffic_share": 0.5085,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/concepts/lc-panini-the-first-substrate/carried-by",
+      "endpoint": "/api/reactions/idea/114-collective-coherence-resonance-flow-friction-health/summary",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -4342,67 +4434,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 5.2252,
+      "total_runtime_ms": 17.3694,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.1752,
+      "average_runtime_ms": 17.1418,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.95,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_2b325cc1e78fb69a/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 5.1752,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 5.1393,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9505,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/discovery/lc-the-trace-is-the-memory",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 5.1393,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 5.0907,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.951,
+      "cumulative_traffic_share": 0.509,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_5a4b55bc5da71f16",
+      "endpoint": "/api/agent/tasks/task_3536ec8d13ba4b2c",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4411,21 +4457,3310 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 5.0907,
+      "total_runtime_ms": 17.1418,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.07,
+      "average_runtime_ms": 17.1149,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9515,
+      "cumulative_traffic_share": 0.5095,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6fe79f1aab4003a2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 17.1149,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 16.9796,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.51,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2fd886e591f06caa",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 16.9796,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 16.8487,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5105,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3fce9aded713cbda",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 16.8487,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 16.6391,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.511,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_42abff3619848fbf",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 16.6391,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 15.9938,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5115,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_78a842fdf49c31fc",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 15.9938,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 15.9064,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.512,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_10e28ccace232dc9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 15.9064,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 15.8627,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5125,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_06162ecbf0eba069/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 15.8627,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 14.707,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.513,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6fe79f1aab4003a2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 14.707,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 14.6834,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5135,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-agent-memory/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 14.6834,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 14.402,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.514,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_27232402bfeb148b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 14.402,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 14.3403,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5145,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_058bd2dc0bb0be65/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 14.3403,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 14.3244,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.515,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3536ec8d13ba4b2c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 14.3244,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 14.2835,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5155,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7ed6d065d4801913/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 14.2835,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 14.195,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.516,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8ddcbc10725cca97",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 14.195,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 14.1297,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5165,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/lc-v-ceremony/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 14.1297,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 13.9818,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.517,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_c0565106c75118e0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 13.9818,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 13.874,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5175,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7fd77c539207f40a/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 13.874,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 13.7259,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.518,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6dfcdfd39fdd9f3f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 13.7259,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 13.4493,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5185,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/lc-edges-as-vitality/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 13.4493,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 13.2569,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.519,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_heartbeat",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presence/concept/lc-nourishing",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "POST",
+      "methods": [
+        "POST"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 13.2569,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 13.1743,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5195,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_90135f84eb46f8f5/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 13.1743,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 13.1181,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.52,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_06162ecbf0eba069",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 13.1181,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 12.9616,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5205,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2fd886e591f06caa/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.9616,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 12.8679,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.521,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-resource-composted-wisdom",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.8679,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 12.721,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5215,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_240d9f91012854c9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.721,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 12.7162,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.522,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B002V8LKTE/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 12.7162,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 12.5494,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5225,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_67b511baedc53c37",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.5494,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 12.549,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.523,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-audible-evolution-by-ryk-brown-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.549,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 12.4193,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5235,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_c5ddf9147f110e64/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.4193,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 12.2729,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.524,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0be36af81af85860",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 12.2729,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 12.2566,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5245,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/contributor:codex/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 12.2566,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 11.8875,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.525,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B01I5SFG3Y/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 11.8875,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 11.6251,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5255,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_058bd2dc0bb0be65",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.6251,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 11.5596,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.526,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_14587a2c3ba69725",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.5596,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 11.4968,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5265,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_49862271ee62a5ea",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.4968,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 11.4395,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.527,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_c0565106c75118e0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.4395,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 11.2327,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5275,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:6c41e632532117e7/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 11.2327,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 11.1706,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.528,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7fd77c539207f40a",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.1706,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 11.1379,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5285,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/lc-release-what-drifts/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 11.1379,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 11.0266,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.529,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_90135f84eb46f8f5",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 11.0266,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.8929,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5295,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6721d889a864438a",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.8929,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.8489,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.53,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/lc-inner-travel/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 10.8489,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.7741,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5305,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8ddcbc10725cca97/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.7741,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.7012,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.531,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/lc-network-unanchored/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 10.7012,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.5803,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5315,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/lc-the-recipe-remembers-its-source/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 10.5803,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.4888,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.532,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_240d9f91012854c9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.4888,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.422,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5325,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/visual-lc-nourishment-2/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 10.422,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.421,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.533,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/ramtha/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 10.421,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.3663,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5335,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B073VYC1WW",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.3663,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.3328,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.534,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7368e9d7ef595601/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.3328,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 10.2196,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5345,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-presence-Next-Level-Soul",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 10.2196,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.9344,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.535,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/contributor:alain-colmerauer/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.9344,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.8545,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5355,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_857c46e4ce2d6c25",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.8545,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.7989,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.536,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/contributor:154d95f1c412d671/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.7989,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.6532,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5365,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/scene-play/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.6532,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.5602,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.537,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/visual-lc-elders-story-2/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.5602,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.5026,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5375,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:fc31024f1d7a5e1b/places",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.5026,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.4867,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.538,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_67b511baedc53c37/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.4867,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.4771,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5385,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0be36af81af85860/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.4771,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.4417,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.539,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_c5ddf9147f110e64",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.4417,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.3949,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5395,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_130af61132e3a10e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.3949,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.2455,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.54,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B0B8LP8CPD",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.2455,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.2284,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5405,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_526942af9eeb326b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.2284,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.206,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.541,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4d944cca783d43d4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.206,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.1647,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5415,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_14587a2c3ba69725/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.1647,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.1457,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.542,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_353de7a2bbde34c8",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.1457,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.1068,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5425,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B016N7P4OU/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.1068,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.0837,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.543,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B005GFQ5WQ/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.0837,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.0619,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5435,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/ramtha",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.0619,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.0574,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.544,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/community-earthship/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.0574,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.0459,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5445,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_509f1aa22269c615/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.0459,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.0226,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.545,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_684cf311e957d833",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 9.0226,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.0202,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5455,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/contributor:ramtha/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.0202,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 9.0011,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.546,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B01IRUA5VI/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 9.0011,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.9473,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5465,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/places/place:seattle-washington/presences",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.9473,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.9321,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.547,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8bcbc0d54024ec95",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.9321,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.8456,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5475,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:fc31024f1d7a5e1b/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.8456,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.8015,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.548,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_9125767b3db4bde2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.8015,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.7778,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5485,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/artifact:coherence-network-repository/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.7778,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.7402,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.549,
+      "current_grammar": "BML",
+      "current_handler": "api_views_stats",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/views/stats/lc-the-recipe-remembers-its-source",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.7402,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.7271,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5495,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/contributor:32d3f1314f9db298/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.7271,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.7001,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.55,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1c6b2684c7d1ebb6/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.7001,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.6567,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5505,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:73a0c783-b3aa-46c2-8631-5de94b36eac8",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.6567,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.5874,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.551,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/discovery/lc-the-living-equation",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.5874,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.5341,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5515,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6721d889a864438a/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.5341,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.5294,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.552,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B002V0QK4C/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.5294,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.5035,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5525,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B07BN33KPK/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.5035,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.4547,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.553,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_49862271ee62a5ea/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.4547,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.3881,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5535,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:aa2132f21d9b26df/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.3881,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.3733,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.554,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-1494589060/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.3733,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.3724,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5545,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3db134095d08aadc",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.3724,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.3541,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.555,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5f93ba17cc91880b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.3541,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.2973,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5555,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B014LL6Y4O/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.2973,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.2544,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.556,
+      "current_grammar": "BML",
+      "current_handler": "api_views_stats",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/views/stats/tammy-beattie",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.2544,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.2442,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5565,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_56d473468166f597",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.2442,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.207,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.557,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B002V8DH5Y/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.207,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.1751,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5575,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1e4842f53d77bac5",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 8.1751,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 8.136,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.558,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B014LL69TO/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 8.136,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.9776,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5585,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6036c89e6a2c62c2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.9776,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.9473,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.559,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_66abdd2a6882f95f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.9473,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.9095,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5595,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B00LWDBWH4/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.9095,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.8638,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.56,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-154363933X/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.8638,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.8387,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5605,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-inner-travel/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.8387,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.7543,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.561,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5b678622c171d554",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.7543,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.7533,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5615,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-1774240602/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.7533,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.6354,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.562,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7c6bff5cacc8eeb9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.6354,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.6198,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5625,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/contributor:peter-naur/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.6198,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.6033,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.563,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B002V5B9SO/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.6033,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.5923,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5635,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1549ef0047b9ec61/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.5923,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.5782,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.564,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_c7aa6b0d5da04fb9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.5782,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.5457,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5645,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1aaea5815f56e32e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.5457,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.4918,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.565,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B074WH171J",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.4918,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.4825,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5655,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/place:seattle-washington/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.4825,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.4752,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.566,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-the-living-equation/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.4752,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.424,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5665,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/visual-lc-offering-1/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.424,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.3966,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.567,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0d66c3010131384f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.3966,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.338,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5675,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/contributor:mudra-cafe/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.338,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.3177,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.568,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2161cf55670e9d0d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.3177,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.3128,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5685,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-lc-edges-as-vitality",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.3128,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.2541,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.569,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_21defa7fc80f818e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.2541,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.1687,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5695,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B0F514WLWD/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.1687,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.1368,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.57,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-transmission-story-2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.1368,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.1256,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5705,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2bf58d13bf2f0453",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.1256,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.112,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.571,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_980c271906a21d94",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.112,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.1115,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5715,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8298a5378c6c3d41",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.1115,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.0853,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.572,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_03d890ca058cd8ff/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.0853,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.0718,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5725,
+      "current_grammar": "BML",
+      "current_handler": "api_inspired_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/inspired-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.0718,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.0631,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.573,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/contributor/lc-the-recipe-remembers-its-source",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.0631,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.0544,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5735,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/meeting/concept/lc-nourishing",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.0544,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.0539,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.574,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7b7d2ff502364b3a",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 7.0539,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 7.0048,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5745,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B00CBXCSZY/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 7.0048,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.9524,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.575,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B0GC832YN8/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 6.9524,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.9505,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5755,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B00CLWTGPA/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 6.9505,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.9473,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.576,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B006WP75QE",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.9473,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.9408,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5765,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_65c091f4110957b9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.9408,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.8702,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.577,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-1772308641/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 6.8702,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.7938,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5775,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_36188d7d81d995b1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.7938,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.79,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.578,
+      "current_grammar": "BML",
+      "current_handler": "api_views_stats",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/views/stats/codex",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.79,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.7599,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5785,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7803625d8fd2867f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.7599,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.7339,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.579,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B0C6RCB8K2/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 6.7339,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.7144,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5795,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8d1a62ad5aee9b03/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.7144,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.708,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.58,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1c6b2684c7d1ebb6",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.708,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.6685,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5805,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_76d26796d377ba9d",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.6685,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.6365,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.581,
       "current_grammar": "BML",
       "current_handler": "api_concept_voices",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/concepts/lc-traces-teach-the-recipe/voices",
+      "endpoint": "/api/concepts/lc-the-living-equation/voices",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4434,136 +7769,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 5.07,
+      "total_runtime_ms": 6.6365,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 5.0664,
+      "average_runtime_ms": 6.6036,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.952,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_1a3154579ecf2eb0/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 5.0664,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 5.0445,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9525,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/v1/me",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 5.0445,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 5.0417,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.953,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/grant-coherence-triadic/threads",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 5.0417,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 5.009,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9535,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/codex-graph-query/threads",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 5.009,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.983,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.954,
-      "current_grammar": "BML",
-      "current_handler": "api_concept_voices",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/concepts/lc-identity-dissolution/voices",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.983,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.9772,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9545,
+      "cumulative_traffic_share": 0.5815,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_69a8422dc0dd09e2",
+      "endpoint": "/api/agent/tasks/task_41069b365e900aa2",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4572,21 +7792,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.9772,
+      "total_runtime_ms": 6.6036,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.9572,
+      "average_runtime_ms": 6.5882,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.955,
+      "cumulative_traffic_share": 0.582,
       "current_grammar": "BML",
-      "current_handler": "api_concept_voices",
+      "current_handler": "api_agent_task_log",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/concepts/lc-energy/voices",
+      "endpoint": "/api/agent/tasks/task_12a12a3a31feaa4e/log",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4595,113 +7815,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.9572,
+      "total_runtime_ms": 6.5882,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.9435,
+      "average_runtime_ms": 6.5819,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9555,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_4da448858e8acdfe/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.9435,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.9313,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.956,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_8f08fa841e96bc68/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.9313,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.9074,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9565,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_4058a62e9b5ae373/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.9074,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.902,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.957,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/proposals/by-idea/codex-graph-query",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.902,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.8829,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9575,
+      "cumulative_traffic_share": 0.5825,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_51f77ea2d4c20853",
+      "endpoint": "/api/agent/tasks/task_145e308fd3c5581b",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4710,44 +7838,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.8829,
+      "total_runtime_ms": 6.5819,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.8745,
+      "average_runtime_ms": 6.5598,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.958,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/contributor/lc-identity-dissolution",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.8745,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.8561,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9585,
+      "cumulative_traffic_share": 0.583,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_79371b205b52fadb",
+      "endpoint": "/api/agent/tasks/task_fbdd3d502325e7ab",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4756,136 +7861,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.8561,
+      "total_runtime_ms": 6.5598,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.8405,
+      "average_runtime_ms": 6.5564,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.959,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_7863edc939753105/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.8405,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.7944,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9595,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_26ea9a9bf3831c96",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.7944,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.7818,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.96,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_12f0fc3417254255/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.7818,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.7812,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9605,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_194d74939f091ab5/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.7812,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.76,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.961,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_8f43a5d873abd888",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.76,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.753,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9615,
+      "cumulative_traffic_share": 0.5835,
       "current_grammar": "BML",
       "current_handler": "api_translations_entity",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/claim-contributor:alain-colmerauer",
+      "endpoint": "/api/translations/page/people-audible-the-count-of-monte-cristo-by-alexandre-dumas-edit",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -4894,21 +7884,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.753,
+      "total_runtime_ms": 6.5564,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.7487,
+      "average_runtime_ms": 6.5426,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.962,
+      "cumulative_traffic_share": 0.584,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/discovery/lc-energy",
+      "endpoint": "/api/graph/nodes/asset:audible-B002V0PN36/edges",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -4917,21 +7907,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 4.7487,
+      "total_runtime_ms": 6.5426,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.7384,
+      "average_runtime_ms": 6.4839,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9625,
+      "cumulative_traffic_share": 0.5845,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/cli-noninteractive-identity/summary",
+      "endpoint": "/api/graph/nodes/asset:audible-B0BX7DLW2D/edges",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -4940,90 +7930,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 4.7384,
+      "total_runtime_ms": 6.4839,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.6456,
+      "average_runtime_ms": 6.4681,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.963,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_5a4b55bc5da71f16/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.6456,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.6384,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9635,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_51f77ea2d4c20853/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.6384,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.6201,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.964,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_6f055a8b4b5a6eac/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.6201,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.5872,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9645,
+      "cumulative_traffic_share": 0.585,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_21f0ba3822fdbd4a",
+      "endpoint": "/api/agent/tasks/task_5f93ba17cc91880b",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5032,21 +7953,44 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.5872,
+      "total_runtime_ms": 6.4681,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.5791,
+      "average_runtime_ms": 6.461,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.965,
+      "cumulative_traffic_share": 0.5855,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/asset:audible-B00I5N3J70/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 6.461,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.4489,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.586,
       "current_grammar": "BML",
-      "current_handler": "api_agent_task",
+      "current_handler": "api_concept_carried_by",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_480ea655c45aed09",
+      "endpoint": "/api/concepts/lc-the-recipe-remembers-its-source/carried-by",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5055,21 +7999,113 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.5791,
+      "total_runtime_ms": 6.4489,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.5535,
+      "average_runtime_ms": 6.4431,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9655,
+      "cumulative_traffic_share": 0.5865,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_32af1256de00283e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.4431,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.441,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.587,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_901d0665032559e3/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.441,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.4205,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5875,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2bdc05401ce373c5",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.4205,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.4158,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.588,
+      "current_grammar": "BML",
+      "current_handler": "api_presence_count",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/presence/concept/lc-nourishing",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.4158,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.3926,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5885,
       "current_grammar": "BML",
       "current_handler": "api_translations_entity",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/come-in",
+      "endpoint": "/api/translations/page/nodes-contributor:154d95f1c412d671",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5078,21 +8114,113 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.5535,
+      "total_runtime_ms": 6.3926,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.542,
+      "average_runtime_ms": 6.3863,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.966,
+      "cumulative_traffic_share": 0.589,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_87bebc773d5999e9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.3863,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.3692,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5895,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_14e28e5a9921da4e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.3692,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.366,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.59,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1949141205200e2f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.366,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.3512,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5905,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_73a898d843bce8a3/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.3512,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.35,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.591,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/discovery/lc-panini-the-first-substrate",
+      "endpoint": "/api/graph/nodes/contributor:mile-hi-church/edges",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -5101,21 +8229,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 4.542,
+      "total_runtime_ms": 6.35,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.5412,
+      "average_runtime_ms": 6.3457,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9665,
+      "cumulative_traffic_share": 0.5915,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_12f0fc3417254255",
+      "endpoint": "/api/agent/tasks/task_2161cf55670e9d0d",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5124,21 +8252,67 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.5412,
+      "total_runtime_ms": 6.3457,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.5375,
+      "average_runtime_ms": 6.3436,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.967,
+      "cumulative_traffic_share": 0.592,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5c7b6235ca8f74fb/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.3436,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.3284,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5925,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_66abdd2a6882f95f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.3284,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.3118,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.593,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/views/contributor/lc-panini-the-first-substrate",
+      "endpoint": "/api/reactions/idea/grant-explanation-traces/summary",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -5147,21 +8321,21 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 4.5375,
+      "total_runtime_ms": 6.3118,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.5341,
+      "average_runtime_ms": 6.2811,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9675,
+      "cumulative_traffic_share": 0.5935,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_4c412a6cb9e6b87f",
+      "endpoint": "/api/agent/tasks/task_900b53036c7a17fc",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5170,21 +8344,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.5341,
+      "total_runtime_ms": 6.2811,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.5104,
+      "average_runtime_ms": 6.2425,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.968,
+      "cumulative_traffic_share": 0.594,
       "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
+      "current_handler": "api_concept_carried_by",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/today",
+      "endpoint": "/api/concepts/lc-network-unanchored/carried-by",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5193,90 +8367,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.5104,
+      "total_runtime_ms": 6.2425,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.4897,
+      "average_runtime_ms": 6.2174,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9685,
-      "current_grammar": "BML",
-      "current_handler": "api_concept_voices",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/concepts/lc-panini-the-first-substrate/voices",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.4897,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.4787,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.969,
-      "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/substrate-concept-lc-inner-travel",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.4787,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.4545,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9695,
-      "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/substrate-concept-lc-awareness-as-self",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.4545,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.4481,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.97,
+      "cumulative_traffic_share": 0.5945,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_036f396e77876608",
+      "endpoint": "/api/agent/tasks/task_8c82099a209695b2",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5285,21 +8390,113 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.4481,
+      "total_runtime_ms": 6.2174,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.4355,
+      "average_runtime_ms": 6.2168,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9705,
+      "cumulative_traffic_share": 0.595,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3a6d341a020b04a2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.2168,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.2062,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5955,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8bbe96ad452c60d9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.2062,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.1898,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.596,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6f7ec8b210369630",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.1898,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.1552,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5965,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:c656add55daa28a3",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.1552,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.1433,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.597,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/codex-oneshot-breath/summary",
+      "endpoint": "/api/views/contributor/lc-the-living-equation",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -5308,21 +8505,343 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 4.4355,
+      "total_runtime_ms": 6.1433,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.4319,
+      "average_runtime_ms": 6.1383,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.971,
+      "cumulative_traffic_share": 0.5975,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_746f779297e54f2b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.1383,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.1355,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.598,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_27e745fe76fdd360/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.1355,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.1347,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5985,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0e166eb9cba485a1/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.1347,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.1324,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.599,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6dfcdfd39fdd9f3f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.1324,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.1178,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.5995,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8a8cfba459a3ebef",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.1178,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.0725,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_900b53036c7a17fc/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.0725,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.0685,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6005,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1539d53c17ad530d",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.0685,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.0606,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.601,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_11e620bb51876cf4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.0606,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.0565,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6015,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_701a686c5975848f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.0565,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.0511,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.602,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8a0e88846b1d764e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.0511,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.039,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6025,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/presences/asset:f38bc24449ffbcd2/places",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 6.039,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 6.0077,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.603,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_32505076ba1055ed",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 6.0077,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.9676,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6035,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/graph/nodes/contributor:tammy-beattie/edges",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 5.9676,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.9659,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.604,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5293199a6e61b8ad",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.9659,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.9478,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6045,
       "current_grammar": "BML",
       "current_handler": "api_reaction_concept_threads",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-panini-the-first-substrate/threads",
+      "endpoint": "/api/reactions/concept/lc-the-recipe-remembers-its-source/threads",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5331,21 +8850,159 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.4319,
+      "total_runtime_ms": 5.9478,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.425,
+      "average_runtime_ms": 5.9207,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9715,
+      "cumulative_traffic_share": 0.605,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_947acacda19d4c3b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.9207,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.903,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6055,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-edges-as-vitality/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.903,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.8688,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.606,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_62235ff38c43aa83/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.8688,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.8373,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6065,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6aa9d3f8da1224c2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.8373,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.8195,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.607,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1949141205200e2f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.8195,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.8098,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6075,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3cbf480179e26c3e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.8098,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.8041,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.608,
       "current_grammar": "BML",
       "current_handler": "api_translations_entity",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/nodes-asset:6d72693b5441066c",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B01D274C5Q",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5354,67 +9011,67 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.425,
+      "total_runtime_ms": 5.8041,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.4055,
+      "average_runtime_ms": 5.7661,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.972,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/smart-task-reaper/threads",
+      "cumulative_traffic_share": 0.6085,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_38370a08507c672b",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.4055,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.7661,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.3828,
+      "average_runtime_ms": 5.7656,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9725,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/cli-noninteractive-identity/threads",
+      "cumulative_traffic_share": 0.609,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3031cf0066d52f97",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.3828,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.7656,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.3825,
+      "average_runtime_ms": 5.7629,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.973,
+      "cumulative_traffic_share": 0.6095,
       "current_grammar": "BML",
       "current_handler": "api_translations_entity",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/contributors-64be49a6-2d2a-42a4-870d-4c48077cc753-portfolio",
+      "endpoint": "/api/translations/page/contributors-f06c8b09-e11d-49cb-b30d-44cd58d7410c-portfolio",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5423,67 +9080,44 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.3825,
+      "total_runtime_ms": 5.7629,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.3593,
+      "average_runtime_ms": 5.7038,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9735,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/047-heal-completion-issue-resolution/threads",
+      "cumulative_traffic_share": 0.61,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_288ff508afd442b7/log",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.3593,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.7038,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.3334,
+      "average_runtime_ms": 5.7027,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.974,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_02fabc340cd3ef6c/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.3334,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.2908,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9745,
+      "cumulative_traffic_share": 0.6105,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_57e5fec9a8483558",
+      "endpoint": "/api/agent/tasks/task_2b9b9b2cbdef0763",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5492,21 +9126,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.2908,
+      "total_runtime_ms": 5.7027,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.2553,
+      "average_runtime_ms": 5.6776,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.975,
+      "cumulative_traffic_share": 0.611,
       "current_grammar": "BML",
       "current_handler": "api_translations_entity",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/nodes-lc-traces-teach-the-recipe",
+      "endpoint": "/api/translations/page/nodes-asset:audible-177424800X",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5515,44 +9149,228 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.2553,
+      "total_runtime_ms": 5.6776,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.2311,
+      "average_runtime_ms": 5.6468,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9755,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_4bb8150d91e4c658/log",
+      "cumulative_traffic_share": 0.6115,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7803625d8fd2867f/log",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.2311,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.6468,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.1925,
+      "average_runtime_ms": 5.642,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.976,
+      "cumulative_traffic_share": 0.612,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_09010a455df425d4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.642,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.6385,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6125,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5445b9f03dc7dbd7/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.6385,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.6353,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.613,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_792dfbb074300815",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.6353,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.6305,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6135,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_32ac883c002f0fac",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.6305,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.6289,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.614,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_399eb3cb27e4ca52/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.6289,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.6261,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6145,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1aaea5815f56e32e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.6261,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.6143,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.615,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6a62e1ed79110cd7/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.6143,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.5883,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6155,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_03d890ca058cd8ff",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.5883,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.567,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.616,
       "current_grammar": "BML",
       "current_handler": "api_translations_entity",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/claim-contributor:susan-muff-sprenger",
+      "endpoint": "/api/translations/page/presence-walk-node-bloomurian",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5561,21 +9379,159 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.1925,
+      "total_runtime_ms": 5.567,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.1882,
+      "average_runtime_ms": 5.5136,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9765,
+      "cumulative_traffic_share": 0.6165,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_48d5e53fff729c08",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.5136,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.5081,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.617,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1599f57e04040672/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.5081,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.5076,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6175,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_summary",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-the-recipe-remembers-its-source/summary",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.5076,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.501,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.618,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_37032005f35c5c9c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.501,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.4812,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6185,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_47e59abc4411700a",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.4812,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.4727,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.619,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2569f35c753c3276/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.4727,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.4707,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6195,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/proposals/by-idea/cli-noninteractive-identity",
+      "endpoint": "/api/proposals/by-idea/ux-drilldown-hierarchy",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -5584,21 +9540,67 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 4.1882,
+      "total_runtime_ms": 5.4707,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.1875,
+      "average_runtime_ms": 5.4677,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.977,
+      "cumulative_traffic_share": 0.62,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0d473e14254be31f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.4677,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.4623,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6205,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7f8b623eee94bb6e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.4623,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.4531,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.621,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/reactions/idea/codex-oneshot-breath/threads",
+      "endpoint": "/api/views/contributor/lc-release-what-drifts",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -5607,21 +9609,320 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 4.1875,
+      "total_runtime_ms": 5.4531,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.1858,
+      "average_runtime_ms": 5.4481,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9775,
+      "cumulative_traffic_share": 0.6215,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/contributor/lc-edges-as-vitality",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 5.4481,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.4426,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.622,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_509f1aa22269c615",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.4426,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.4194,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6225,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7f0764fcc8666531",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.4194,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.4116,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.623,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_9289bbca5350c677",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.4116,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.4003,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6235,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_c7aa6b0d5da04fb9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.4003,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.3999,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.624,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6150519e4273e098/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.3999,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.3868,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6245,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8cd808e52eef1b8c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.3868,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.3845,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.625,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_voices",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-edges-as-vitality/voices",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.3845,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.3712,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6255,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6150519e4273e098",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.3712,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.3509,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.626,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_20a6fb896c2ec481/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.3509,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.3445,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6265,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_57e6d03aaa9c82c5",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.3445,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.343,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.627,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5293199a6e61b8ad/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.343,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.2993,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6275,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3e8f96decd55e970/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2993,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.2947,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.628,
       "current_grammar": "BML",
       "current_handler": "api_translations_entity",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/deploy",
+      "endpoint": "/api/translations/page/nodes-asset:4ffbaad6df079a6b",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5630,21 +9931,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.1858,
+      "total_runtime_ms": 5.2947,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.1843,
+      "average_runtime_ms": 5.2815,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.978,
+      "cumulative_traffic_share": 0.6285,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_3f0345fb72d57f8b",
+      "endpoint": "/api/agent/tasks/task_1c0575b17186b3a0",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5653,67 +9954,90 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.1843,
+      "total_runtime_ms": 5.2815,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.1704,
+      "average_runtime_ms": 5.2683,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9785,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_95116d7f24bc6c60/log",
+      "cumulative_traffic_share": 0.629,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_96c6ec0e13ccc799/log",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.1704,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2683,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.1405,
+      "average_runtime_ms": 5.2635,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.979,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_44ab1528729ca8af/log",
+      "cumulative_traffic_share": 0.6295,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7555f499871c1e3e/log",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.1405,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2635,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.1299,
+      "average_runtime_ms": 5.2612,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9795,
+      "cumulative_traffic_share": 0.63,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_05f7ffa800064757/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2612,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.2506,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6305,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_4da448858e8acdfe",
+      "endpoint": "/api/agent/tasks/task_1549ef0047b9ec61",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5722,67 +10046,21 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.1299,
+      "total_runtime_ms": 5.2506,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 4.0998,
+      "average_runtime_ms": 5.2486,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.98,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_3b0bc50932ace3e3",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 4.0998,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.0105,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9805,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_21f0ba3822fdbd4a/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 4.0105,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 4.0044,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.981,
+      "cumulative_traffic_share": 0.631,
       "current_grammar": "",
       "current_handler": "",
       "current_required_header": "",
       "current_source": "",
       "desired_grammar": "BML route catalog",
-      "endpoint": "/api/internal",
+      "endpoint": "/api/views/contributor/lc-network-unanchored",
       "event_count": 1,
       "high_grammar_native": false,
       "method": "GET",
@@ -5791,21 +10069,67 @@
       ],
       "native_executable": false,
       "status": "python-fanout",
-      "total_runtime_ms": 4.0044,
+      "total_runtime_ms": 5.2486,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.9851,
+      "average_runtime_ms": 5.2475,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9815,
+      "cumulative_traffic_share": 0.6315,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0d66c3010131384f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2475,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.2399,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.632,
+      "current_grammar": "BML",
+      "current_handler": "api_views_stats",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/views/stats/ramtha",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2399,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.2288,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6325,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_5eb073c25b9df1ff",
+      "endpoint": "/api/agent/tasks/task_5005632aa6b487b7",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -5814,573 +10138,44 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.9851,
+      "total_runtime_ms": 5.2288,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.9474,
+      "average_runtime_ms": 5.2239,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.982,
+      "cumulative_traffic_share": 0.633,
       "current_grammar": "BML",
-      "current_handler": "api_reaction_concept_threads",
+      "current_handler": "api_agent_task_log",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/reactions/concept/lc-the-trace-is-the-memory/threads",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.9474,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.8925,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9825,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_2b80ad37331f8d89",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.8925,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.8802,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.983,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_5ec4bf495cb63baa/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.8802,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.821,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9835,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_69a8422dc0dd09e2/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.821,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.8197,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.984,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/deploy/status",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.8197,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.8171,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9845,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_0165da84f43df1c6/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.8171,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.789,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.985,
-      "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/nodes-lc-the-trace-is-the-memory",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.789,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.7769,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9855,
-      "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/with-us",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.7769,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.776,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.986,
-      "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/substrate-form",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.776,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.729,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9865,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_2b80ad37331f8d89/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.729,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.7235,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.987,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_6f055a8b4b5a6eac",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.7235,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.7138,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9875,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_194d74939f091ab5",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.7138,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.692,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.988,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_57e5fec9a8483558/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.692,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.691,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9885,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_18d2cc4a3983eca5/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.691,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.6442,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.989,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_4bb8150d91e4c658",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.6442,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.6372,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9895,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_0165da84f43df1c6",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.6372,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.6321,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.99,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_4c412a6cb9e6b87f/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.6321,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.5922,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9905,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/proposals/by-idea/047-heal-completion-issue-resolution",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.5922,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.5451,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.991,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/users",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.5451,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.516,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9915,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_576c1f3214e9a104",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.516,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.5029,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.992,
-      "current_grammar": "BML",
-      "current_handler": "api_agent_task",
-      "current_required_header": "Accept",
-      "current_source": "deploy/front-door/api.bml",
-      "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_1a3154579ecf2eb0",
-      "event_count": 1,
-      "high_grammar_native": true,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": true,
-      "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.5029,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.4862,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9925,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
       "endpoint": "/api/agent/tasks/task_548d392386337c9a/log",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.4862,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2239,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.483,
+      "average_runtime_ms": 5.2216,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.993,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/debug",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.483,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.4606,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.9935,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_3f0345fb72d57f8b/log",
-      "event_count": 1,
-      "high_grammar_native": false,
-      "method": "GET",
-      "methods": [
-        "GET"
-      ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.4606,
-      "traffic_share": 0.0005
-    },
-    {
-      "average_runtime_ms": 3.4097,
-      "by_source": {
-        "web_api": 1
-      },
-      "cumulative_traffic_share": 0.994,
+      "cumulative_traffic_share": 0.6335,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_4058a62e9b5ae373",
+      "endpoint": "/api/agent/tasks/task_201869cabd025ba8",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -6389,15 +10184,1625 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.4097,
+      "total_runtime_ms": 5.2216,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.4033,
+      "average_runtime_ms": 5.2216,
       "by_source": {
         "web_api": 1
       },
-      "cumulative_traffic_share": 0.9945,
+      "cumulative_traffic_share": 0.634,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3fb5e559ebd81707",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2216,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.2122,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6345,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_12135455b03903ac",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2122,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.2118,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.635,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3078956ca6b2f4c3/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2118,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.2011,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6355,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2cb1a0f611499a12/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.2011,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1964,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.636,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_45b4d18ecf8e8f6f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1964,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.196,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6365,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4d6991d2acbea4f2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.196,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1854,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.637,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6487656f24c562cb/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1854,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1846,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6375,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/contributor/lc-v-ceremony",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 5.1846,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1806,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.638,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_857245cf53038aed",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1806,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1781,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6385,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-125024188X",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1781,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1619,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.639,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8bdf59705d73afa7/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1619,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1612,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6395,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_78ea0d151eebc5bd",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1612,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1459,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.64,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5b678622c171d554/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1459,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1395,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6405,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-nourishing-2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1395,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1381,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.641,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_carried_by",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-release-what-drifts/carried-by",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1381,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1369,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6415,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_31867bb768dab298",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1369,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1194,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.642,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-asset:6c41e632532117e7-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1194,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1141,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6425,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B00A0XYUTE",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1141,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1125,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.643,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2c5322053279557c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1125,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1076,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6435,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_672e6889da47f91e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1076,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1064,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.644,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0361c6707ffda575/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1064,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.1023,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6445,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6239a24a0cef88f2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.1023,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.102,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.645,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8a65d15c1def2716",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.102,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0943,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6455,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_767ea280f2c9e5c2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0943,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0892,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.646,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_40323928863e272a/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0892,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0888,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6465,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-audible-best-served-cold-by-joe-abercrombie-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0888,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0879,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.647,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_26a71efdac3610f0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0879,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0872,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6475,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6e7bad7995f86c4c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0872,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0837,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.648,
+      "current_grammar": "BML",
+      "current_handler": "api_views_stats",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/views/stats/mudra-cafe",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0837,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0785,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6485,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1cdd2067dff3fad0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0785,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.074,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.649,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_056070714d2ed52f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.074,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0527,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6495,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4016cbac57e78053",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0527,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0493,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.65,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7cbb4b68fccb3606",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0493,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0476,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6505,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_voices",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-inner-travel/voices",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0476,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0471,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.651,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_097dd9b16abb38ec/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0471,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0434,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6515,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/ideas",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0434,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0352,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.652,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-0062960172",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0352,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0305,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6525,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0b8bb7b80357e49c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0305,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0201,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.653,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_36e47b0f0d400be8/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0201,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0196,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6535,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_42a68c8b5ef0cac6",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0196,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 5.0102,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.654,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_9125767b3db4bde2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 5.0102,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9996,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6545,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_264b8af6a9813622/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9996,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9986,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.655,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:aa2132f21d9b26df",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9986,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9965,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6555,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_81a0cd4d12bf3860/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9965,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9964,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.656,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_57535ef9658e0797",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9964,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9852,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6565,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1239a087069b28e9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9852,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9847,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.657,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_80c924f70fd45862/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9847,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9755,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6575,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_165ba3727b93ab32/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9755,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9727,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.658,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_d23f8eb7c3dec8a9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9727,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9723,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6585,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2ae05c479987cb17/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9723,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.966,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.659,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7d05f3be6f8cd41e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.966,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9618,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6595,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_008ff9444153f95b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9618,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9607,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.66,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0fd794c14d1c78e0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9607,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9556,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6605,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8b492aa60d628dd4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9556,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9531,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.661,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6f7ec8b210369630/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9531,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9463,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6615,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_145e308fd3c5581b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9463,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9456,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.662,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8b02901e5ac77add",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9456,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9396,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6625,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_64430aa8c5fd47f8",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9396,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.939,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.663,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7eff950352d16fdb/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.939,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9371,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6635,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5e105967f0dd9f77",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9371,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9338,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.664,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7ed6d065d4801913",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9338,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9306,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6645,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/discovery/lc-edges-as-vitality",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 4.9306,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9132,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.665,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_27e745fe76fdd360",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9132,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9088,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6655,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5cdf926d5f63a9a5",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9088,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9086,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.666,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0883cfbefa768f86/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9086,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.9024,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6665,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5ec4bf495cb63baa/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.9024,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8974,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.667,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_92708d10d1b490dd",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8974,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8971,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6675,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8741bf5ed00f19de/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8971,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8895,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.668,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1f4882d7d3d4a4f2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8895,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8893,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6685,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_043a9d1e59f69085",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8893,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8844,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.669,
       "current_grammar": "BML",
       "current_handler": "api_agent_task",
       "current_required_header": "Accept",
@@ -6412,11 +11817,14984 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.4033,
+      "total_runtime_ms": 4.8844,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.3006,
+      "average_runtime_ms": 4.8834,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6695,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/discovery/lc-v-ceremony",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 4.8834,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8832,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.67,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6aa9d3f8da1224c2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8832,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8705,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6705,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_96c6ec0e13ccc799",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8705,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8703,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.671,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-health-2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8703,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8624,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6715,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1cdd2067dff3fad0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8624,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8619,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.672,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_698737e21cf2a259",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8619,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8613,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6725,
+      "current_grammar": "BML",
+      "current_handler": "api_reaction_concept_threads",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/reactions/concept/lc-the-living-equation/threads",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8613,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8605,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.673,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_32af1256de00283e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8605,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8474,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6735,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-language_view-de",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8474,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8353,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.674,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6447398264aac9aa",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8353,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8352,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6745,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_463510f28993add7",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8352,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8332,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.675,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_465466580d704bf3",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8332,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8168,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6755,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_56e39b4aeda30135",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8168,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8102,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.676,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_481cad1e2613c4f0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8102,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8093,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6765,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_394609be643ba9b4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8093,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.8051,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.677,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_40f1f31e6294ea75",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.8051,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7997,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6775,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2b72dc18285df332/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7997,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7829,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.678,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5aba3ef667db5b76",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7829,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.778,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6785,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_09010a455df425d4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.778,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7765,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.679,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0e166eb9cba485a1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7765,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7716,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6795,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_27f8f4aa7860616f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7716,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7588,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.68,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-circulation-0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7588,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.757,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6805,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7cbb4b68fccb3606/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.757,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7468,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.681,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1ade1ee6a18987ea/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7468,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7468,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6815,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_92708d10d1b490dd/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7468,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7435,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.682,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_238ec924f286c9b2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7435,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7337,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6825,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-vitality-story-1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7337,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7315,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.683,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1539d53c17ad530d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7315,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7254,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6835,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5cd7b1038f2fa8b8/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7254,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.725,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.684,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2b72dc18285df332",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.725,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7198,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6845,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_12a12a3a31feaa4e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7198,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7196,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.685,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_51f684dd0a56b8b5",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7196,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.712,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6855,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_36e47b0f0d400be8",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.712,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7119,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.686,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_056070714d2ed52f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7119,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7108,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6865,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4016cbac57e78053/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7108,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7084,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.687,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_889d0ec2e80d4b38",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7084,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7021,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6875,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-place:seattle-washington-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7021,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.7011,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.688,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2384b5c2981b55dc",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.7011,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6898,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6885,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3a818884f9eae698",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6898,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6862,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.689,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2bdc05401ce373c5/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6862,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6856,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6895,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1239a087069b28e9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6856,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6816,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.69,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/reactions/idea/grant-explanation-traces/threads",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 4.6816,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6811,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6905,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_828a4c77f20c2e76/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6811,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6751,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.691,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_37dd877f4f1a9da6",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6751,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6747,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6915,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_06332092ff017ca7",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6747,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6694,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.692,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8c22c1d2e3e3b4b4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6694,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6691,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6925,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7687d0534f5d8883",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6691,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6673,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.693,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-1774240041",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6673,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6591,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6935,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8e778063cd9c4b2d",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6591,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6576,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.694,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B002V0PW2I",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6576,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6558,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6945,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7f1dadd07e47b70e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6558,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.654,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.695,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7942439d18ce268f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.654,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.652,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6955,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_33526dda2f5aad30",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.652,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.651,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.696,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3a7b05b825cced7f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.651,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6489,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6965,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_010e788be3d1e555/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6489,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6488,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.697,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5b7f44655fab75d6",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6488,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6486,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6975,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_334d86253ab3ee8d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6486,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6473,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.698,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_043a9d1e59f69085/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6473,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6445,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6985,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2c5becf9bdde6616",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6445,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6414,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.699,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-expressing-story-0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6414,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.641,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.6995,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B073VW3VPH",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.641,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6394,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3031cf0066d52f97/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6394,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6374,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7005,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_39fc596ee2ab973e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6374,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6369,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.701,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-w-shakti-story-0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6369,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6323,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7015,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1bc1653b96fd1236/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6323,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.632,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.702,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_126af05f4d59005e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.632,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.631,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7025,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_588ba81dc1088845",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.631,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6201,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.703,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7c9f997249716ff3",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6201,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6191,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7035,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_21defa7fc80f818e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6191,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.618,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.704,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_47e59abc4411700a/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.618,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6166,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7045,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7a8ba12911943605/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6166,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6109,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.705,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_260420d5d37d7049",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6109,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6061,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7055,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-lc-inner-travel",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6061,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6023,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.706,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_57535ef9658e0797/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6023,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.6005,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7065,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0035b13f53905a50/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.6005,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5939,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.707,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_48d5e53fff729c08/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5939,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5936,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7075,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6d468f683c74d479/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5936,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5906,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.708,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7ae3a8deeb01d69b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5906,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5892,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7085,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5d9c88d725606975",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5892,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5881,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.709,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1471ed1c890da5fb",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5881,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5875,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7095,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_66c13e9ee10b4376/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5875,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5857,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.71,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_39fb2e20eae537cf",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5857,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5801,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7105,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-sensing-story-0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5801,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5788,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.711,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1471ed1c890da5fb/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5788,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5737,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7115,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-1713586681",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5737,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5733,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.712,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8d1a62ad5aee9b03",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5733,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5718,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7125,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_02fabc340cd3ef6c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5718,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5671,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.713,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_64d0d8beb68736bf",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5671,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5626,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7135,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6d468f683c74d479",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5626,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5614,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.714,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3ae52c81564f3b90",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5614,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5601,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7145,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_21bdd413fccd3c17/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5601,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5585,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.715,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-attunement-joining-story-1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5585,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.554,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7155,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_45400e630f250de6",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.554,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5482,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.716,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:093975ece6046c7e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5482,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.547,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7165,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0210454af6cfe140",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.547,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5454,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.717,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1bc1653b96fd1236",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5454,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5405,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7175,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0e7b7e6530149f06",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5405,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5364,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.718,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:3d9728d820161239",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5364,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5355,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7185,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_134ea23d55fd7b42",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5355,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5343,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.719,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B00DVN8U82",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5343,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.534,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7195,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0361c6707ffda575",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.534,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5339,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.72,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-land-0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5339,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5339,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7205,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_56e39b4aeda30135/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5339,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5334,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.721,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_06332092ff017ca7/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5334,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5306,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7215,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7687d0534f5d8883/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5306,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5305,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.722,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8bcbc0d54024ec95/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5305,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5285,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7225,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3cbf480179e26c3e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5285,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5254,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.723,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_9289bbca5350c677/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5254,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5214,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7235,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_51772eafef3437f4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5214,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5202,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.724,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_684cf311e957d833/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5202,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5199,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7245,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6f234dbad7a5c452/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5199,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5192,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.725,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B00DC3XD60",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5192,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5182,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7255,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_62d63ccf712b0873/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5182,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5131,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.726,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_672e6889da47f91e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5131,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5119,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7265,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_334ad94aeeb2f49e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5119,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5111,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.727,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_11636eef8aa95834",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5111,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5092,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7275,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8cd808e52eef1b8c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5092,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.506,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.728,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_37032005f35c5c9c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.506,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5045,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7285,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_41770b8c5d7a3bb2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5045,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.5029,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.729,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_43f1117b83ad0eb2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.5029,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4997,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7295,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-audible-the-naked-god-by-peter-f-hamilton-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4997,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4995,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.73,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_010e788be3d1e555",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4995,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4888,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7305,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_134ea23d55fd7b42/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4888,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4884,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.731,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5b913d9f9b248c24",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4884,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4854,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7315,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_885be0e3c1a9575e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4854,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4839,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.732,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5a54baf86bbc453d",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4839,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4837,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7325,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2d33530faf653594/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4837,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.482,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.733,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_30534ff58135b709/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.482,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4704,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7335,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/discovery/lc-network-unanchored",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 4.4704,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4693,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.734,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/discovery/lc-release-what-drifts",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 4.4693,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4679,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7345,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6e7bad7995f86c4c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4679,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4668,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.735,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-ceremony-2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4668,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4613,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7355,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_40323928863e272a",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4613,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4592,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.736,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_767ea280f2c9e5c2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4592,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4561,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7365,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5e91132a137ee7ee/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4561,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4522,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.737,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8bdf59705d73afa7",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4522,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4493,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7375,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6a62e1ed79110cd7",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4493,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4461,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.738,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2ff2afcd1d57b8e1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4461,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4448,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7385,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0feb688940035c43/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4448,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4443,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.739,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_90ccdc1f7daa4c21",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4443,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4388,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7395,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-place:seattle-washington",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4388,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4355,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.74,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2569f35c753c3276",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4355,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4348,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7405,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_38370a08507c672b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4348,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4277,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.741,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_65c091f4110957b9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4277,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4253,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7415,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-103940006X",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4253,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4225,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.742,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-concept-lc-attunement",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4225,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4209,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7425,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_20a6fb896c2ec481",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4209,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4136,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.743,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-spec-value-lineage-and-payout-attribution",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4136,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4129,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7435,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_74b35fa9ffec4aa0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4129,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.409,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.744,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_37dd877f4f1a9da6/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.409,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4076,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7445,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-mile-hi-church-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4076,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4051,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.745,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_62235ff38c43aa83",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4051,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4043,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7455,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7f1dadd07e47b70e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4043,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4037,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.746,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0210454af6cfe140/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4037,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.4023,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7465,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1e4842f53d77bac5/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.4023,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3988,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.747,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2757bcee39a56a0d",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3988,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3937,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7475,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_19ca75f5e6a244d6",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3937,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3936,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.748,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3078956ca6b2f4c3",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3936,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3924,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7485,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_748050f5f2ae9e49",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3924,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3913,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.749,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4af42b8bac8f90f9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3913,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3865,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7495,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_792dfbb074300815/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3865,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.385,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.75,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6317ddfc6fbeaec8/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.385,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3847,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7505,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_394609be643ba9b4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3847,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3845,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.751,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_980c271906a21d94/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3845,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3805,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7515,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6548a0f5fdb06ba6",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3805,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3805,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.752,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_763582508d9ffddf/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3805,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3801,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7525,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_83cc98c5cde495e3",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3801,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3785,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.753,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2265f347664d0790/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3785,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3778,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7535,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_18ec41e05a4059c5",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3778,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3765,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.754,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_02b7a40e9e5496dd",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3765,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3761,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7545,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_869888f550da76e7",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3761,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3758,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.755,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B01DAU1F00",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3758,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3742,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7555,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_828a4c77f20c2e76",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3742,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3731,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.756,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_502f94186f7f4b8b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3731,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3694,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7565,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-artifact:coherence-network-repository-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3694,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3682,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.757,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2757bcee39a56a0d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3682,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3649,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7575,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B005GFQ5WQ",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3649,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3646,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.758,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2ee56b09dcd65e8c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3646,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3638,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7585,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_44d5114185080732",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3638,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3635,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.759,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_40f1f31e6294ea75/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3635,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3612,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7595,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8e3ebc05b213d0d9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3612,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3611,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.76,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6239a24a0cef88f2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3611,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3603,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7605,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7f5e8bfbceafef1b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3603,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3586,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.761,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-phase-transitions-story-1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3586,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3581,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7615,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4dcba05322198d02",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3581,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3559,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.762,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_465466580d704bf3/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3559,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3551,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7625,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_32ac883c002f0fac/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3551,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3537,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.763,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7e565d95f25cb92c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3537,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.353,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7635,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_461f697ad9b99b37/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.353,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3416,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.764,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3fce9aded713cbda/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3416,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3414,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7645,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8126859edfbe67cb",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3414,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3396,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.765,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_80215741908a9495/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3396,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3394,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7655,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2b9bd40f4e216ead",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3394,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3359,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.766,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8088c0b397d99c52",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3359,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3298,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7665,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_857245cf53038aed/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3298,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3295,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.767,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7555f499871c1e3e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3295,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3275,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7675,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7e401f5d8f173ff7/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3275,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3249,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.768,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/reactions/idea/114-collective-coherence-resonance-flow-friction-health/threads",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 4.3249,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3232,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7685,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2ae05c479987cb17",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3232,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3199,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.769,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7eff950352d16fdb",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3199,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3156,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7695,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_26932be493f763f5",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3156,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3148,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.77,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/feed",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3148,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3146,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7705,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6cb0f5053d927e56",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3146,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3134,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.771,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_28a94ee9c8c9ae28/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3134,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.312,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7715,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3fb5e559ebd81707/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.312,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3114,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.772,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5e105967f0dd9f77/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3114,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3106,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7725,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5a812378ea974514/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3106,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3097,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.773,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-attunement-joining-story-0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3097,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3059,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7735,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B0BHJDMHFQ",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3059,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3055,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.774,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-asset:f38bc24449ffbcd2-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3055,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3026,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7745,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_173049489020f566/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3026,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.3025,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.775,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6bf198faeb651094",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.3025,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2978,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7755,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1c0575b17186b3a0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2978,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2971,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.776,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_91a0d94abefb917f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2971,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2964,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7765,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B002V1NSN2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2964,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2959,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.777,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6447398264aac9aa/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2959,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2945,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7775,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_12135455b03903ac/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2945,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2897,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.778,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2dc98555bce7232e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2897,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2879,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7785,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_353de7a2bbde34c8/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2879,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2871,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.779,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_131e19f2543d072d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2871,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.286,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7795,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_14e28e5a9921da4e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.286,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2853,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.78,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/contributor/lc-inner-travel",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 4.2853,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2837,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7805,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_091aacbafe145436/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2837,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2818,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.781,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4e0c921c4ed2ce21/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2818,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2807,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7815,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0883cfbefa768f86",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2807,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2805,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.782,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6bbd7cd96f43f440",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2805,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2802,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7825,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_33ad55b1e0fa6f06/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2802,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2795,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.783,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7d05f3be6f8cd41e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2795,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2763,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7835,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_33ad55b1e0fa6f06",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2763,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2747,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.784,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_698737e21cf2a259/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2747,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2746,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7845,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_62d63ccf712b0873",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2746,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2731,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.785,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1edd6b22edef51ba",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2731,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2682,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7855,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5005632aa6b487b7/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2682,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2636,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.786,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_830701133caafd1e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2636,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.263,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7865,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_731cf2e546e960f5/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.263,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2617,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.787,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0e7b7e6530149f06/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2617,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2582,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7875,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2706bc802bec60ff",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2582,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2572,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.788,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4d6991d2acbea4f2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2572,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2525,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7885,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_293859fc4c354a34/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2525,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.251,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.789,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_748050f5f2ae9e49/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.251,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2509,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7895,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_701a686c5975848f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2509,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2504,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.79,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4a6249b00874ca24",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2504,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2495,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7905,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2384b5c2981b55dc/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2495,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2466,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.791,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_502f94186f7f4b8b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2466,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2448,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7915,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-resonating-story-1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2448,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2428,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.792,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_763582508d9ffddf",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2428,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2409,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7925,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4ffa5c41c5666d7f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2409,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2405,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.793,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_43e7a354deba47fb/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2405,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2394,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7935,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_85b1e7031308feaa",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2394,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2364,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.794,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8b2c6d58e9f1b51e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2364,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.235,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7945,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4fc8b42b35994205",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.235,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.23,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.795,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_038c9ec045b6b308/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.23,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2281,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7955,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_11636eef8aa95834/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2281,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2276,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.796,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6c13359f4f8ac292/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2276,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2243,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7965,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8088c0b397d99c52/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2243,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2226,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.797,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3e8f96decd55e970",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2226,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2225,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7975,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8bbe96ad452c60d9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2225,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2219,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.798,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0feb688940035c43",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2219,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2196,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7985,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_02b7a40e9e5496dd/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2196,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2194,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.799,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5bec794731eded84/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2194,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2178,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.7995,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_39fb2e20eae537cf/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2178,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.217,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1599f57e04040672",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.217,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2164,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8005,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_063bf7d3d39b9c2a/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2164,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2164,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.801,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/proposals/by-idea/grant-explanation-traces",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 4.2164,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2127,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8015,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_95078c7b23c0255b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2127,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2111,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.802,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-ceremony-0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2111,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2111,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8025,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_voices",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-v-ceremony/voices",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2111,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2093,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.803,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_238ec924f286c9b2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2093,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2085,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8035,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_561d964c2dd9493e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2085,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2073,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.804,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_52636ca82c939113",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2073,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2056,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8045,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_45b4d18ecf8e8f6f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2056,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2032,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.805,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_d23f8eb7c3dec8a9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2032,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.2029,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8055,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-circulation-story-1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.2029,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.198,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.806,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8ee17d3ac3f44001",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.198,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1978,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8065,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2811df0dbba62c3b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1978,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1977,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.807,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_24ad15060a8e8a91/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1977,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1973,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8075,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_165ba3727b93ab32",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1973,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1964,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.808,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_401186ee3e04af8c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1964,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1955,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8085,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2dc98555bce7232e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1955,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1936,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.809,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8b02901e5ac77add/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1936,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1924,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8095,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_423c9b14a0583323/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1924,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.19,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.81,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_293859fc4c354a34",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.19,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1897,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8105,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-community-earthship",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1897,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1889,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.811,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_04e48698a403bf0f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1889,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1851,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8115,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5cc34c1f4b25d8fc/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1851,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1828,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.812,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_885be0e3c1a9575e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1828,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1823,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8125,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5e91132a137ee7ee",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1823,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1813,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.813,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3be0b1e2c3bf3657/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1813,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1788,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8135,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_830701133caafd1e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1788,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1753,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.814,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4f8c18bd30ab3f18",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1753,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1749,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8145,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_70bd8e7ccbb97020/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1749,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1731,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.815,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-vitality-story-0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1731,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1718,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8155,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0fd794c14d1c78e0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1718,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1707,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.816,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_18ec41e05a4059c5/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1707,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1651,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8165,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-v-shelter-organism-1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1651,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1648,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.817,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1f77146d19a0bfa9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1648,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1645,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8175,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7f0764fcc8666531/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1645,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1623,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.818,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1edd6b22edef51ba/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1623,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1614,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8185,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/discovery/lc-inner-travel",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 4.1614,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1523,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.819,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8e0ee23a6ce9eaf2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1523,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.152,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8195,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_voices",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-release-what-drifts/voices",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.152,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.151,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.82,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_44d5114185080732/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.151,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1504,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8205,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8ef65636461b5155",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1504,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1496,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.821,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3db134095d08aadc/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1496,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1478,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8215,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5445b9f03dc7dbd7",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1478,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1465,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.822,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6bbd7cd96f43f440/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1465,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1444,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8225,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4ffa5c41c5666d7f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1444,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1426,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.823,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8bb7e7acb77d7340/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1426,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1415,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8235,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_731cf2e546e960f5",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1415,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1401,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.824,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5f0daae16f20eaa5",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1401,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1399,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8245,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_05f7ffa800064757",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1399,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1392,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.825,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_32c943e29218bc0e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1392,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1378,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8255,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_889d0ec2e80d4b38/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1378,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1334,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.826,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_725c28216a56c959/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1334,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1334,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8265,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6bf198faeb651094/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1334,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.131,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.827,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5b7c0abebdb6869c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.131,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1308,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8275,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6f1a731834aa473d",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1308,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.129,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.828,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7e565d95f25cb92c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.129,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1276,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8285,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7f8b623eee94bb6e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1276,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1275,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.829,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3a6d341a020b04a2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1275,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1235,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8295,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4c431f455de6df94",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1235,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1194,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.83,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_008ff9444153f95b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1194,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.119,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8305,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_725c28216a56c959",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.119,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1188,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.831,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_66e11e50d4ac1fcc/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1188,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1171,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8315,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_186bc713604f2ca3",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1171,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.114,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.832,
+      "current_grammar": "",
+      "current_handler": "",
+      "current_required_header": "",
+      "current_source": "",
+      "desired_grammar": "BML route catalog",
+      "endpoint": "/api/views/discovery/lc-the-recipe-remembers-its-source",
+      "event_count": 1,
+      "high_grammar_native": false,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": false,
+      "status": "python-fanout",
+      "total_runtime_ms": 4.114,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1127,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8325,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7ae3a8deeb01d69b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1127,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1111,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.833,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-expressing-story-2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1111,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1108,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8335,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7b7d2ff502364b3a/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1108,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1107,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.834,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7247511123625f46",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1107,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1105,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8345,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-scene-play-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1105,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1056,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.835,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0baa40e51514d1e4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1056,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1045,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8355,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8126859edfbe67cb/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1045,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1029,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.836,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/contributors-78dc5401-46f7-4a8a-bfb9-0350e1c0c72a-portfolio",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1029,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.1027,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8365,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_78eac052fdb12897",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.1027,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.099,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.837,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0b8bb7b80357e49c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.099,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0978,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8375,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-presence-Paradiso-Ubud",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0978,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0955,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.838,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_20770bc64c836606",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0955,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0931,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8385,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2bf58d13bf2f0453/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0931,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0923,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.839,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_781633697aae0578",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0923,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0898,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8395,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_66e11e50d4ac1fcc",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0898,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0875,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.84,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_27f8f4aa7860616f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0875,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.086,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8405,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4dcba05322198d02/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.086,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0855,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.841,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_52636ca82c939113/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0855,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0849,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8415,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8a0e88846b1d764e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0849,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0805,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.842,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-spec-veda-austin-water-lineage",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0805,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0805,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8425,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_24ad15060a8e8a91",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0805,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0797,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.843,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_05d786eb1537318d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0797,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0734,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8435,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-goethes-faust-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0734,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0709,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.844,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3a0e6e4616103ed0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0709,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0708,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8445,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6beb389b1c1b3922/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0708,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0708,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.845,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_66c13e9ee10b4376",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0708,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0676,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8455,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-elders-story-2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0676,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0662,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.846,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_17079f6310c57191",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0662,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0651,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8465,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_85b1e7031308feaa/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0651,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0631,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.847,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_038c9ec045b6b308",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0631,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0629,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8475,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7c14460fba7dd8d1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0629,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0628,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.848,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_31867bb768dab298/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0628,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0613,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8485,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_00fb605e0aa11826",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0613,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0612,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.849,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_80215741908a9495",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0612,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0602,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8495,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_288ff508afd442b7",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0602,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0592,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.85,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7d716496f1bd79a0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0592,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0579,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8505,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_51859b1addfb8f8b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0579,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0567,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.851,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_857c46e4ce2d6c25/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0567,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0554,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8515,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5a54baf86bbc453d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0554,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.055,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.852,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_74b35fa9ffec4aa0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.055,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0516,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8525,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_698fc0604d85f202/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0516,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0488,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.853,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_652570a4d2aec16f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0488,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0475,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8535,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_481cad1e2613c4f0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0475,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0453,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.854,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7a8ba12911943605",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0453,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0451,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8545,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3be0b1e2c3bf3657",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0451,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0445,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.855,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8e0ee23a6ce9eaf2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0445,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0431,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8555,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7c848871b5fbf4d4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0431,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0414,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.856,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_28a94ee9c8c9ae28",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0414,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0391,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8565,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_334d86253ab3ee8d",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0391,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0382,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.857,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3f723d7be81fdf9f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0382,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0366,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8575,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_04e48698a403bf0f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0366,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0346,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.858,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-1774240602",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0346,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0344,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8585,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5aba3ef667db5b76/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0344,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0334,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.859,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_584c82a57b3febbd/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0334,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0333,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8595,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1d9bf1a1dfa0bc55",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0333,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0331,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.86,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4fc8b42b35994205/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0331,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0326,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8605,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3a7b05b825cced7f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0326,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0319,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.861,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0b0f21ab1aa7743f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0319,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0311,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8615,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_87230cb6b336dd2c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0311,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.029,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.862,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_17079f6310c57191/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.029,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0288,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8625,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-contributor:codex",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0288,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0287,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.863,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0b0f21ab1aa7743f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0287,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0287,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8635,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5e5937ce95eff12d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0287,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0284,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.864,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_264b8af6a9813622",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0284,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0228,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8645,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_51772eafef3437f4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0228,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0195,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.865,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3f723d7be81fdf9f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0195,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0194,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8655,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2c5322053279557c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0194,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0182,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.866,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_81a0cd4d12bf3860",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0182,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.016,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8665,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_354a13917054a680/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.016,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0157,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.867,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_26932be493f763f5/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0157,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0152,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8675,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_062e75ff91436232",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0152,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0114,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.868,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_584c82a57b3febbd",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0114,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0084,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8685,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_e8b77f876134d847/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0084,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0084,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.869,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_21bdd413fccd3c17",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0084,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0037,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8695,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-visual-lc-elders-story-2-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0037,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0021,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.87,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_51859b1addfb8f8b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0021,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 4.0005,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8705,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5b9785c016f44121/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 4.0005,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9998,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.871,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_710f72ea3e2272e3/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9998,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.999,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8715,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_57e389030532aedc",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.999,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9958,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.872,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7c848871b5fbf4d4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9958,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9951,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8725,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_41770b8c5d7a3bb2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9951,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9938,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.873,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_33526dda2f5aad30/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9938,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9918,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8735,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5b7c0abebdb6869c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9918,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9911,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.874,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/people-asset:aa2132f21d9b26df-edit",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9911,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9858,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8745,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_331b16153795e5d6/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9858,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9851,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.875,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_64d0d8beb68736bf/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9851,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9836,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8755,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0035b13f53905a50",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9836,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9822,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.876,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8a8cfba459a3ebef/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9822,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9813,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8765,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_588ba81dc1088845/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9813,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9804,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.877,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7942439d18ce268f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9804,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9792,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8775,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_66001bb77067a089",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9792,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9775,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.878,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5e5937ce95eff12d",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9775,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9726,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8785,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_87bebc773d5999e9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9726,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.971,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.879,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_32c943e29218bc0e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.971,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9678,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8795,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-guide-lc-health-guide",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9678,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9667,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.88,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3a0e6e4616103ed0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9667,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9654,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8805,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_a1fec44882c486ec",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9654,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9642,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.881,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6f1a731834aa473d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9642,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9626,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8815,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2c111af9364c762c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9626,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9594,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.882,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7368e9d7ef595601",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9594,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9593,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8825,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3935d94110754e48",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9593,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9566,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.883,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_526942af9eeb326b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9566,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9558,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8835,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_43f1117b83ad0eb2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9558,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9523,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.884,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_934c01d8b9207bfe",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9523,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9494,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8845,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_423c9b14a0583323",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9494,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9479,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.885,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_201869cabd025ba8/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9479,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9441,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8855,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8e778063cd9c4b2d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9441,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9426,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.886,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7c9f997249716ff3/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9426,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9418,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8865,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2ff2afcd1d57b8e1/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9418,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9369,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.887,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_86b041e8e1dcc04b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9369,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9354,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8875,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5b9785c016f44121",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9354,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9335,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.888,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2d33530faf653594",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9335,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9332,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8885,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4af42b8bac8f90f9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9332,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9331,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.889,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-substrate-vocabulary-BDomain.IDEA",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9331,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9322,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8895,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_57e389030532aedc/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9322,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9317,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.89,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6289dab591468b45/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9317,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9307,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8905,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_947acacda19d4c3b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9307,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9298,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.891,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_47150069eed15799/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9298,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.917,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8915,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3d6ea91a18cb0acc",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.917,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9169,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.892,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6f234dbad7a5c452",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9169,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9143,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8925,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2cb1a0f611499a12",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9143,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9124,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.893,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5c256a60ac0c3de0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9124,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9114,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8935,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5bec794731eded84",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9114,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.91,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.894,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_56d473468166f597/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.91,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9095,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8945,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_39fc596ee2ab973e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9095,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9022,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.895,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_66001bb77067a089/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9022,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.9016,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8955,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3b11c03ad227154c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.9016,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8996,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.896,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_652570a4d2aec16f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8996,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.897,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8965,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_05d786eb1537318d",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.897,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8962,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.897,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-instruments-story-2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8962,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8955,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8975,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4c9004ea74124146/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8955,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8914,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.898,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_voices",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-network-unanchored/voices",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8914,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.887,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8985,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_045cdbc596a1fcac/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.887,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8858,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.899,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_00fb605e0aa11826/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8858,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8857,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.8995,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_41069b365e900aa2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8857,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8823,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1d9bf1a1dfa0bc55/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8823,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.882,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9005,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2b9b9b2cbdef0763/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.882,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8811,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.901,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8a19f7ddf6f52e72",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8811,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8807,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9015,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3bba2ee2074a5628",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8807,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8794,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.902,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_73a898d843bce8a3",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8794,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8784,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9025,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1f77146d19a0bfa9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8784,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8782,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.903,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3ae52c81564f3b90/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8782,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8775,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9035,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_097dd9b16abb38ec",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8775,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8767,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.904,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_36188d7d81d995b1/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8767,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8746,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9045,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_710f72ea3e2272e3",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8746,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8726,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.905,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7927d862ece5f5f2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8726,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8693,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9055,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_65102655d6443663",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8693,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8687,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.906,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2d5d3b983421405b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8687,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8606,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9065,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_045cdbc596a1fcac",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8606,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8587,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.907,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2265f347664d0790",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8587,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8561,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9075,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-guide-lc-resonating-guide",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8561,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8549,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.908,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2ae48ba9c5c42b91",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8549,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8509,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9085,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_42a68c8b5ef0cac6/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8509,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8482,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.909,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5cdf926d5f63a9a5/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8482,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8445,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9095,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_33a8f20059bb50f2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8445,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8439,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.91,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7554cf9cfbad81e9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8439,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8411,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9105,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0e2cba7bbb0736e3",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8411,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8411,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.911,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3ef406d6862b22f2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8411,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8382,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9115,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2ae48ba9c5c42b91/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8382,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8379,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.912,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2c111af9364c762c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8379,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8361,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9125,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5c7b6235ca8f74fb",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8361,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8329,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.913,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_91a0d94abefb917f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8329,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8291,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9135,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7e401f5d8f173ff7",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8291,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8225,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.914,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5b7f44655fab75d6/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8225,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8208,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9145,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_063bf7d3d39b9c2a",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8208,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8205,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.915,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7374194101ac92c9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8205,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8192,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9155,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6c13359f4f8ac292",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8192,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8175,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.916,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_126af05f4d59005e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8175,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8169,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9165,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7374194101ac92c9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8169,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8151,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.917,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_27fafa7fc0c00b46",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8151,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8128,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9175,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_83cc98c5cde495e3/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8128,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8096,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.918,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0baa40e51514d1e4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8096,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8092,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9185,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3a818884f9eae698/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8092,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8033,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.919,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_90ccdc1f7daa4c21/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8033,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8009,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9195,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_893e3fa4bd875951/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8009,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.8,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.92,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_062e75ff91436232/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.8,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7992,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9205,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2fb4f51c950d9f12/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7992,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7985,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.921,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_33a8f20059bb50f2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7985,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7981,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9215,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_55243fa835375df8",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7981,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7971,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.922,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8dc9ea8119886766/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7971,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7923,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9225,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_77e0898b2107ee2a/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7923,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7899,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.923,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7927d862ece5f5f2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7899,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7889,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9235,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7778438a3a0176f1/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7889,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7885,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.924,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2c5becf9bdde6616/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7885,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7863,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9245,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6487656f24c562cb",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7863,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7859,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.925,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:bloomurian-the-portal-dome-psychedelic-s-f81825333c80",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7859,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7856,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9255,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_173049489020f566",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7856,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7812,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.926,
+      "current_grammar": "BML",
+      "current_handler": "api_concept_voices",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/concepts/lc-the-recipe-remembers-its-source/voices",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7812,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7731,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9265,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4d944cca783d43d4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7731,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7728,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.927,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_091aacbafe145436",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7728,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7726,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9275,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3ef406d6862b22f2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7726,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7694,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.928,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3bba2ee2074a5628/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7694,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7665,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9285,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8926a39f453ba3ef/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7665,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7597,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.929,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7a32836a96873332/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7597,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7589,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9295,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/profile-rhythm-sanctuary",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7589,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7549,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.93,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5cc34c1f4b25d8fc",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7549,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7527,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9305,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_65102655d6443663/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7527,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7522,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.931,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2811df0dbba62c3b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7522,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7505,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9315,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_131e19f2543d072d",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7505,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7421,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.932,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6548a0f5fdb06ba6/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7421,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7394,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9325,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2706bc802bec60ff/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7394,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7356,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.933,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-presence-Quark-Virtual-DOM",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7356,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.735,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9335,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/substrate-presence-Schindler-HC11-7-layer-protocol-in-hardware",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.735,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7343,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.934,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_80c924f70fd45862",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7343,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7343,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9345,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_72aa87dfc41d51dc",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7343,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7331,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.935,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_399eb3cb27e4ca52",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7331,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7315,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9355,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_fbdd3d502325e7ab/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7315,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7311,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.936,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7f5e8bfbceafef1b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7311,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7262,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9365,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_75f57ebcd1dd547f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7262,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7253,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.937,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_47150069eed15799",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7253,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7234,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9375,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6beb389b1c1b3922",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7234,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7233,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.938,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2f10f2015f841ba7",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7233,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7221,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9385,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_72aa87dfc41d51dc/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7221,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7186,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.939,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6cb0f5053d927e56/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7186,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7164,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9395,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6317ddfc6fbeaec8",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7164,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7088,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.94,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:258c5524-b389-4e5c-8288-dd6d22d87e86",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7088,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7066,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9405,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_26e6697f8c4d06b2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7066,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7043,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.941,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8c22c1d2e3e3b4b4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7043,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7009,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9415,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_19ca75f5e6a244d6/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7009,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.7001,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.942,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2d44ee2dc745d8ef/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.7001,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6989,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9425,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5a812378ea974514",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6989,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.697,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.943,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_95078c7b23c0255b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.697,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.696,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9435,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7a32836a96873332",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.696,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6899,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.944,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_20770bc64c836606/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6899,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6883,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9445,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_331b16153795e5d6",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6883,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6869,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.945,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6a9f9d172f96505c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6869,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6822,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9455,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4f8c18bd30ab3f18/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6822,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6818,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.946,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_26a71efdac3610f0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6818,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6777,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9465,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_260420d5d37d7049/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6777,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6755,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.947,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2d44ee2dc745d8ef",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6755,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6753,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9475,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_32505076ba1055ed/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6753,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6717,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.948,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7778438a3a0176f1",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6717,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6708,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9485,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_26e6697f8c4d06b2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6708,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6639,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.949,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_186bc713604f2ca3/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6639,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6637,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9495,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_746f779297e54f2b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6637,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6617,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.95,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8dc9ea8119886766",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6617,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6605,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9505,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_55243fa835375df8/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6605,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6585,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.951,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_151542d70341915e/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6585,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6584,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9515,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_30534ff58135b709",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6584,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6575,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.952,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8c82099a209695b2/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6575,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6573,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9525,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2fb4f51c950d9f12",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6573,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6565,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.953,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5ebb5402dea1a637/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6565,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.655,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9535,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_463510f28993add7/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.655,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6523,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.954,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-lc-the-recipe-remembers-its-source",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6523,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6511,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9545,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8b2c6d58e9f1b51e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6511,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6479,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.955,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8a19f7ddf6f52e72/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6479,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6479,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9555,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_561d964c2dd9493e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6479,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6456,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.956,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_401186ee3e04af8c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6456,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.639,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9565,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-visual-lc-instruments-0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.639,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6372,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.957,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5b913d9f9b248c24/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6372,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.632,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9575,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8b492aa60d628dd4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.632,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6261,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.958,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_78ea0d151eebc5bd/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6261,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6255,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9585,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_354a13917054a680",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6255,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6229,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.959,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0d473e14254be31f/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6229,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6189,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9595,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3327bc2acb0d2bc4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6189,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6162,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.96,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2f10f2015f841ba7/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6162,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.6052,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9605,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8ee17d3ac3f44001/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.6052,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5964,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.961,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5ebb5402dea1a637",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5964,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5943,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9615,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_61de4ddfca8f2a16/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5943,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5802,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.962,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_51f684dd0a56b8b5/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5802,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5784,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9625,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4a6249b00874ca24/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5784,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5781,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.963,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3eb91ac680d8b06b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5781,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5724,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9635,
+      "current_grammar": "BML",
+      "current_handler": "api_translations_entity",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/translations/page/nodes-asset:audible-B07BN33KPK",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5724,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5721,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.964,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7c14460fba7dd8d1/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5721,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5719,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9645,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_934c01d8b9207bfe/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5719,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5713,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.965,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_45400e630f250de6/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5713,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5676,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9655,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8ef65636461b5155/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5676,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5647,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.966,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_75f57ebcd1dd547f",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5647,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5638,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9665,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8e3ebc05b213d0d9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5638,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5608,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.967,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5cd7b1038f2fa8b8",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5608,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5597,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9675,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3e14c8074134c952",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5597,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5501,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.968,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8a65d15c1def2716/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5501,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5488,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9685,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4c9004ea74124146",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5488,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5347,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.969,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2ee56b09dcd65e8c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5347,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5342,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9695,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8741bf5ed00f19de",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5342,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5339,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.97,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_698fc0604d85f202",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5339,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5316,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9705,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7d716496f1bd79a0/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5316,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5276,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.971,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6036c89e6a2c62c2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5276,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5256,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9715,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3935d94110754e48/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5256,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5089,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.972,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0a99ec91c66793ae/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5089,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5087,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9725,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7c6bff5cacc8eeb9",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5087,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5017,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.973,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6a9f9d172f96505c",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5017,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.5012,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9735,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3eb91ac680d8b06b",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.5012,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4939,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.974,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_14bcb6b1158896ad/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4939,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4917,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9745,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_118c573bf8fdde43",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4917,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4803,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.975,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3e14c8074134c952/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4803,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4765,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9755,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_61de4ddfca8f2a16",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4765,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4744,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.976,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_43e7a354deba47fb",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4744,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4731,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9765,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_1f4882d7d3d4a4f2",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4731,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4626,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.977,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_869888f550da76e7/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4626,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4514,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9775,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3d6ea91a18cb0acc/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4514,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4481,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.978,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_334ad94aeeb2f49e",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4481,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4381,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9785,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_8926a39f453ba3ef",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4381,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4331,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.979,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7554cf9cfbad81e9/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4331,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4325,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9795,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4e0c921c4ed2ce21",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4325,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4316,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.98,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2df3a7d4c119b392",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4316,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4193,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9805,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_461f697ad9b99b37",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4193,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4183,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.981,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_11e7ea09c764e711",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4183,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4157,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9815,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_86b041e8e1dcc04b/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4157,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.4124,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.982,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_02a79f1d70f451d4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.4124,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3977,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9825,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3b11c03ad227154c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3977,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.386,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.983,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2b9bd40f4e216ead/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.386,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3787,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9835,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_14bcb6b1158896ad",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3787,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3754,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.984,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_70bd8e7ccbb97020",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3754,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3749,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9845,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3469de7597785486/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3749,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3724,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.985,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3469de7597785486",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3724,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3705,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9855,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5c256a60ac0c3de0",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3705,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3631,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.986,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_a1fec44882c486ec/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3631,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3616,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9865,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_118c573bf8fdde43/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3616,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3571,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.987,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_27fafa7fc0c00b46/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3571,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3524,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9875,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_11e620bb51876cf4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3524,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3361,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.988,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_5d9c88d725606975/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3361,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3352,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9885,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2df3a7d4c119b392/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3352,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3172,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.989,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_02a79f1d70f451d4",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3172,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3142,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9895,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_3327bc2acb0d2bc4/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3142,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3134,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.99,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_9570e26f75b4e8fe/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3134,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3112,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9905,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_78eac052fdb12897/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3112,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.3078,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.991,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_57e6d03aaa9c82c5/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.3078,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.2938,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9915,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_64430aa8c5fd47f8/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2938,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.2931,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.992,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_6289dab591468b45",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2931,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.2827,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9925,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_87230cb6b336dd2c/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2827,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.2827,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.993,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_7247511123625f46/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2827,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.2698,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9935,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_9570e26f75b4e8fe",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2698,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.2697,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.994,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_76d26796d377ba9d/log",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2697,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.2647,
+      "by_source": {
+        "web_api": 1
+      },
+      "cumulative_traffic_share": 0.9945,
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_77e0898b2107ee2a",
+      "event_count": 1,
+      "high_grammar_native": true,
+      "method": "GET",
+      "methods": [
+        "GET"
+      ],
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2647,
+      "traffic_share": 0.0005
+    },
+    {
+      "average_runtime_ms": 3.2478,
       "by_source": {
         "web_api": 1
       },
@@ -6426,7 +26804,7 @@
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_0337df4443a95ed7",
+      "endpoint": "/api/agent/tasks/task_1ade1ee6a18987ea",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -6435,113 +26813,113 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.3006,
+      "total_runtime_ms": 3.2478,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.2188,
+      "average_runtime_ms": 3.2337,
       "by_source": {
         "web_api": 1
       },
       "cumulative_traffic_share": 0.9955,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/tags",
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_2d5d3b983421405b/log",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.2188,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2337,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.173,
+      "average_runtime_ms": 3.2218,
       "by_source": {
         "web_api": 1
       },
       "cumulative_traffic_share": 0.996,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_5eb073c25b9df1ff/log",
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_781633697aae0578/log",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.173,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2218,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.1049,
+      "average_runtime_ms": 3.2217,
       "by_source": {
         "web_api": 1
       },
       "cumulative_traffic_share": 0.9965,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_79371b205b52fadb/log",
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_893e3fa4bd875951",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.1049,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2217,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.0918,
+      "average_runtime_ms": 3.2198,
       "by_source": {
         "web_api": 1
       },
       "cumulative_traffic_share": 0.997,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/v1/admin",
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_4c431f455de6df94/log",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.0918,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2198,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.0781,
+      "average_runtime_ms": 3.2147,
       "by_source": {
         "web_api": 1
       },
       "cumulative_traffic_share": 0.9975,
       "current_grammar": "BML",
-      "current_handler": "api_field_story_trace",
+      "current_handler": "api_agent_task_log",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/field-stories/urs-field-story/trace/author/Mose - Topic",
+      "endpoint": "/api/agent/tasks/task_11e7ea09c764e711/log",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -6550,44 +26928,44 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.0781,
+      "total_runtime_ms": 3.2147,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.0714,
+      "average_runtime_ms": 3.2088,
       "by_source": {
         "web_api": 1
       },
       "cumulative_traffic_share": 0.998,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "BML route catalog",
-      "endpoint": "/api/admin",
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_0a99ec91c66793ae",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 3.0714,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.2088,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 3.0304,
+      "average_runtime_ms": 3.2029,
       "by_source": {
         "web_api": 1
       },
       "cumulative_traffic_share": 0.9985,
       "current_grammar": "BML",
-      "current_handler": "api_translations_entity",
+      "current_handler": "api_agent_task",
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/translations/page/substrate-concept-lc-relationships-as-mirrors",
+      "endpoint": "/api/agent/tasks/task_901d0665032559e3",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -6596,57 +26974,57 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 3.0304,
+      "total_runtime_ms": 3.2029,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 2.9803,
+      "average_runtime_ms": 3.0906,
       "by_source": {
         "web_api": 1
       },
       "cumulative_traffic_share": 0.999,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_3b0bc50932ace3e3/log",
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_151542d70341915e",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 2.9803,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.0906,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 2.855,
+      "average_runtime_ms": 3.0792,
       "by_source": {
         "web_api": 1
       },
       "cumulative_traffic_share": 0.9995,
-      "current_grammar": "",
-      "current_handler": "",
-      "current_required_header": "",
-      "current_source": "",
-      "desired_grammar": "agent task grammar",
-      "endpoint": "/api/agent/tasks/task_480ea655c45aed09/log",
+      "current_grammar": "BML",
+      "current_handler": "api_agent_task_log",
+      "current_required_header": "Accept",
+      "current_source": "deploy/front-door/api.bml",
+      "desired_grammar": "BML",
+      "endpoint": "/api/agent/tasks/task_02fabc340cd3ef6c/log",
       "event_count": 1,
-      "high_grammar_native": false,
+      "high_grammar_native": true,
       "method": "GET",
       "methods": [
         "GET"
       ],
-      "native_executable": false,
-      "status": "python-fanout",
-      "total_runtime_ms": 2.855,
+      "native_executable": true,
+      "status": "kernel-native-high-grammar",
+      "total_runtime_ms": 3.0792,
       "traffic_share": 0.0005
     },
     {
-      "average_runtime_ms": 2.8132,
+      "average_runtime_ms": 2.997,
       "by_source": {
         "web_api": 1
       },
@@ -6656,7 +27034,7 @@
       "current_required_header": "Accept",
       "current_source": "deploy/front-door/api.bml",
       "desired_grammar": "BML",
-      "endpoint": "/api/agent/tasks/task_4539d67a5c787b0a",
+      "endpoint": "/api/agent/tasks/task_8bb7e7acb77d7340",
       "event_count": 1,
       "high_grammar_native": true,
       "method": "GET",
@@ -6665,7 +27043,7 @@
       ],
       "native_executable": true,
       "status": "kernel-native-high-grammar",
-      "total_runtime_ms": 2.8132,
+      "total_runtime_ms": 2.997,
       "traffic_share": 0.0005
     }
   ],
@@ -6674,6 +27052,6 @@
   "source_requested": "web_api",
   "target_share": 0.9,
   "total_events": 2000,
-  "total_runtime_ms": 716635.8384,
+  "total_runtime_ms": 171310.6599,
   "window_seconds": 86400
 }

--- a/form/form-stdlib/tests/source-language-route-class-template-band.fk
+++ b/form/form-stdlib/tests/source-language-route-class-template-band.fk
@@ -7,6 +7,7 @@
 ; a BML `==` expression, and a valid candidate matrix for the direct route.
 
 (defn route_runtime_health () "ok")
+(defn api_agent_task_log (request) "ok")
 
 section [form.route] {
     def route_runtime_eq_probe(request) = if kh-request-method(request) == "GET" then "eq" else "neq";
@@ -17,6 +18,7 @@ section [form.route] {
         member route: KernelHTTPRoute;
     }
     class RuntimeHealthRoute : RouteCell<KernelHTTPRequest, KernelHTTPResponse> = route("runtime-health", "GET", "/api/runtime/health", 9, "route_runtime_health", "Accept", 0);
+    class AgentTaskLogRoute : RouteCell<KernelHTTPRequest, KernelHTTPResponse> = route("agent-task-log", "GET", "/api/agent/tasks/{task_id}/log", 89, "api_agent_task_log", "Accept", 35);
     class RuntimeDataRoute : RouteCell<KernelHTTPRequest, KernelHTTPResponse> {
         def handle(request) {
             route_runtime_health();

--- a/kernels/SOURCE_LANGUAGE_KERNEL_ROUTER_TRACKING.md
+++ b/kernels/SOURCE_LANGUAGE_KERNEL_ROUTER_TRACKING.md
@@ -55,6 +55,8 @@ graph/domain grammar is asking to emerge; whether the response shape is the
 right shape rather than only the compatible shape; and whether frequency serves
 the highest goal instead of only the route-count goal.
 
+2026-06-12 promotion pass: `GET /api/agent/tasks/{task_id}/log` is now a BML route in `deploy/front-door/api.bml` mapped natively as `/api/agent/tasks/{task_id}/log`. The handler parses the `task_id` segment from the path, connects to the database, queries the task record, checks if `api/logs/task_{task_id}.log` exists, and reads its content. If the file is not found on disk, the handler constructs a fallback snapshot log from DB state fields (`status`, `current_step`, `updated_at`, and `output` limited to 5000 characters), fully matching the Python FastAPI handler's response contract and returning with `log_source: "task_snapshot"` or `"file"`.
+
 2026-06-07 health movement: `GET /api/health` was already BML/high-grammar
 native and the current `web_api` route-goal window read `47/47` observed events
 on `/api/health`, so the movement was not a route-count promotion. The route


### PR DESCRIPTION
Promote the GET /api/agent/tasks/{task_id}/log route to a Form-native BML handler in the front-door catalog.