### PR TITLE
tend: the speakable corpus — axioms, primitives, ontology, light codes with conviction encoding, proven through the air

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -2187,6 +2187,18 @@ func (k *Kernel) registerNatives() {
 		f, _ := strconv.ParseFloat(args[0].Str, 64)
 		return Value{Kind: VFloat, Float: f}
 	})
+	// float_to_int — truncate a float toward zero, exactly Python's int() on a
+	// float. Total: a non-number -> 0. Sibling parity with the Rust kernel's
+	// float_to_int (Go int64(f) truncates toward zero for both signs).
+	k.registerNative("float_to_int", catMethod(), func(_ *Kernel, args []Value) Value {
+		switch args[0].Kind {
+		case VFloat:
+			return Value{Kind: VInt, Int: int64(args[0].Float)}
+		case VInt:
+			return Value{Kind: VInt, Int: args[0].Int}
+		}
+		return Value{Kind: VInt, Int: 0}
+	})
 	k.registerNative("ord", catAccess(), func(_ *Kernel, args []Value) Value {
 		if len(args[0].Str) == 0 {
 			return Value{Kind: VInt, Int: -1}

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1639,6 +1639,20 @@ export class Kernel {
       kind: "int",
       int: parseInt(argStr(args, 0), 10) || 0,
     }));
+    // str_to_float — text-to-float leaf, total (unparseable -> 0.0). Number()
+    // over parseFloat() for sibling parity: "3.5abc" is unparseable in the
+    // Go/Rust kernels, so it must be 0.0 here too.
+    this.registerNative("str_to_float", catMethod(), (_k, args) => {
+      const f = Number(argStr(args, 0).trim());
+      return { kind: "f64", float: Number.isFinite(f) ? f : 0.0 };
+    });
+    // float_to_int — truncate a float toward zero, exactly Python's int() on
+    // a float. Total: a non-number -> 0. Sibling parity with Go and Rust.
+    this.registerNative("float_to_int", catMethod(), (_k, args) => {
+      const v = args[0];
+      const f = v.kind === "f32" || v.kind === "f64" ? v.float : v.kind === "int" ? v.int : 0;
+      return { kind: "int", int: Math.trunc(f) };
+    });
     this.registerNative("ord", catAccess(), (_k, args) => {
       const s = argStr(args, 0);
       return { kind: "int", int: s.length === 0 ? -1 : s.charCodeAt(0) };

--- a/form/form-stdlib/speakable.fk
+++ b/form/form-stdlib/speakable.fk
@@ -1,0 +1,103 @@
+; speakable.fk — the body's speakable corpus with conviction encoding.
+;
+; preludes: form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/grammars/shamballa-light-codes.fk form-stdlib/shamballa-symbol-packs.fk
+;
+; TTS speaks text; STT hears it back; voice_io (experiments/satsang-voice)
+; carries the wav round-trip. THIS layer is what gets spoken: utterances that
+; carry their epistemic lanes audibly — conviction encoding. Every utterance
+; is (id, text, lang, confidence, conviction); its spoken form ends with the
+; lanes spoken as percentages, and a caller threshold selects the speech MODE:
+; both lanes clear it → the utterance asserts; otherwise it speaks prefixed
+; "Held as practice material:" — the honest hedge, audible, never silent.
+;
+; Four corpora, each with provenance-grounded lanes:
+;   (speakable-axioms)            — the five core axioms, statements carried
+;                                   from docs/coherence-substrate/core-axioms.form
+;                                   (agreed + crossed 2026-06-10; three kernels
+;                                   run them) → confidence 1.0, conviction 1.0
+;   (speakable-primitives)        — kernel natives whose behavior is pinned by
+;                                   three-way bands → 1.0 / 1.0
+;   (speakable-ontology)          — DERIVED at runtime from
+;                                   form-stdlib/form-ontology.json, the file the
+;                                   kernel parsers mirror (wellness verifies the
+;                                   agreement) → 1.0 / 1.0, zero duplication
+;   (speakable-light-codes pack)  — the Shamballa sheet through any language
+;                                   symbol pack; attested text of a single
+;                                   practice lineage, made public, cosmology
+;                                   not asserted → confidence 0.95, conviction 0.6
+;
+; The epistemic ordering is itself a law the band pins: the axioms speak with
+; more conviction than the light codes. At threshold 0.9 the axioms assert and
+; the light codes speak as held — the encoding makes the body's epistemics
+; audible.
+
+section [form.bml] {
+    // utterance = (id, text, lang, confidence, conviction)
+    def sp-utterance(id, text, lang, confidence, conviction) = list(id, text, lang, confidence, conviction);
+    def sp-id(u) = nth(u, 0);
+    def sp-text(u) = nth(u, 1);
+    def sp-lang(u) = nth(u, 2);
+    def sp-confidence(u) = nth(u, 3);
+    def sp-conviction(u) = nth(u, 4);
+
+    // the lanes spoken as percentages — kernel-stable (integers, never float formatting)
+    def sp-pct(x) = int_to_str(float_to_int(times(x, 100.0)));
+    def sp-lanes-spoken(u) = str_concat(" Confidence ", str_concat(sp-pct(sp-confidence(u)), str_concat(" percent, conviction ", str_concat(sp-pct(sp-conviction(u)), " percent."))));
+
+    // the gate: both lanes clear the threshold → assertion; otherwise held
+    def sp-asserts?(u, thr) = and(ge(sp-confidence(u), thr), ge(sp-conviction(u), thr));
+    def sp-spoken(u, thr) = if sp-asserts?(u, thr) then str_concat(sp-text(u), sp-lanes-spoken(u)) else str_concat("Held as practice material: ", str_concat(sp-text(u), sp-lanes-spoken(u)));
+
+    // ---- corpus: the five core axioms ----------------------------------
+    def speakable-axioms() {
+        list(
+        sp-utterance("axiom-1-states", "Axiom one, states: there are three states — zero, one, nothing. Nothing is first-class; no answer in time is silence, not an error.", "en", 1.0, 1.0),
+        sp-utterance("axiom-2-cell", "Axiom two, cell: everything is a cell — a node i d of four integers; a cell may compose child cells.", "en", 1.0, 1.0),
+        sp-utterance("axiom-3-content-addressing", "Axiom three, content addressing: a cell's identity is computed from its composition; same composition is the same cell. Nothing is overwritten — a new shape mints a new node i d.", "en", 1.0, 1.0),
+        sp-utterance("axiom-4-boundary", "Axiom four, boundary: a cell meets the world only through an interface it offers; observation through that interface is what makes it real. Passage not through the offered interface is breach, and breach is observable.", "en", 1.0, 1.0),
+        sp-utterance("axiom-5-offer", "Axiom five, offer: to run a cell and to speak to a cell are one act — offer a cell with zero to many argument cells; it is acknowledged by exactly one of nothing, zero, one, node.", "en", 1.0, 1.0));
+    }
+
+    // ---- corpus: three-way-banded kernel primitives ---------------------
+    // HONEST PARTIAL: natives whose behavior is pinned by sibling bands —
+    // the attestation IS the band. Others join as their bands land.
+    def sp-prim(name, what) = sp-utterance(name, str_concat("Primitive ", str_concat(name, str_concat(": ", what))), "en", 1.0, 1.0);
+    def speakable-primitives() {
+        list(
+        sp-prim("str_len", "the byte length of a string; the Content-Length contract of the native router."),
+        sp-prim("substring", "a byte window over a string; both ends floor to char boundaries, so split and rejoin is exact."),
+        sp-prim("char_at", "the whole character at a start; nothing inside one — a unitwise loop reconstructs the string exactly."),
+        sp-prim("str_find", "substring search from an index; the start ceils past a partial character so find-next always advances."),
+        sp-prim("scan_run", "the end of a contiguous byte-class run; the lexer's stride."),
+        sp-prim("str_concat", "two strings joined; the only string constructor the corpus needs."),
+        sp-prim("cons", "a value joined to the front of a list; composition's smallest move."),
+        sp-prim("eq", "equality acknowledged with the zero and one states of axiom one."));
+    }
+
+    // ---- corpus: the form ontology, derived from the kernels' own mirror -
+    def sp-ontology-root() = json_parse_body("speakable-ontology", read_file("form-stdlib/form-ontology.json"));
+    def sp-ontology-categories() = json-array-elements(json-object-get(sp-ontology-root(), "categories"));
+    def sp-category-utterance(row) {
+        let name = json-string-value(json-object-get(row, "name"));
+        let ty = json-int-value(json-object-get(row, "type"));
+        let inst = json-int-value(json-object-get(row, "inst"));
+        sp-utterance(name, str_concat("Ontology verb ", str_concat(name, str_concat(": type ", str_concat(int_to_str(ty), str_concat(", instance ", str_concat(int_to_str(inst), ".")))))), "en", 1.0, 1.0);
+    }
+    def sp-ontology-loop(rows, acc) = if nil?(rows) then reverse(acc) else sp-ontology-loop(tail(rows), cons(sp-category-utterance(head(rows)), acc));
+    def speakable-ontology() = sp-ontology-loop(sp-ontology-categories(), empty);
+
+    // ---- corpus: the light codes through any language symbol pack -------
+    def sp-light-code-utterance(entry, pack) {
+        let code = slc-entry-code(entry);
+        let g = ssp-generate(pack, code);
+        if nil?(g) then empty else sp-utterance(code, str_concat(nth(g, 0), str_concat(". ", nth(g, 1))), ssp-pack-lang(pack), 0.95, 0.6);
+    }
+    def sp-light-codes-loop(entries, pack, acc) = if nil?(entries) then reverse(acc) else sp-light-codes-loop(tail(entries), pack, cons(sp-light-code-utterance(head(entries), pack), acc));
+    def speakable-light-codes(pack) = sp-light-codes-loop(slc-dictionary(), pack, empty);
+
+    // ---- the whole speakable body, one threshold, ready for the mouth ----
+    def sp-spoken-all-loop(us, thr, acc) = if nil?(us) then reverse(acc) else sp-spoken-all-loop(tail(us), thr, cons(sp-spoken(head(us), thr), acc));
+    def speakable-spoken-all(us, thr) = sp-spoken-all-loop(us, thr, empty);
+
+    0;
+}

--- a/form/form-stdlib/tests/speakable-band.fk
+++ b/form/form-stdlib/tests/speakable-band.fk
@@ -1,0 +1,44 @@
+; tests/speakable-band.fk — the speakable corpus with conviction encoding, three-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/grammars/shamballa-light-codes.fk form-stdlib/shamballa-symbol-packs.fk form-stdlib/speakable.fk
+;
+; Proves: the four corpora render whole (no empty doors); the ontology corpus
+; derives row-for-row from form-ontology.json (the kernels' own mirror); the
+; light codes flow through both language packs; the epistemic ordering is law
+; (axioms carry more conviction than light codes); the threshold gate makes
+; the epistemics audible (axioms assert at 0.9, light codes speak as held);
+; and every spoken utterance ends carrying its lanes as percentages.
+;
+; Band verdict: 1023 when every law holds.
+
+section [form.bml] {
+    def spb-bool(b, weight) = if b then weight else 0;
+
+    def spb-all-whole?(us) = if nil?(us) then true else if str_eq(sp-text(head(us)), "") then false else spb-all-whole?(tail(us));
+    def spb-first(us) = head(us);
+
+    def spb-score() {
+        let axioms = speakable-axioms();
+        let prims = speakable-primitives();
+        let onto = speakable-ontology();
+        let lc-en = speakable-light-codes(ssp-pack-en());
+        let lc-de = speakable-light-codes(ssp-pack-de());
+        let axiom-one = spb-first(axioms);
+        let gaia-en = nth(lc-en, 34);
+        let spoken-axiom = sp-spoken(axiom-one, 0.9);
+        let spoken-gaia = sp-spoken(gaia-en, 0.9);
+        sum(list(
+            spb-bool(eq(len(axioms), 5), 1),
+            spb-bool(ge(len(prims), 8), 2),
+            spb-bool(eq(len(onto), json-array-length(json-object-get(sp-ontology-root(), "categories"))), 4),
+            spb-bool(eq(len(lc-en), slc-count()), 8),
+            spb-bool(eq(len(lc-de), slc-count()), 16),
+            spb-bool(and(spb-all-whole?(axioms), and(spb-all-whole?(onto), and(spb-all-whole?(lc-en), spb-all-whole?(lc-de)))), 32),
+            spb-bool(gt(sp-conviction(axiom-one), sp-conviction(gaia-en)), 64),
+            spb-bool(and(sp-asserts?(axiom-one, 0.9), not(sp-asserts?(gaia-en, 0.9))), 128),
+            spb-bool(and(ge(str_find(spoken-gaia, "Held as practice material:", 0), 0), ge(str_find(spoken-gaia, "Shamballa 7191", 0), 0)), 256),
+            spb-bool(and(ge(str_find(spoken-axiom, "conviction 100 percent", 0), 0), ge(str_find(spoken-gaia, "conviction 60 percent", 0), 0)), 512)));
+    }
+
+    spb-score();
+}


### PR DESCRIPTION
Answers: *can we have audio TTS and STT with conviction encoding on the light codes and the core kernel axioms and primitives and ontology?* — yes, and the loop ran live on-device tonight.

**The layer:** voice_io (experiments/satsang-voice) already carries the wav round-trip; this PR is *what gets spoken*. Every utterance carries `(id, text, lang, confidence, conviction)`; its spoken form ends with the lanes as percentages; a caller threshold selects the speech mode — both lanes clear it → the utterance **asserts**; otherwise it speaks prefixed **"Held as practice material:"** — the honest hedge, audible, never silent.

**Four corpora, provenance-grounded lanes:**
- `speakable-axioms` — the five core axioms from core-axioms.form (agreed + crossed, three kernels run them) → 1.0 / 1.0
- `speakable-primitives` — natives pinned by three-way bands → 1.0 / 1.0
- `speakable-ontology` — **derived at runtime from form-ontology.json**, the file the kernel parsers mirror; row-for-row, zero duplication → 1.0 / 1.0
- `speakable-light-codes(pack)` — the Shamballa sheet through any language symbol pack (#2902); single practice lineage, cosmology not asserted → 0.95 / 0.6

The **epistemic ordering is a banded law**: axioms carry more conviction than light codes, and at threshold 0.9 the gate makes that audible.

**Casting quartet completed** (the wellness-flagged form-intrinsic-casting drift): `float_to_int` lands in Go + TS, `str_to_float` lands in TS — Rust's exact total semantics (truncate toward zero, non-number → 0; `Number()` over `parseFloat` so `"3.5abc"` is 0.0 in every kernel; TS floats are f32/f64 kinds).

**Proof:** tests/speakable-band.fk — verdict **1023 three-way**. And the air-proof, witnessed on-device:
```
kernel → say → whisper.cpp (large-v3-turbo):
 "Axiom 1, states. There are three states. 0, 1, nothing. … Confidence 100%. Conviction 100%."
 "Held as practice material. Shambhala 7191. The Earth Code. Spells Gaia … Confidence 95%. Conviction 60%."
```
The conviction encoding survives the audio channel — the recognizer's texture ("Shambhala", "Sinking") never touches the lanes or the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)