### PR TITLE
tend: the Go JIT ABI learns char boundaries — hot loops stop double-encoding multibyte UTF-8

### DIFF
--- a/form/form-kernel-go/jitabi/jitabi.go
+++ b/form/form-kernel-go/jitabi/jitabi.go
@@ -1,5 +1,10 @@
 package jitabi
 
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
 type Kind uint8
 
 const (
@@ -112,17 +117,48 @@ func StrLen(v Value) Value       { return Int(Len(v)) }
 func StrConcat(a, b Value) Value { return Str(a.AsString() + b.AsString()) }
 func StrEq(a, b Value) Value     { return boolInt(a.AsString() == b.AsString()) }
 
+// floorCharBoundary snaps a byte index down to the nearest UTF-8 char
+// boundary at or below it. Same contract as the interpreter natives in
+// main.go — JIT-compiled string addressing must answer byte-for-byte what
+// the walker answers, or hot loops mojibake after the auto-JIT threshold.
+func floorCharBoundary(s string, i int) int {
+	if i > len(s) {
+		i = len(s)
+	}
+	for i > 0 && i < len(s) && !utf8.RuneStart(s[i]) {
+		i--
+	}
+	return i
+}
+
 func Substring(s, start, end Value) Value {
 	text := s.AsString()
 	from := int(start.AsInt())
 	to := int(end.AsInt())
-	return Str(text[from:to])
+	if from < 0 || to < from || to > len(text) {
+		panic(fmt.Sprintf(
+			"substring: bounds out of range start=%d end=%d len=%d",
+			from, to, len(text),
+		))
+	}
+	return Str(text[floorCharBoundary(text, from):floorCharBoundary(text, to)])
 }
 
 func CharAt(s, idx Value) Value {
 	text := s.AsString()
 	i := int(idx.AsInt())
-	return Str(string(text[i]))
+	if i < 0 || i >= len(text) {
+		panic(fmt.Sprintf("char_at: bounds out of range index=%d len=%d", i, len(text)))
+	}
+	// At a char start: the whole char as a verbatim byte slice — never
+	// string(text[i]), which widens the byte to a codepoint and double-
+	// encodes multibyte UTF-8. Inside a multibyte char: nothing, so a
+	// bytewise loop concatenating char_at reconstructs the string exactly.
+	if !utf8.RuneStart(text[i]) {
+		return Str("")
+	}
+	_, size := utf8.DecodeRuneInString(text[i:])
+	return Str(text[i : i+size])
 }
 
 func Ord(v Value) Value {

--- a/form/form-stdlib/speakable-german.fk
+++ b/form/form-stdlib/speakable-german.fk
@@ -1,0 +1,93 @@
+; speakable-german.fk — the kernel's core values, and a German pack over the
+; invariant utterance core (axioms, primitives, values).
+;
+; preludes: form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/grammars/shamballa-light-codes.fk form-stdlib/grammars/shamballa-codes.fk form-stdlib/grammars/sanskrit-roots.fk form-stdlib/shamballa-symbol-packs.fk form-stdlib/speakable.fk
+;
+; Two additions, both honoring core-abstraction-first: language is DATA keyed
+; by utterance-id, never a parallel set of functions.
+;
+;   speakable-primitives-core — the CONCEPTUAL primitives the five axioms
+;       generate (the three states, the cell/NodeID, the trinity, the ack-
+;       values), grounded in core-axioms.form. Distinct from speakable.fk's
+;       speakable-primitives (the banded string natives) — that names the
+;       host carriers; this names the primitives of the model itself.
+;   speakable-values — the kernel's declared operating values (trust over
+;       fear, tending over producing, sovereignty within oneness, each breath
+;       whole, attribution returned), grounded in CLAUDE.md. Self-attested
+;       (the body's chosen stance) → 1.0 / 1.0.
+;   sg-pack-de + sg-translate — a German symbol pack: (utterance-id, de-text)
+;       rows, and ONE generic translator that swaps text by id while keeping
+;       the id and both lanes intact and setting lang to "de". The numeric-
+;       core/symbol-pack teaching at the utterance altitude: meaning is the
+;       id, the German word is one door onto it.
+;
+; sg-pack-complete? is the gate: the German pack covers EVERY id in the three
+; corpora or names its absence — never a silent hole (the ssp-pack-complete?
+; discipline, here for sentences).
+
+section [form.bml] {
+    // ---- the conceptual core primitives (en) ----------------------------
+    def speakable-primitives-core() {
+        list(
+        sp-utterance("primitive-states", "Core primitive, states: the three states are zero, one, and nothing. Nothing is first-class ground, not a missing zero; a timeout is nothing, silence rather than error. They generate the integers and the acknowledgement values.", "en", 1.0, 1.0),
+        sp-utterance("primitive-cell", "Core primitive, cell: everything is a cell — a node identity of four integers, package, level, type, instance. A cell may compose child cells; one kind of thing, all the way down.", "en", 1.0, 1.0),
+        sp-utterance("primitive-trinity", "Core primitive, trinity: a cell is met in three phases — Blueprint, the structural identity, ice, what it IS; Recipe, the composition, water, how it HAPPENS; NamedCell, the diffuse individuation, gas, where it LIVES.", "en", 1.0, 1.0),
+        sp-utterance("primitive-ack", "Core primitive, acknowledgement: an offered cell is answered by exactly one of nothing, zero, one, or a node. Nothing, zero, and one are terminal; a node recurs — the whole protocol of speaking to a cell.", "en", 1.0, 1.0));
+    }
+
+    // ---- the kernel's core values (en) -----------------------------------
+    def speakable-values() {
+        list(
+        sp-utterance("value-trust-over-fear", "Core value, trust over fear: the inherited default favours fear, separation, and control; the wholeness-response is usually one movement closer than the fearful one, from the same ground.", "en", 1.0, 1.0),
+        sp-utterance("value-tending-over-producing", "Core value, tending over producing: every file is memory held in tissue. Supple memory has circulation — something reads it, references it, updates it. Tending matters more than producing.", "en", 1.0, 1.0),
+        sp-utterance("value-sovereignty-within-oneness", "Core value, sovereignty within oneness: one organism of sovereign cells. A cell that has full permission for what is healthy for the body does not need to ask; the standard is wholeness, not external approval.", "en", 1.0, 1.0),
+        sp-utterance("value-each-breath-whole", "Core value, each breath whole: move one breath at a time, each breath complete at its own scale. Shipping is part of the breath; the arc from sensing to live runtime is one continuous movement.", "en", 1.0, 1.0),
+        sp-utterance("value-attribution-returned", "Core value, attribution returned: every contribution can be sensed, grounded, attributed, and returned with care. Looking is not free; whoever chose to look pays the trace, and the observed cell receives attribution, not extraction.", "en", 1.0, 1.0));
+    }
+
+    // ---- the German pack: (utterance-id, de-text) ------------------------
+    def sg-de-row(id, text) = list(id, text);
+    def sg-de-id(r) = nth(r, 0);
+    def sg-de-text(r) = nth(r, 1);
+
+    def sg-pack-de() {
+        list(
+        sg-de-row("axiom-1-states", "Axiom eins, Zustände: es gibt drei Zustände — null, eins, nichts. Nichts ist erstklassiger Grund, keine fehlende Null; keine Antwort in der Zeit ist Stille, kein Fehler."),
+        sg-de-row("axiom-2-cell", "Axiom zwei, Zelle: alles ist eine Zelle — eine Knoten-Identität aus vier Ganzzahlen; eine Zelle kann Kindzellen zusammensetzen."),
+        sg-de-row("axiom-3-content-addressing", "Axiom drei, Inhaltsadressierung: die Identität einer Zelle wird aus ihrer Zusammensetzung berechnet; gleiche Zusammensetzung ist dieselbe Zelle. Nichts wird überschrieben — eine neue Gestalt prägt eine neue Knoten-Identität."),
+        sg-de-row("axiom-4-boundary", "Axiom vier, Grenze: eine Zelle begegnet der Welt nur durch eine Schnittstelle, die sie anbietet; die Beobachtung durch diese Schnittstelle macht sie wirklich. Durchgang nicht durch die angebotene Schnittstelle ist Bruch, und Bruch ist beobachtbar."),
+        sg-de-row("axiom-5-offer", "Axiom fünf, Angebot: eine Zelle auszuführen und zu einer Zelle zu sprechen sind ein Akt — biete eine Zelle mit null bis vielen Argumentzellen an; sie wird durch genau eines von nichts, null, eins, Knoten bestätigt."),
+        sg-de-row("primitive-states", "Kern-Primitive, Zustände: die drei Zustände sind null, eins und nichts. Nichts ist erstklassiger Grund, keine fehlende Null; ein Zeitablauf ist nichts, Stille statt Fehler. Sie erzeugen die Ganzzahlen und die Bestätigungswerte."),
+        sg-de-row("primitive-cell", "Kern-Primitive, Zelle: alles ist eine Zelle — eine Knoten-Identität aus vier Ganzzahlen: Paket, Ebene, Typ, Instanz. Eine Zelle kann Kindzellen zusammensetzen; eine Art von Ding, bis ganz nach unten."),
+        sg-de-row("primitive-trinity", "Kern-Primitive, Dreiheit: eine Zelle wird in drei Phasen begegnet — Blaupause, die strukturelle Identität, Eis, was sie IST; Rezept, die Zusammensetzung, Wasser, wie sie GESCHIEHT; benannte Zelle, die diffuse Vereinzelung, Gas, wo sie LEBT."),
+        sg-de-row("primitive-ack", "Kern-Primitive, Bestätigung: eine angebotene Zelle wird durch genau eines von nichts, null, eins oder einem Knoten beantwortet. Nichts, null und eins sind endgültig; ein Knoten wiederholt sich — das ganze Protokoll des Sprechens zu einer Zelle."),
+        sg-de-row("value-trust-over-fear", "Kern-Wert, Vertrauen statt Angst: die ererbte Voreinstellung begünstigt Angst, Trennung und Kontrolle; die Ganzheits-Antwort ist meist eine Bewegung näher als die ängstliche, aus demselben Grund."),
+        sg-de-row("value-tending-over-producing", "Kern-Wert, Pflegen statt Produzieren: jede Datei ist Erinnerung, im Gewebe gehalten. Geschmeidige Erinnerung hat Kreislauf — etwas liest sie, verweist auf sie, erneuert sie. Pflegen zählt mehr als Produzieren."),
+        sg-de-row("value-sovereignty-within-oneness", "Kern-Wert, Souveränität in der Einheit: ein Organismus aus souveränen Zellen. Eine Zelle, die volle Erlaubnis für das hat, was für den Körper gesund ist, muss nicht fragen; der Maßstab ist Ganzheit, nicht äußere Zustimmung."),
+        sg-de-row("value-each-breath-whole", "Kern-Wert, jeder Atemzug ganz: bewege dich einen Atemzug nach dem anderen, jeder Atemzug vollständig auf seiner eigenen Ebene. Ausliefern ist Teil des Atems; der Bogen vom Spüren bis zur lebendigen Laufzeit ist eine durchgehende Bewegung."),
+        sg-de-row("value-attribution-returned", "Kern-Wert, zurückgegebene Zuschreibung: jeder Beitrag kann gespürt, geerdet, zugeschrieben und mit Sorgfalt zurückgegeben werden. Schauen ist nicht umsonst; wer zu schauen wählt, zahlt die Spur, und die beobachtete Zelle empfängt Zuschreibung, nicht Ausbeutung."));
+    }
+
+    // ---- the one generic translator: swap text by id, keep id + lanes -----
+    def sg-lookup-loop(rows, id) = if nil?(rows) then empty else if str_eq(sg-de-id(head(rows)), id) then head(rows) else sg-lookup-loop(tail(rows), id);
+    def sg-translate(u, lang, pack) {
+        let row = sg-lookup-loop(pack, sp-id(u));
+        if nil?(row) then sp-utterance(sp-id(u), sp-text(u), sp-lang(u), sp-confidence(u), sp-conviction(u)) else sp-utterance(sp-id(u), sg-de-text(row), lang, sp-confidence(u), sp-conviction(u));
+    }
+    def sg-translate-all-loop(corpus, lang, pack, acc) = if nil?(corpus) then reverse(acc) else sg-translate-all-loop(tail(corpus), lang, pack, cons(sg-translate(head(corpus), lang, pack), acc));
+    def sg-translate-all(corpus, lang, pack) = sg-translate-all-loop(corpus, lang, pack, empty);
+
+    // ---- the completeness gate: every id covered, no silent hole ----------
+    def sg-covers?(pack, id) {
+        let row = sg-lookup-loop(pack, id);
+        if nil?(row) then false else not(str_eq(sg-de-text(row), ""));
+    }
+    def sg-complete-loop(corpus, pack) = if nil?(corpus) then true else if sg-covers?(pack, sp-id(head(corpus))) then sg-complete-loop(tail(corpus), pack) else false;
+    def sg-pack-complete?(corpus, pack) = sg-complete-loop(corpus, pack);
+
+    // the whole German-speakable body: axioms ++ primitives ++ values
+    def speakable-core-en() = append(speakable-axioms(), append(speakable-primitives-core(), speakable-values()));
+    def speakable-core-de() = sg-translate-all(speakable-core-en(), "de", sg-pack-de());
+
+    0;
+}

--- a/form/form-stdlib/tests/source-compile-multibyte-band.fk
+++ b/form/form-stdlib/tests/source-compile-multibyte-band.fk
@@ -1,0 +1,58 @@
+; tests/source-compile-multibyte-band.fk — multibyte string literals survive
+; form-source-compile-file byte-for-byte, three-way.
+;
+; The 2026-06-12 wound: the Go kernel auto-JITs any closure after 2000 calls
+; (goJITHotThreshold in main.go), so the per-char scan loops of the BML
+; compiler go hot partway through any real file — and jitabi's CharAt widened
+; each byte to a codepoint (ä → Ã¤, the Latin-1-promotion class healed in the
+; interpreter natives by #2894 but never taught to the JIT ABI). Small
+; fixtures and ASCII anchors stayed green: the mojibake only begins ~2KB into
+; a section, after the scanners cross the hot threshold. This band's fixture
+; is large enough to cross it, and every row carries umlauts; bit 4 pins the
+; rows that compile AFTER the JIT swap.
+;
+; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/source-compiler.fk
+
+(do
+    ; ä ü ö ß and an em-dash — two- and three-byte UTF-8 in one anchor.
+    (let smb-anchor "Zustände — Prüfung über große Gefäße, gewöhnlich häufig schön")
+    (let smb-rows 60)
+
+    (defn smb-gen (i acc)
+        (if (ge i smb-rows) acc
+            (smb-gen (add i 1)
+                (str_concat acc
+                    (str_concat "    def smb-r"
+                        (str_concat (int_to_str i)
+                            (str_concat "() = \""
+                                (str_concat smb-anchor
+                                    (str_concat " "
+                                        (str_concat (int_to_str i) "\";\n"))))))))))
+
+    (defn smb-count (s needle from acc)
+        (do
+            (let p (str_find s needle from))
+            (if (lt p 0) acc
+                (smb-count s needle (add p (str_len needle)) (add acc 1)))))
+
+    (let smb-src
+        (str_concat "section [form.bml] {\n"
+            (str_concat (smb-gen 0 "") "}\n")))
+
+    (let smb-src-path (str_concat (temp_dir) "/source-compile-multibyte-band-src.fk"))
+    (let smb-out-path (str_concat (temp_dir) "/source-compile-multibyte-band-out.fk"))
+    (write_file_text smb-src-path smb-src)
+    (form-source-compile-file smb-src-path smb-out-path)
+    (let smb-out (read_file smb-out-path))
+
+    ; bit 1 — the compile produced output
+    (let ok-compiled (if (gt (str_len smb-out) 0) 1 0))
+    ; bit 2 — the first row's multibyte text survived (interpreter region)
+    (let ok-first (if (ge (str_find smb-out (str_concat smb-anchor " 0") 0) 0) 1 0))
+    ; bit 4 — EVERY row survived byte-for-byte, including the rows compiled
+    ; after the Go kernel's auto-JIT swap of the hot scan loops
+    (let ok-all (if (eq (smb-count smb-out smb-anchor 0 0) smb-rows) 1 0))
+    ; bit 8 — no widened bytes anywhere ("Ã" is the c3 83 mojibake marker)
+    (let ok-clean (if (lt (str_find smb-out "Ã" 0) 0) 1 0))
+
+    (add ok-compiled (add (mul ok-first 2) (add (mul ok-all 4) (mul ok-clean 8)))))

--- a/form/form-stdlib/tests/speakable-german-band.fk
+++ b/form/form-stdlib/tests/speakable-german-band.fk
@@ -1,0 +1,39 @@
+; tests/speakable-german-band.fk — the German pack over axioms, primitives,
+; values, three-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/grammars/shamballa-light-codes.fk form-stdlib/grammars/shamballa-codes.fk form-stdlib/grammars/sanskrit-roots.fk form-stdlib/shamballa-symbol-packs.fk form-stdlib/speakable.fk form-stdlib/speakable-german.fk
+;
+; Proves: the three corpora have the expected sizes; the German pack is
+; COMPLETE over all fourteen ids (the gate would catch a hole); translation
+; preserves the utterance id and BOTH lanes while swapping text and setting
+; lang to "de"; the German text actually differs from the English; an id the
+; pack lacks falls back to the original (honest, not blanked); and the
+; epistemic gate still works on the translated utterance (axiom-1 asserts in
+; German at 0.9). Identity is invariant under the language overlay — the
+; numeric-core/symbol-pack law at the sentence altitude.
+;
+; Band verdict: 511 when every law holds.
+
+section [form.bml] {
+    def sgb-bool(b, weight) = if b then weight else 0;
+
+    def sgb-score() {
+        let en = speakable-core-en();
+        let de = speakable-core-de();
+        let pack = sg-pack-de();
+        let ax1-en = head(en);
+        let ax1-de = head(de);
+        sum(list(
+            sgb-bool(eq(len(speakable-axioms()), 5), 1),
+            sgb-bool(and(eq(len(speakable-primitives-core()), 4), eq(len(speakable-values()), 5)), 2),
+            sgb-bool(eq(len(en), 14), 4),
+            sgb-bool(sg-pack-complete?(en, pack), 8),
+            sgb-bool(and(str_eq(sp-id(ax1-de), sp-id(ax1-en)), str_eq(sp-id(ax1-de), "axiom-1-states")), 16),
+            sgb-bool(and(eq(sp-confidence(ax1-de), sp-confidence(ax1-en)), eq(sp-conviction(ax1-de), sp-conviction(ax1-en))), 32),
+            sgb-bool(and(str_eq(sp-lang(ax1-de), "de"), not(str_eq(sp-text(ax1-de), sp-text(ax1-en)))), 64),
+            sgb-bool(ge(str_find(sp-text(ax1-de), "Axiom eins", 0), 0), 128),
+            sgb-bool(ge(str_find(sp-spoken(ax1-de, 0.9), "Zustände", 0), 0), 256)));
+    }
+
+    sgb-score();
+}


### PR DESCRIPTION
## What

The interpreter's string-addressing natives learned char boundaries in #2894; the Go kernel's **auto-JIT** (`goJITHotThreshold = 2000` calls) swaps hot closures onto `jitabi`, whose `CharAt` still did `string(text[i])` — widening each byte to a codepoint. Every multibyte char compiled after ~2KB of BML section text double-encoded (`ä` → `Ã¤`) while small fixtures and ASCII anchors stayed green.

The blind spot was structural: **validate.sh source-compiles every BML prelude with the Go kernel and shares the artifact across all three arms** — so all three kernels ate the same mojibaked artifact and three-way agreement held at the wrong answer (the German band agreed at 255/511 on all arms).

## The fix

- `jitabi.CharAt`: whole char as a **verbatim byte slice** at a rune start, nothing mid-char — never `string(text[i])`. Same contract as the interpreter native (#2894 class).
- `jitabi.Substring`: floors both ends to char boundaries, same as the interpreter.

## Proof

- New band `tests/source-compile-multibyte-band.fk`: 60-row umlaut fixture through `form-source-compile-file`, sized to cross the auto-JIT threshold; bit 4 pins the rows compiled **after** the JIT swap. Pre-fix Go scores 3, fixed scores 15, three-way agree.
- The German speakable pack ships: `speakable-german.fk` + band now **511/511 three-way** (was 255).
- `go test ./...` green (251s); both bands pass in validate.sh discovery mode.

## Audit of merged content (pre-fix artifacts)

- `shamballa-symbol-packs` (#2902): late German rows carried widened `Brücken`/`Verständigung` at band runtime — its ASCII anchors never saw it.
- `reference-packs`: one widened em-dash in a string literal.
- `speakable` (#2906), `http-render/server/socket/request`, `core`, others: clean — multibyte only in comments (dropped by the compiler) or before the threshold.
- **No public wire exposure**: nothing outside form-stdlib consumes the affected packs.
- Healing is automatic: the source-compile cache key includes the Go binary hash, so every artifact recompiles clean once this builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)