### PR TITLE
tend: the pack manifest + seal — self-containment becomes a number the kernel verifies about itself

### DIFF
--- a/form/form-stdlib/pack-manifest.fk
+++ b/form/form-stdlib/pack-manifest.fk
@@ -1,0 +1,101 @@
+; pack-manifest.fk — the contract that makes a pack local, sealed, and counted.
+;
+; preludes: form-stdlib/core.fk form-stdlib/adler32.fk
+;
+; The fourth kernel grows inside-out from packs (symbol, reference, ontology,
+; axiom, grammar, codec, model, host-carrier — any shape). This file is the
+; keystone: the manifest entry every pack declares, and the seal + count that
+; turn "fully self-contained with the minimal number of external packs" from
+; an aspiration into a property the kernel can VERIFY about itself.
+;
+; A manifest entry is (id, shape, descriptor-hash, seal, deps):
+;   descriptor-hash — content-address of the pack's ASCII descriptor
+;                     (id | shape | dep-ids), adler32 over its bytes. Integrity:
+;                     a tampered descriptor mints a different hash (axiom-3).
+;                     ASCII by design — raw multibyte content hashing awaits the
+;                     kernel unit-alignment work (the named TS/byte gap), so the
+;                     seal is byte-identical three-way today, honest absence for
+;                     content hashing until alignment lands.
+;   seal            — adler32 over (trust-seed ++ descriptor): the body's own
+;                     current convention (cell-registry.fk: "hash-of-secret-seed
+;                     pattern; ed25519 when crypto lands"). Authenticity: only a
+;                     holder of the trust-seed reproduces the seal. NAMED HONESTLY
+;                     as a keyed integrity tag, not yet a cryptographic signature
+;                     — ed25519 verify drops in behind pack-sealed? with ZERO
+;                     manifest change, the recipe shaped for exactly that.
+;   deps            — each (target-id, locality); locality is one of:
+;                       "internal"  — another pack in this body (composes freely)
+;                       "host"      — an OS carrier door (fs/tcp/audio/camera;
+;                                     allowed by host-kernel.form, expected)
+;                       "anchor"    — an irreducible external trust root
+;                       "reference" — an outward provenance pointer (a DOI, an
+;                                     archive.org door); points out BY DESIGN,
+;                                     does NOT reduce self-containment
+;
+; The self-containment measure: external-anchor-count — distinct "anchor" deps.
+; North star is 0; the honest floor is 1 (a single root trust key), and below
+; that only the satsang shape (N mutual keys, no single prover). Reference
+; pointers and host carriers are expected and NOT counted against the kernel's
+; self-containment — only anchors are the irreducible external debt.
+;
+;   (pack-entry id shape deps trust-seed)  → a sealed manifest entry
+;   (pack-sealed? entry trust-seed)        → integrity AND authenticity hold
+;   (pack-self-contained? entry)           → every dep is internal
+;   (manifest-anchor-count manifest)       → the external-debt number
+;   (manifest-self-contained? manifest)    → anchor-count is 0
+
+section [form.bml] {
+    // ---- ascii string → byte list (ASCII only: byte == scalar, three-way) -
+    def pm-ascii-bytes-loop(s, i, n, acc) = if ge(i, n) then reverse(acc) else pm-ascii-bytes-loop(s, add(i, 1), n, cons(ord(char_at(s, i)), acc));
+    def pm-ascii-bytes(s) = pm-ascii-bytes-loop(s, 0, str_len(s), empty);
+    def pm-hash(s) = adler32(pm-ascii-bytes(s));
+
+    // ---- dep = (target-id, locality) ------------------------------------
+    def pm-dep(target, locality) = list(target, locality);
+    def pm-dep-target(d) = nth(d, 0);
+    def pm-dep-locality(d) = nth(d, 1);
+    def pm-dep-anchor?(d) = str_eq(pm-dep-locality(d), "anchor");
+    def pm-dep-internal?(d) = str_eq(pm-dep-locality(d), "internal");
+
+    // ---- the canonical ASCII descriptor: id | shape | dep-ids joined ------
+    def pm-dep-ids-loop(deps, acc) = if nil?(deps) then acc else pm-dep-ids-loop(tail(deps), str_concat(acc, str_concat(",", pm-dep-target(head(deps)))));
+    def pm-descriptor(id, shape, deps) = str_concat(id, str_concat("|", str_concat(shape, str_concat("|", pm-dep-ids-loop(deps, "")))));
+
+    // ---- a sealed entry --------------------------------------------------
+    def pm-entry-make(id, shape, descriptor-hash, seal, deps) = list(id, shape, descriptor-hash, seal, deps);
+    def pm-entry-id(e) = nth(e, 0);
+    def pm-entry-shape(e) = nth(e, 1);
+    def pm-entry-hash(e) = nth(e, 2);
+    def pm-entry-seal(e) = nth(e, 3);
+    def pm-entry-deps(e) = nth(e, 4);
+
+    // seal = hash(trust-seed ++ descriptor) — keyed, ed25519-ready
+    def pm-seal-of(descriptor, trust-seed) = pm-hash(str_concat(trust-seed, descriptor));
+    def pack-entry(id, shape, deps, trust-seed) {
+        let descriptor = pm-descriptor(id, shape, deps);
+        pm-entry-make(id, shape, pm-hash(descriptor), pm-seal-of(descriptor, trust-seed), deps);
+    }
+
+    // verify: the descriptor still hashes to the stored hash (integrity) AND
+    // the seal reproduces under the trust-seed (authenticity). Tamper the
+    // descriptor → hash breaks; tamper without the seed → seal breaks.
+    def pack-sealed?(e, trust-seed) {
+        let descriptor = pm-descriptor(pm-entry-id(e), pm-entry-shape(e), pm-entry-deps(e));
+        and(eq(pm-hash(descriptor), pm-entry-hash(e)), eq(pm-seal-of(descriptor, trust-seed), pm-entry-seal(e)));
+    }
+
+    // ---- self-containment counts ----------------------------------------
+    def pm-all-internal?(deps) = if nil?(deps) then true else if pm-dep-internal?(head(deps)) then pm-all-internal?(tail(deps)) else false;
+    def pack-self-contained?(e) = pm-all-internal?(pm-entry-deps(e));
+
+    def pm-anchor-count-deps(deps, acc) = if nil?(deps) then acc else pm-anchor-count-deps(tail(deps), if pm-dep-anchor?(head(deps)) then add(acc, 1) else acc);
+    def pm-entry-anchor-count(e) = pm-anchor-count-deps(pm-entry-deps(e), 0);
+    def manifest-anchor-count-loop(es, acc) = if nil?(es) then acc else manifest-anchor-count-loop(tail(es), add(acc, pm-entry-anchor-count(head(es))));
+    def manifest-anchor-count(m) = manifest-anchor-count-loop(m, 0);
+    def manifest-self-contained?(m) = eq(manifest-anchor-count(m), 0);
+
+    // every entry in a manifest sealed under one trust-seed
+    def manifest-all-sealed?(m, trust-seed) = if nil?(m) then true else if pack-sealed?(head(m), trust-seed) then manifest-all-sealed?(tail(m), trust-seed) else false;
+
+    0;
+}

--- a/form/form-stdlib/tests/pack-manifest-band.fk
+++ b/form/form-stdlib/tests/pack-manifest-band.fk
@@ -1,0 +1,59 @@
+; tests/pack-manifest-band.fk — the pack seal + self-containment count, three-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/adler32.fk form-stdlib/pack-manifest.fk
+;
+; Proves the contract that makes "local, sealed, minimal external" verifiable:
+; a sealed entry verifies under its trust-seed; a TAMPERED descriptor breaks
+; integrity; a WRONG seed breaks authenticity; an all-internal pack is self-
+; contained while one carrying an anchor is not; the manifest anchor-count is
+; the external-debt number (a fully internal body counts 0 — north star); and
+; a manifest of internal packs is all-sealed under one seed.
+;
+; The manifest under test is the fourth kernel's inner shells: ontology, axiom,
+; and symbol-packs depend only on each other (internal); reference-packs points
+; outward (a DOI — locality "reference", NOT counted); a host-fs carrier door
+; (locality "host", expected); and ONE trust-anchor (the root key — the honest
+; floor of 1, the only thing standing between this body and north-star 0).
+;
+; Band verdict: 1023 when every law holds.
+
+section [form.bml] {
+    def pmb-bool(b, weight) = if b then weight else 0;
+
+    def pmb-seed() = "root-trust-seed-v0";
+
+    // the inner-shell manifest: each pack and its dependency localities
+    def pmb-ontology() = pack-entry("ontology", "data", list(pm-dep("axiom", "internal")), pmb-seed());
+    def pmb-axiom() = pack-entry("axiom", "data", empty, pmb-seed());
+    def pmb-symbols() = pack-entry("symbol-packs", "symbol-pack", list(pm-dep("ontology", "internal")), pmb-seed());
+    def pmb-reference() = pack-entry("reference-packs", "reference-pack", list(pm-dep("scarselli-gnn-2009", "reference"), pm-dep("ontology", "internal")), pmb-seed());
+    def pmb-hostfs() = pack-entry("host-fs", "host-carrier", list(pm-dep("os-filesystem", "host")), pmb-seed());
+
+    // the fully-internal core (north-star manifest: anchor-count 0)
+    def pmb-core-manifest() = list(pmb-ontology(), pmb-axiom(), pmb-symbols());
+    // the realistic manifest with a reference pointer and a host door (still 0 anchors)
+    def pmb-grown-manifest() = list(pmb-ontology(), pmb-axiom(), pmb-symbols(), pmb-reference(), pmb-hostfs());
+    // the honest-floor manifest: one trust anchor remains (count 1)
+    def pmb-anchored() = pack-entry("trust-root", "anchor-pack", list(pm-dep("root-public-key", "anchor")), pmb-seed());
+    def pmb-floor-manifest() = list(pmb-ontology(), pmb-anchored());
+
+    // a tampered entry: same fields rebuilt with a forged stored hash/seal
+    def pmb-forged() = pm-entry-make("symbol-packs", "symbol-pack", 999999, 888888, list(pm-dep("ontology", "internal")));
+
+    def pmb-score() {
+        let onto = pmb-ontology();
+        sum(list(
+            pmb-bool(pack-sealed?(onto, pmb-seed()), 1),
+            pmb-bool(not(pack-sealed?(onto, "wrong-seed")), 2),
+            pmb-bool(not(pack-sealed?(pmb-forged(), pmb-seed())), 4),
+            pmb-bool(pack-self-contained?(pmb-axiom()), 8),
+            pmb-bool(not(pack-self-contained?(pmb-reference())), 16),
+            pmb-bool(eq(manifest-anchor-count(pmb-core-manifest()), 0), 32),
+            pmb-bool(and(manifest-self-contained?(pmb-grown-manifest()), eq(manifest-anchor-count(pmb-grown-manifest()), 0)), 64),
+            pmb-bool(eq(manifest-anchor-count(pmb-floor-manifest()), 1), 128),
+            pmb-bool(manifest-all-sealed?(pmb-grown-manifest(), pmb-seed()), 256),
+            pmb-bool(not(manifest-all-sealed?(pmb-grown-manifest(), "wrong-seed")), 512)));
+    }
+
+    pmb-score();
+}


### PR DESCRIPTION
The keystone of the inside-out fourth-kernel map: the contract that turns *fully self-contained with the minimal number of external packs* from an aspiration into a property the kernel **verifies about itself**.

Every pack declares `(id, shape, descriptor-hash, seal, deps)`:
- **descriptor-hash** — adler32 over the ASCII descriptor (`id|shape|dep-ids`); integrity by content-address (axiom-3). ASCII by design — raw multibyte content hashing awaits the named kernel unit-alignment gap; honest absence until then, never a diverging hash.
- **seal** — adler32 over `(trust-seed ++ descriptor)`: the body's *own* current convention (cell-registry.fk's "hash-of-secret-seed pattern; ed25519 when crypto lands"), named honestly as a **keyed integrity tag, not yet a cryptographic signature**. ed25519 verify drops in behind `pack-sealed?` with **zero manifest change** — the recipe is shaped for exactly that door.
- **deps** carry a **locality**: `internal | host | anchor | reference`. The self-containment measure is **external-anchor-count** — distinct irreducible trust roots. **North star 0**; honest floor **1** (a single root key); below that only the satsang shape (N mutual keys, no single prover). Reference pointers (DOIs, the archive.org door) point outward *by design* and host carriers are allowed by host-kernel.form — **neither counts against self-containment**. Only anchors are the irreducible external debt.

**Verdict 1023 three-way** (tests/pack-manifest-band.fk): seal verifies under its seed · descriptor-tamper breaks integrity · wrong-seed breaks authenticity · all-internal is self-contained · an anchored pack is not · the inner-shell manifest (ontology/axiom/symbol-packs + a reference pointer + a host door) counts **0 anchors** — north-star-clean — while the honest-floor manifest counts its single root key.

This is the door every other pack on the map (symbol, grammar, hardware-grammar, codec, model, host-carrier) loads through; the anchor-count is the headline number wellness can one day read to watch the kernel walk toward 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)