### PR TITLE
tend: TS bare-integer arithmetic folds in int64, not int32 — three-way parity restored

### DIFF
--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -4424,16 +4424,17 @@ function walkMath(
       : { kind: "u64", bigint: acc };
   }
 
-  // I32 default path — backward-compat fast path.
-  //
-  // Runtime float promotion: the bare-width op (`add`/`+`/`sub`/… with no
-  // width-encoded inst) is what Python's polymorphic `+` lowers to. When any
-  // operand walks to a float at runtime, promote the whole fold to f64 —
-  // matching the Rust + Go MATH walker arms, which dispatch on the actual
-  // operand kind rather than the encoded width. This keeps int+int on the
-  // fast i32 path while opening float-field folds (sum of float `actual_cost`
-  // across a list of records) to three-way parity. Mirrors Python:
-  // int+float→float, float+int→float, float+float→float.
+  // Default integer path — the bare-width op (`add`/`+`/`sub`/… with no
+  // width-encoded inst) is what Python's polymorphic `+` lowers to, so it
+  // carries Python's arbitrary-precision integer semantics, NOT int32 wrap.
+  // Go and Rust compute this fold in int64 (`a * b`, `a + b`); a JS number
+  // holds integers exactly to 2^53, so plain arithmetic matches them across
+  // that whole range — `(mul 100000 100000)` is 10000000000 on all three, not
+  // a Math.imul-wrapped 1410065408. (Beyond 2^53 the explicit typed I64 width
+  // path carries full precision via BigInt.) Float promotion: when any operand
+  // walks to a float at runtime, promote the whole fold to f64 — matching the
+  // Rust + Go MATH arms, which dispatch on the actual operand kind rather than
+  // the encoded width. Mirrors Python: int+float→float, float+float→float.
   const vals = kids.map((kid) => walk(k, kid!, frame));
   if (vals.some((v) => v.kind === "f32" || v.kind === "f64")) {
     let facc = expectFloat(vals[0]!, "math.f64");
@@ -4461,29 +4462,31 @@ function walkMath(
     }
     return { kind: "f64", float: facc };
   }
-  let acc = expectInt(vals[0]!, "math.i32");
+  let acc = expectInt(vals[0]!, "math.int");
   for (let i = 1; i < vals.length; i++) {
-    const x = expectInt(vals[i]!, "math.i32");
+    const x = expectInt(vals[i]!, "math.int");
     switch (op) {
       case RMath.PLUS:
-        acc = (acc + x) | 0;
+        acc = acc + x;
         break;
       case RMath.MINUS:
-        acc = (acc - x) | 0;
+        acc = acc - x;
         break;
       case RMath.MUL:
-        acc = Math.imul(acc, x);
+        acc = acc * x;
         break;
       case RMath.DIV:
+        // Truncate toward zero — matches Go/Rust integer `/` (and Python's
+        // int() of the quotient), without int32 wrap. Math.trunc, not `| 0`.
         if (x === 0) throw new Error("division by zero");
-        acc = (acc / x) | 0;
+        acc = Math.trunc(acc / x);
         break;
       case RMath.MOD:
         if (x === 0) throw new Error("modulo by zero");
-        acc = acc - ((acc / x) | 0) * x;
+        acc = acc - Math.trunc(acc / x) * x;
         break;
       default:
-        throw new Error(`math.i32: unknown op ${op}`);
+        throw new Error(`math.int: unknown op ${op}`);
     }
   }
   return { kind: "int", int: acc };

--- a/form/form-stdlib/tests/int-literal-width-band.fk
+++ b/form/form-stdlib/tests/int-literal-width-band.fk
@@ -1,33 +1,41 @@
-; tests/int-literal-width-band.fk — integer literals wider than int32 survive
-; parsing, arithmetic, and round-trip across all three kernels.
+; tests/int-literal-width-band.fk — integers wider than int32 survive both
+; PARSING and ARITHMETIC, identically across all three kernels.
 ;
-; The bug this pins: an integer literal was packed into the 32-bit `inst` slot
-; of its trivial NodeID, so any value with bit 31 set was read back as a signed
-; int32. 3596153792 = 0xD65F03C0 became -698813504, and (div 3596153792
-; 16777216) printed -41 instead of 214 — WRONG, yet identical across Go/Rust/TS,
-; so three-way agreement alone never caught it. The fix routes literals past the
-; int32 ceiling through an i64 overflow table (TrivInt64 = 5), exactly as
-; FLOAT64 overflows into f64s. See docs/coherence-substrate/form-to-asm.form
-; closing-cell "kernel-int" for where the byte-image workaround named this hole.
+; Two holes in the same family, both invisible to three-way agreement because
+; the kernels failed together:
 ;
-; Vectors (all chosen so the high word is non-zero — the int32 trap):
-;   (div 3596153792 16777216) = 0xD65F03C0 >> 24 = 0xD6 = 214
-;   (mod 3596153792 256)      = 0xD65F03C0 & 0xFF = 0xC0 = 192
-;   round-trip identity       — the literal interns and decodes to itself
-;   2^53-1 = 9007199254740991 — the documented preservation bar, intact
+;   Parse: an integer literal was packed into the 32-bit `inst` slot of its
+;   trivial NodeID, so any value with bit 31 set read back as a signed int32.
+;   3596153792 = 0xD65F03C0 became -698813504, and (div 3596153792 16777216)
+;   returned -41 instead of 214. Fixed by routing wide literals through an i64
+;   overflow table (TrivInt64 = 5), exactly as FLOAT64 overflows into f64s.
 ;
-; Verdict: 4 when every check holds. A kernel still truncating to int32 returns
-; a smaller count (the div/mod checks fail), so the companion gate
-; form/scripts/int-literal-width-test.sh asserts the verdict is exactly 4 —
-; agreement on a wrong number is not a pass.
+;   Compute: TS's bare-integer math fold used `| 0` and Math.imul, wrapping
+;   every RESULT at int32, while Go/Rust fold in int64. (mul 100000 100000)
+;   was 1410065408 on TS vs 10000000000 on Go/Rust — a real divergence even
+;   from small literals. Fixed by folding in plain JS number (exact to 2^53,
+;   the bare op's Python-polymorphic semantics) with Math.trunc for division.
+;
+; Both are gated here so neither can silently return. A kernel still truncating
+; on either path returns a smaller verdict; form/scripts/int-literal-width-test.sh
+; asserts the verdict is exactly 9 — agreement on a wrong number is not a pass.
 
 (do
     (let big 3596153792)
 
-    (let ok-div (if (eq (div big 16777216) 214) 1 0))   ; high byte 0xD6
-    (let ok-mod (if (eq (mod big 256)      192) 1 0))   ; low  byte 0xC0
+    ;; Parse — wide literals survive intern → decode
+    (let ok-div (if (eq (div big 16777216) 214) 1 0))   ; 0xD65F03C0 >> 24 = 0xD6
+    (let ok-mod (if (eq (mod big 256)      192) 1 0))   ; 0xD65F03C0 & 0xFF = 0xC0
     (let ok-id  (if (eq big 3596153792)        1 0))    ; intern → decode → self
     (let ok-max (if (eq 9007199254740991
                         9007199254740991)     1 0))     ; 2^53-1 preserved
 
-    (add ok-div (add ok-mod (add ok-id ok-max))))
+    ;; Compute — wide results survive the bare-integer fold (no int32 wrap)
+    (let ok-mul    (if (eq (mul 100000 100000) 10000000000) 1 0))   ; > 2^33
+    (let ok-add    (if (eq (add 2000000000 2000000000) 4000000000) 1 0))
+    (let ok-u32    (if (eq (mul 65536 65536) 4294967296) 1 0))      ; 2^32 exactly
+    (let ok-divneg (if (eq (div -10000000000 7) -1428571428) 1 0)) ; trunc toward 0
+    (let ok-modneg (if (eq (mod -10000000000 7) -4) 1 0))          ; sign of dividend
+
+    (add ok-div (add ok-mod (add ok-id (add ok-max
+        (add ok-mul (add ok-add (add ok-u32 (add ok-divneg ok-modneg)))))))))

--- a/form/scripts/int-literal-width-test.sh
+++ b/form/scripts/int-literal-width-test.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 #
-# int-literal-width-test.sh — prove integer literals wider than int32 compute
-# CORRECTLY (not merely identically) across all three kernels.
+# int-literal-width-test.sh — prove integers wider than int32 compute CORRECTLY
+# (not merely identically) across all three kernels, on both the parse and the
+# arithmetic paths.
 #
-# The trap: 3596153792 = 0xD65F03C0 has bit 31 set. Packed into the 32-bit
-# `inst` slot of a trivial NodeID it read back as the signed int32 -698813504,
-# so (div 3596153792 16777216) yielded -41 instead of 214 — and all three
-# kernels agreed on the wrong answer, so validate.sh's three-way agreement check
-# stayed green. This gate runs the band on each kernel and asserts the verdict
-# is exactly 4 (every check in tests/int-literal-width-band.fk holds). Agreement
-# on a wrong number is a FAIL here.
+# Two traps in the same family, both invisible to plain agreement:
+#   parse   — 3596153792 (0xD65F03C0, bit 31 set) packed into the 32-bit `inst`
+#             slot read back as -698813504, so (div ... 16777216) = -41 not 214,
+#             and all three kernels agreed on the wrong answer.
+#   compute — TS's bare-int fold wrapped RESULTS at int32 (Math.imul / `| 0`),
+#             so (mul 100000 100000) = 1410065408 vs Go/Rust's 10000000000.
 #
-# Exit 0 on the expected verdict (4) from all three kernels, 1 otherwise.
+# This gate runs the band on each kernel and asserts the verdict is exactly 9
+# (every check in tests/int-literal-width-band.fk holds). Agreement on a wrong
+# number is a FAIL here.
+#
+# Exit 0 on the expected verdict (9) from all three kernels, 1 otherwise.
 set -euo pipefail
 
 FORMDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -21,7 +25,7 @@ cd "$FORMDIR"
 # standalone — no stdlib prelude, no source-compilation. validate.sh's
 # auto-discovery additionally exercises it with core.fk prepended.
 BAND="form-stdlib/tests/int-literal-width-band.fk"
-EXPECT=4
+EXPECT=9
 
 GO_BIN="form-kernel-go/bin-go"
 RS_BIN="form-kernel-rust/target/release/form-kernel-rust"
@@ -50,6 +54,7 @@ if [[ "$go_out" == "$EXPECT" && "$rs_out" == "$EXPECT" && "$ts_out" == "$EXPECT"
   exit 0
 else
   echo "int literal width: FAIL — expected $EXPECT from every kernel (a smaller" >&2
-  echo "  verdict means a kernel is still truncating wide literals to int32)." >&2
+  echo "  verdict means a kernel is still truncating wide literals or results" >&2
+  echo "  to int32)." >&2
   exit 1
 fi


### PR DESCRIPTION
## What

Sibling of the [int-literal-width fix](https://github.com/seeker71/Coherence-Network/pull/2922): that one preserved wide *literals/operands*; this closes the matching hole on the arithmetic **result**. TS's default integer math path folded with `| 0` and `Math.imul`, wrapping every result at int32, while Go and Rust fold in int64:

| expr | Go | Rust | TS (before) |
|---|---|---|---|
| `(mul 100000 100000)` | 10000000000 | 10000000000 | **1410065408** |
| `(add 2000000000 2000000000)` | 4000000000 | 4000000000 | **-294967296** |
| `(mul 65536 65536)` | 4294967296 | 4294967296 | **0** |

Real three-way divergences from small literals, invisible only because no band exercised a bare-int result past 2³¹.

## How

The kernel comment already names this path as *"what Python's polymorphic `+` lowers to"* — and Python ints are arbitrary-precision, so non-wrapping is the **intended** semantics, with Go/Rust the correct reference. The fold now uses plain JS number (exact to 2⁵³, the same frontier the literal fix documents) with `Math.trunc` for division (truncate toward zero, matching Go/Rust integer `/` and `%`).

**Bit-identical for every result that fits int32** — `acc*x` equals `Math.imul`, `Math.trunc` equals `| 0` when the result fits — so only the previously-broken wide-result case changes. Explicit narrow-width ops (`make_int32`, the u32 hash helpers in crc32/sha256/adler32) are untouched and keep their wrapping.

## Proof

Extended `form/form-stdlib/tests/int-literal-width-band.fk` with five arithmetic-result vectors (mul/add past 2³¹, the 2³² boundary, negative trunc-toward-zero div, dividend-signed mod) → **verdict 9 three-way, source + binary**. `form/scripts/int-literal-width-test.sh` asserts exactly 9. Rust **52 tests pass**; crc32/adler32/sha256/hmac/format-arith/tensor-quant/transformer-numerics bands all stay green three-way (full `validate.sh` suite running as backstop).

Safe by construction: Go/Rust are the unchanged reference, so TS can only *converge* toward them within 2⁵³ — no currently-passing band can have relied on bare-op int32 wrap, since Go/Rust never produced the wrapped value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)