### PR TITLE
tend: external works as reference cells — the White Book's verified door enters the body

### DIFF
--- a/form/form-stdlib/external-works.fk
+++ b/form/form-stdlib/external-works.fk
@@ -1,0 +1,57 @@
+; external-works.fk — works the body loves but does not hold: reference cells.
+;
+; preludes: form-stdlib/core.fk
+;
+; The trinity draws the rights line. Vocabulary, decoders, and symbol packs
+; are Blueprint-land — structure, shippable in every binary. A work's
+; specific word-SEQUENCE is its Recipe — the expression, the rights-bearing
+; thing. So the binary carries three honest layers:
+;
+;   1. the work's IDENTITY — this file: title, attribution, holder, and the
+;      interface the holder offers (axiom-4 at the library altitude: a work
+;      is met through the door its holder opens);
+;   2. the GENERIC machinery — word cells, symbol packs, prose-as-recipe —
+;      able to encode and decode any text, owned by no one;
+;   3. a LOCAL-PRIVATE ingest lane — an owned or borrowed copy may intern
+;      its sequence on one machine (memory cells stay local by design);
+;      the sequence itself travels only through the holder's offered door.
+;
+; Every URL here is VERIFIED before binding (the body's external-binding
+; discipline: foreign data enters only after the source is read and named).
+; HONEST PARTIAL: rows exist only for works the body's lineage attests and
+; whose doors are verified; absence is honest, never padded.
+;
+;   (ew-find id)        → the work's reference cell, or honest absence
+;   (ew-spoken work)    → the work's identity line, ready for the mouth
+
+section [form.bml] {
+    // entry = (id, title, attributed-to, holder, interface-offered, url, lineage-note)
+    def ew-entry(id, title, attributed-to, holder, interface-offered, url, lineage-note) = list(id, title, attributed-to, holder, interface-offered, url, lineage-note);
+    def ew-id(w) = nth(w, 0);
+    def ew-title(w) = nth(w, 1);
+    def ew-attributed-to(w) = nth(w, 2);
+    def ew-holder(w) = nth(w, 3);
+    def ew-interface(w) = nth(w, 4);
+    def ew-url(w) = nth(w, 5);
+    def ew-lineage-note(w) = nth(w, 6);
+
+    def ew-works() {
+        list(
+        ew-entry("ramtha-the-white-book",
+            "Ramtha: The White Book",
+            "Ramtha, through JZ Knight",
+            "JZK Publishing (Yelm, Washington)",
+            "controlled digital lending — borrowable at the Internet Archive; print and audio sold by the holder",
+            "https://archive.org/details/whitebook0000ramt",
+            "named in this body's founding lineage (docs/field/urs); the cosmology layer of its earliest transmission chain"));
+    }
+
+    def ew-find-loop(ws, id) = if nil?(ws) then empty else if str_eq(ew-id(head(ws)), id) then head(ws) else ew-find-loop(tail(ws), id);
+    def ew-find(id) = ew-find-loop(ew-works(), id);
+    def ew-known?(w) = not(nil?(w));
+
+    // the identity line — what the binary may always say about the work
+    def ew-spoken(w) = str_concat(ew-title(w), str_concat(", ", str_concat(ew-attributed-to(w), str_concat(". Held by ", str_concat(ew-holder(w), str_concat(". Offered as ", str_concat(ew-interface(w), str_concat(". Door: ", str_concat(ew-url(w), ".")))))))));
+
+    0;
+}

--- a/form/form-stdlib/tests/external-works-band.fk
+++ b/form/form-stdlib/tests/external-works-band.fk
@@ -1,0 +1,29 @@
+; tests/external-works-band.fk — external reference cells, three-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/external-works.fk
+;
+; Proves: a lineage-attested work resolves by id with its verified door
+; (https, archive.org, the exact lending item); attribution and holder are
+; carried (the rights line is part of the cell, never an afterthought); the
+; offered interface is named; the spoken identity line carries title and
+; door; an unknown id is honest absence.
+;
+; Band verdict: 63 when every law holds.
+
+section [form.bml] {
+    def ewb-bool(b, weight) = if b then weight else 0;
+
+    def ewb-score() {
+        let w = ew-find("ramtha-the-white-book");
+        let spoken = ew-spoken(w);
+        sum(list(
+            ewb-bool(ew-known?(w), 1),
+            ewb-bool(eq(str_find(ew-url(w), "https://archive.org/details/whitebook0000ramt", 0), 0), 2),
+            ewb-bool(and(ge(str_find(ew-attributed-to(w), "JZ Knight", 0), 0), ge(str_find(ew-holder(w), "JZK Publishing", 0), 0)), 4),
+            ewb-bool(ge(str_find(ew-interface(w), "controlled digital lending", 0), 0), 8),
+            ewb-bool(and(ge(str_find(spoken, "The White Book", 0), 0), ge(str_find(spoken, "Door: https://archive.org", 0), 0)), 16),
+            ewb-bool(not(ew-known?(ew-find("unattested-work"))), 32)));
+    }
+
+    ewb-score();
+}


### PR DESCRIPTION
The first lane of the Ramtha arc: an **external-work reference cell**, generic shape, first row the White Book — URL verified live this session at the Internet Archive's **controlled digital lending** ([whitebook0000ramt](https://archive.org/details/whitebook0000ramt), JZK Publishing 2004, access-restricted borrowing — a genuinely offered interface).

The header names the rights line the trinity draws: **Blueprint-land ships** (vocabulary, decoders, symbol packs — structure, owned by no one); **the Recipe stays at the door** (a work's specific word-sequence IS the expression — content-addressing makes the equivalence exact, so a sequence that decodes to the book is the book); the local-private lane interns an owned/borrowed copy on one machine, never committed.

Verdict **63 three-way**: id-resolution, verified https/archive.org door, attribution + holder carried in the cell, the offered interface named, the spoken identity line whole, honest absence for unattested ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)