### PR TITLE
tend: sibling kernels agree on every band — compare contract aligned, legs get their own scratch

### DIFF
--- a/form/form-kernel-go/core/core.go
+++ b/form/form-kernel-go/core/core.go
@@ -182,6 +182,36 @@ func (v Value) AsFloat() float64 {
 	panic(fmt.Sprintf("AsFloat: %v", v))
 }
 
+// AsNid — the NodeID-typed boundary: only a VNodeID passes. Reading .Nid
+// raw on any other kind yields the zero NodeID — a silent false positive
+// (two mistyped values "agree"); naming the violation is the honest answer.
+// Sibling to Rust's as_nid and TS's argNodeID.
+func (v Value) AsNid() NodeID {
+	if v.Kind == VNodeID {
+		return v.Nid
+	}
+	panic(fmt.Sprintf("as_nid: %v", v))
+}
+
+// AsInt — the integer lane's coercion: ints pass through, floats truncate,
+// bools are the 0/1 states (axiom-1, core-axioms.form). Any other kind is a
+// type-contract violation — str_eq, node_eq, and value_eq are the typed
+// doors for those kinds. Sibling to Rust's as_int and the TS compare lane.
+func (v Value) AsInt() int64 {
+	switch v.Kind {
+	case VInt:
+		return v.Int
+	case VFloat:
+		return int64(v.Float)
+	case VBool:
+		if v.Bool {
+			return 1
+		}
+		return 0
+	}
+	panic(fmt.Sprintf("as_int: %v", v))
+}
+
 // FormatFloatJS — JS String(number) semantics: shortest round-trippable form,
 // NaN/Infinity spelled out.
 func FormatFloatJS(f float64) string {

--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -1898,7 +1898,7 @@ func (k *Kernel) registerNatives() {
 	//
 	// record_new — (record_new blueprint k1 v1 k2 v2 ...) → Record.
 	k.registerNative("record_new", catMethod(), func(k *Kernel, args []Value) Value {
-		rec := &Record{Blueprint: args[0].Nid}
+		rec := &Record{Blueprint: args[0].AsNid()}
 		i := 1
 		for i+1 < len(args) {
 			rec.Set(k.internName(args[i].Str), args[i+1])
@@ -1950,7 +1950,7 @@ func (k *Kernel) registerNatives() {
 		if args[2].Kind != VClosure {
 			panic("method_define: third arg must be a closure")
 		}
-		k.methods[methodKey{args[0].Nid, k.internName(args[1].Str)}] = args[2].Cl
+		k.methods[methodKey{args[0].AsNid(), k.internName(args[1].Str)}] = args[2].Cl
 		return args[0]
 	})
 	// method_has — (method_has record-or-blueprint "name") → bool.
@@ -2770,7 +2770,7 @@ func (k *Kernel) registerNatives() {
 	//   Serializes a Recipe subtree to the .fkb wire format as a byte
 	//   list — usable over any byte channel without a file detour.
 	k.registerNative("recipe_to_bytes", catWitness(), func(k *Kernel, args []Value) Value {
-		bytes := serializeArtifact(k, args[0].Nid)
+		bytes := serializeArtifact(k, args[0].AsNid())
 		out := make([]Value, len(bytes))
 		for i, b := range bytes {
 			out[i] = Value{Kind: VInt, Int: int64(b)}
@@ -3026,7 +3026,7 @@ func (k *Kernel) registerNatives() {
 	// fresh string tables on load. This format embeds the strings.
 	k.registerNative("write_form_binary", catCall(), func(k *Kernel, args []Value) Value {
 		path := resolveKernelHostPath(args[0].Str)
-		nid := args[1].Nid
+		nid := args[1].AsNid()
 		bytes := serializeArtifact(k, nid)
 		if err := os.WriteFile(path, bytes, 0644); err != nil {
 			return Value{Kind: VInt, Int: -1}
@@ -3484,10 +3484,10 @@ func (k *Kernel) registerNatives() {
 	})
 
 	k.registerNative("intern_node", catWitness(), func(k *Kernel, args []Value) Value {
-		cat := args[0].Nid
+		cat := args[0].AsNid()
 		kids := make([]NodeID, len(args[1].List))
 		for i, c := range args[1].List {
-			kids[i] = c.Nid
+			kids[i] = c.AsNid()
 		}
 		return Value{Kind: VNodeID, Nid: k.intern(cat, kids)}
 	})
@@ -3553,10 +3553,10 @@ func (k *Kernel) registerNatives() {
 		return Value{Kind: VList, List: k.substrateGC(args[0].List, nil)}
 	})
 	k.registerNative("node_category", catWitness(), func(k *Kernel, args []Value) Value {
-		return Value{Kind: VNodeID, Nid: k.category(args[0].Nid)}
+		return Value{Kind: VNodeID, Nid: k.category(args[0].AsNid())}
 	})
 	k.registerNative("node_children", catWitness(), func(k *Kernel, args []Value) Value {
-		kids := k.children(args[0].Nid)
+		kids := k.children(args[0].AsNid())
 		out := make([]Value, len(kids))
 		for i, c := range kids {
 			out[i] = Value{Kind: VNodeID, Nid: c}
@@ -3564,19 +3564,19 @@ func (k *Kernel) registerNatives() {
 		return Value{Kind: VList, List: out}
 	})
 	k.registerNative("node_value", catWitness(), func(k *Kernel, args []Value) Value {
-		return k.trivialValue(args[0].Nid)
+		return k.trivialValue(args[0].AsNid())
 	})
 	k.registerNative("node_pkg", catWitness(), func(_ *Kernel, args []Value) Value {
-		return Value{Kind: VInt, Int: int64(args[0].Nid.Pkg)}
+		return Value{Kind: VInt, Int: int64(args[0].AsNid().Pkg)}
 	})
 	k.registerNative("node_level", catWitness(), func(_ *Kernel, args []Value) Value {
-		return Value{Kind: VInt, Int: int64(args[0].Nid.Level)}
+		return Value{Kind: VInt, Int: int64(args[0].AsNid().Level)}
 	})
 	k.registerNative("node_type", catWitness(), func(_ *Kernel, args []Value) Value {
-		return Value{Kind: VInt, Int: int64(args[0].Nid.Type)}
+		return Value{Kind: VInt, Int: int64(args[0].AsNid().Type)}
 	})
 	k.registerNative("node_inst", catWitness(), func(_ *Kernel, args []Value) Value {
-		return Value{Kind: VInt, Int: int64(args[0].Nid.Inst)}
+		return Value{Kind: VInt, Int: int64(args[0].AsNid().Inst)}
 	})
 	// node_eq — compare two NodeIDs structurally. Sibling to Rust's node_eq.
 	// Form code (emit-engine.fk lookup-template) uses this for category
@@ -3609,11 +3609,11 @@ func (k *Kernel) registerNatives() {
 	// state is traceable back to the recipe lines that authored it.
 	// Args: (category, children, file_string, line_int, col_int)
 	k.registerNative("intern_node_at", catWitness(), func(k *Kernel, args []Value) Value {
-		cat := args[0].Nid
+		cat := args[0].AsNid()
 		kidsV := args[1].List
 		kids := make([]NodeID, len(kidsV))
 		for i, c := range kidsV {
-			kids[i] = c.Nid
+			kids[i] = c.AsNid()
 		}
 		nid := k.intern(cat, kids)
 		fileNid := k.internString(args[2].Str)
@@ -3628,7 +3628,7 @@ func (k *Kernel) registerNatives() {
 	// node_source — read back a Recipe's source attribution.
 	// Returns (list file_string line col) or empty list if none recorded.
 	k.registerNative("node_source", catWitness(), func(k *Kernel, args []Value) Value {
-		loc, ok := k.sourceAttr[args[0].Nid]
+		loc, ok := k.sourceAttr[args[0].AsNid()]
 		if !ok {
 			return Value{Kind: VList, List: []Value{}}
 		}
@@ -3723,7 +3723,7 @@ func (k *Kernel) registerNatives() {
 	// NodeID is reconstructed at deserialize via intern.
 	k.registerNative("serialize-recipe", catWitness(), func(k *Kernel, args []Value) Value {
 		bytes := []byte{}
-		bytes = serializeNid(k, args[0].Nid, bytes)
+		bytes = serializeNid(k, args[0].AsNid(), bytes)
 		out := make([]Value, len(bytes))
 		for i, b := range bytes {
 			out[i] = Value{Kind: VInt, Int: int64(b)}
@@ -3791,14 +3791,14 @@ func (k *Kernel) registerNatives() {
 	})
 	// walk-cached — JIT-vector memoization. Caller asserts purity.
 	k.registerNative("walk-cached", catWitness(), func(k *Kernel, args []Value) Value {
-		if v, ok := k.walkCache[args[0].Nid]; ok {
+		if v, ok := k.walkCache[args[0].AsNid()]; ok {
 			k.walkCacheHits++
 			return v
 		}
 		k.walkCacheMisses++
 		env := NewFrame(nil)
-		v := k.walk(args[0].Nid, env)
-		k.walkCache[args[0].Nid] = v
+		v := k.walk(args[0].AsNid(), env)
+		k.walkCache[args[0].AsNid()] = v
 		return v
 	})
 	k.registerNative("walk-cache-clear", catWitness(), func(k *Kernel, _ []Value) Value {
@@ -3867,7 +3867,7 @@ func (k *Kernel) registerNatives() {
 	})
 	k.registerNative("walk_recipe", catWitness(), func(k *Kernel, args []Value) Value {
 		env := NewFrame(nil)
-		return k.walk(args[0].Nid, env)
+		return k.walk(args[0].AsNid(), env)
 	})
 	// walk_recipe_here — walks a Recipe in the CALLER's env, so let-
 	// bindings inside the Recipe land in the caller's scope. This is
@@ -3882,8 +3882,8 @@ func (k *Kernel) registerNatives() {
 		// aren't reachable from the source-parsed root, so without this pin
 		// a subsequent substrate_gc would sweep them and leave the env
 		// holding closures with deleted bodies.
-		k.activeRoots = append(k.activeRoots, args[0].Nid)
-		return k.walk(args[0].Nid, env)
+		k.activeRoots = append(k.activeRoots, args[0].AsNid())
+		return k.walk(args[0].AsNid(), env)
 	})
 	walkParallel := func(k *Kernel, args []Value) Value {
 		roots := make([]NodeID, len(args[0].List))
@@ -4062,6 +4062,21 @@ func (k *Kernel) registerNatives() {
 	k.registerNative("now_unix_ms", catCall(), func(_ *Kernel, _ []Value) Value {
 		return Value{Kind: VInt, Int: time.Now().UnixMilli()}
 	})
+
+	// `temp_dir` — the host's scratch directory: TMPDIR when the carrier
+	// names one, /tmp otherwise (no trailing slash). External read (host
+	// env) so it's catCall. The door that lets a band's scratch files land
+	// in per-leg space: validate.sh points each sibling kernel at its own
+	// TMPDIR, so concurrent legs never share a scratch path. Sibling
+	// parity holds on shape, NOT on value — each leg's dir differs by
+	// design; bands fold the path into effects, never into the verdict.
+	k.registerNative("temp_dir", catCall(), func(_ *Kernel, _ []Value) Value {
+		dir := os.Getenv("TMPDIR")
+		if dir == "" {
+			dir = "/tmp"
+		}
+		return Value{Kind: VStr, Str: strings.TrimRight(dir, "/")}
+	})
 }
 
 // Category constructors for native attribution live further down alongside
@@ -4167,8 +4182,8 @@ func (k *Kernel) walk(n NodeID, env *Frame) Value {
 					return boolInt(l >= r)
 				}
 			}
-			a := lv.Int
-			b := rv.Int
+			a := lv.AsInt()
+			b := rv.AsInt()
 			switch cat.Inst {
 			case RCompareEq:
 				return boolInt(a == b)

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -5872,6 +5872,20 @@ impl Kernel {
             Value::Int(now_unix_ms_value())
         });
 
+        // `temp_dir` — the host's scratch directory: TMPDIR when the carrier
+        // names one, /tmp otherwise (no trailing slash). External read (host
+        // env) so it's cat_call. The door that lets a band's scratch files
+        // land in per-leg space: validate.sh points each sibling kernel at
+        // its own TMPDIR, so concurrent legs never share a scratch path.
+        // Sibling parity holds on shape, NOT on value — each leg's dir
+        // differs by design; bands fold the path into effects, never into
+        // the verdict.
+        self.register_native("temp_dir", cat_call(), |_, _, _| {
+            let dir = std::env::var("TMPDIR").unwrap_or_default();
+            let dir = if dir.is_empty() { "/tmp".to_string() } else { dir };
+            Value::Str(dir.trim_end_matches('/').to_string().into())
+        });
+
         // No Form category claimed — `trace` is a debug surface, honest
         // about being outside the structural vocabulary.
         self.register_native("trace", cat_undefined(), |_, _, args| {

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1263,7 +1263,10 @@ export class Kernel {
       case "f64":
         return String(v.float);
       case "str":
-        return JSON.stringify(v.str);
+        // Bare, not JSON-quoted — the Go (Value.String) and Rust
+        // (Value::display) siblings render strings without quotes, and
+        // band outputs are byte-compared across kernels.
+        return v.str;
       case "bool":
         return v.bool ? "true" : "false";
       case "list":
@@ -3235,6 +3238,18 @@ export class Kernel {
       int: Date.now(),
     }));
 
+    // `temp_dir` — the host's scratch directory: TMPDIR when the carrier
+    // names one, /tmp otherwise (no trailing slash). External read (host
+    // env) so it's catCall. The door that lets a band's scratch files land
+    // in per-leg space: validate.sh points each sibling kernel at its own
+    // TMPDIR, so concurrent legs never share a scratch path. Sibling
+    // parity holds on shape, NOT on value — each leg's dir differs by
+    // design; bands fold the path into effects, never into the verdict.
+    this.registerNative("temp_dir", catCall(), (_k, _args) => ({
+      kind: "str",
+      str: (process.env["TMPDIR"] ?? "/tmp").replace(/\/+$/, "") || "/tmp",
+    }));
+
     // `unix_ms_to_iso_utc` — render a millisecond instant as the
     // second-resolution ISO UTC string the Go carrier emits.
     this.registerNative("unix_ms_to_iso_utc", catCall(), (_k, args) => ({
@@ -4487,20 +4502,22 @@ function walkCompare(
 
   // A comparison acknowledges with the 0/1 integer states (axiom-1,
   // core-axioms.form) so its answer flows directly into arithmetic —
-  // the shape the compiled lane's JS coercion already implied. Proven
-  // three-way by tests/eq-shape-band.fk.
-  if (op === RCmp.EQ || op === RCmp.NE) {
-    const equal = valueEqual(av, bv);
-    return boolInt(op === RCmp.EQ ? equal : !equal);
-  }
-
-  // Width-mixing in comparisons: if either side is float, compare as float;
-  // if either side is bigint, compare as bigint; else as int.
+  // the shape the compiled lane's JS coercion already implied. Operands
+  // meet the same numeric coercion in every lane: bools are the 0/1
+  // states, and non-numeric kinds are a type-contract violation —
+  // str_eq, node_eq, and value_eq are the typed doors for those kinds.
+  // Sibling to the Go and Rust walkers; proven three-way by
+  // tests/eq-shape-band.fk.
+  //
+  // Width-mixing: if either side is float, compare as float; if either
+  // side is bigint, compare as bigint; else as int.
   let r: boolean;
   if (av.kind === "f32" || av.kind === "f64" || bv.kind === "f32" || bv.kind === "f64") {
-    const a = expectFloat(av, "compare");
-    const b = expectFloat(bv, "compare");
+    const a = av.kind === "bool" ? (av.bool ? 1 : 0) : expectFloat(av, "compare");
+    const b = bv.kind === "bool" ? (bv.bool ? 1 : 0) : expectFloat(bv, "compare");
     switch (op) {
+      case RCmp.EQ: r = a === b; break;
+      case RCmp.NE: r = a !== b; break;
       case RCmp.LT: r = a < b; break;
       case RCmp.LE: r = a <= b; break;
       case RCmp.GT: r = a > b; break;
@@ -4508,9 +4525,11 @@ function walkCompare(
       default: throw new Error(`compare: unknown op ${op}`);
     }
   } else if (av.kind === "i64" || av.kind === "u64" || bv.kind === "i64" || bv.kind === "u64") {
-    const a = expectBigInt(av, "compare");
-    const b = expectBigInt(bv, "compare");
+    const a = av.kind === "bool" ? (av.bool ? 1n : 0n) : expectBigInt(av, "compare");
+    const b = bv.kind === "bool" ? (bv.bool ? 1n : 0n) : expectBigInt(bv, "compare");
     switch (op) {
+      case RCmp.EQ: r = a === b; break;
+      case RCmp.NE: r = a !== b; break;
       case RCmp.LT: r = a < b; break;
       case RCmp.LE: r = a <= b; break;
       case RCmp.GT: r = a > b; break;
@@ -4518,9 +4537,11 @@ function walkCompare(
       default: throw new Error(`compare: unknown op ${op}`);
     }
   } else {
-    const a = expectInt(av, "compare");
-    const b = expectInt(bv, "compare");
+    const a = av.kind === "bool" ? (av.bool ? 1 : 0) : expectInt(av, "compare");
+    const b = bv.kind === "bool" ? (bv.bool ? 1 : 0) : expectInt(bv, "compare");
     switch (op) {
+      case RCmp.EQ: r = a === b; break;
+      case RCmp.NE: r = a !== b; break;
       case RCmp.LT: r = a < b; break;
       case RCmp.LE: r = a <= b; break;
       case RCmp.GT: r = a > b; break;

--- a/form/form-stdlib/tests/async-correlation-band.fk
+++ b/form/form-stdlib/tests/async-correlation-band.fk
@@ -15,8 +15,8 @@
 
     ;; A separate /tmp path so this band doesn't collide with the
     ;; sample or other band runs.
-    (let request-path "/tmp/async-correlation-band-req.fkb")
-    (let reply-path   "/tmp/async-correlation-band-rep.fkb")
+    (let request-path (str_concat (temp_dir) "/async-correlation-band-req.fkb"))
+    (let reply-path   (str_concat (temp_dir) "/async-correlation-band-rep.fkb"))
     (channel-create request-path)
     (channel-create reply-path)
 

--- a/form/form-stdlib/tests/bml-compiler-fkb-image-proof.fk
+++ b/form/form-stdlib/tests/bml-compiler-fkb-image-proof.fk
@@ -58,7 +58,7 @@
                         expected-return)))))
 
     (let source-path "form-stdlib/bml/bmf-bml-compiler-picture.bml")
-    (let image-path "/tmp/bml-compiler-source-image.fkb")
+    (let image-path (str_concat (temp_dir) "/bml-compiler-source-image.fkb"))
     (let parsed (bml-source-file-parse-declarations source-path))
     (let nodes (bml-source-exec-parse-nodes parsed))
     (let model (bml-source-declaration-model parsed))

--- a/form/form-stdlib/tests/boot-band.fk
+++ b/form/form-stdlib/tests/boot-band.fk
@@ -41,12 +41,12 @@
 ;        the cell read from the minted image (identity crossed the gap)
 
 (do
-    (let seed-image   "/tmp/boot-band-seed.fkb")
-    (let minted-image "/tmp/boot-band-minted.fkb")
-    (let registry     "/tmp/boot-band-registry.fkb")
-    (let boot-channel "/tmp/boot-band-channel.fkb")
-    (let second-life  "/tmp/boot-band-channel-2.fkb")
-    (let third-life   "/tmp/boot-band-channel-3.fkb")
+    (let seed-image   (str_concat (temp_dir) "/boot-band-seed.fkb"))
+    (let minted-image (str_concat (temp_dir) "/boot-band-minted.fkb"))
+    (let registry     (str_concat (temp_dir) "/boot-band-registry.fkb"))
+    (let boot-channel (str_concat (temp_dir) "/boot-band-channel.fkb"))
+    (let second-life  (str_concat (temp_dir) "/boot-band-channel-2.fkb"))
+    (let third-life   (str_concat (temp_dir) "/boot-band-channel-3.fkb"))
 
     ;; A CTOR is structure-first: fields are (key, value) pairs under a
     ;; FIELDS node — never a flat blob (the persistence-band markers).

--- a/form/form-stdlib/tests/cell-log-store-band.fk
+++ b/form/form-stdlib/tests/cell-log-store-band.fk
@@ -27,7 +27,7 @@
 ;   compaction keeps live set, reclaims dead → 1000000
 
 (do
-    (let dir "/tmp/cell-log-store-band.d")
+    (let dir (str_concat (temp_dir) "/cell-log-store-band.d"))
     (fs_rmdir dir)
     (fs_rmdir (str_concat dir ".compact"))
 

--- a/form/form-stdlib/tests/cell-registry-band.fk
+++ b/form/form-stdlib/tests/cell-registry-band.fk
@@ -7,12 +7,12 @@
 ; addressing layer.
 
 (do
-    (let registry-path "/tmp/cell-registry-band.fkb")
+    (let registry-path (str_concat (temp_dir) "/cell-registry-band.fkb"))
     (channel-create registry-path)
 
-    (register-cell registry-path 1 "/tmp/c1" (list "a" "b"))
-    (register-cell registry-path 2 "/tmp/c2" (list "b" "c"))
-    (register-cell registry-path 3 "/tmp/c3" (list "c"))
+    (register-cell registry-path 1 (str_concat (temp_dir) "/c1") (list "a" "b"))
+    (register-cell registry-path 2 (str_concat (temp_dir) "/c2") (list "b" "c"))
+    (register-cell registry-path 3 (str_concat (temp_dir) "/c3") (list "c"))
 
     ;; All three are registered.
     (let all (lookup-cells registry-path))

--- a/form/form-stdlib/tests/channel-band.fk
+++ b/form/form-stdlib/tests/channel-band.fk
@@ -15,7 +15,7 @@
 ; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/channel.fk
 
 (do
-    (let path "/tmp/coh-channel-band.fkb")
+    (let path (str_concat (temp_dir) "/coh-channel-band.fkb"))
 
     ;; --- 1. create -------------------------------------------------
     ;; channel-create writes an empty CHANNEL-V0 Recipe; native

--- a/form/form-stdlib/tests/channel-bml-band.fk
+++ b/form/form-stdlib/tests/channel-bml-band.fk
@@ -24,4 +24,4 @@ section [form.bml] {
     }
 }
 
-(bml_channel_roundtrip "/tmp/coh-channel-bml-band.fkb")
+(bml_channel_roundtrip (str_concat (temp_dir) "/coh-channel-bml-band.fkb"))

--- a/form/form-stdlib/tests/channel-breath-band.fk
+++ b/form/form-stdlib/tests/channel-breath-band.fk
@@ -6,7 +6,7 @@
 ; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/channel.fk
 
 (do
-    (let path "/tmp/coh-channel-breath-band.fkb")
+    (let path (str_concat (temp_dir) "/coh-channel-breath-band.fkb"))
     (channel-create path)
 
     (let gift (channel-breath-offer "small useful artifact"))

--- a/form/form-stdlib/tests/chat-band.fk
+++ b/form/form-stdlib/tests/chat-band.fk
@@ -35,8 +35,8 @@
         (node_value (head (tail (tail (node_children m))))))
 
     ;; ---------- two mailboxes ---------------------------------------
-    (let chat-a-path "/tmp/chat-band-a.fkb")
-    (let chat-b-path "/tmp/chat-band-b.fkb")
+    (let chat-a-path (str_concat (temp_dir) "/chat-band-a.fkb"))
+    (let chat-b-path (str_concat (temp_dir) "/chat-band-b.fkb"))
     (channel-create chat-a-path)
     (channel-create chat-b-path)
 

--- a/form/form-stdlib/tests/eq-shape-band.fk
+++ b/form/form-stdlib/tests/eq-shape-band.fk
@@ -26,4 +26,15 @@
     ; c8 — str_eq and value_eq answer 0/1: positives add to 2, negatives to 0.
     (let c8 (if (eq (add (add (str_eq "a" "a") (value_eq 7 7))
                          (add (str_eq "a" "b") (value_eq 7 "7"))) 2) 256 0))
-    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 c8)))))))))
+    ; c9 — bool OPERANDS coerce to the same 0/1 states inside compare:
+    ;      true meets 1, false meets 0, and a comparison's own answer
+    ;      meets a bool literal (the theme-resonance shape).
+    (let c9 (if (eq (add (add (eq true 1) (eq false 0))
+                         (add (eq (eq 18 68) false) (eq (eq 5 5) true))) 4) 512 0))
+    ; c10 — the ordering family coerces bools identically: false < true,
+    ;       true ≤ 1, true > false = 1+1+1.
+    (let c10 (if (eq (add (lt false true) (add (le true 1) (gt true false))) 3) 1024 0))
+    ; c11 — the float lane meets bools through the same coercion:
+    ;       1.0 = true, and 2.5 > true = 1+1.
+    (let c11 (if (eq (add (eq 1.0 true) (gt 2.5 true)) 2) 2048 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 (add c9 (add c10 c11))))))))))))

--- a/form/form-stdlib/tests/external-uri-band.fk
+++ b/form/form-stdlib/tests/external-uri-band.fk
@@ -45,7 +45,7 @@
             (ext-bytes-eq claimed computed)))
 
     ;; Stage the fixture: short bytes "hello".
-    (let fixture-path "/tmp/external-uri-band-fixture.txt")
+    (let fixture-path (str_concat (temp_dir) "/external-uri-band-fixture.txt"))
     (let fixture-bytes (list 104 101 108 108 111))
     (write_file_bytes fixture-path fixture-bytes)
 

--- a/form/form-stdlib/tests/file-append-band.fk
+++ b/form/form-stdlib/tests/file-append-band.fk
@@ -19,7 +19,7 @@
 ;   offset-read record 3 after all writes     → 10000
 
 (do
-    (let path "/tmp/file-append-band.log")
+    (let path (str_concat (temp_dir) "/file-append-band.log"))
     (fs_remove path)                          ; clean slate (ignore if absent)
 
     ;; bytes for "AA" (65,65), "BBB" (66x3), "CCCC" (67x4)

--- a/form/form-stdlib/tests/form-action-bmf-source-compiler-rewrite.fk
+++ b/form/form-stdlib/tests/form-action-bmf-source-compiler-rewrite.fk
@@ -131,7 +131,7 @@
     ;; Recipe-emit path (a12b8f71): section bindings live in the sibling
     ;; .fkb; the returned text is a walk_recipe_here driver. Check the
     ;; driver shape + the sidecar's existence on disk.
-    (let out-path "/tmp/form-test-fa-bmf-source-compiler-rewrite")
+    (let out-path (str_concat (temp_dir) "/form-test-fa-bmf-source-compiler-rewrite"))
     (let compiled (form-source-compile-text sample out-path))
     (let rule-score
         (add

--- a/form/form-stdlib/tests/form-binary-multi-emit.fk
+++ b/form/form-stdlib/tests/form-binary-multi-emit.fk
@@ -33,7 +33,7 @@
     ;; ── Step 2: write to disk as .fkb (artifact format read_form_binary
     ;; reads — FORMBIN2 with string-table header). This is the same
     ;; format the Go/Rust/TS --emit-binary CLI mode produces.
-    (let path "/tmp/form-binary-multi-emit.fkb")
+    (let path (str_concat (temp_dir) "/form-binary-multi-emit.fkb"))
     (let bytes-written (write_form_binary path source-recipe))
 
     ;; ── Probe 1: write succeeded (byte count > 0; -1 on failure)

--- a/form/form-stdlib/tests/fs-crud-band.fk
+++ b/form/form-stdlib/tests/fs-crud-band.fk
@@ -26,7 +26,7 @@
 ;   rmdir tears the tree down      → 10000000
 
 (do
-    (let root "/tmp/fs-crud-band")
+    (let root (str_concat (temp_dir) "/fs-crud-band"))
     ;; clean slate (ignore result — may not exist yet)
     (fs_rmdir root)
 

--- a/form/form-stdlib/tests/graph-node-mutation-carrier-band.fk
+++ b/form/form-stdlib/tests/graph-node-mutation-carrier-band.fk
@@ -16,7 +16,7 @@
 ;   reopened file keeps deleted spec out -> 10000
 
 (do
-    (let dir "/tmp/graph-node-mutation-carrier-band.d")
+    (let dir (str_concat (temp_dir) "/graph-node-mutation-carrier-band.d"))
     (fs_rmdir dir)
 
     (let mem-verdict (gn-mutation-test (carrier-memory) ""))

--- a/form/form-stdlib/tests/graph-node-port-band.fk
+++ b/form/form-stdlib/tests/graph-node-port-band.fk
@@ -14,7 +14,7 @@
 ;   reopened file keeps typed node list   -> 10000
 
 (do
-    (let dir "/tmp/graph-node-port-band.d")
+    (let dir (str_concat (temp_dir) "/graph-node-port-band.d"))
     (fs_rmdir dir)
 
     (let mem-verdict (gn-test (carrier-memory) ""))

--- a/form/form-stdlib/tests/host-kernel-cell-band.fk
+++ b/form/form-stdlib/tests/host-kernel-cell-band.fk
@@ -116,7 +116,7 @@
                 64 0))
 
     ; ── 128: the cell shrinks to a .fkb of just recipes and comes back ──
-    (let image-path "/tmp/host-kernel-cell-image.fkb")
+    (let image-path (str_concat (temp_dir) "/host-kernel-cell-image.fkb"))
     (let cell-kernel (hkc-as-kernel swapped))
     (let cell-image (ksat-kernel-image cell-kernel))
     (let bytes-written (write_form_binary image-path cell-image))

--- a/form/form-stdlib/tests/host-kernel-metal-band.fk
+++ b/form/form-stdlib/tests/host-kernel-metal-band.fk
@@ -100,7 +100,7 @@
                 16 0))
 
     ; ── 32: WORLD-FS — a real file ──
-    (let path "/tmp/host-kernel-metal.txt")
+    (let path (str_concat (temp_dir) "/host-kernel-metal.txt"))
     (let wrote (write_file_text path "metal"))
     (let c5 (if (and (eq wrote 5)
                  (and (eq (fs_exists path) 1)

--- a/form/form-stdlib/tests/ideas-graph-projection-band.fk
+++ b/form/form-stdlib/tests/ideas-graph-projection-band.fk
@@ -11,7 +11,7 @@
 ;   reopened file projects no concepts   -> 10000
 
 (do
-    (let dir "/tmp/ideas-graph-projection-band.d")
+    (let dir (str_concat (temp_dir) "/ideas-graph-projection-band.d"))
     (fs_rmdir dir)
 
     (let mem-verdict (igp-test (carrier-memory) ""))

--- a/form/form-stdlib/tests/install-leaf-band.fk
+++ b/form/form-stdlib/tests/install-leaf-band.fk
@@ -35,7 +35,7 @@
 ;        original (content-addressing crossed the protocol)
 
 (do
-    (let table "/tmp/install-leaf-band-table.fkb")
+    (let table (str_concat (temp_dir) "/install-leaf-band-table.fkb"))
 
     ;; two capabilities: thunks whose bodies realize 42 and 7
     (let body-42 (intern_node (bp "add")

--- a/form/form-stdlib/tests/kernel-core-image-compiler-proof.fk
+++ b/form/form-stdlib/tests/kernel-core-image-compiler-proof.fk
@@ -28,7 +28,7 @@
         (if (node_eq actual expected) 1 0))
 
     (let source-path (kernel-core-source-path 0))
-    (let image-path "/tmp/kernel-core-compiler-image.fkb")
+    (let image-path (str_concat (temp_dir) "/kernel-core-compiler-image.fkb"))
     (let compiled (kernel-core-compile-image source-path image-path))
     (let image (kernel-core-compiled-image-node compiled))
     (let image-kids (node_children image))

--- a/form/form-stdlib/tests/kernel-core-self-proof.fk
+++ b/form/form-stdlib/tests/kernel-core-self-proof.fk
@@ -73,7 +73,7 @@
                         expected-value)))))
 
     (let source-path "form-stdlib/bml/kernel-core.bml")
-    (let image-path "/tmp/kernel-core-self-image.fkb")
+    (let image-path (str_concat (temp_dir) "/kernel-core-self-image.fkb"))
     (let parsed (bml-source-file-parse-declarations source-path))
     (let nodes (bml-source-exec-parse-nodes parsed))
     (let model (bml-source-declaration-model parsed))

--- a/form/form-stdlib/tests/kernel-satsang-band.fk
+++ b/form/form-stdlib/tests/kernel-satsang-band.fk
@@ -82,7 +82,7 @@
                 8 0))
 
     ; ── 16: the whole kernel through the .fkb binary and back to shape ──
-    (let image-path "/tmp/kernel-satsang-image.fkb")
+    (let image-path (str_concat (temp_dir) "/kernel-satsang-image.fkb"))
     (let kernel-image (ksat-kernel-image kernel))
     (let bytes-written (write_form_binary image-path kernel-image))
     (let loaded (read_form_binary image-path))

--- a/form/form-stdlib/tests/kv-store-band.fk
+++ b/form/form-stdlib/tests/kv-store-band.fk
@@ -19,9 +19,9 @@
     (defn kb-nth (xs i)
         (if (eq i 0) (head xs) (kb-nth (tail xs) (sub i 1))))
 
-    (let registry-path  "/tmp/kv-store-band-registry.fkb")
-    (let k-channel-path "/tmp/kv-store-band-k.fkb")
-    (let a-reply-path   "/tmp/kv-store-band-a-reply.fkb")
+    (let registry-path  (str_concat (temp_dir) "/kv-store-band-registry.fkb"))
+    (let k-channel-path (str_concat (temp_dir) "/kv-store-band-k.fkb"))
+    (let a-reply-path   (str_concat (temp_dir) "/kv-store-band-a-reply.fkb"))
 
     (channel-create registry-path)
     (channel-create k-channel-path)

--- a/form/form-stdlib/tests/minimal-surface-band.fk
+++ b/form/form-stdlib/tests/minimal-surface-band.fk
@@ -32,7 +32,7 @@
                 (if (eq (ms-choice 0 (ms-choice 0 5)) 5)
                     (if (eq (ms-choice 3 5) 3) 4 0) 0) 0))
 
-    (let p "/tmp/minimal-surface-band.txt")
+    (let p (str_concat (temp_dir) "/minimal-surface-band.txt"))
     (ms-port-out p "the membrane returns what crossed it")
     (let c3 (if (str_eq (ms-port-in p) "the membrane returns what crossed it") 8 0))
 

--- a/form/form-stdlib/tests/multi-hop-band.fk
+++ b/form/form-stdlib/tests/multi-hop-band.fk
@@ -26,11 +26,11 @@
         (if (band-nil? xs) ys (cons (head xs) (band-append (tail xs) ys))))
 
     ;; ---------- topology ----------
-    (let registry-path  "/tmp/multi-hop-band-registry.fkb")
-    (let b-channel-path "/tmp/multi-hop-band-b.fkb")
-    (let c-channel-path "/tmp/multi-hop-band-c.fkb")
-    (let b-reply-path   "/tmp/multi-hop-band-b-reply.fkb")
-    (let a-reply-path   "/tmp/multi-hop-band-a-reply.fkb")
+    (let registry-path  (str_concat (temp_dir) "/multi-hop-band-registry.fkb"))
+    (let b-channel-path (str_concat (temp_dir) "/multi-hop-band-b.fkb"))
+    (let c-channel-path (str_concat (temp_dir) "/multi-hop-band-c.fkb"))
+    (let b-reply-path   (str_concat (temp_dir) "/multi-hop-band-b-reply.fkb"))
+    (let a-reply-path   (str_concat (temp_dir) "/multi-hop-band-a-reply.fkb"))
 
     (channel-create registry-path)
     (channel-create b-channel-path)

--- a/form/form-stdlib/tests/natural-bmf-bidirectional.fk
+++ b/form/form-stdlib/tests/natural-bmf-bidirectional.fk
@@ -66,7 +66,7 @@ section [form.action] {
     let python_source_section = "section [python.bmf] {\n  assign-int ::= $target:name \"=\" $value:int => pybmf-emit-assign-int <= pybmf-source-assign-int;\n}\n";
     // Recipe-emit path (a12b8f71): section bindings live in sibling .fkb,
     // the returned text is one walk_recipe_here driver per section.
-    let compiled_out_path = "/tmp/form-test-natural-bmf-bidirectional";
+    let compiled_out_path = str_concat(temp_dir(), "/form-test-natural-bmf-bidirectional");
     let compiled = form-source-compile-text(str_concat(natural_source_section, python_source_section), compiled_out_path);
 
     let rule_score = sum(list(len(natural-bmf-rules), rt_score(fact_rt), rt_score(fact_the_rt), rt_score(fact_equals_rt), rt_score(fact_id_rt), rt_score(relation_rt), rt_score(relates_rt), rt_score(question_rt), rt_score(meaning_rt)));

--- a/form/form-stdlib/tests/offers-in-flight-band.fk
+++ b/form/form-stdlib/tests/offers-in-flight-band.fk
@@ -24,8 +24,8 @@
         (if (eq i 0) (head xs) (band-nth (tail xs) (sub i 1))))
 
     ;; Separate /tmp paths so this band collides with no sibling band run.
-    (let offer-path "/tmp/offers-in-flight-band-offer.fkb")
-    (let ack-path   "/tmp/offers-in-flight-band-ack.fkb")
+    (let offer-path (str_concat (temp_dir) "/offers-in-flight-band-offer.fkb"))
+    (let ack-path   (str_concat (temp_dir) "/offers-in-flight-band-ack.fkb"))
     (channel-create offer-path)
     (channel-create ack-path)
 

--- a/form/form-stdlib/tests/persistence-band.fk
+++ b/form/form-stdlib/tests/persistence-band.fk
@@ -26,7 +26,7 @@
 ;   - 1: the idea cell's composed CTOR round-trips (a field value reads back)
 
 (do
-    (let store-path "/tmp/persistence-band-store.fkb")
+    (let store-path (str_concat (temp_dir) "/persistence-band-store.fkb"))
 
     ;; A blueprint is a structural NodeID; we pass real ones through as
     ;; child 2 (a ref, not a slug). These mirror BID_idea / BID_spec

--- a/form/form-stdlib/tests/pubsub-band.fk
+++ b/form/form-stdlib/tests/pubsub-band.fk
@@ -7,7 +7,7 @@
 ; register, and stays put when an unrelated capability registers.
 
 (do
-    (let registry-path "/tmp/pubsub-band-registry.fkb")
+    (let registry-path (str_concat (temp_dir) "/pubsub-band-registry.fkb"))
     (channel-create registry-path)
 
     (let watched "compute")
@@ -17,17 +17,17 @@
     (let s0-ok (if (eq s0 0) 1 0))
 
     ;; Step 1: one cell registers with "compute".
-    (register-cell registry-path 1 "/tmp/p-b" (list "compute"))
+    (register-cell registry-path 1 (str_concat (temp_dir) "/p-b") (list "compute"))
     (let s1 (len (find-by-capability registry-path watched)))
     (let s1-ok (if (eq s1 1) 1 0))
 
     ;; Step 2: second cell registers with "compute" (plus another verb).
-    (register-cell registry-path 2 "/tmp/p-c" (list "compute" "witness"))
+    (register-cell registry-path 2 (str_concat (temp_dir) "/p-c") (list "compute" "witness"))
     (let s2 (len (find-by-capability registry-path watched)))
     (let s2-ok (if (eq s2 2) 1 0))
 
     ;; Step 3: a cell with a DIFFERENT verb registers. Count must not move.
-    (register-cell registry-path 3 "/tmp/p-d" (list "fetch"))
+    (register-cell registry-path 3 (str_concat (temp_dir) "/p-d") (list "fetch"))
     (let s3 (len (find-by-capability registry-path watched)))
     (let s3-ok (if (eq s3 2) 1 0))
 

--- a/form/form-stdlib/tests/qualcomm-nr-trusted-agent-band.fk
+++ b/form/form-stdlib/tests/qualcomm-nr-trusted-agent-band.fk
@@ -11,14 +11,7 @@
 ;
 ; Verdict: 127 when every claim lands across Go/Rust/TS.
 ;
-; preludes:
-;   form-stdlib/core.fk
-;   form-stdlib/resource-port.fk
-;   form-stdlib/recognition-router.fk
-;   form-stdlib/champion-challenger.fk
-;   form-stdlib/grammars/living-equation.fk
-;   form-stdlib/all-life-north-star.fk
-;   form-stdlib/qualcomm-nr-trusted-agent.fk
+; preludes: form-stdlib/resource-port.fk form-stdlib/recognition-router.fk form-stdlib/champion-challenger.fk form-stdlib/grammars/living-equation.fk form-stdlib/all-life-north-star.fk form-stdlib/qualcomm-nr-trusted-agent.fk
 
 (do
     (let lens-ok

--- a/form/form-stdlib/tests/resource-port-band.fk
+++ b/form/form-stdlib/tests/resource-port-band.fk
@@ -42,25 +42,25 @@
 
     ;; --- two physically-unalike resources, one efferent driver -------------
     (let light (mk-resource "kitchen-light" "Light"
-                  (list (mk-terminal (efferent-bool) "/tmp/rpb-light.line"))))
+                  (list (mk-terminal (efferent-bool) (str_concat (temp_dir) "/rpb-light.line")))))
     (let relay (mk-resource "pump-relay" "Relay"
-                  (list (mk-terminal (efferent-bool) "/tmp/rpb-relay.line"))))
+                  (list (mk-terminal (efferent-bool) (str_concat (temp_dir) "/rpb-relay.line")))))
     (act light (efferent-bool) "1")
     (act relay (efferent-bool) "1")
     (let drive-ok
-        (if (str_eq (read_file "/tmp/rpb-light.line") "1")
-            (if (str_eq (read_file "/tmp/rpb-relay.line") "1") 100 0) 0))
+        (if (str_eq (read_file (str_concat (temp_dir) "/rpb-light.line")) "1")
+            (if (str_eq (read_file (str_concat (temp_dir) "/rpb-relay.line")) "1") 100 0) 0))
 
     ;; --- two afferent kinds, one sense driver ------------------------------
     ;; a Thermostat exposes a scalar read; a Human exposes a text read. Both
     ;; are sensed through the identical `sense` driver — only the port differs.
-    (write_file_text "/tmp/rpb-thermo.adc" "21")          ; the world holds 21°
-    (write_file_text "/tmp/rpb-human.line" "i am here")   ; the human's line
+    (write_file_text (str_concat (temp_dir) "/rpb-thermo.adc") "21")          ; the world holds 21°
+    (write_file_text (str_concat (temp_dir) "/rpb-human.line") "i am here")   ; the human's line
     (let thermo (mk-resource "room-thermostat" "Thermostat"
-                  (list (mk-terminal (afferent-scalar) "/tmp/rpb-thermo.adc"))))
+                  (list (mk-terminal (afferent-scalar) (str_concat (temp_dir) "/rpb-thermo.adc")))))
     (let human  (mk-resource "visitor" "Human"
-                  (list (mk-terminal (afferent-text)   "/tmp/rpb-human.line")
-                        (mk-terminal (efferent-text)   "/tmp/rpb-human.out"))))
+                  (list (mk-terminal (afferent-text)   (str_concat (temp_dir) "/rpb-human.line"))
+                        (mk-terminal (efferent-text)   (str_concat (temp_dir) "/rpb-human.out")))))
     (let sense-ok
         (if (str_eq (sense thermo (afferent-scalar)) "21")
             (if (str_eq (sense human (afferent-text)) "i am here") 1000 0) 0))
@@ -68,8 +68,8 @@
     ;; --- efferent → afferent round-trip on one resource --------------------
     ;; a Valve we can both open AND read back: drive "open", sense it returned.
     (let valve (mk-resource "inlet-valve" "Valve"
-                  (list (mk-terminal (efferent-text) "/tmp/rpb-valve.state")
-                        (mk-terminal (afferent-text) "/tmp/rpb-valve.state"))))
+                  (list (mk-terminal (efferent-text) (str_concat (temp_dir) "/rpb-valve.state"))
+                        (mk-terminal (afferent-text) (str_concat (temp_dir) "/rpb-valve.state")))))
     (act valve (efferent-text) "open")
     (let roundtrip-ok
         (if (str_eq (sense valve (afferent-text)) "open") 10000 0))
@@ -86,7 +86,7 @@
     ;; terminal — the same cell shape as a Light, a Valve, a Socket.
     (act human (efferent-text) "welcome")
     (let human-ok
-        (if (str_eq (read_file "/tmp/rpb-human.out") "welcome")
+        (if (str_eq (read_file (str_concat (temp_dir) "/rpb-human.out")) "welcome")
             (if (eq (resource-has-port? human (afferent-text)) 1) 1000000 0) 0))
 
     (sum (list id-ok shape-ok drive-ok sense-ok roundtrip-ok refusal-ok human-ok)))

--- a/form/form-stdlib/tests/runtime-grammar-selector-registry-band.fk
+++ b/form/form-stdlib/tests/runtime-grammar-selector-registry-band.fk
@@ -37,16 +37,16 @@ section [form.action] {
 
     let config_text = "extension=.aa\ngrammar=/tmp/form-runtime-grammar-a.fk\n";
     let grammar_a = "; runtime grammar plugin\n; dialect=surface-a\n; block=surface-a.bmf\n; word=surface-a-word\n; rule=greeting\n; literal=hello\n(do 0)\n";
-    let config_write = write_file_text("/tmp/form-runtime-grammar.config", config_text);
-    let grammar_a_write = write_file_text("/tmp/form-runtime-grammar-a.fk", grammar_a);
-    let source_a_write = write_file_text("/tmp/source.aa", "hello field");
+    let config_write = write_file_text((str_concat (temp_dir) "/form-runtime-grammar.config"), config_text);
+    let grammar_a_write = write_file_text((str_concat (temp_dir) "/form-runtime-grammar-a.fk"), grammar_a);
+    let source_a_write = write_file_text((str_concat (temp_dir) "/source.aa"), "hello field");
 
     let registry0 = form-runtime-grammar-registry-empty();
-    let registry = form-runtime-grammar-load-config-for-file(registry0, "/tmp/form-runtime-grammar.config", "/tmp/source.aa", form-capsule-root(132, 1, 9, 1), surface_a_source, surface_a_form, parse_kind, emit_kind, effect_pure, reversible_yes, lossless_yes, deterministic_yes, proof_roundtrip, proof_ok, 1, selector_extension, selector_section, missing);
+    let registry = form-runtime-grammar-load-config-for-file(registry0, (str_concat (temp_dir) "/form-runtime-grammar.config"), (str_concat (temp_dir) "/source.aa"), form-capsule-root(132, 1, 9, 1), surface_a_source, surface_a_form, parse_kind, emit_kind, effect_pure, reversible_yes, lossless_yes, deterministic_yes, proof_roundtrip, proof_ok, 1, selector_extension, selector_section, missing);
 
-    let missing_cc = form-runtime-grammar-config-path(read_file("/tmp/form-runtime-grammar.config"), ".cc", missing);
+    let missing_cc = form-runtime-grammar-config-path(read_file((str_concat (temp_dir) "/form-runtime-grammar.config")), ".cc", missing);
     let binding_a = form-runtime-grammar-resolve-value(registry, ".aa", empty);
-    let result_a = form-runtime-grammar-parse-source-file(registry, "/tmp/source.aa", "greeting", ctx, empty);
+    let result_a = form-runtime-grammar-parse-source-file(registry, (str_concat (temp_dir) "/source.aa"), "greeting", ctx, empty);
     let registry_score = sum(list(str_score(missing_cc, missing, 100), if nil?(binding_a) then 0 else 200, int_score(len(form-runtime-grammar-registry-bindings(registry)), 2, 300), int_score(len(form-recipe-registry-capsules(form-runtime-grammar-registry-recipe-registry(registry))), 1, 400)));
     let parse_score = sum(list(str_score(bmf-object-kind(parsed_object(result_a)), "greeting", 500), str_score(node_value(node_child(parsed_node(result_a), 0)), "field", 600)));
 

--- a/form/form-stdlib/tests/source-compiler-multi-dialect-band.fk
+++ b/form/form-stdlib/tests/source-compiler-multi-dialect-band.fk
@@ -34,7 +34,7 @@
 }
 ")))))
 
-    (let out-path "/tmp/form-test-multi-dialect")
+    (let out-path (str_concat (temp_dir) "/form-test-multi-dialect"))
     (let compiled (form-source-compile-text source out-path))
 
     (sum

--- a/form/form-stdlib/tests/source-compiler-runtime.fk
+++ b/form/form-stdlib/tests/source-compiler-runtime.fk
@@ -19,7 +19,7 @@ section [form.action] {
     let quote = "\"";
     let rule-source = str_concat("[bml.bmf] {\n      field ::= $type:name $name:name ", str_concat(quote, str_concat(";", str_concat(quote, " => bml-emit-field;\n    }\n"))));
     let sample = str_concat("section ", rule-source);
-    let out-path = "/tmp/form-test-source-compiler-runtime";
+    let out-path = (str_concat (temp_dir) "/form-test-source-compiler-runtime");
     let compiled = form-source-compile-text(sample, out-path);
     let sidecar = str_concat(out-path, ".bml.bmf.fkb");
 

--- a/form/form-stdlib/tests/source-corpus-roundtrip-band.fk
+++ b/form/form-stdlib/tests/source-corpus-roundtrip-band.fk
@@ -124,7 +124,7 @@
     ;; Recipe-first path: form-source-compile-text builds section Recipe objects
     ;; first, then emits executable Form source only as this test's observation
     ;; lens. Runtime carriers can use recipe_to_bytes directly.
-    (let compiled-out-path "/tmp/form-test-source-corpus-roundtrip")
+    (let compiled-out-path (str_concat (temp_dir) "/form-test-source-corpus-roundtrip"))
     (let compiled-source (form-source-compile-text active-source compiled-out-path))
     (let anchor "active-corpus/add")
     (let binary (active-add-binary "add" "a" "int" "b" "int" "int" "a" "b"))

--- a/form/form-stdlib/tests/storage-port-band.fk
+++ b/form/form-stdlib/tests/storage-port-band.fk
@@ -21,7 +21,7 @@
 ;   memory is ephemeral, file is durable — both honest   → 10000
 
 (do
-    (let dir "/tmp/storage-port-band.d")
+    (let dir (str_concat (temp_dir) "/storage-port-band.d"))
     (fs_rmdir dir)
 
     ;; --- the SAME test, two carriers ---------------------------------------
@@ -43,7 +43,7 @@
     ;; --- both carriers are honest about their nature -----------------------
     ;; a fresh memory store is empty; a fresh file store at a NEW dir is empty.
     (let fresh-mem (storage-open (carrier-memory) ""))
-    (let fresh-dir "/tmp/storage-port-band-fresh.d")
+    (let fresh-dir (str_concat (temp_dir) "/storage-port-band-fresh.d"))
     (fs_rmdir fresh-dir)
     (let fresh-file (storage-open cf fresh-dir))
     (let honest-ok

--- a/form/validate.sh
+++ b/form/validate.sh
@@ -163,10 +163,16 @@ run_siblings() {
     # The three kernels run CONCURRENTLY: a band's wall time is max(leg), not
     # sum — on compiler-heavy bands the Go+Rust legs ride inside the TS leg's
     # shadow for free. Outputs stay byte-compared exactly as before.
+    #
+    # Each leg gets its OWN TMPDIR under the legs dir: bands reach scratch
+    # space through the `temp_dir` native, so concurrent sibling legs (and
+    # concurrent validate runs) never share a scratch path. The legs dir is
+    # removed after comparison, so band scratch leaves no sediment.
     legs="$(mktemp -d "${TMPDIR:-/tmp}/form-legs.XXXXXX")"
-    ( "$GO_BIN" "${prepared_args[@]}" > "$legs/go" 2>&1 || true ) &
-    ( "$RS_BIN" "${prepared_args[@]}" > "$legs/rs" 2>&1 || true ) &
-    ( run_ts "${prepared_args[@]}" > "$legs/ts" 2>&1 || true ) &
+    mkdir -p "$legs/tmp-go" "$legs/tmp-rs" "$legs/tmp-ts"
+    ( TMPDIR="$legs/tmp-go" "$GO_BIN" "${prepared_args[@]}" > "$legs/go" 2>&1 || true ) &
+    ( TMPDIR="$legs/tmp-rs" "$RS_BIN" "${prepared_args[@]}" > "$legs/rs" 2>&1 || true ) &
+    ( TMPDIR="$legs/tmp-ts" run_ts "${prepared_args[@]}" > "$legs/ts" 2>&1 || true ) &
     wait
     go_out=$(cat "$legs/go"); rs_out=$(cat "$legs/rs"); ts_out=$(cat "$legs/ts")
     rm -rf "$legs"


### PR DESCRIPTION
## What this heals

`form/validate.sh` (full suite) showed 11 divergent bands. Sorted per [lc-sovereign-kernels-one-execution](docs/vision-kb/concepts/lc-sovereign-kernels-one-execution.md) into value-divergence (kernels must agree — healed) and harness collision (isolated):

### Value-divergences — healed three-way

**COMPARE arm coercion contract.** Probe `(list (eq 18 68) (eq it false) (eq it 0) (eq false 0) (eq true 1))` answered `[0,1,1,1,0]` (Go), `[0,1,1,1,1]` (Rust), `[0,0,1,0,0]` (TS):
- Go read `.Int` raw in the integer lane — `VBool{true}.Int == 0`, so `(eq true 1)` = 0 and `(eq null 0)` = 1. Now coerces via new `core.Value.AsInt` (ints pass, floats truncate, bools are the 0/1 states, anything else is `as_int: <v>` — the type-contract violation the route classifier already names).
- TS used polymorphic `valueEqual` for EQ/NE — cross-kind false, so `(eq false 0)` = 0. Now EQ/NE ride the same width lanes as the ordering ops with the same bool coercion.
- Rust was already the documented contract (both Go's and Rust's `node_eq` comments name it); unchanged.

`eq-shape-band` extends with the bool corners (c9–c11, verdict **4095** three-way). `theme-resonance-band` heals downstream (**111111** three-way — its `(eq (eq chai chayim) false)` was the TS-divergent shape).

**Go NodeID-typed boundaries.** 23 natives (intern_node, node_children, node_value, write_form_binary, walk_recipe, …) read `args[N].Nid` raw — any mistyped value yields the zero NodeID, a silent false positive. New `core.Value.AsNid` names the violation (`as_nid: <v>`), sibling to Rust's `as_nid` and TS's `argNodeID`.

**TS result rendering.** TS rendered strings JSON-quoted at the result surface; Go/Rust render bare. Aligned to bare (band outputs are byte-compared).

### Harness collision — isolated, not a kernel bug

`run_siblings` now runs the three kernel legs **concurrently** (perf change already on main), and ~36 bands wrote fixed `/tmp` paths — sibling legs deleted each other's channel/segment files mid-flight. That was the whole flaky fatal family (`as_nid: Null` / `as_str: Null` = reads of files a sibling leg had just removed; also why the divergent set wobbled 13→11 between runs). 

- New `temp_dir` native in all three kernels (TMPDIR, fallback `/tmp`, no trailing slash).
- `validate.sh` points each leg at its own TMPDIR under the per-workload legs dir it already creates and removes.
- Every band scratch path composes `(str_concat (temp_dir) "/…")` — concurrent legs and concurrent validate runs never share scratch.

**Manifest fix:** `qualcomm-nr-trusted-agent-band` declared preludes as a multi-line comment list the harness reads as empty (`unbound function` on all three legs); collapsed to the single `; preludes:` line (verdict **127** three-way).

## Proof

```
494 ok, 0 divergent — kernels agree on every sample.
```

Full suite, all three kernels, with every heal included.

Known failing on pristine main (not this PR): `TestHealthRouteNativeOperationalShape` — `api.bml`'s no-db health branch hardcodes `smart_reap_available:false`; flagged separately (sibling worktree is active in that file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)