### PR TITLE
Normalize health deploy config strings

### DIFF
--- a/deploy/front-door/api.bml
+++ b/deploy/front-door/api.bml
@@ -215,8 +215,10 @@ section [form.bml] {
     def api-started-at-iso() = unix_ms_to_iso_utc(kernel_started_unix_ms());
     def api-uptime-seconds() = div(sub(now_unix_ms(), kernel_started_unix_ms()), 1000);
     def api-version() = "1.0.0";
-    def api-deployed-sha() = config_value_or("deployed_sha", "");
-    def api-deployed-sha-source() = if api-deployed-sha() == "" then "" else "config:deployed_sha";
+    def api-string-or(value, default_value) = if str_eq(value_kind(value), "null") then default_value else value;
+    def api-config-string-or(path, default_value) = api-string-or(config_value_or(path, default_value), default_value);
+    def api-deployed-sha() = api-config-string-or("deployed_sha", "");
+    def api-deployed-sha-source() = if str_eq(api-deployed-sha(), "") then "" else "config:deployed_sha";
     def api-strip-trailing-slash(s) = if and(gt(str_len(s), 0), char_at(s, sub(str_len(s), 1)) == "/") then substring(s, 0, sub(str_len(s), 1)) else s;
     def api-gate-main-head-cache-key(repo, branch) = str_concat(repo, str_concat("|", branch));
     def api-gate-main-head-cache-ttl-ms() = mul(config_value_or("release_gates.branch_head_sha_cache_ttl_seconds", 45.0), 1000.0);

--- a/docs/system_audit/commit_evidence_20260612_api_health_config_null.json
+++ b/docs/system_audit/commit_evidence_20260612_api_health_config_null.json
@@ -1,0 +1,86 @@
+{
+  "date": "2026-06-12",
+  "thread_branch": "codex/api-health-config-null-20260612",
+  "commit_scope": "Normalize nullable deploy config strings before native health comparisons",
+  "files_owned": [
+    "deploy/front-door/api.bml"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/tests/json-emitter-band.fk",
+      "scripts/test_hostinger_deploy_form_paths.sh",
+      "git diff --check"
+    ],
+    "notes": "After PR #2891 merged, a 30-probe public /api/health CORS window still caught fatal[type_contract_violation]: as_str: Null at attempt 17 with trace .cache/form-kernel-rust/crash-1781216311100730001-1.json. The remaining concrete health-path comparison was api-deployed-sha-source comparing api-deployed-sha() to an empty string before normalizing explicit config null values. This patch adds api-config-string-or and uses str_eq only after Null is mapped to the default empty string."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "Hostinger Auto Deploy on main after merge",
+      "repeat /api/health CORS probes against https://api.coherencycoin.com"
+    ],
+    "notes": "Deploy proof should show repeated native /api/health CORS probes return 200 without X-Form-Fatal-Kind."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed; PR CI and deploy proof remain pending."
+  },
+  "idea_ids": [
+    "form-os-information-protocol",
+    "native-api-lane",
+    "pipeline-reliability"
+  ],
+  "spec_ids": [
+    "pulse-silence-boundary-repair",
+    "evidence-grounding",
+    "native-route-goal-state"
+  ],
+  "task_ids": [
+    "api-health-config-null-20260612"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5-codex"
+  },
+  "evidence_refs": [
+    "deploy/front-door/api.bml#api-string-or",
+    "deploy/front-door/api.bml#api-config-string-or",
+    "deploy/front-door/api.bml#api-deployed-sha-source",
+    "public-trace:.cache/form-kernel-rust/crash-1781216311100730001-1.json"
+  ],
+  "change_files": [
+    "deploy/front-door/api.bml",
+    "docs/system_audit/commit_evidence_20260612_api_health_config_null.json"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Native /api/health should normalize explicit null deploy config fields before comparison and emit a health JSON response instead of crashing with as_str: Null.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/health"
+    ],
+    "test_flows": [
+      "Probe /api/health repeatedly with Origin: https://coherencycoin.com and verify HTTP 200 plus Access-Control-Allow-Origin.",
+      "Confirm no response includes X-Form-Router: native-kernel-error or X-Form-Fatal-Kind."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- normalize explicit null deploy config values before /api/health compares them
- add api-string-or / api-config-string-or to the BML front-door health area
- keep deployed_sha JSON emission and deployed_sha_source comparison on string values only

## Why
After #2891 merged, repeated public CORS probes still caught one native /api/health fatal after 16 clean native responses:

fatal[type_contract_violation]: as_str: Null
x-form-router: native-kernel-error
x-form-fatal-kind: type_contract_violation
x-form-crash-trace: .cache/form-kernel-rust/crash-1781216311100730001-1.json

#2891 fixed nullable JSON emission. This closes the pre-emission comparison path in api-deployed-sha-source where config_value_or can preserve an explicit JSON null.

## Proof
- make prompt-guide
- make wellness
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/tests/json-emitter-band.fk
- scripts/test_hostinger_deploy_form_paths.sh
- git diff --check
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260612_api_health_config_null.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict