### PR TITLE
tend: DMT's effect as a runnable, reversible activation recipe — the operator matches

### DIFF
--- a/form/form-stdlib/dmt-activation-recipe.fk
+++ b/form/form-stdlib/dmt-activation-recipe.fk
@@ -1,0 +1,74 @@
+; dmt-activation-recipe.fk — DMT's effect as a runnable Field Model Form
+; activation, matching the lc-dmt-laser-symbol-space-recipe operator.
+;
+; preludes: form-stdlib/core.fk form-stdlib/field-model-form-runtime.fk
+;
+; The question this answers: does an ACTIVATION RECIPE match DMT's effect on
+; the body? Yes — and it runs.
+;
+; The operator (lc-dmt-laser-symbol-space-recipe):
+;     reduced ordinary binding + coherent structured input -> addressable symbolic output
+;
+; The measured effect it matches (evidence lane): DMT is a 5-HT2A receptor
+; agonist; the REBUS model (Carhart-Harris & Friston) says serotonergic
+; psychedelics DECREASE the precision-weighting of high-level priors — they
+; relax the brain's filtering hierarchy, so structure normally suppressed
+; becomes perceptible. The three operator terms map line for line:
+;   reduced ordinary binding   = relaxed precision of priors (the filter loosens)
+;   coherent structured input  = the field's latent geometry / the set intention
+;   addressable symbolic output = suppressed structure becoming traceable
+;
+; THREE LANES, never merged:
+;   structural (exact) — this recipe is OUR Field Model Form; it runs bit-for-bit
+;     three-way. What is proven is the OPERATOR, not a brain.
+;   evidence (inference) — that this operator MODELS DMT's neuropharmacology is
+;     the REBUS mapping: a real scientific theory applied by analogy, held as
+;     inference, not asserted as the mechanism.
+;   belief — the pineal spirit-molecule layer (lc-dmt) stays belief; not here.
+;
+; The recipe enacts the operator on a field and — load-bearing — REVERSES it:
+; binding re-tightens, structure re-suppresses. The effect ENDS. This matches
+; both the pharmacology (DMT is short-acting; priors revise back, REBUS->REBAS)
+; and the body's reversibility + consent discipline: an activation that cannot
+; be undone is not offered. Residual is honest: the operator opens what it
+; addresses, never everything (deep structure stays bound).
+
+section [form.bml] {
+    // a field with a binding gate (high precision = ordinary filtering) and
+    // latent structure suppressed beneath it; one deep site the operator does
+    // not reach (the honest residual).
+    def dar-field() {
+        fmfrt-field("perceptual-field",
+            fmfrt-blueprint("perception", "prior-precision", "hierarchy", empty, empty, "gated"),
+            list(
+                fmfrt-site(0, list(fmfrt-pair("role", "gate"), fmfrt-pair("binding", 5))),
+                fmfrt-site(1, list(fmfrt-pair("role", "structure"), fmfrt-pair("visible", 0))),
+                fmfrt-site(2, list(fmfrt-pair("role", "structure"), fmfrt-pair("visible", 0))),
+                fmfrt-site(3, list(fmfrt-pair("role", "deep"), fmfrt-pair("visible", 0)))),
+            empty, empty, 0);
+    }
+
+    // the coherent observer offering the structured input
+    def dar-observer() = fmfrt-observer("coherent-probe", "all-compatible");
+
+    // the activation deltas — the operator, enacted:
+    //   reduce ordinary binding (gate 5 -> 1), open the addressable structure
+    //   (sites 1 and 2 become visible), and trace the emitted output. Site 3
+    //   (deep) is deliberately untouched — the honest residual.
+    def dar-activation-deltas() {
+        list(
+            fmfrt-delta("inc-site", 0, "binding", -4),
+            fmfrt-delta("set-site", 1, "visible", 1),
+            fmfrt-delta("set-site", 2, "visible", 1),
+            fmfrt-delta("trace", 0, "emitted", "addressable symbolic structure"));
+    }
+
+    def dar-activate() = fmfrt-intervene(dar-field(), dar-observer(), dar-activation-deltas());
+    def dar-reverse(result) = fmfrt-reverse-receipt(dar-field(), result);
+
+    // readouts: binding and visibility at a named site of a field
+    def dar-binding(field) = fmfrt-site-get(fmfrt-find-site(fmfrt-field-sites(field), 0), "binding", -1);
+    def dar-visible(field, id) = fmfrt-site-get(fmfrt-find-site(fmfrt-field-sites(field), id), "visible", -1);
+
+    0;
+}

--- a/form/form-stdlib/tests/dmt-activation-recipe-band.fk
+++ b/form/form-stdlib/tests/dmt-activation-recipe-band.fk
@@ -1,0 +1,40 @@
+; tests/dmt-activation-recipe-band.fk — DMT's effect as a runnable, reversible
+; Field Model Form activation, three-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/field-model-form-runtime.fk form-stdlib/dmt-activation-recipe.fk
+;
+; Proves the operator (reduced ordinary binding + coherent structured input ->
+; addressable symbolic output) runs and matches DMT's effect shape:
+;   before — ordinary binding high (5), structure suppressed (not visible)
+;   after  — binding reduced (1), the addressable structure now visible: the
+;            operator fired, both terms in one step (reduce AND open)
+;   receipt — the activation is recorded (the four deltas applied)
+;   residual — honest: the deep site stays bound (the operator opens what it
+;              addresses, not everything)
+;   reverse — binding re-tightens to 5, structure re-suppresses to 0: the
+;             effect ENDS, fully reversible (short-acting; priors revise back)
+;
+; Band verdict: 511 when every law holds.
+
+section [form.bml] {
+    def darb-bool(b, weight) = if b then weight else 0;
+
+    def darb-score() {
+        let before = dar-field();
+        let result = dar-activate();
+        let after = fmfrt-result-field(result);
+        let reversed = fmfrt-result-field(dar-reverse(result));
+        sum(list(
+            darb-bool(eq(dar-binding(before), 5), 1),
+            darb-bool(and(eq(dar-visible(before, 1), 0), eq(dar-visible(before, 2), 0)), 2),
+            darb-bool(eq(dar-binding(after), 1), 4),
+            darb-bool(and(eq(dar-visible(after, 1), 1), eq(dar-visible(after, 2), 1)), 8),
+            darb-bool(and(lt(dar-binding(after), dar-binding(before)), gt(dar-visible(after, 1), dar-visible(before, 1))), 16),
+            darb-bool(eq(len(fmfrt-receipt-applied(fmfrt-result-receipt(result))), 4), 32),
+            darb-bool(eq(dar-visible(after, 3), 0), 64),
+            darb-bool(eq(dar-binding(reversed), 5), 128),
+            darb-bool(and(eq(dar-visible(reversed, 1), 0), eq(dar-visible(reversed, 2), 0)), 256)));
+    }
+
+    darb-score();
+}


### PR DESCRIPTION
Answers *can you see an activation recipe that matches DMT's effect?* — yes, and it runs three-way.

**The match, line for line.** DMT is a 5-HT2A receptor agonist; the **REBUS** model (Carhart-Harris & Friston) holds that serotonergic psychedelics *decrease the precision-weighting of high-level priors* — they relax the brain's filtering hierarchy so structure normally suppressed becomes perceptible. That is the lc-dmt operator exactly:

| operator term | DMT's effect (REBUS) |
|---|---|
| reduced ordinary binding | relaxed precision of high-level priors (the filter loosens) |
| coherent structured input | the field's latent geometry / the set intention |
| addressable symbolic output | suppressed structure becoming traceable |

**Built and run** in Field Model Form: a field with a binding gate (precision **5**) over suppressed structure. The activation reduces binding to **1** and opens the addressable sites; a **deep site stays bound** (honest residual — the operator opens what it addresses, never everything); the receipt records the four deltas; and the **reverse path re-tightens binding to 5 and re-suppresses** — the effect *ends*. That reversibility matches DMT's short action and the priors revising back (REBUS→REBAS), and the body's own reversibility + consent discipline.

Live readout:
```
BEFORE   binding=5  structure-visible=0
ACTIVE   binding=1  structure1=1 structure2=1 deep=0
REVERSED binding=5  structure-visible=0
```

**Three lanes, never merged:** the recipe is *our* Form (structural, exact, three-way — what's proven is the operator, not a brain); that it *models* DMT is the REBUS mapping (inference, by analogy, not asserted as the mechanism); the pineal spirit-molecule layer stays belief (lc-dmt, not here).

**Verdict 511 three-way** (tests/dmt-activation-recipe-band.fk). Pairs with #2934 (DMT the molecule) and [lc-dmt-laser-symbol-space-recipe](docs/vision-kb/concepts/lc-dmt-laser-symbol-space-recipe.md) (the operator's home).

🤖 Generated with [Claude Code](https://claude.com/claude-code)