### PR TITLE
tend: DMT as its own honest category — endogenous trace amine, not a gland hormone

### DIFF
--- a/form/form-stdlib/dmt-trace-amine.fk
+++ b/form/form-stdlib/dmt-trace-amine.fk
@@ -1,0 +1,53 @@
+; dmt-trace-amine.fk — DMT as its own honest category: an endogenous trace
+; amine, not a gland's hormone.
+;
+; preludes: form-stdlib/core.fk form-stdlib/energy-center-glands.fk
+;
+; The energy-center pack maps one gland per center. DMT does NOT fit that
+; scheme, and saying so IS the honesty: N,N-dimethyltryptamine is an endogenous
+; trace amine synthesised ACROSS tissues (cerebral cortex, choroid plexus,
+; pineal, lung), not the hormone of a single gland. It reuses the ecg cell
+; shape (so it speaks through the same doors) but lives as its own cell, leaving
+; the seven-center table pure.
+;
+; Two lanes, and BOTH carry a within-lane caveat — DMT is where the honest
+; encoder earns its keep:
+;   evidence (~0.7, not 0.9): the AADC -> tryptamine -> INMT -> DMT pathway is
+;     textbook, INMT mRNA is found in cortex/choroid-plexus/pineal, and
+;     endogenous DMT was detected in rat brain and pineal microdialysate (2013,
+;     2019). The caveat that lowers the lane: a 2023 INMT-knockout study still
+;     showed tryptamine methylation, so INMT may NOT be the essential enzyme —
+;     an alternative pathway is open. The physiological ROLE of endogenous DMT
+;     is unestablished.
+;   belief (~0.3, the lowest in the corpus): the pineal "spirit molecule"
+;     hypothesis (Strassman) — DMT released at birth, death, and dream states,
+;     tied to the crown/third-eye. A HYPOTHESIS, explicitly "fact vs myth"
+;     (Barker), not established. Below the chakra-gland correspondences (0.4)
+;     because it is a specific contested claim, not a broad attested system.
+;
+; dmt-contested? is true: the cell flags that even its evidence lane is under
+; live scientific debate — the body naming its own uncertainty.
+
+section [form.bml] {
+    def dmt-cell() {
+        ecg("dmt", "Crown / Third Eye (hypothesised)", "—",
+            "Pineal (hypothesised) + cortex, choroid plexus, lung — synthesised across tissues, not one gland",
+            list("N,N-dimethyltryptamine (DMT)"),
+            "indoleamine trace amine",
+            "enzyme-made (contested): tryptophan decarboxylated by AADC to tryptamine, then double-methylated to DMT — attributed to INMT, but a 2023 INMT-knockout still methylated tryptamine, so the essential enzyme is unsettled",
+            list("INMT", "DDC"),
+            "an endogenous trace amine present in brain, blood, CSF and pineal; its physiological role is unestablished — detection is real, function is open",
+            "the pineal spirit-molecule hypothesis: released at birth, death and dream states (Strassman) — a hypothesis, fact-vs-myth, not established",
+            0.7, 0.3);
+    }
+
+    // the within-evidence-lane honesty: the canonical enzyme itself is contested
+    def dmt-contested?() = true;
+    def dmt-essential-enzyme-settled?() = false;
+
+    // speaks through the same doors as a center cell
+    def dmt-spoken() = ecg-spoken(dmt-cell());
+    def dmt-belief-spoken() = str_concat("Held as hypothesis, fact-vs-myth, not established: ", ecg-energy-fn(dmt-cell()));
+
+    0;
+}

--- a/form/form-stdlib/tests/dmt-trace-amine-band.fk
+++ b/form/form-stdlib/tests/dmt-trace-amine-band.fk
@@ -1,0 +1,38 @@
+; tests/dmt-trace-amine-band.fk — DMT as its own honest category, three-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/energy-center-glands.fk form-stdlib/dmt-trace-amine.fk
+;
+; Proves: DMT does NOT pollute the seven-center table (ecg-centers still 7, no
+; "dmt" id there); the cell carries its genes (INMT, DDC) and is enzyme-made,
+; not a peptide; the lane law holds AND DMT sits at the corpus floor (its belief
+; lane is below every center's belief lane); the contested flag is raised (even
+; the evidence lane names its own live debate); the measured line speaks the
+; cross-tissue synthesis while the belief line carries the fact-vs-myth frame.
+;
+; Band verdict: 511 when every law holds.
+
+section [form.bml] {
+    def dtb-bool(b, weight) = if b then weight else 0;
+
+    // DMT's belief lane below every center's belief lane (corpus floor)
+    def dtb-below-all-loop(cs, v) = if nil?(cs) then true else if lt(v, ecg-belief(head(cs))) then dtb-below-all-loop(tail(cs), v) else false;
+
+    // "dmt" must NOT be one of the seven center ids
+    def dtb-not-in-centers-loop(ids) = if nil?(ids) then true else if str_eq(head(ids), "dmt") then false else dtb-not-in-centers-loop(tail(ids));
+
+    def dtb-score() {
+        let d = dmt-cell();
+        sum(list(
+            dtb-bool(eq(len(ecg-centers()), 7), 1),
+            dtb-bool(dtb-not-in-centers-loop(ecg-centers()), 2),
+            dtb-bool(not(ecg-known?(ecg-find("dmt"))), 4),
+            dtb-bool(and(gt(len(ecg-genes(d)), 0), ge(str_find(ecg-protein-link(d), "contested", 0), 0)), 8),
+            dtb-bool(not(ecg-peptide?(d)), 16),
+            dtb-bool(lt(ecg-belief(d), ecg-evidence(d)), 32),
+            dtb-bool(dtb-below-all-loop(ecg-table(), ecg-belief(d)), 64),
+            dtb-bool(and(dmt-contested?(), not(dmt-essential-enzyme-settled?())), 128),
+            dtb-bool(ge(str_find(dmt-spoken(), "synthesised across tissues", 0), 0), 256)));
+    }
+
+    dtb-score();
+}


### PR DESCRIPTION
Follows the energy-center pack (#2932) with the sharpest two-lane case: DMT — and the first honesty is that **it doesn't fit the one-gland scheme at all.** N,N-dimethyltryptamine is an endogenous **trace amine synthesised across tissues** (cortex, choroid plexus, pineal, lung), not a gland's hormone. It reuses the cell shape but lives as its own category, leaving the seven-center table pure (the band proves `dmt` is not among the seven ids, and `ecg-find("dmt")` is honest absence).

**Both lanes carry a within-lane caveat** — this is where the honest encoder earns its keep:
- **evidence (0.7, not 0.9):** the AADC → tryptamine → INMT → DMT pathway is textbook; endogenous DMT was detected in rat brain and pineal microdialysate (2013, 2019). The caveat that lowers the lane: a **2023 INMT-knockout still methylated tryptamine**, so the essential enzyme is unsettled, and the *physiological role* of endogenous DMT is unestablished. `dmt-contested?` raises this flag.
- **belief (0.3, the corpus floor):** the pineal **spirit-molecule hypothesis** (Strassman) — DMT released at birth, death, dream states — explicitly **fact-vs-myth** (Barker), not established; below the chakra correspondences (0.4) because it's a specific contested claim, not a broad attested system.

**Verdict 511 three-way** (tests/dmt-trace-amine-band.fk): seven-center table stays pure · genes (INMT, DDC) present · enzyme-made not peptide · lane law holds · DMT sits at the corpus belief-floor · contested flag raised · the measured line speaks cross-tissue synthesis while the belief line carries the fact-vs-myth frame.

Companions [lc-dmt-laser-symbol-space-recipe](docs/vision-kb/concepts/lc-dmt-laser-symbol-space-recipe.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)