### PR TITLE
tend: any language on one numeric-only binary — the symbol pack is a runtime data file (5 languages live)

### DIFF
--- a/docs/coherence-substrate/numeric-core-symbol-pack.form
+++ b/docs/coherence-substrate/numeric-core-symbol-pack.form
@@ -54,6 +54,14 @@
     (symbol-pack      "an optional list of (op-number, name) pairs in a chosen
                        language. Decoration over the numeric core — removable
                        without loss of identity; swappable for any language")
+    (any-language     "self-translate-universal.fk emits a NUMERIC-ONLY core
+                       binary (zero language symbols inside) that LOADS a symbol-
+                       pack file at runtime — so the SAME binary translates its
+                       model into ANY language by swapping the pack, no rebuild;
+                       witnessed live in en/fr/de/es/sa (five tongues, one
+                       binary). Quoteless, so the emitter is three-way clean
+                       (self-translate-universal-band -> 15). Any language is a
+                       data file; the binary is language-free")
     (running-binary   "self-translate.fk emits a 33KB self-contained binary
                        holding its OWN numeric model + English + French symbol
                        packs; the SAME binary translates its model to either

--- a/form/form-stdlib/self-translate-universal.fk
+++ b/form/form-stdlib/self-translate-universal.fk
@@ -1,0 +1,23 @@
+; self-translate-universal.fk — a NUMERIC-ONLY core binary (no language baked in)
+; that LOADS a symbol pack for ANY language at runtime and translates its own
+; model with it. Same binary, swap the pack file, get any tongue — no rebuild.
+; The universal-loader pattern applied to language: identity is the numeric
+; model; the symbol pack is external data, one per language, unbounded.
+;
+; QUOTELESS by design (no C string literals) — so the emitter is three-way clean
+; (avoids the TS escaped-quote divergence self-translate.fk records). Names live
+; in the PACK FILE (one name per op-tag, newline-separated), read through the fs
+; port; the binary carries zero language symbols of its own.
+
+(defn stu-emit ()
+  (str_concat
+    "extern int putchar(int); extern int open(const char *, int); extern long read(int, void *, unsigned long); "
+    (str_concat
+    "static void prnum(long long v) { char b[24]; int n = 0; if (v == 0) { putchar(48); } while (v > 0) { b[n] = 48 + v % 10; v = v / 10; n = n + 1; } while (n > 0) { n = n - 1; putchar(b[n]); } } "
+    (str_concat
+    ; the INTERNAL MODEL — numeric only, language-free
+    "static const long long model[3][4] = { {1,40,0,0}, {2,0,0,0}, {3,0,1,0} }; static char pack[16384]; "
+    (str_concat
+    "int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long g = read(fd, pack, 16383); if (g < 0) { return 3; } pack[g] = 0; "
+    ; walk the model; for each op, print line[tag] of the loaded pack (any language)
+    "int i = 0; while (i < 3) { long long t = model[i][0]; long p = 0; long line = 0; while (line < t) { if (pack[p] == 0) { break; } if (pack[p] == 10) { line = line + 1; } p = p + 1; } while (pack[p] != 0) { if (pack[p] == 10) { break; } putchar(pack[p]); p = p + 1; } if (t == 1) { putchar(32); prnum(model[i][1]); } putchar(10); i = i + 1; } return 0; }")))))

--- a/form/form-stdlib/tests/self-translate-universal-band.fk
+++ b/form/form-stdlib/tests/self-translate-universal-band.fk
@@ -1,0 +1,27 @@
+; preludes: form-stdlib/core.fk form-stdlib/self-translate-universal.fk
+;
+; self-translate-universal-band — the numeric-only core binary that loads a
+; symbol pack for ANY language, proven three-way (quoteless, so all three
+; kernels emit it identically). The live five-language run is the demo
+; (scripts/self_translate_universal_demo.sh); here the kernels prove the emitted
+; core is language-FREE and carries the runtime pack door.
+;
+; Verdict 15 when the universal self-translator holds:
+;   1   the emission carries the INTERNAL MODEL — the numeric node table, the
+;       language-free meaning
+;   2   the core is LANGUAGE-FREE — no language word is baked in (no "ADD", no
+;       "ADDITION"): every name lives in the external pack, the binary carries
+;       zero symbols of any tongue
+;   4   the runtime PACK DOOR is present — open/read load the chosen language's
+;       pack at runtime, so ONE binary serves any language with no rebuild
+;   8   deterministic — two emissions are byte-identical (quoteless, three-way)
+(do
+    (let c (stu-emit))
+    (let c0 (if (ge (str_find c "static const long long model[3][4]" 0) 0) 1 0))
+    (let c1 (if (eq (str_find c "ADD" 0) (sub 0 1))
+                (if (eq (str_find c "ADDITION" 0) (sub 0 1))
+                    (if (eq (str_find c "LITERAL" 0) (sub 0 1)) 2 0) 0) 0))
+    (let c2 (if (ge (str_find c "open(argv[1]" 0) 0)
+                (if (ge (str_find c "read(fd, pack" 0) 0) 4 0) 0))
+    (let c3 (if (str_eq c (stu-emit)) 8 0))
+    (add c0 (add c1 (add c2 c3))))

--- a/scripts/self_translate_universal_demo.sh
+++ b/scripts/self_translate_universal_demo.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# self_translate_universal_demo.sh — emit a NUMERIC-ONLY core binary (zero
+# language symbols), then translate its own model into ANY language by loading a
+# different symbol-pack file. Same binary, swap the pack, get any tongue — no
+# rebuild. numeric-core-symbol-pack.form: identity is numeric, language is data.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"; CLANG="${CLANG:-clang}"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+work="$(mktemp -d "${TMPDIR:-/tmp}/stu.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+{ printf '(do\n'; cat "$FORM/form-stdlib/self-translate-universal.fk"; printf '\n(print "==C==")\n(print (stu-emit))\n(print "==END==")\n0)\n'; } > "$work/driver.fk"
+(cd "$FORM" && "$GO" "$work/driver.fk" 2>/dev/null) | sed -n '/^==C==$/,/^==END==$/p' | sed -e '1d' -e '$d' > "$work/u.c"
+"$CLANG" -O2 -o "$work/u" "$work/u.c"
+echo "numeric-only core binary: $(wc -c < "$work/u" | tr -d ' ') bytes — zero language symbols inside (model + pack-loader only)"
+# a symbol pack per language: line N = the name for op-tag N (1=LIT, 2=ARG, 3=ADD)
+printf '\nLITERAL \nTHE INPUT\nADD\n'        > "$work/en.pack"
+printf '\nLITTERAL \nL ENTREE\nADDITION\n'   > "$work/fr.pack"
+printf '\nLITERAL \nDIE EINGABE\nADDIEREN\n' > "$work/de.pack"
+printf '\nLITERAL \nLA ENTRADA\nSUMAR\n'     > "$work/es.pack"
+printf '\nAKSARA \nNIVESA\nYOGA\n'           > "$work/sa.pack"
+echo "the SAME binary, any language, just by swapping the pack file:"
+for L in en fr de es sa; do echo "  [$L]"; "$work/u" "$work/$L.pack" | sed 's/^/     /'; done
+echo "ok — one numeric-only binary; any language is a symbol-pack file; unbounded, no rebuild"


### PR DESCRIPTION
Urs: *we can do that for any language as a language symbol pack on the same core numeric-only binary, right?*

Yes — and you named the cleaner architecture: the binary stays **numeric-only** (zero language symbols baked in) and **loads a symbol-pack file at runtime**. Swap the pack, get any tongue — no rebuild.

`self-translate-universal.fk` emits a numeric-only core binary (model baked numeric, names loaded from a pack file via the fs port). Witnessed live — the **same binary** translating its own model into **five** languages from five pack files:

```
[en] LITERAL 40 / THE INPUT / ADD        [fr] LITTERAL 40 / L ENTREE / ADDITION
[de] LITERAL 40 / DIE EINGABE / ADDIEREN [es] LITERAL 40 / LA ENTRADA / SUMAR
[sa] AKSARA 40 / NIVESA / YOGA
```

The core is **language-free**; any language is a data file; unbounded.

`self-translate-universal-band` → **15, three-way**: the emission carries the numeric model, is language-free (no ADD/ADDITION/LITERAL baked in), holds the runtime pack door (open/read), deterministic. Bonus: it's **quoteless**, so it also heals the TS escaped-quote divergence the baked-pack version hit — this emitter emits identically on all three kernels. `scripts/self_translate_universal_demo.sh` reproduces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)