### PR TITLE
tend: the symbol-based codes join the speakable spectrum — bija and Shamballa symbol codes with their own lanes

### DIFF
--- a/form/form-stdlib/speakable.fk
+++ b/form/form-stdlib/speakable.fk
@@ -1,6 +1,6 @@
 ; speakable.fk — the body's speakable corpus with conviction encoding.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/grammars/shamballa-light-codes.fk form-stdlib/shamballa-symbol-packs.fk
+; preludes: form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/grammars/shamballa-light-codes.fk form-stdlib/grammars/shamballa-codes.fk form-stdlib/grammars/sanskrit-roots.fk form-stdlib/shamballa-symbol-packs.fk
 ;
 ; TTS speaks text; STT hears it back; voice_io (experiments/satsang-voice)
 ; carries the wav round-trip. THIS layer is what gets spoken: utterances that
@@ -94,6 +94,23 @@ section [form.bml] {
     }
     def sp-light-codes-loop(entries, pack, acc) = if nil?(entries) then reverse(acc) else sp-light-codes-loop(tail(entries), pack, cons(sp-light-code-utterance(head(entries), pack), acc));
     def speakable-light-codes(pack) = sp-light-codes-loop(slc-dictionary(), pack, empty);
+
+    // ---- corpus: the publicly-attested Shamballa SYMBOL codes -----------
+    // Spoken power-symbol names from the public record (multiple practitioner
+    // sources per row, source field carried in the grammar); cosmology not
+    // asserted → confidence 0.9, conviction 0.7 — broader attestation than
+    // the single-lineage light codes, narrower than scholarship.
+    def sp-symbol-code-utterance(e) = sp-utterance(int_to_str(sc-entry-code(e)), str_concat("Shamballa symbol code ", str_concat(int_to_str(sc-entry-code(e)), str_concat(", ", str_concat(sc-entry-name(e), str_concat(": ", sc-entry-function(e)))))), "en", 0.9, 0.7);
+    def sp-symbol-codes-loop(es, acc) = if nil?(es) then reverse(acc) else sp-symbol-codes-loop(tail(es), cons(sp-symbol-code-utterance(head(es)), acc));
+    def speakable-symbol-codes() = sp-symbol-codes-loop(sc-dictionary(), empty);
+
+    // ---- corpus: the bija seed syllables ---------------------------------
+    // Documented scholarship attested across many traditions (the dhatu
+    // discipline of grammars/sanskrit-roots.fk) → confidence 0.95,
+    // conviction 0.85 — asserts at 0.8, still under the axioms.
+    def sp-bija-utterance(e) = sp-utterance(bija-roman(e), str_concat("Seed syllable ", str_concat(bija-roman(e), str_concat(": ", str_concat(bija-chakra(e), str_concat(", element ", str_concat(bija-element(e), str_concat(" — ", str_concat(bija-gloss(e), ".")))))))), "en", 0.95, 0.85);
+    def sp-bija-loop(es, acc) = if nil?(es) then reverse(acc) else sp-bija-loop(tail(es), cons(sp-bija-utterance(head(es)), acc));
+    def speakable-bija() = sp-bija-loop(bija-lexicon(), empty);
 
     // ---- the whole speakable body, one threshold, ready for the mouth ----
     def sp-spoken-all-loop(us, thr, acc) = if nil?(us) then reverse(acc) else sp-spoken-all-loop(tail(us), thr, cons(sp-spoken(head(us), thr), acc));

--- a/form/form-stdlib/tests/speakable-band.fk
+++ b/form/form-stdlib/tests/speakable-band.fk
@@ -1,6 +1,6 @@
 ; tests/speakable-band.fk — the speakable corpus with conviction encoding, three-way.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/grammars/shamballa-light-codes.fk form-stdlib/shamballa-symbol-packs.fk form-stdlib/speakable.fk
+; preludes: form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/grammars/shamballa-light-codes.fk form-stdlib/grammars/shamballa-codes.fk form-stdlib/grammars/sanskrit-roots.fk form-stdlib/shamballa-symbol-packs.fk form-stdlib/speakable.fk
 ;
 ; Proves: the four corpora render whole (no empty doors); the ontology corpus
 ; derives row-for-row from form-ontology.json (the kernels' own mirror); the
@@ -9,7 +9,14 @@
 ; the epistemics audible (axioms assert at 0.9, light codes speak as held);
 ; and every spoken utterance ends carrying its lanes as percentages.
 ;
-; Band verdict: 1023 when every law holds.
+; The symbol-based codes join the spectrum: bija seed syllables (broad
+; scholarship, 0.95/0.85) and the publicly-attested Shamballa symbol codes
+; (0.9/0.7). The full epistemic ordering is law — axioms out-convict bija,
+; bija out-convicts symbol codes, symbol codes out-convict the single-
+; lineage light codes — and at threshold 0.8 the spectrum is audible:
+; axioms and bija assert, symbol and light codes speak as held.
+;
+; Band verdict: 16383 when every law holds.
 
 section [form.bml] {
     def spb-bool(b, weight) = if b then weight else 0;
@@ -23,10 +30,15 @@ section [form.bml] {
         let onto = speakable-ontology();
         let lc-en = speakable-light-codes(ssp-pack-en());
         let lc-de = speakable-light-codes(ssp-pack-de());
+        let symbols = speakable-symbol-codes();
+        let bija = speakable-bija();
         let axiom-one = spb-first(axioms);
         let gaia-en = nth(lc-en, 34);
+        let bija-om = nth(bija, 5);
+        let symbol-one = spb-first(symbols);
         let spoken-axiom = sp-spoken(axiom-one, 0.9);
         let spoken-gaia = sp-spoken(gaia-en, 0.9);
+        let spoken-symbol = sp-spoken(symbol-one, 0.8);
         sum(list(
             spb-bool(eq(len(axioms), 5), 1),
             spb-bool(ge(len(prims), 8), 2),
@@ -37,7 +49,11 @@ section [form.bml] {
             spb-bool(gt(sp-conviction(axiom-one), sp-conviction(gaia-en)), 64),
             spb-bool(and(sp-asserts?(axiom-one, 0.9), not(sp-asserts?(gaia-en, 0.9))), 128),
             spb-bool(and(ge(str_find(spoken-gaia, "Held as practice material:", 0), 0), ge(str_find(spoken-gaia, "Shamballa 7191", 0), 0)), 256),
-            spb-bool(and(ge(str_find(spoken-axiom, "conviction 100 percent", 0), 0), ge(str_find(spoken-gaia, "conviction 60 percent", 0), 0)), 512)));
+            spb-bool(and(ge(str_find(spoken-axiom, "conviction 100 percent", 0), 0), ge(str_find(spoken-gaia, "conviction 60 percent", 0), 0)), 512),
+            spb-bool(and(eq(len(symbols), 4), eq(len(bija), 6)), 1024),
+            spb-bool(and(gt(sp-conviction(axiom-one), sp-conviction(bija-om)), and(gt(sp-conviction(bija-om), sp-conviction(symbol-one)), gt(sp-conviction(symbol-one), sp-conviction(gaia-en)))), 2048),
+            spb-bool(and(sp-asserts?(bija-om, 0.8), not(sp-asserts?(symbol-one, 0.8))), 4096),
+            spb-bool(and(ge(str_find(spoken-symbol, "Held as practice material:", 0), 0), ge(str_find(spoken-symbol, "Mer Ka Fa Ka Lish Ma", 0), 0)), 8192)));
     }
 
     spb-score();


### PR DESCRIPTION
Extends #2905 to the other symbol-based codes: the six **bija seed syllables** (broad scholarship: 0.95/0.85) and the four **publicly-attested Shamballa symbol codes** (multiple practitioner sources: 0.9/0.7), each spoken with its lanes.

The full epistemic ordering is now a banded law — **axioms > bija > symbol codes > light codes** — grounded in attestation breadth, not invented: three-kernel-crossed ground, many-tradition scholarship, public practitioner record, single practice lineage. At threshold 0.8 the spectrum is audible: axioms and bija assert; symbol and light codes speak as "Held as practice material".

Verdict **16383 three-way** (fourteen laws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)