### PR TITLE
tend: a self-contained binary that translates its own model to English and French (shown, running)

### DIFF
--- a/docs/coherence-substrate/numeric-core-symbol-pack.form
+++ b/docs/coherence-substrate/numeric-core-symbol-pack.form
@@ -54,6 +54,12 @@
     (symbol-pack      "an optional list of (op-number, name) pairs in a chosen
                        language. Decoration over the numeric core — removable
                        without loss of identity; swappable for any language")
+    (running-binary   "self-translate.fk emits a 33KB self-contained binary
+                       holding its OWN numeric model + English + French symbol
+                       packs; the SAME binary translates its model to either
+                       language (`scripts/self_translate_demo.sh`): en -> LITERAL
+                       40 / THE INPUT / ADD; fr -> LITTERAL 40 / L ENTREE /
+                       ADDITION; reads nothing external. The two versions, alive")
     (separation-proven "the band: the core's identity is INVARIANT under the pack
                        (c4 lang-independence), the same root carries different
                        words (c1, c3), and the pack strips cleanly (the numeric

--- a/form/form-stdlib/self-translate.fk
+++ b/form/form-stdlib/self-translate.fk
@@ -1,0 +1,40 @@
+; NOTE (2026-06-12): this emitter uses C STRING LITERALS for the symbol packs,
+; which need quote characters. Go and Rust parse the escaped quotes; the TS
+; kernel's string parser currently REJECTS them ("unexpected token rparen") — a
+; real three-way divergence in escaped-quote handling, recorded honestly. So the
+; emitter runs on the Go kernel to produce the binary (the artifact is the
+; binary, not a three-way value); the SEPARATION it demonstrates (numeric core +
+; two packs over one model) is proven three-way, quoteless, by
+; tests/numeric-core-symbol-pack-band.fk. A quoteless rewrite (names as putchar
+; codes) would make the emitter itself three-way — a named next stone.
+;
+; self-translate.fk — a Form recipe that EMITS a self-contained binary holding
+; its own internal model (a program-as-cells) plus English + French symbol packs,
+; able to translate its own model into either language with NO external content.
+; The numeric-core-symbol-pack teaching made into a running binary.
+;
+; The model: a tiny program (LITERAL 40, ARGUMENT, ADD) — its meaning is the
+; numeric node table; the symbol packs are removable name overlays (one per
+; language). The binary walks its OWN table and names each op in the chosen
+; tongue. recipe = the emitter (this file); content = the table + both packs,
+; all baked into the binary.
+
+(defn stx-emit ()
+  (str_concat
+    "extern int putchar(int); "
+    (str_concat
+    "static void pr(const char *s) { while (*s) { putchar(*s); s = s + 1; } } "
+    (str_concat
+    "static void prnum(long long v) { char b[24]; int n = 0; if (v == 0) { putchar(48); } while (v > 0) { b[n] = 48 + v % 10; v = v / 10; n = n + 1; } while (n > 0) { n = n - 1; putchar(b[n]); } } "
+    (str_concat
+    ; the INTERNAL MODEL — the program-as-cells, baked numeric (tag, lit, a, b)
+    "static const long long model[3][4] = { {1,40,0,0}, {2,0,0,0}, {3,0,1,0} }; "
+    (str_concat
+    ; the SYMBOL PACKS — one name per op-tag, two languages, baked in
+    "static const char *en[4] = { \"\", \"LITERAL \", \"THE INPUT\", \"ADD\" }; "
+    (str_concat
+    "static const char *fr[4] = { \"\", \"LITTERAL \", \"L ENTREE\", \"ADDITION\" }; "
+    (str_concat
+    ; main: pick the language from argv, then translate the model row by row
+    "int main(int argc, char **argv) { const char **w = en; if (argc > 1) { if (argv[1][0] == 102) { w = fr; } } "
+    "int i = 0; while (i < 3) { long long t = model[i][0]; pr(w[t]); if (t == 1) { prnum(model[i][1]); } putchar(10); i = i + 1; } return 0; }")))))))))

--- a/scripts/self_translate_demo.sh
+++ b/scripts/self_translate_demo.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# self_translate_demo.sh — emit, compile, and run the self-contained binary that
+# translates its OWN internal model into English and French with no external
+# content. The running proof of numeric-core-symbol-pack.form: identity is the
+# numeric model; the language is a removable symbol pack baked beside it.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"; CLANG="${CLANG:-clang}"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+work="$(mktemp -d "${TMPDIR:-/tmp}/self-xlate.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+{ printf '(do\n'; cat "$FORM/form-stdlib/self-translate.fk"; printf '\n(print "==C==")\n(print (stx-emit))\n(print "==END==")\n0)\n'; } > "$work/driver.fk"
+(cd "$FORM" && "$GO" "$work/driver.fk" 2>/dev/null) | sed -n '/^==C==$/,/^==END==$/p' | sed -e '1d' -e '$d' > "$work/self.c"
+"$CLANG" -O2 -o "$work/self" "$work/self.c"
+echo "self-contained binary: $(wc -c < "$work/self" | tr -d ' ') bytes (internal model + en + fr packs baked in)"
+echo "imports (no fs/net = reads nothing external):"
+otool -Iv "$work/self" 2>/dev/null | grep -iE "_open|_read|_socket|_fopen" | head -3 || true
+echo "-- the binary translating its OWN model -> ENGLISH:"; "$work/self" en
+echo "-- the SAME binary -> FRENCH:";                       "$work/self" fr
+echo "ok — one binary, one numeric model, two languages, zero external content"


### PR DESCRIPTION
Urs: *show me a recipe + content — a self-contained internal model in the binary that translates itself to English and French.*

Shown, running. `form/form-stdlib/self-translate.fk` (the recipe) emits a **33 KB self-contained binary** holding its OWN numeric model (a program-as-cells node table) **plus** English and French symbol packs — all baked in. `scripts/self_translate_demo.sh` emits → clang → runs both:

```
-- the binary translating its OWN model -> ENGLISH:     -- the SAME binary -> FRENCH:
LITERAL 40                                              LITTERAL 40
THE INPUT                                               L ENTREE
ADD                                                     ADDITION
```

Reads **nothing external** (no fs/net imports). The numeric model is the *meaning*; the language is a *removable symbol pack* laid beside it — numeric-core-symbol-pack.form made into a running binary, the two versions alive.

**Honest finding** (recorded in the recipe header): the C-string-literal packs need quote characters; Go and Rust parse the escaped quotes, but the **TS kernel's parser currently rejects them** — a real three-way divergence in escaped-quote handling. So the emitter runs on Go to produce the binary (the artifact is the binary, not a three-way value); the *separation* it demonstrates is proven three-way quoteless by `numeric-core-symbol-pack-band` (→ 31). A quoteless rewrite (names as putchar codes) would make the emitter itself three-way — named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)