### PR TITLE
tend: a fatal names the Form line that produced it — the call stack lives in all three kernels

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -593,6 +593,17 @@ type Kernel struct {
 	// surface: every cell's state traceable to the source line that
 	// authored it. The practice of self-knowing.
 	sourceAttr map[NodeID]sourceLoc
+	// formStack — the Form-level call chain currently live (closure and
+	// native names, innermost last; closure labels carry file:line:col
+	// when the body recipe is attributed). Pushed at dispatch, truncated
+	// on the walk's success path — so after a panic the frames that were
+	// live at the crash are still here for the recover site to surface.
+	formStack []string
+	// readingFiles — line map for the source currently being read:
+	// (file_name_id, first_global_line) per concatenated part. When
+	// non-empty, readSexpr attributes every parenthesized form so fatal
+	// diagnostics can name the Form source line.
+	readingFiles []readingPart
 	importSeq  uint32
 	// walkCache — JIT-vector memoization for pure recipes. Keyed by
 	// recipe NodeID. Real JIT replaces this with compiled native code;
@@ -646,6 +657,11 @@ type switchTable struct {
 type switchArm struct {
 	pattern NodeID
 	body    NodeID
+}
+
+type readingPart struct {
+	FileID    NameID
+	StartLine uint32
 }
 
 type sourceLoc struct {
@@ -1250,6 +1266,52 @@ func (k *Kernel) identID(n NodeID) NameID {
 // nameStr — resolve a NameID back to its source-level string. Error
 // messages and parse-time only; never in the walker's hot path.
 func (k *Kernel) nameStr(id NameID) string { return k.strs[id] }
+
+// resolveReadingLine — map a global line in the concatenated read buffer
+// back to (file_name_id, line_within_that_file). Entries are in
+// concatenation order; the last entry at or before the line owns it.
+func (k *Kernel) resolveReadingLine(globalLine uint32) (NameID, uint32, bool) {
+	var fileID NameID
+	var local uint32
+	found := false
+	for _, part := range k.readingFiles {
+		if part.StartLine <= globalLine {
+			fileID = part.FileID
+			local = globalLine - part.StartLine + 1
+			found = true
+		} else {
+			break
+		}
+	}
+	return fileID, local, found
+}
+
+// formStackDisplay — the live Form call chain, innermost first, capped.
+func (k *Kernel) formStackDisplay(max int) string {
+	if len(k.formStack) == 0 {
+		return ""
+	}
+	total := len(k.formStack)
+	var frames []string
+	for i := total - 1; i >= 0 && len(frames) < max; i-- {
+		frames = append(frames, k.formStack[i])
+	}
+	out := strings.Join(frames, " < ")
+	if total > max {
+		out += fmt.Sprintf(" … (+%d more)", total-max)
+	}
+	return out
+}
+
+// formFrameLabel — a closure frame's display label: the function name,
+// plus file:line:col when the body recipe carries source attribution.
+func (k *Kernel) formFrameLabel(name NameID, body NodeID) string {
+	label := k.nameStr(name)
+	if loc, ok := k.sourceAttr[body]; ok && int(loc.FileID) < len(k.strs) {
+		label = fmt.Sprintf("%s@%s:%d:%d", label, k.strs[loc.FileID], loc.Line, loc.Col)
+	}
+	return label
+}
 
 // ---------------------------------------------------------------------------
 // Values — runtime tagged values
@@ -4127,6 +4189,16 @@ func (k *Kernel) registerNatives() {
 // ---------------------------------------------------------------------------
 
 func (k *Kernel) walk(n NodeID, env *Frame) Value {
+	// One Form-stack slot per host walk invocation (see walkInner's closure
+	// arm). The truncation runs only on the success path — a panic leaves
+	// the live frames in place for the recover site to read.
+	depth := len(k.formStack)
+	v := k.walkInner(n, env)
+	k.formStack = k.formStack[:depth]
+	return v
+}
+
+func (k *Kernel) walkInner(n NodeID, env *Frame) Value {
 	// Tail-call optimization: a tail-position call — a closure body, a cond
 	// branch, or a do-block's last expr — reassigns n/env and loops here
 	// instead of recursing, so tail-recursive Form loops (gm-rep-loop,
@@ -4135,6 +4207,10 @@ func (k *Kernel) walk(n NodeID, env *Frame) Value {
 	// not. Result-transparent — identical values to plain recursion, far less
 	// stack (a long member/statement list no longer recurses N-deep), which is
 	// what lets the strictest kernel parse the full thesis grammar files.
+	// myFrame — index of this walk invocation's Form-stack slot, -1 until
+	// a closure is entered. TCO re-entry REPLACES the slot (the tail
+	// caller's frame is complete), mirroring the host stack's collapse.
+	myFrame := -1
 	for {
 		if n.Level == LevelTrivial {
 			return k.trivialValue(n)
@@ -4365,7 +4441,10 @@ func (k *Kernel) walk(n NodeID, env *Frame) Value {
 						k.Trace.recordNative(k.nameStr(ne.Name))
 					}
 					k.observeNamedDispatch("observe/go/native-dispatch", ne.Name)
-					return ne.Fn(k, env, args)
+					k.formStack = append(k.formStack, k.nameStr(ne.Name))
+					v := ne.Fn(k, env, args)
+					k.formStack = k.formStack[:len(k.formStack)-1]
+					return v
 				}
 			}
 			// Native takes priority unless user shadowed with a closure.
@@ -4382,7 +4461,10 @@ func (k *Kernel) walk(n NodeID, env *Frame) Value {
 						k.Trace.recordNative(k.nameStr(ne.Name))
 					}
 					k.observeNamedDispatch("observe/go/native-dispatch", ne.Name)
-					return ne.Fn(k, args)
+					k.formStack = append(k.formStack, k.nameStr(ne.Name))
+					v := ne.Fn(k, args)
+					k.formStack = k.formStack[:len(k.formStack)-1]
+					return v
 				}
 			}
 			// Closure lookup uses the original function name so user code stays
@@ -4497,6 +4579,12 @@ func (k *Kernel) walk(n NodeID, env *Frame) Value {
 				k.Trace.recordFn(k.nameStr(cl.Name))
 			}
 			k.observeNamedDispatch("observe/go/function-dispatch", cl.Name)
+			if label := k.formFrameLabel(cl.Name, cl.Body); myFrame >= 0 && myFrame < len(k.formStack) {
+				k.formStack[myFrame] = label
+			} else {
+				myFrame = len(k.formStack)
+				k.formStack = append(k.formStack, label)
+			}
 			n = cl.Body // TCO: closure body is in tail position.
 			env = call
 			continue
@@ -4521,8 +4609,11 @@ func (k *Kernel) walk(n NodeID, env *Frame) Value {
 }
 
 func (k *Kernel) walkChoiceBranch(branch NodeID, env *Frame) (value Value, ok bool, stopped bool) {
+	depth := len(k.formStack)
 	defer func() {
 		if r := recover(); r != nil {
+			// A swallowed branch failure must not leave its frames behind.
+			k.formStack = k.formStack[:depth]
 			switch r.(type) {
 			case choiceFailSignal:
 				value = Value{Kind: VNull}
@@ -4928,7 +5019,18 @@ func (k *Kernel) readSexpr(toks []sexpToken, i int) (NodeID, int) {
 			args = append(args, arg)
 			i = ni
 		}
-		return k.buildVerb(verb, args), i
+		node := k.buildVerb(verb, args)
+		// Source attribution at read time: every parenthesized form
+		// remembers the file:line:col of its opening paren, so a fatal
+		// mid-walk can name the Form source line. Content-addressing
+		// means a shape interned from two sites keeps its FIRST
+		// authoring site.
+		if fileID, localLine, ok := k.resolveReadingLine(uint32(openLine)); ok {
+			if _, exists := k.sourceAttr[node]; !exists {
+				k.sourceAttr[node] = sourceLoc{FileID: fileID, Line: localLine, Col: uint32(openCol)}
+			}
+		}
+		return node, i
 	}
 	panic(fmt.Sprintf("parse error at line %d col %d: unexpected token %s %q", t.line, t.col, t.kind, t.value))
 }
@@ -5196,11 +5298,21 @@ func kernelModeFromArgs(args []string) string {
 	}
 }
 
-func writeKernelCrashTrace(args []string, src string, recovered any) string {
-	return writeKernelCrashTraceWithContext(args, src, recovered, "", "")
+// formStackInnermostFirst — reverse the live stack for the trace record
+// so the first entry answers "where exactly" (sibling to Rust's form_stack).
+func formStackInnermostFirst(stack []string) []string {
+	out := make([]string, 0, len(stack))
+	for i := len(stack) - 1; i >= 0; i-- {
+		out = append(out, stack[i])
+	}
+	return out
 }
 
-func writeKernelCrashTraceWithContext(args []string, src string, recovered any, sourceLabel string, operation string) string {
+func writeKernelCrashTrace(args []string, src string, recovered any, formStack []string) string {
+	return writeKernelCrashTraceWithContext(args, src, recovered, "", "", formStack)
+}
+
+func writeKernelCrashTraceWithContext(args []string, src string, recovered any, sourceLabel string, operation string, formStack []string) string {
 	dir := filepath.Join(".cache", "form-kernel-go")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		dir = os.TempDir()
@@ -5230,6 +5342,7 @@ func writeKernelCrashTraceWithContext(args []string, src string, recovered any, 
 		"source_bytes":      len(src),
 		"source_line_count": kernelSourceLineCount(src),
 		"source_head":       kernelSourceExcerpt(src, 2000),
+		"form_stack":        formStackInnermostFirst(formStack),
 		"source_tail":       src[tailStart:],
 		"go_stack":          string(debug.Stack()),
 	}
@@ -5251,6 +5364,12 @@ func main() {
 	}
 
 	var src string
+	var crashK *Kernel
+	type lineMapPart struct {
+		path      string
+		startLine uint32
+	}
+	var lineMapParts []lineMapPart
 
 	// Catch parse-time and walk-time panics and convert them to clean error
 	// output. The trace file keeps the host stack and source excerpt for
@@ -5258,7 +5377,17 @@ func main() {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Fprintf(os.Stderr, "form-kernel-go: %v\n", r)
-			if tracePath := writeKernelCrashTrace(args, src, r); tracePath != "" {
+			var stack []string
+			if crashK != nil {
+				stack = crashK.formStack
+				// The Form-level call chain live at the crash, innermost
+				// first — the line that produced the fatal is the innermost
+				// attributed frame.
+				if display := crashK.formStackDisplay(16); display != "" {
+					fmt.Fprintf(os.Stderr, "form-kernel-go: form stack: %s\n", display)
+				}
+			}
+			if tracePath := writeKernelCrashTrace(args, src, r, stack); tracePath != "" {
 				fmt.Fprintf(os.Stderr, "form-kernel-go: crash trace: %s\n", tracePath)
 			}
 			os.Exit(1)
@@ -5332,21 +5461,32 @@ func main() {
 		// Multiple files load sequentially into a shared top-level scope.
 		// Concatenation works because the kernel wraps multi-form input in
 		// an implicit do-block — definitions from earlier files become
-		// visible to later ones.
+		// visible to later ones. The line map remembers each file's first
+		// global line so read-time attribution names the ORIGINAL file:line.
 		var parts []string
+		nextLine := uint32(1)
 		for _, path := range args {
 			b, err := os.ReadFile(path)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "read %s: %v\n", path, err)
 				os.Exit(1)
 			}
-			parts = append(parts, string(b))
+			s := string(b)
+			lineMapParts = append(lineMapParts, lineMapPart{path: path, startLine: nextLine})
+			// +1 for the join newline between parts.
+			nextLine += uint32(strings.Count(s, "\n")) + 1
+			parts = append(parts, s)
 		}
 		src = strings.Join(parts, "\n")
 	}
 
 	k := NewKernel()
+	crashK = k
+	for _, part := range lineMapParts {
+		k.readingFiles = append(k.readingFiles, readingPart{FileID: k.internName(part.path), StartLine: part.startLine})
+	}
 	root := readRootFromSource(k, src)
+	k.readingFiles = nil
 	if args[0] == "--emit-binary" {
 		if err := os.WriteFile(args[1], serializeArtifact(k, root), 0644); err != nil {
 			fmt.Fprintf(os.Stderr, "write %s: %v\n", args[1], err)

--- a/form/form-kernel-go/server.go
+++ b/form/form-kernel-go/server.go
@@ -1525,12 +1525,16 @@ func (wkr *goServeWorker) serve(w http.ResponseWriter, r *http.Request) {
 				where = nativeRouteWhere(activeRoute, r)
 			}
 			operation := fmt.Sprintf("request=%s %s %s", r.Method, r.URL.RequestURI(), where)
+			formStack := append([]string(nil), wkr.k.formStack...)
+			// The pooled worker serves the next request with a clean stack.
+			wkr.k.formStack = wkr.k.formStack[:0]
 			tracePath := writeKernelCrashTraceWithContext(
 				[]string{"serve", r.Method, r.URL.RequestURI()},
 				source,
 				recovered,
 				sourceLabel,
 				operation,
+				formStack,
 			)
 			setRouteDecisionHeaders(
 				w.Header(),

--- a/form/form-kernel-go/server_test.go
+++ b/form/form-kernel-go/server_test.go
@@ -670,3 +670,29 @@ func TestGatesMainHeadRouteFetchesExternalHTTPInBML(t *testing.T) {
 		}
 	}
 }
+
+// TestFatalNamesFormSourceLine — a typed-boundary fatal must name the Form
+// call chain live at the crash, with file:line attribution from the reader.
+// This is the diagnostic that turns "as_nid: null at the host accessor"
+// into "node_children inside inner@probe.fk:2" — the line that produced it.
+func TestFatalNamesFormSourceLine(t *testing.T) {
+	k := NewKernel()
+	k.readingFiles = []readingPart{{FileID: k.internName("probe.fk"), StartLine: 1}}
+	root := readRootFromSource(k, "(do\n  (defn inner (x) (node_children x))\n  (inner (head (empty))))")
+	k.readingFiles = nil
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected a typed-boundary panic, walk returned normally")
+		}
+		display := k.formStackDisplay(16)
+		if !strings.Contains(display, "node_children") {
+			t.Fatalf("form stack missing the native frame: %q", display)
+		}
+		if !strings.Contains(display, "inner@probe.fk:2:") {
+			t.Fatalf("form stack missing the attributed closure frame: %q", display)
+		}
+	}()
+	env := NewFrame(nil)
+	k.walk(root, env)
+}

--- a/form/form-kernel-rust/src/main.rs
+++ b/form/form-kernel-rust/src/main.rs
@@ -60,6 +60,64 @@ fn crash_trace_context() -> &'static Mutex<CrashTraceContext> {
 thread_local! {
     static THREAD_CRASH_TRACE_CONTEXT: RefCell<Option<CrashTraceContext>> = const { RefCell::new(None) };
     static THREAD_LAST_CRASH_TRACE_PATH: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+    static FORM_CALL_STACK: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+// FormStackFrame — one live frame on the Form-level call stack. Pushed when
+// the walker dispatches into a native or closure, popped on Drop. The panic
+// hook runs BEFORE unwinding, so a fatal reads the frames that were live at
+// the crash; unwinding then pops them, which keeps the stack honest across
+// the serve worker's per-request catch_unwind. Closure labels carry source
+// attribution ("name@file:line:col") when the body recipe has it.
+struct FormStackFrame;
+
+impl FormStackFrame {
+    fn push(label: String) -> FormStackFrame {
+        FORM_CALL_STACK.with(|s| s.borrow_mut().push(label));
+        FormStackFrame
+    }
+
+    // Tail call: the caller's frame is complete (its body ended in this
+    // call), so the new label REPLACES the top instead of stacking — the
+    // same collapse a tail-call-optimized host stack performs.
+    fn replace_top(self, label: String) -> FormStackFrame {
+        FORM_CALL_STACK.with(|s| {
+            let mut stack = s.borrow_mut();
+            stack.pop();
+            stack.push(label);
+        });
+        self
+    }
+}
+
+impl Drop for FormStackFrame {
+    fn drop(&mut self) {
+        FORM_CALL_STACK.with(|s| {
+            s.borrow_mut().pop();
+        });
+    }
+}
+
+fn form_stack_snapshot() -> Vec<String> {
+    FORM_CALL_STACK.with(|s| s.borrow().iter().rev().cloned().collect())
+}
+
+fn form_stack_display(max: usize) -> String {
+    let stack = form_stack_snapshot();
+    if stack.is_empty() {
+        return String::new();
+    }
+    let total = stack.len();
+    let mut out = stack
+        .iter()
+        .take(max)
+        .map(|s| s.as_str())
+        .collect::<Vec<_>>()
+        .join(" < ");
+    if total > max {
+        out.push_str(&format!(" … (+{} more)", total - max));
+    }
+    out
 }
 
 fn source_excerpt_head(src: &str, max_chars: usize) -> String {
@@ -255,6 +313,11 @@ fn write_kernel_crash_trace(message: &str, location: Option<String>) -> Option<P
         "source_line_count": source_line_count(&ctx.source),
         "source_head": source_excerpt_head(&ctx.source, 2000),
         "source_tail": source_excerpt_tail(&ctx.source, 2000),
+        // Innermost frame first — the Form-level call chain live at the
+        // crash. The line that produced the fatal is the innermost closure
+        // frame's attribution (name@file:line:col) or, failing that, the
+        // named native plus its caller.
+        "form_stack": form_stack_snapshot(),
         "rust_backtrace": format!("{:?}", Backtrace::force_capture()),
     });
     let data = serde_json::to_vec_pretty(&report).ok()?;
@@ -1200,6 +1263,12 @@ pub(crate) struct Kernel {
     // The satsang-load-bearing surface: every cell's state is traceable
     // back to the source line of the recipe that authored it.
     source_attr: HashMap<NodeID, (NameID, u32, u32)>,
+    // Line map for the source currently being read: (file_name_id,
+    // first_global_line) per concatenated part. When non-empty, read_sexp
+    // attributes every parenthesized form it builds so fatal diagnostics
+    // can name the Form source file:line. Empty outside file loads
+    // (inline strings, route bodies that carry their own labels).
+    reading_files: Vec<(NameID, u32)>,
     // walk_cache — JIT-vector memoization: pure recipes (no I/O, no
     // external state) can have their walk result cached by NodeID.
     // Content-addressing means same recipe shape → same NodeID, so
@@ -1633,6 +1702,7 @@ impl Kernel {
             by_shape: HashMap::new(),
             by_id: HashMap::new(),
             source_attr: HashMap::new(),
+            reading_files: Vec::new(),
             walk_cache: HashMap::new(),
             walk_cache_hits: 0,
             walk_cache_misses: 0,
@@ -2070,6 +2140,7 @@ impl Kernel {
             by_shape: self.by_shape.clone(),
             by_id: self.by_id.clone(),
             source_attr: self.source_attr.clone(),
+            reading_files: Vec::new(),
             walk_cache: HashMap::new(),
             walk_cache_hits: 0,
             walk_cache_misses: 0,
@@ -2161,6 +2232,21 @@ impl Kernel {
 
     // Resolve a NameID back to its source-level string. Only used in error
     // messages and on the parse-time slow path.
+    // Map a global line in the concatenated read buffer back to
+    // (file_name_id, line_within_that_file). Entries are in concatenation
+    // order; the last entry whose start is at or before the line owns it.
+    fn resolve_reading_line(&self, global_line: u32) -> Option<(NameID, u32)> {
+        let mut owner: Option<(NameID, u32)> = None;
+        for (file_id, start) in &self.reading_files {
+            if *start <= global_line {
+                owner = Some((*file_id, global_line - start + 1));
+            } else {
+                break;
+            }
+        }
+        owner
+    }
+
     fn name_str(&self, id: NameID) -> &str {
         &self.strs[id as usize]
     }
@@ -6875,6 +6961,11 @@ fn walk_inner(k: &mut Kernel, a: &mut Arena, n: NodeID, env: FrameId) -> Value {
     // kernel parse the full thesis grammar files without overflowing.
     let mut n = n;
     let mut env = env;
+    // One Form-stack slot per host walk invocation: a closure entered by TCO
+    // REPLACES the slot (its tail-caller's frame is complete); a closure
+    // entered through a fresh recursive walk (arg evaluation, native
+    // interiors) gets its own slot in that invocation.
+    let mut form_frame: Option<FormStackFrame> = None;
     loop {
         if n.level == LEVEL_TRIVIAL {
             return k.trivial_value(n);
@@ -7054,6 +7145,7 @@ fn walk_inner(k: &mut Kernel, a: &mut Arena, n: NodeID, env: FrameId) -> Value {
                         if let Some(t) = &mut k.trace {
                             t.record_native(&native_name);
                         }
+                        let _form_frame = FormStackFrame::push(native_name);
                         return (ne.func)(k, a, env, &args);
                     }
                 }
@@ -7080,6 +7172,7 @@ fn walk_inner(k: &mut Kernel, a: &mut Arena, n: NodeID, env: FrameId) -> Value {
                         if let Some(t) = &mut k.trace {
                             t.record_native(&native_name);
                         }
+                        let _form_frame = FormStackFrame::push(native_name);
                         return (ne.func)(k, a, &args);
                     }
                 }
@@ -7101,6 +7194,7 @@ fn walk_inner(k: &mut Kernel, a: &mut Arena, n: NodeID, env: FrameId) -> Value {
                         if let Some(t) = &mut k.trace {
                             t.record_native(&leaf_name);
                         }
+                        let _form_frame = FormStackFrame::push(leaf_name.clone());
                         // Arc held through the call — the Library can't be
                         // dropped mid-call (same contract as the closure jit
                         // fast path below).
@@ -7141,6 +7235,16 @@ fn walk_inner(k: &mut Kernel, a: &mut Arena, n: NodeID, env: FrameId) -> Value {
                 if let Some(t) = &mut k.trace {
                     t.record_fn(&fn_name);
                 }
+                let frame_label = match k.source_attr.get(&cl2.body).copied() {
+                    Some((file_id, line, col)) => {
+                        format!("{}@{}:{}:{}", fn_name, k.name_str(file_id), line, col)
+                    }
+                    None => fn_name.clone(),
+                };
+                form_frame = Some(match form_frame.take() {
+                    Some(f) => f.replace_top(frame_label),
+                    None => FormStackFrame::push(frame_label),
+                });
                 // JIT-compiled fast path: if (jit_compile "name") landed for
                 // this closure's body, dispatch through the loaded function
                 // pointer. Form recipe stays canonical truth; the .so is opt-in
@@ -7542,7 +7646,19 @@ fn read_sexp(k: &mut Kernel, toks: &[SexpTok], i: usize) -> (NodeID, usize) {
                 args.push(arg);
                 j = nj;
             }
-            (build_verb(k, &verb, args), j)
+            let node = build_verb(k, &verb, args);
+            // Source attribution at read time: every parenthesized form
+            // remembers the file:line:col of its opening paren, so a fatal
+            // mid-walk can name the Form source line, not just the host
+            // accessor. Content-addressing means a shape interned from two
+            // sites keeps its FIRST authoring site — an honest "this shape
+            // was written here (first)".
+            if let Some((file_id, local_line)) = k.resolve_reading_line(t.line) {
+                k.source_attr
+                    .entry(node)
+                    .or_insert((file_id, local_line, t.col));
+            }
+            (node, j)
         }
         _ => panic!(
             "parse error at line {} col {}: unexpected token {} {:?}",
@@ -7802,6 +7918,20 @@ fn count_top_level(toks: &[SexpTok]) -> usize {
 pub(crate) fn run_source(src: &str) -> Value {
     let mut k = Kernel::new();
     let root = read_root_from_source(&mut k, src);
+    execute_root(&mut k, root)
+}
+
+// Run a concatenated multi-file source with a line map so read-time
+// attribution names each form's ORIGINAL file:line. The map entries are
+// (file_name, first_global_line_of_that_file) in concatenation order.
+pub(crate) fn run_source_mapped(src: &str, line_map: &[(String, u32)]) -> Value {
+    let mut k = Kernel::new();
+    k.reading_files = line_map
+        .iter()
+        .map(|(name, start)| (k.intern_string(name).inst, *start))
+        .collect();
+    let root = read_root_from_source(&mut k, src);
+    k.reading_files.clear();
     execute_root(&mut k, root)
 }
 
@@ -14068,6 +14198,14 @@ fn install_panic_hook() {
             .unwrap_or("unknown error");
         let diagnosis = diagnose_kernel_panic(msg);
         eprintln!("form-kernel-rust: fatal[{}]: {}", diagnosis.fatal_kind, msg);
+        // The Form-level call chain live at the crash, innermost first —
+        // the hook runs before unwinding, so the frames are still pushed.
+        // This is the line that answers "WHERE in the Form source": the
+        // innermost named frames, with file:line:col when attributed.
+        let stack = form_stack_display(16);
+        if !stack.is_empty() {
+            eprintln!("form-kernel-rust: form stack: {}", stack);
+        }
         eprintln!(
             "form-kernel-rust: likely root cause: {}",
             diagnosis.likely_root_cause
@@ -14085,6 +14223,40 @@ fn install_panic_hook() {
 #[cfg(test)]
 mod crash_diagnostics_tests {
     use super::*;
+
+    // The reader attributes every parenthesized form to its file:line so a
+    // fatal mid-walk can name the Form source line (the diagnostic that
+    // turns "as_nid: Null at the host accessor" into "node_children inside
+    // inner@probe.fk:2").
+    #[test]
+    fn reader_attributes_forms_to_file_lines() {
+        let mut k = Kernel::new();
+        let file_id = k.intern_string("probe.fk").inst;
+        k.reading_files = vec![(file_id, 1)];
+        let _root =
+            read_root_from_source(&mut k, "(do\n  (defn inner (x) (node_children x)))");
+        k.reading_files.clear();
+        let hit = k
+            .source_attr
+            .values()
+            .any(|(f, line, _)| *f == file_id && *line == 2);
+        assert!(hit, "expected a line-2 attribution for the defn body");
+    }
+
+    // Frames display innermost first — the order a reader scans to find
+    // the failing call. Runs on a dedicated thread so the thread-local
+    // stack starts clean.
+    #[test]
+    fn form_stack_displays_innermost_first() {
+        let display = std::thread::spawn(|| {
+            let _outer = FormStackFrame::push("inner@probe.fk:2:19".to_string());
+            let _native = FormStackFrame::push("node_children".to_string());
+            form_stack_display(16)
+        })
+        .join()
+        .expect("probe thread");
+        assert_eq!(display, "node_children < inner@probe.fk:2:19");
+    }
 
     #[test]
     fn diagnose_null_string_contract_as_type_violation() {
@@ -14179,6 +14351,7 @@ fn main_with_args(args: Vec<String>) -> i32 {
         "check" => cli_check(&args[1..]),
         _ => {
             // Source adapter: --expr or <file.fk> [more.fk ...]
+            let mut line_map: Vec<(String, u32)> = Vec::new();
             let src = if args[0] == "--expr" {
                 if args.len() < 2 {
                     eprintln!("--expr requires an argument");
@@ -14187,9 +14360,15 @@ fn main_with_args(args: Vec<String>) -> i32 {
                 args[1].clone()
             } else {
                 let mut parts = Vec::with_capacity(args.len());
+                let mut next_line = 1u32;
                 for path in &args {
                     match fs::read_to_string(path) {
-                        Ok(s) => parts.push(s),
+                        Ok(s) => {
+                            line_map.push((path.clone(), next_line));
+                            // +1 for the join newline between parts.
+                            next_line += s.matches('\n').count() as u32 + 1;
+                            parts.push(s);
+                        }
                         Err(e) => {
                             eprintln!("read {}: {}", path, e);
                             std::process::exit(1);
@@ -14204,7 +14383,7 @@ fn main_with_args(args: Vec<String>) -> i32 {
                 "source"
             };
             set_crash_trace_context(mode, &args, Some(&src));
-            let result = run_source(&src);
+            let result = run_source_mapped(&src, &line_map);
             println!("{}", result.display());
             0
         }

--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -709,6 +709,65 @@ export class Kernel {
   byID = new Map<string, Recipe>();
   private nextInst = 1; // next instance number for composites
   private sourceAttr = new Map<string, { file: NameID; line: number; col: number }>();
+  // formStack — the Form-level call chain currently live (closure and
+  // native names, innermost last; closure labels carry file:line:col when
+  // the body recipe is attributed). Pushed at dispatch, popped on the
+  // success path only — after a throw the frames that were live at the
+  // crash remain for the top-level catch to surface.
+  formStack: string[] = [];
+  // readingFiles — line map for the source currently being read:
+  // (file name, first global line) per concatenated part. When non-empty,
+  // the reader attributes every parenthesized form so fatal diagnostics
+  // can name the Form source line.
+  readingFiles: { file: string; startLine: number }[] = [];
+
+  // resolveReadingLine — map a global line in the concatenated read buffer
+  // back to (file, line within that file).
+  resolveReadingLine(globalLine: number): { file: string; line: number } | null {
+    let owner: { file: string; line: number } | null = null;
+    for (const part of this.readingFiles) {
+      if (part.startLine <= globalLine) {
+        owner = { file: part.file, line: globalLine - part.startLine + 1 };
+      } else {
+        break;
+      }
+    }
+    return owner;
+  }
+
+  // attributeSource — record a node's authoring site (first writer wins —
+  // content-addressing means a shape interned from two sites keeps its
+  // first authoring site).
+  attributeSource(node: NodeID, file: string, line: number, col: number): void {
+    const key = nodeKey(node);
+    if (!this.sourceAttr.has(key)) {
+      this.sourceAttr.set(key, { file: this.internName(file), line, col });
+    }
+  }
+
+  // formStackDisplay — the live Form call chain, innermost first, capped.
+  formStackDisplay(max: number): string {
+    if (this.formStack.length === 0) return "";
+    const total = this.formStack.length;
+    const frames: string[] = [];
+    for (let i = total - 1; i >= 0 && frames.length < max; i--) {
+      frames.push(this.formStack[i]!);
+    }
+    let out = frames.join(" < ");
+    if (total > max) out += ` … (+${total - max} more)`;
+    return out;
+  }
+
+  // formFrameLabel — a closure frame's display label: the function name,
+  // plus file:line:col when the body recipe carries source attribution.
+  formFrameLabel(name: NameID, body: NodeID): string {
+    let label = this.nameStr(name);
+    const loc = this.sourceAttr.get(nodeKey(body));
+    if (loc !== undefined) {
+      label = `${label}@${this.nameStr(loc.file)}:${loc.line}:${loc.col}`;
+    }
+    return label;
+  }
   private importSeq = 1;
   private walkCache = new Map<string, Value>();
   private walkCacheHits = 0;
@@ -4817,7 +4876,10 @@ function walkFnCall(
         k.trace?.record(envNe.category.type, envNe.category.inst);
       }
       k.trace?.recordNative(k.nameStr(envNe.name));
-      return envNe.fn(k, frame, envArgs);
+      k.formStack.push(k.nameStr(envNe.name));
+      const envOut = envNe.fn(k, frame, envArgs);
+      k.formStack.pop();
+      return envOut;
     }
     // Native dispatch
     const ne = k.natives.get(dispatchName);
@@ -4833,7 +4895,10 @@ function walkFnCall(
         k.trace.record(ne.category.type, ne.category.inst);
       }
       k.trace?.recordNative(k.nameStr(ne.name));
-      return ne.fn(k, args);
+      k.formStack.push(k.nameStr(ne.name));
+      const neOut = ne.fn(k, args);
+      k.formStack.pop();
+      return neOut;
     }
     // Closure via frame — use the ORIGINAL function-name (not the JIT-
     // aliased one): the user defined this function under rawName and
@@ -4875,6 +4940,7 @@ function invokeClosure(
     callFrame.bind(closure.params[i]!, v);
   }
   k.trace?.recordFn(k.nameStr(closure.name));
+  k.formStack.push(k.formFrameLabel(closure.name, closure.body));
   // JIT-compiled fast path: if this closure's body has been compiled
   // via (jit_compile ...), dispatch through the host-JIT'd function
   // instead of walking the recipe tree. Form recipe stays canonical
@@ -4882,15 +4948,23 @@ function invokeClosure(
   const bodyKey = nodeIDKey(closure.body);
   const compiled = k.jitCompiled.get(bodyKey);
   if (compiled !== undefined) {
+    const depth = k.formStack.length;
     try {
-      return compiled(callFrame);
+      const out = compiled(callFrame);
+      k.formStack.pop();
+      return out;
     } catch (err) {
+      // The walker retries below — a swallowed JIT failure must not
+      // leave its frames behind.
+      k.formStack.length = depth;
       const reason = err instanceof Error ? err.message : String(err);
       k.jitFailedReason.set(bodyKey, reason);
       k.jitDispatchMisses.set(bodyKey, (k.jitDispatchMisses.get(bodyKey) ?? 0) + 1);
     }
   }
-  return walk(k, closure.body, callFrame);
+  const out = walk(k, closure.body, callFrame);
+  k.formStack.pop();
+  return out;
 }
 
 function nodeIDKey(nid: NodeID): string {

--- a/form/form-kernel-ts/src/main.ts
+++ b/form/form-kernel-ts/src/main.ts
@@ -35,6 +35,11 @@ const crashTraceContext: CrashTraceContext = {
   source: "",
 };
 
+// The kernel whose Form call stack the top-level catch surfaces. Set as
+// soon as the CLI kernel exists; the frames live at the crash answer
+// "which Form source line produced this".
+let crashKernel: Kernel | null = null;
+
 function setCrashTraceContext(mode: string, args: string[], source?: string): void {
   crashTraceContext.mode = mode;
   crashTraceContext.args = [...args];
@@ -69,6 +74,8 @@ async function writeKernelCrashTrace(err: unknown): Promise<string | null> {
     source_head: source.slice(0, 2000),
     source_tail: source.slice(Math.max(0, source.length - 2000)),
     js_stack: stack ?? null,
+    // Innermost frame first — the Form-level call chain live at the crash.
+    form_stack: crashKernel === null ? [] : [...crashKernel.formStack].reverse(),
   };
   try {
     await writeFile(path, `${JSON.stringify(report, null, 2)}\n`);
@@ -104,6 +111,7 @@ async function main(): Promise<void> {
   }
 
   const k = new Kernel();
+  crashKernel = k;
   // Install the Form→host-JS JIT hook so (jit_compile "name") from Form
   // code compiles the named closure's body through compiler.ts.
   k.jitCompileHook = compileNode;
@@ -174,11 +182,18 @@ async function main(): Promise<void> {
     console.error("missing source file");
     process.exit(2);
   }
-  const src = (
-    await Promise.all(paths.map((path) => readFile(path, "utf8")))
-  ).join("\n");
+  const parts = await Promise.all(paths.map((path) => readFile(path, "utf8")));
+  // Line map: each file's first global line in the joined source, so
+  // read-time attribution names the ORIGINAL file:line (+1 per join newline).
+  let nextLine = 1;
+  for (let i = 0; i < paths.length; i++) {
+    k.readingFiles.push({ file: paths[i]!, startLine: nextLine });
+    nextLine += (parts[i]!.match(/\n/g)?.length ?? 0) + 1;
+  }
+  const src = parts.join("\n");
   setCrashTraceContext("source", args, src);
   const node = readAll(k, src);
+  k.readingFiles = [];
   k.setActiveRoots([node]);
   const value = walk(k, node, frame);
   k.substrateGC([value], frame);
@@ -236,6 +251,12 @@ main()
   .catch(async (err: unknown) => {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`form-kernel-ts: ${msg}`);
+    // The Form-level call chain live at the crash, innermost first — the
+    // line that produced the fatal is the innermost attributed frame.
+    const formStack = crashKernel?.formStackDisplay(16) ?? "";
+    if (formStack !== "") {
+      console.error(`form-kernel-ts: form stack: ${formStack}`);
+    }
     const tracePath = await writeKernelCrashTrace(err);
     if (tracePath !== null) {
       console.error(`form-kernel-ts: crash trace: ${tracePath}`);

--- a/form/form-kernel-ts/src/reader.ts
+++ b/form/form-kernel-ts/src/reader.ts
@@ -110,6 +110,10 @@ function tokenize(src: string): Token[] {
 interface ParseState {
   toks: Token[];
   i: number;
+  // attribute — when set, every parenthesized form is recorded with the
+  // file:line:col of its opening paren so fatal diagnostics can name the
+  // Form source line (sibling to the Go/Rust readers).
+  attribute: ((node: NodeID, pos: number) => void) | null;
 }
 
 function peek(s: ParseState): Token | undefined {
@@ -124,7 +128,7 @@ function consume(s: ParseState): Token {
 }
 
 export function readForm(k: Kernel, src: string): NodeID {
-  const s: ParseState = { toks: tokenize(src), i: 0 };
+  const s: ParseState = { toks: tokenize(src), i: 0, attribute: makeAttributor(k, src) };
   const node = readOne(k, s);
   if (s.i !== s.toks.length) {
     const t = s.toks[s.i];
@@ -134,7 +138,7 @@ export function readForm(k: Kernel, src: string): NodeID {
 }
 
 export function readAll(k: Kernel, src: string): NodeID {
-  const s: ParseState = { toks: tokenize(src), i: 0 };
+  const s: ParseState = { toks: tokenize(src), i: 0, attribute: makeAttributor(k, src) };
   const forms: NodeID[] = [];
   while (s.i < s.toks.length) {
     forms.push(readOne(k, s));
@@ -145,6 +149,37 @@ export function readAll(k: Kernel, src: string): NodeID {
     { pkg: 1, level: Level.BASIC, type: RBasic.BLOCK, inst: RBlock.DO },
     forms,
   );
+}
+
+// makeAttributor — byte position → (file, line, col) recorder. Line starts
+// are precomputed once per read; the kernel's readingFiles line map (set by
+// the CLI when loading multiple files) translates global lines back to the
+// original file. Returns null when no line map is active.
+function makeAttributor(
+  k: Kernel,
+  src: string,
+): ((node: NodeID, pos: number) => void) | null {
+  if (k.readingFiles.length === 0) return null;
+  const lineStarts: number[] = [0];
+  for (let i = 0; i < src.length; i++) {
+    if (src[i] === "\n") lineStarts.push(i + 1);
+  }
+  return (node, pos) => {
+    // Binary search: last line start at or before pos.
+    let lo = 0;
+    let hi = lineStarts.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (lineStarts[mid]! <= pos) lo = mid;
+      else hi = mid - 1;
+    }
+    const globalLine = lo + 1;
+    const col = pos - lineStarts[lo]! + 1;
+    const owner = k.resolveReadingLine(globalLine);
+    if (owner !== null) {
+      k.attributeSource(node, owner.file, owner.line, col);
+    }
+  };
 }
 
 function readOne(k: Kernel, s: ParseState): NodeID {
@@ -177,7 +212,11 @@ function readOne(k: Kernel, s: ParseState): NodeID {
     );
   }
   if (t.kind === "lparen") {
-    return readList(k, s);
+    const node = readList(k, s);
+    if (s.attribute !== null && node.level !== Level.TRIVIAL) {
+      s.attribute(node, t.pos);
+    }
+    return node;
   }
   throw new Error(`unexpected token ${t.kind} at ${t.pos}`);
 }


### PR DESCRIPTION
## What this heals

A typed-boundary fatal named only the host accessor's location (`as_nid: Null` at `src/main.rs:2302`) — where in the *kernel*, never where in the *Form source*. Healing one such crash this morning cost an hour of probe bisection that one line number would have spared.

Every kernel now keeps a Form-level call stack and surfaces it on fatal:

```
form-kernel-rust: fatal[type_contract_violation]: as_nid: Null
form-kernel-rust: form stack: node_children < channel-msg-payload@form-stdlib/channel.fk:105:5
```

— the failing native, inside the function, at the file:line:col where that function's body was written.

## How

- **Frames.** Natives push/pop a name at dispatch (scope guards in Rust; success-path pops in Go/TS so a panic leaves the live frames readable). Closures entered by tail call REPLACE the top frame — the TCO-honest collapse, like Scheme traces; TS, which doesn't TCO, keeps tail frames.
- **Attribution.** The s-expr readers record every parenthesized form's file:line:col at read time (first-writer-wins under content-addressing). The CLI builds a line map so multi-file concatenation attributes each form to its ORIGINAL file. Read-time cost only — the walk hot path pays one map probe per closure call, nothing per dispatch.
- **Surfacing.** A `form stack:` stderr line plus `form_stack` (innermost first) in the crash-trace JSON. Rust reads the thread-local stack in the panic hook (before unwinding drops the guards); Go at recover (CLI + serve worker, which also resets the pooled worker's stack); TS at the top-level catch. Swallow points (Go `walkChoiceBranch`, TS JIT retry) restore depth.

## Proof

- Suite: **508 ok**, the single divergence pre-existing on pristine main (`choice-receipt-band` — TS `sum` native drops i64 elements introduced by #2922's wide literals; separate heal follows).
- Rust: 54 tests (2 new — reader attribution lands `probe.fk:2`, display is innermost-first).
- Go: full suite green including new end-to-end `TestFatalNamesFormSourceLine`.
- Three-way manual probe: identical stack lines on the channel.fk crash that motivated this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)