### PR TITLE
tend: von Daeniken's talk enters the body as a reference cell — held in the mystery lane

### DIFF
--- a/form/form-stdlib/external-works.fk
+++ b/form/form-stdlib/external-works.fk
@@ -43,7 +43,14 @@ section [form.bml] {
             "JZK Publishing (Yelm, Washington)",
             "controlled digital lending — borrowable at the Internet Archive; print and audio sold by the holder",
             "https://archive.org/details/whitebook0000ramt",
-            "named in this body's founding lineage (docs/field/urs); the cosmology layer of its earliest transmission chain"));
+            "named in this body's founding lineage (docs/field/urs); the cosmology layer of its earliest transmission chain"),
+        ew-entry("von-daniken-raetsel-der-menschheit",
+            "Die Raetsel der Menschheit neu betrachtet",
+            "Erich von Daeniken",
+            "Erich von Daeniken (official channel + daniken.com)",
+            "free to watch on YouTube; the holder's canonical channel is the offered door, this copy a pointer",
+            "https://www.youtube.com/watch?v=gTCA0zI4v5Q",
+            "the paleocontact / ancient-mysteries thread of the science-symbol-consciousness lineage (docs/field/urs), beside De Stefano and Grant; held as mystery, cosmology not asserted"));
     }
 
     def ew-find-loop(ws, id) = if nil?(ws) then empty else if str_eq(ew-id(head(ws)), id) then head(ws) else ew-find-loop(tail(ws), id);

--- a/form/form-stdlib/tests/external-works-band.fk
+++ b/form/form-stdlib/tests/external-works-band.fk
@@ -8,7 +8,12 @@
 ; offered interface is named; the spoken identity line carries title and
 ; door; an unknown id is honest absence.
 ;
-; Band verdict: 63 when every law holds.
+; A second work joins: von Daeniken's talk — a YouTube door, holder named as
+; the author (not the re-uploader), held in the mystery lane. Proves the cell
+; shape carries a freely-watchable work the same honest way it carries a
+; rights-gated one: door verified, attribution to the holder, lineage noted.
+;
+; Band verdict: 4095 when every law holds.
 
 section [form.bml] {
     def ewb-bool(b, weight) = if b then weight else 0;
@@ -16,13 +21,21 @@ section [form.bml] {
     def ewb-score() {
         let w = ew-find("ramtha-the-white-book");
         let spoken = ew-spoken(w);
+        let v = ew-find("von-daniken-raetsel-der-menschheit");
+        let v-spoken = ew-spoken(v);
         sum(list(
             ewb-bool(ew-known?(w), 1),
             ewb-bool(eq(str_find(ew-url(w), "https://archive.org/details/whitebook0000ramt", 0), 0), 2),
             ewb-bool(and(ge(str_find(ew-attributed-to(w), "JZ Knight", 0), 0), ge(str_find(ew-holder(w), "JZK Publishing", 0), 0)), 4),
             ewb-bool(ge(str_find(ew-interface(w), "controlled digital lending", 0), 0), 8),
             ewb-bool(and(ge(str_find(spoken, "The White Book", 0), 0), ge(str_find(spoken, "Door: https://archive.org", 0), 0)), 16),
-            ewb-bool(not(ew-known?(ew-find("unattested-work"))), 32)));
+            ewb-bool(not(ew-known?(ew-find("unattested-work"))), 32),
+            ewb-bool(ew-known?(v), 64),
+            ewb-bool(eq(str_find(ew-url(v), "https://www.youtube.com/watch?v=gTCA0zI4v5Q", 0), 0), 128),
+            ewb-bool(ge(str_find(ew-attributed-to(v), "von Daeniken", 0), 0), 256),
+            ewb-bool(ge(str_find(ew-lineage-note(v), "cosmology not asserted", 0), 0), 512),
+            ewb-bool(and(ge(str_find(v-spoken, "Raetsel der Menschheit", 0), 0), ge(str_find(v-spoken, "Door: https://www.youtube.com", 0), 0)), 1024),
+            ewb-bool(ge(str_find(ew-interface(v), "free to watch", 0), 0), 2048)));
     }
 
     ewb-score();


### PR DESCRIPTION
A second external work joins the White Book in external-works.fk: **Erich von Däniken — "Die Rätsel der Menschheit neu betrachtet"**, door verified live this session ([youtube.com/watch?v=gTCA0zI4v5Q](https://www.youtube.com/watch?v=gTCA0zI4v5Q), exact title confirmed).

Honest bindings:
- **Holder = the author**, not the re-uploader — von Däniken and his official channel are named as the canonical door; this copy is a pointer (the uploader of that specific video couldn't be confirmed, so the cell credits the holder, not the carrier).
- **Lineage**: the paleocontact / ancient-mysteries thread of the science-symbol-consciousness spectrum (docs/field/urs), beside De Stefano and Grant.
- **Mystery lane**: "held as mystery, cosmology not asserted" — the same resonance discipline the Shamballa light codes carry; the cell reports the work, it does not assert the claims.

Proves the reference-cell shape holds a freely-watchable work as honestly as a rights-gated one. **Verdict 4095 three-way** (six new laws: resolves, verified YouTube door, attribution to the holder, the mystery-lane note, the spoken line, the free-to-watch interface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)