### PR TITLE
tend: Prolog resolves natively; five tongues ride the fourth kernel's BMF compiler as one pack

### DIFF
--- a/docs/coherence-substrate/fourth-kernel.form
+++ b/docs/coherence-substrate/fourth-kernel.form
@@ -106,6 +106,15 @@
                          tests/fourth-union-band.fk -> 31 three-way. Textual
                          source through the op-17 cursor and the full
                          nesting/choose/fail engine remain the richer doors)
+    (language-packs      SHIPPED — five tongues (python, typescript, go, rust,
+                         prolog) parse their own surface through their real BMF
+                         grammars on the walkers and land on ONE content-addressed
+                         pack; the pack rows ride the union binary and a swapped
+                         pack bakes a sibling compiler whose quine also closes
+                         (form_union_demo.sh gate 4: wide pack -> 202).
+                         rulefind packs op*1000000+arg so wide pack operands fit.
+                         Band tests/language-packs-fourth-band.fk -> 31 three-way;
+                         packs sealed internal-only via pack-manifest)
 
     # ── The BMF discipline (Urs, 2026-06-11) — bmf-architecture.form's record ──
     # BMF is NOT tokenize-then-parse. Rules match bytes STRAIGHT OFF a streaming

--- a/form/form-stdlib/fourth-union.fk
+++ b/form/form-stdlib/fourth-union.fk
@@ -129,13 +129,15 @@
            (fk-lit 1)
            (fk-node 42 (ms-intern (fk-lit 10) (fk-call 7 (fk-sub (fk-arg) (fk-lit 1)))))))
 
-; fn8 rulefind(i): scan grammar rows; token in mem[3]; returns op*100+arg.
+; fn8 rulefind(i): scan grammar rows; token in mem[3]; returns op*1000000+arg
+; (base 1000000 so pack operands up to 999999 ride without colliding with the
+; op digit — the language-pack lane's wide operands fit).
 ; equality by two le's: skip while NODE < tok; match when also NODE <= tok.
 (defn fku-fn-rulefind ()
     (fk-if (fk-le (fkd-node (fk-arg) (fk-lit 0)) (fk-sub (fku-load (fk-lit 3)) (fk-lit 1)))
            (fk-call 8 (fk-add (fk-arg) (fk-lit 1)))
            (fk-if (fk-le (fkd-node (fk-arg) (fk-lit 0)) (fku-load (fk-lit 3)))
-                  (fk-add (fk-node 42 (ms-intern (fkd-node (fk-arg) (fk-lit 1)) (fk-lit 100)))
+                  (fk-add (fk-node 42 (ms-intern (fkd-node (fk-arg) (fk-lit 1)) (fk-lit 1000000)))
                           (fkd-node (fk-arg) (fk-lit 2)))
                   (fk-call 8 (fk-add (fk-arg) (fk-lit 1))))))
 
@@ -151,11 +153,11 @@
     (fku-do (fku-store (fk-lit 3) (fku-tok-k))
     (fku-do (fku-store (fk-lit 4) (fk-call 8 (fk-lit (fku-p p 18))))
     (fkd-seq (fkd-ch 123) (fkd-seq (fkd-ch 49) (fkd-seq (fkd-ch 44)
-    (fkd-seq (fku-callnum (fkd-mod (fku-load (fk-lit 4)) (fk-lit 100)))
+    (fkd-seq (fku-callnum (fkd-mod (fku-load (fk-lit 4)) (fk-lit 1000000)))
     (fkd-seq (fkd-ch 44) (fkd-seq (fkd-ch 48) (fkd-seq (fkd-ch 44) (fkd-seq (fkd-ch 48)
     (fkd-seq (fkd-ch 125) (fkd-seq (fkd-ch 44)
     (fkd-seq (fkd-ch 123)
-    (fkd-seq (fku-callnum (fkd-div (fku-load (fk-lit 4)) (fk-lit 100)))
+    (fkd-seq (fku-callnum (fkd-div (fku-load (fk-lit 4)) (fk-lit 1000000)))
     (fkd-seq (fkd-ch 44)
     (fkd-seq (fku-callnum (fk-node 42 (ms-intern (fk-arg) (fk-lit 2))))
     (fkd-seq (fkd-ch 44)

--- a/form/form-stdlib/grammars/rust-bmf.fk
+++ b/form/form-stdlib/grammars/rust-bmf.fk
@@ -11,11 +11,13 @@
     (defn rust-src-name (value) (bmf-atom "rust-name" value))
     (defn rust-src-op (value) (bmf-atom "rust-op" value))
     (defn rust-src-string (value) (bmf-atom "rust-string" value))
+    (defn rust-src-int (value) (bmf-atom "rust-int" value))
 
     (defn rust-kw (value) (object-lit "rust-keyword" value))
     (defn rust-op (value) (object-lit "rust-op" value))
     (defn rust-name (capture-name) (list "capture" capture-name (object-lit "rust-name" "")))
     (defn rust-string-lit (capture-name) (list "capture" capture-name (object-lit "rust-string" "")))
+    (defn rust-int-lit (capture-name) (list "capture" capture-name (object-lit "rust-int" "")))
 
     (defn rsbmf-value (objects capture-name)
         (bmf-collection-value objects capture-name))
@@ -114,6 +116,23 @@
                   (rust-src-name (node_value (nth kids 0)))
                   (rust-src-op "=")
                   (rust-src-name (node_value (nth kids 1)))
+                  (rust-src-op ";"))))
+
+    (defn rsbmf-int (objects capture-name)
+        (intern_trivial_int (str_to_int (rsbmf-value objects capture-name))))
+
+    (defn rsbmf-emit-let-int (objects)
+        (intern_node RS-BMF-LET
+                     (list (rsbmf-string objects "name")
+                           (rsbmf-int objects "value"))))
+
+    (defn rsbmf-source-let-int (object)
+        (do
+            (let kids (rsbmf-node-kids object))
+            (list (rust-src-keyword "let")
+                  (rust-src-name (node_value (nth kids 0)))
+                  (rust-src-op "=")
+                  (rust-src-int (int_to_str (node_value (nth kids 1))))
                   (rust-src-op ";"))))
 
     (defn rsbmf-emit-return-ident (objects)
@@ -217,6 +236,7 @@
             (bmf-native "rsbmf-emit-trait" rsbmf-emit-trait RS-BMF-TRAIT)
             (bmf-native "rsbmf-emit-macro" rsbmf-emit-macro RS-BMF-MACRO)
             (bmf-native "rsbmf-emit-let-ident" rsbmf-emit-let-ident RS-BMF-LET)
+            (bmf-native "rsbmf-emit-let-int" rsbmf-emit-let-int RS-BMF-LET)
             (bmf-native "rsbmf-emit-return-ident" rsbmf-emit-return-ident RS-BMF-RETURN)
             (bmf-native "rsbmf-emit-match-default-ident" rsbmf-emit-match-default-ident RS-BMF-MATCH)
             (bmf-native "rsbmf-emit-if-pass" rsbmf-emit-if-pass RS-BMF-IF)
@@ -238,6 +258,7 @@
       trait ::= "trait" $name:name "{" "}" => rsbmf-emit-trait;
       macro-call ::= $name:name "!" "(" $arg:string ")" ";" => rsbmf-emit-macro <= rsbmf-source-macro;
       let-ident ::= "let" $name:name "=" $value:name ";" => rsbmf-emit-let-ident <= rsbmf-source-let-ident;
+      let-int ::= "let" $name:name "=" $value:int ";" => rsbmf-emit-let-int <= rsbmf-source-let-int;
       return-ident ::= "return" $value:name ";" => rsbmf-emit-return-ident <= rsbmf-source-return-ident;
       match-default-ident ::= "match" $value:name "{" $arm:name "=>" $result:name "}" => rsbmf-emit-match-default-ident <= rsbmf-source-match-default-ident;
       if-pass ::= "if" $cond:name "{" "}" => rsbmf-emit-if-pass <= rsbmf-source-if-pass;

--- a/form/form-stdlib/prolog-bmf-eval.fk
+++ b/form/form-stdlib/prolog-bmf-eval.fk
@@ -1,0 +1,210 @@
+; prolog-bmf-eval.fk - resolution over PL-BMF clause nodes: unification,
+; backtracking across candidate clauses, cut as clause commitment.
+;
+; The lift pattern python-bmf-eval and typescript-bmf-eval established, carried
+; to logic programming: grammars/prolog-bmf.fk parses clauses into PL-BMF-*
+; recipe nodes; this file walks them as a knowledge base. Terms are
+; (functor, args) pairs over strings; a variable is a name whose first
+; character is uppercase or underscore (Prolog's own convention). Solutions
+; are binding lists; pl-solve-goal returns every solution a query has, in
+; clause order, so backtracking IS the list of branches. A cut clause
+; (head :- goal, !.) commits to its first solution and stops the clause scan
+; — the same commitment shape engine.fk's fail-cut discipline carries for
+; grammar choice.
+;
+; Renaming discipline: every clause application renames clause variables with
+; a namespace suffix ("X" -> "X#k"). Namespaces are base-10 paths — a body
+; goal at position i inside namespace k solves in namespace k*10+i — so no
+; two clause applications on one binding chain ever share a suffix.
+
+(do
+    ;; --- terms and variables -----------------------------------------
+
+    (defn pl-term (functor args) (list functor args))
+    (defn pl-term-functor (t) (head t))
+    (defn pl-term-args (t) (head (tail t)))
+
+    (defn pl-var? (s)
+        (ge (str_find "ABCDEFGHIJKLMNOPQRSTUVWXYZ_" (char_at s 0) 0) 0))
+
+    ;; --- bindings: alist of (var value) -------------------------------
+
+    (defn pl-lookup (var bindings)
+        (if (nil? bindings) (empty)
+            (if (str_eq (head (head bindings)) var)
+                (head (tail (head bindings)))
+                (pl-lookup var (tail bindings)))))
+
+    ;; follow a variable chain until an atom or an unbound variable
+    (defn pl-resolve (v bindings)
+        (if (pl-var? v)
+            (do
+                (let bound (pl-lookup v bindings))
+                (if (nil? bound) v (pl-resolve bound bindings)))
+            v))
+
+    ;; --- unification ---------------------------------------------------
+    ;; result: (list "yes" bindings) | (list "no")
+
+    (defn pl-yes (bindings) (list "yes" bindings))
+    (defn pl-no () (list "no"))
+    (defn pl-yes? (r) (str_eq (head r) "yes"))
+    (defn pl-yes-bindings (r) (head (tail r)))
+
+    (defn pl-unify-arg (a b bindings)
+        (do
+            (let ra (pl-resolve a bindings))
+            (let rb (pl-resolve b bindings))
+            (if (str_eq ra rb) (pl-yes bindings)
+            (if (pl-var? ra) (pl-yes (cons (list ra rb) bindings))
+            (if (pl-var? rb) (pl-yes (cons (list rb ra) bindings))
+                (pl-no))))))
+
+    (defn pl-unify-args (as bs bindings)
+        (if (nil? as)
+            (if (nil? bs) (pl-yes bindings) (pl-no))
+            (if (nil? bs) (pl-no)
+                (do
+                    (let r (pl-unify-arg (head as) (head bs) bindings))
+                    (if (pl-yes? r)
+                        (pl-unify-args (tail as) (tail bs) (pl-yes-bindings r))
+                        (pl-no))))))
+
+    (defn pl-unify-term (t1 t2 bindings)
+        (if (str_eq (pl-term-functor t1) (pl-term-functor t2))
+            (pl-unify-args (pl-term-args t1) (pl-term-args t2) bindings)
+            (pl-no)))
+
+    ;; --- clause variable renaming --------------------------------------
+
+    (defn pl-rename-arg (a k)
+        (if (pl-var? a) (str_concat a (str_concat "#" (int_to_str k))) a))
+
+    (defn pl-rename-args (as k)
+        (if (nil? as) (empty)
+            (cons (pl-rename-arg (head as) k) (pl-rename-args (tail as) k))))
+
+    (defn pl-rename-term (t k)
+        (pl-term (pl-term-functor t) (pl-rename-args (pl-term-args t) k)))
+
+    (defn pl-rename-terms (ts k)
+        (if (nil? ts) (empty)
+            (cons (pl-rename-term (head ts) k) (pl-rename-terms (tail ts) k))))
+
+    ;; --- clauses from PL-BMF nodes ---------------------------------------
+    ;; clause: (list head-term body-term-list cut-flag)
+
+    (defn pl-clause (head body cut) (list head body cut))
+    (defn pl-clause-head (c) (nth c 0))
+    (defn pl-clause-body (c) (nth c 1))
+    (defn pl-clause-cut? (c) (eq (nth c 2) 1))
+
+    (defn pl-kid (kids i) (node_value (nth kids i)))
+
+    (defn pl-fact-clause (kids)
+        (if (eq (len kids) 1)
+            (pl-clause (pl-term (pl-kid kids 0) (empty)) (empty) 0)
+        (if (eq (len kids) 2)
+            (pl-clause (pl-term (pl-kid kids 0) (list (pl-kid kids 1))) (empty) 0)
+            (pl-clause (pl-term (pl-kid kids 0) (list (pl-kid kids 1) (pl-kid kids 2)))
+                       (empty) 0))))
+
+    (defn pl-rule-clause (kids)
+        (if (eq (len kids) 4)
+            (pl-clause (pl-term (pl-kid kids 0) (list (pl-kid kids 1)))
+                       (list (pl-term (pl-kid kids 2) (list (pl-kid kids 3))))
+                       0)
+            (pl-clause (pl-term (pl-kid kids 0) (list (pl-kid kids 1) (pl-kid kids 2)))
+                       (list (pl-term (pl-kid kids 3) (list (pl-kid kids 4) (pl-kid kids 5)))
+                             (pl-term (pl-kid kids 6) (list (pl-kid kids 7) (pl-kid kids 8))))
+                       0)))
+
+    (defn pl-cut-clause (kids)
+        (pl-clause (pl-term (pl-kid kids 0) (empty))
+                   (list (pl-term (pl-kid kids 1) (empty)))
+                   1))
+
+    (defn pl-clause-of-node (node)
+        (do
+            (let cat (node_category node))
+            (let kids (node_children node))
+            (if (node_eq cat PL-BMF-FACT) (pl-fact-clause kids)
+            (if (node_eq cat PL-BMF-RULE) (pl-rule-clause kids)
+            (if (node_eq cat PL-BMF-CUT)  (pl-cut-clause kids)
+                (empty))))))
+
+    (defn pl-kb (nodes)
+        (if (nil? nodes) (empty)
+            (cons (pl-clause-of-node (head nodes)) (pl-kb (tail nodes)))))
+
+    ;; --- resolution ------------------------------------------------------
+    ;; pl-solve-goal: every solution (binding list) for one goal, clause order.
+
+    (defn pl-append (xs ys)
+        (if (nil? xs) ys (cons (head xs) (pl-append (tail xs) ys))))
+
+    (defn pl-solve-clauses (clauses goal bindings kb k)
+        (if (nil? clauses) (empty)
+            (do
+                (let clause (head clauses))
+                (let renamed-head (pl-rename-term (pl-clause-head clause) k))
+                (let r (pl-unify-term goal renamed-head bindings))
+                (if (pl-yes? r)
+                    (do
+                        (let body (pl-rename-terms (pl-clause-body clause) k))
+                        (let sols (pl-solve-goals body (pl-yes-bindings r) kb k 1))
+                        (if (pl-clause-cut? clause)
+                            (if (nil? sols)
+                                (pl-solve-clauses (tail clauses) goal bindings kb (add k 1))
+                                (list (head sols)))
+                            (pl-append sols
+                                (pl-solve-clauses (tail clauses) goal bindings kb (add k 1)))))
+                    (pl-solve-clauses (tail clauses) goal bindings kb (add k 1))))))
+
+    (defn pl-solve-goal (goal bindings kb k)
+        (pl-solve-clauses kb goal bindings kb (mul k 100)))
+
+    (defn pl-flatmap-rest (sols goals kb k idx)
+        (if (nil? sols) (empty)
+            (pl-append (pl-solve-goals goals (head sols) kb k (add idx 1))
+                       (pl-flatmap-rest (tail sols) goals kb k idx))))
+
+    (defn pl-solve-goals (goals bindings kb k idx)
+        (if (nil? goals) (list bindings)
+            (do
+                (let sols (pl-solve-goal (head goals) bindings kb (add (mul k 10) idx)))
+                (pl-flatmap-rest sols (tail goals) kb k idx))))
+
+    ;; --- query door --------------------------------------------------------
+
+    (defn pl-query (functor args kb)
+        (pl-solve-goal (pl-term functor args) (empty) kb 1))
+
+    ;; resolve one variable of interest in every solution
+    (defn pl-answers (var solutions)
+        (if (nil? solutions) (empty)
+            (cons (pl-resolve var (head solutions))
+                  (pl-answers var (tail solutions)))))
+
+    ;; --- built-in goals over PL-BMF expression nodes ------------------------
+
+    ;; X is A + B — numeric add; an argument may be an int trivial (is-add-int)
+    ;; or a name resolved through the bindings to a decimal string.
+    (defn pl-num (v bindings)
+        (if (str_eq (value_kind v) "int") v
+            (str_to_int (pl-resolve v bindings))))
+
+    (defn pl-eval-is (node bindings)
+        (do
+            (let kids (node_children node))
+            (let result (add (pl-num (pl-kid kids 1) bindings)
+                             (pl-num (pl-kid kids 2) bindings)))
+            (pl-yes (cons (list (pl-kid kids 0) (int_to_str result)) bindings))))
+
+    ;; X = Y — one unification step
+    (defn pl-eval-unify (node bindings)
+        (do
+            (let kids (node_children node))
+            (pl-unify-arg (pl-kid kids 0) (pl-kid kids 1) bindings)))
+
+    0)

--- a/form/form-stdlib/tests/language-packs-fourth-band.fk
+++ b/form/form-stdlib/tests/language-packs-fourth-band.fk
@@ -1,0 +1,119 @@
+; language-packs-fourth-band.fk - five tongues, one numeric shape on the fourth
+; kernel's BMF compiler: each language's REAL grammar parses its own surface on
+; the walkers; the parsed operands become that language's grammar pack (rules
+; as data); every pack folds the same token source through bmf-compile into the
+; SAME content-addressed program cell, and the walked value equals the
+; independent reference. Each pack is sealed (pack-manifest) with internal-only
+; deps. The op mapping (tok1 -> ADD, tok2 -> SUB) is the pack's two rows; the
+; OPERANDS are witnessed from each tongue's parse.
+;
+; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/adler32.fk form-stdlib/pack-manifest.fk form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk form-stdlib/bmf-mini.fk form-stdlib/grammars/python-bmf.fk form-stdlib/grammars/typescript-bmf.fk form-stdlib/grammars/go-bmf.fk form-stdlib/grammars/rust-bmf.fk form-stdlib/grammars/prolog-bmf.fk
+;
+; Verdict 31 when the family holds:
+;   1   shared heart — all five packs compile [1,1,2] to the SAME program cell
+;   2   value parity — the program walks 5 -> 22 == bmf-ref
+;   4   rust let-int is reversible — the gap this band closed, roundtripped
+;   8   every pack is sealed and self-contained (internal deps only)
+;   16  grammar is data on this lane too — operand 100 -> different cell, 202
+
+(do
+    (defn result-node (m)
+        (bmf-object-value (cap-get (match-caps m) "result")))
+
+    (defn last-kid-int (node)
+        (do
+            (let kids (node_children node))
+            (node_value (nth kids (sub (len kids) 1)))))
+
+    ;; --- each tongue speaks its constant; its real grammar parses it -------
+
+    (defn py-const (v)
+        (last-kid-int (result-node (apply-python-bmf-rule "assign-int"
+            (list (py-name "step") (py-op "=") (py-int v))))))
+
+    (defn ts-const (v)
+        (last-kid-int (result-node (apply-typescript-bmf-rule "assign-int"
+            (list (ts-src-name "step") (ts-src-op "=") (ts-src-int v) (ts-src-op ";"))))))
+
+    (defn go-const (v)
+        (last-kid-int (result-node (apply-go-bmf-rule "var-int"
+            (list (go-src-keyword "var") (go-src-name "step")
+                  (go-src-op "=") (go-src-int v))))))
+
+    (defn rust-const (v)
+        (last-kid-int (result-node (apply-rust-bmf-rule "let-int"
+            (list (rust-src-keyword "let") (rust-src-name "step")
+                  (rust-src-op "=") (rust-src-int v) (rust-src-op ";"))))))
+
+    (defn prolog-const (v)
+        (last-kid-int (result-node (apply-prolog-bmf-rule "is-add-int"
+            (list (prolog-src-name "Step") (prolog-src-keyword "is")
+                  (prolog-src-name "Acc") (prolog-src-op "+")
+                  (prolog-src-int v))))))
+
+    ;; --- packs: (tok1 -> ADD ten, tok2 -> SUB three), operands from parses --
+
+    (defn lang-pack-rules (ten three)
+        (list (bmf-rule 1 3 ten) (bmf-rule 2 4 three)))
+
+    (let py-rules     (lang-pack-rules (py-const "10")     (py-const "3")))
+    (let ts-rules     (lang-pack-rules (ts-const "10")     (ts-const "3")))
+    (let go-rules     (lang-pack-rules (go-const "10")     (go-const "3")))
+    (let rust-rules   (lang-pack-rules (rust-const "10")   (rust-const "3")))
+    (let prolog-rules (lang-pack-rules (prolog-const "10") (prolog-const "3")))
+
+    (let src (list 1 1 2))
+    (let py-prog     (bmf-compile py-rules src))
+    (let ts-prog     (bmf-compile ts-rules src))
+    (let go-prog     (bmf-compile go-rules src))
+    (let rust-prog   (bmf-compile rust-rules src))
+    (let prolog-prog (bmf-compile prolog-rules src))
+
+    ;; cell 1 — shared heart: five tongues, one content-addressed program
+    (let cell1
+        (if (eq (ms-same py-prog ts-prog) 1)
+        (if (eq (ms-same py-prog go-prog) 1)
+        (if (eq (ms-same py-prog rust-prog) 1)
+        (if (eq (ms-same py-prog prolog-prog) 1) 1 0) 0) 0) 0))
+
+    ;; cell 2 — value parity against the independent reference fold
+    (let cell2
+        (if (eq (fk-run py-prog 5) 22)
+            (if (eq (fk-run prolog-prog 5) (bmf-ref py-rules src 5)) 2 0)
+            0))
+
+    ;; cell 3 — the rust gap closed: let-int roundtrips both directions
+    (let rust-rt
+        (bmf-roundtrip (rust-bmf-find-rule "let-int" rust-bmf-rules)
+            (list (rust-src-keyword "let") (rust-src-name "step")
+                  (rust-src-op "=") (rust-src-int "10") (rust-src-op ";"))))
+    (let cell3 (if (bmf-roundtrip-node-eq? rust-rt) 4 0))
+
+    ;; cell 4 — every pack sealed, deps internal only
+    (defn lang-pack-entry (id grammar-dep)
+        (pack-entry id "fourth-kernel-bmf-grammar"
+            (list (pm-dep "bmf-mini" "internal")
+                  (pm-dep "fourth-walker" "internal")
+                  (pm-dep grammar-dep "internal"))
+            "language-packs"))
+
+    (defn pack-whole? (e)
+        (if (eq (pack-sealed? e "language-packs") 1)
+            (pack-self-contained? e) 0))
+
+    (let cell4
+        (if (eq (pack-whole? (lang-pack-entry "python-pack" "python-bmf")) 1)
+        (if (eq (pack-whole? (lang-pack-entry "typescript-pack" "typescript-bmf")) 1)
+        (if (eq (pack-whole? (lang-pack-entry "go-pack" "go-bmf")) 1)
+        (if (eq (pack-whole? (lang-pack-entry "rust-pack" "rust-bmf")) 1)
+        (if (eq (pack-whole? (lang-pack-entry "prolog-pack" "prolog-bmf")) 1) 8 0) 0) 0) 0) 0))
+
+    ;; cell 5 — grammar stays data: a different witnessed operand, a different cell
+    (let wide-rules (lang-pack-rules (py-const "100") (py-const "3")))
+    (let wide-prog (bmf-compile wide-rules src))
+    (let cell5
+        (if (eq (ms-same py-prog wide-prog) 0)
+            (if (eq (fk-run wide-prog 5) 202) 16 0)
+            0))
+
+    (sum (list cell1 cell2 cell3 cell4 cell5)))

--- a/form/form-stdlib/tests/prolog-bmf-eval-band.fk
+++ b/form/form-stdlib/tests/prolog-bmf-eval-band.fk
@@ -1,0 +1,115 @@
+; prolog-bmf-eval-band.fk - clauses parsed by the grammar, resolved natively:
+; backtracking enumerates solutions, cut commits, is/unify bind.
+;
+; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/grammars/prolog-bmf.fk form-stdlib/prolog-bmf-eval.fk
+
+(do
+    (defn parse-node (rule-name objects)
+        (bmf-object-value
+            (cap-get (match-caps (apply-prolog-bmf-rule rule-name objects)) "result")))
+
+    (defn fact2-node (name a b)
+        (parse-node "fact2"
+            (list (prolog-src-name name) (prolog-src-op "(")
+                  (prolog-src-name a) (prolog-src-op ",")
+                  (prolog-src-name b) (prolog-src-op ")")
+                  (prolog-src-op "."))))
+
+    (defn fact1-node (name a)
+        (parse-node "fact1"
+            (list (prolog-src-name name) (prolog-src-op "(")
+                  (prolog-src-name a) (prolog-src-op ")")
+                  (prolog-src-op "."))))
+
+    (defn fact0-node (name)
+        (parse-node "fact0"
+            (list (prolog-src-name name) (prolog-src-op "."))))
+
+    (defn cut-node (head goal)
+        (parse-node "rule-cut"
+            (list (prolog-src-name head) (prolog-src-op ":-")
+                  (prolog-src-name goal) (prolog-src-op ",")
+                  (prolog-src-op "!") (prolog-src-op "."))))
+
+    ;; grandparent(X,Z) :- parent(X,Y), parent(Y,Z).
+    (let grandparent-node
+        (parse-node "rule2"
+            (list (prolog-src-name "grandparent") (prolog-src-op "(")
+                  (prolog-src-name "X") (prolog-src-op ",")
+                  (prolog-src-name "Z") (prolog-src-op ")")
+                  (prolog-src-op ":-")
+                  (prolog-src-name "parent") (prolog-src-op "(")
+                  (prolog-src-name "X") (prolog-src-op ",")
+                  (prolog-src-name "Y") (prolog-src-op ")")
+                  (prolog-src-op ",")
+                  (prolog-src-name "parent") (prolog-src-op "(")
+                  (prolog-src-name "Y") (prolog-src-op ",")
+                  (prolog-src-name "Z") (prolog-src-op ")")
+                  (prolog-src-op "."))))
+
+    ;; mortal(Q) :- human(Q).
+    (let mortal-node
+        (parse-node "rule1"
+            (list (prolog-src-name "mortal") (prolog-src-op "(")
+                  (prolog-src-name "Q") (prolog-src-op ")")
+                  (prolog-src-op ":-")
+                  (prolog-src-name "human") (prolog-src-op "(")
+                  (prolog-src-name "Q") (prolog-src-op ")")
+                  (prolog-src-op "."))))
+
+    (let kb
+        (pl-kb (list
+            (fact2-node "parent" "tom" "bob")
+            (fact2-node "parent" "tom" "liz")
+            (fact2-node "parent" "bob" "ann")
+            grandparent-node
+            mortal-node
+            (fact1-node "human" "socrates")
+            (fact1-node "human" "plato")
+            (fact0-node "gate")
+            (fact0-node "other")
+            (cut-node "commit" "gate")
+            (cut-node "commit" "other"))))
+
+    ;; cell 1 — ?- grandparent(tom, Z): the two-goal body resolves through
+    ;; the parent chain; exactly one chain reaches a grandchild.
+    (let gp (pl-answers "Z" (pl-query "grandparent" (list "tom" "Z") kb)))
+    (let cell1 (if (and (eq (len gp) 1) (str_eq (head gp) "ann")) 1000 0))
+
+    ;; cell 2 — ?- parent(tom, X): backtracking enumerates both children
+    ;; in clause order.
+    (let kids (pl-answers "X" (pl-query "parent" (list "tom" "X") kb)))
+    (let cell2 (if (and (eq (len kids) 2)
+                        (and (str_eq (nth kids 0) "bob")
+                             (str_eq (nth kids 1) "liz"))) 2000 0))
+
+    ;; cell 3 — cut commits: two commit clauses both satisfiable, the first
+    ;; cut stops the clause scan at one solution. mortal shows the contrast:
+    ;; the same two-clause shape without cut yields both.
+    (let commits (pl-query "commit" (empty) kb))
+    (let mortals (pl-answers "Q" (pl-query "mortal" (list "Q") kb)))
+    (let cell3 (if (and (eq (len commits) 1) (eq (len mortals) 2)) 4000 0))
+    (let cell4 (if (str_eq (head mortals) "socrates") 8000 0))
+
+    ;; cell 5 — Next is N + 1 with N bound: arithmetic binds the target.
+    (let is-node
+        (parse-node "is-add-int"
+            (list (prolog-src-name "Next") (prolog-src-keyword "is")
+                  (prolog-src-name "N") (prolog-src-op "+")
+                  (prolog-src-int "1"))))
+    (let is-r (pl-eval-is is-node (list (list "N" "4"))))
+    (let cell5 (if (and (pl-yes? is-r)
+                        (str_eq (pl-resolve "Next" (pl-yes-bindings is-r)) "5"))
+                   16000 0))
+
+    ;; cell 6 — X = Y unifies through an existing binding.
+    (let u-node
+        (parse-node "unify"
+            (list (prolog-src-name "X") (prolog-src-op "=")
+                  (prolog-src-name "Y"))))
+    (let u-r (pl-eval-unify u-node (list (list "Y" "ann"))))
+    (let cell6 (if (and (pl-yes? u-r)
+                        (str_eq (pl-resolve "X" (pl-yes-bindings u-r)) "ann"))
+                   32000 0))
+
+    (sum (list cell1 cell2 cell3 cell4 cell5 cell6)))

--- a/scripts/form_union_demo.sh
+++ b/scripts/form_union_demo.sh
@@ -61,28 +61,37 @@ for s in A S1 S2 S3 S4 W MQ MS; do
     idx=$((idx + n))
 done
 GS=$idx
-printf '(list 1 3 10 0)\n(list 2 4 3 0)\n' > "$work/rowsG.fk"   # the M2 grammar as data rows
+# The grammar rows are the shared LANGUAGE-PACK shape: five tongues (python,
+# typescript, go, rust, prolog) each parse their own surface through their real
+# BMF grammars and land on these same two rows — proven three-way in
+# form-stdlib/tests/language-packs-fourth-band.fk. They are also the M2 rows.
+printf '(list 1 3 10 0)\n(list 2 4 3 0)\n' > "$work/rowsG.fk"
 NR=$((idx + 2)); NF=11
 read -r AS AE S1S S1E S2S S2E S3S S3E S4S S4E WS WE MQS MQE MSS MSE <<< "$bounds"
 echo "pass 2: NR=$NR; segments A[$AS..$AE] W[$WS..$WE] MQ[$MQS..$MQE] MS[$MSS..$MSE] G[$GS]"
 
 # ── pass 2: bake the real literals, attach the data rows, emit the union C ──
-{ PRELUDE
-  echo "(let p (list $NF $NR $AS $AE $S1S $S1E $S2S $S2E $S3S $S3E $S4S $S4E $WS $WE $MQS $MQE $MSS $MSE $GS))"
-  echo "(let roots (list $(echo "$ROOTS" | tr ',' ' ')))"
-  echo "(let data (list"
-  cat "$work"/rows{A,S1,S2,S3,S4,W,MQ,MS,G}.fk
-  echo "))"
-  cat <<'EOF'
+# build_union <grammar-rows-file> <name>: same segments and bounds (the grammar
+# row COUNT is fixed at 2 — only the baked pack values differ per variant).
+build_union() {
+    { PRELUDE
+      echo "(let p (list $NF $NR $AS $AE $S1S $S1E $S2S $S2E $S3S $S3E $S4S $S4E $WS $WE $MQS $MQE $MSS $MSE $GS))"
+      echo "(let roots (list $(echo "$ROOTS" | tr ',' ' ')))"
+      echo "(let data (list"
+      cat "$work"/rows{A,S1,S2,S3,S4,W,MQ,MS}.fk "$1"
+      echo "))"
+      cat <<'EOF'
 (let flat (fku-with-data (fkc-flatten-many (fku-program p roots)) data))
 (print "==C==")
 (print (fku-emit-c (nth flat 0) (nth flat 1)))
 (print "==END==")
 EOF
-} > "$work/build.fk"
-(cd "$FORM" && "$GO" "$work/build.fk" 2>/dev/null) | sed -n '/^==C==$/,/^==END==$/p' | sed -e '1d' -e '$d' > "$work/union.c"
-[[ -s "$work/union.c" ]] || { echo "FAIL: no C emitted"; exit 1; }
-"$CLANG" -O2 -o "$work/union" "$work/union.c" || { echo "FAIL: clang"; exit 1; }
+    } > "$work/build-$2.fk"
+    (cd "$FORM" && "$GO" "$work/build-$2.fk" 2>/dev/null) | sed -n '/^==C==$/,/^==END==$/p' | sed -e '1d' -e '$d' > "$work/$2.c"
+    [[ -s "$work/$2.c" ]] || { echo "FAIL: no C emitted ($2)"; exit 1; }
+    "$CLANG" -O2 -o "$work/$2" "$work/$2.c" || { echo "FAIL: clang ($2)"; exit 1; }
+}
+build_union "$work/rowsG.fk" union
 echo "union binary: $(wc -c < "$work/union" | tr -d ' ') bytes  (C source: $(wc -c < "$work/union.c" | tr -d ' ') bytes)"
 
 # ── gate 1: the FULL-SOURCE quine — mode 0 output == its own source, byte-exact ──
@@ -110,6 +119,22 @@ if [[ "$v" == "22" ]]; then
     echo "GATE 3  compiler: mode 112 -> a complete new binary; (5+10+10)-3 = $v (the M2 check)"
 else
     echo "GATE 3 FAIL: expected 22, got $v"; exit 1
+fi
+
+# ── gate 4: the pack is data on the NATIVE lane — the wide language pack
+#            (operand 100, witnessed in language-packs-fourth-band.fk cell 5)
+#            bakes into a sibling union; same source tokens, different value,
+#            and the sibling's own quine still closes ──
+printf '(list 1 3 100 0)\n(list 2 4 3 0)\n' > "$work/rowsG-wide.fk"
+build_union "$work/rowsG-wide.fk" union-wide
+"$work/union-wide" 112 > "$work/prog-wide.c"
+"$CLANG" -O2 -o "$work/prog-wide" "$work/prog-wide.c" || { echo "GATE 4 FAIL: emitted C does not compile"; exit 1; }
+vw="$("$work/prog-wide" 5 | head -1)"
+"$work/union-wide" 0 > "$work/self-wide.c"
+if [[ "$vw" == "202" ]] && cmp -s "$work/self-wide.c" "$work/union-wide.c"; then
+    echo "GATE 4  pack swap: the wide pack -> (5+100+100)-3 = $vw on a sibling binary; its quine closes too"
+else
+    echo "GATE 4 FAIL: expected 202 + byte-exact sibling quine (got $vw)"; exit 1
 fi
 
 echo


### PR DESCRIPTION
## What

Two movements, one arc — Prolog becomes a voice the kernel executes, and every language grammar becomes a pack the fourth kernel's BMF compiler carries.

### Prolog execution lift
- **`form/form-stdlib/prolog-bmf-eval.fk`** — resolution over PL-BMF clause nodes: unification over (functor, args) terms, backtracking enumerates every solution in clause order, cut commits a clause and stops the scan, `is`/`=` bind. Clause variables rename per application on base-10 namespace paths so no two applications on one binding chain collide.
- **`tests/prolog-bmf-eval-band.fk` → 63000 three-way**: `?- grandparent(tom, Z)` resolves through the two-goal body to `ann`; `?- parent(tom, X)` enumerates both children; two cut clauses yield one solution while the same shape without cut yields two; `Next is N + 1` and `X = Y` bind.

### Language packs on the fourth kernel's BMF compiler
- **`tests/language-packs-fourth-band.fk` → 31 three-way**: python, typescript, go, rust, and prolog each parse their own surface through their **real** BMF grammars; the witnessed operands become each tongue's pack rows; all five packs compile the same token source through `bmf-compile` into **one content-addressed program cell** (`ms-same`), walking to 22 == the independent reference. Each pack seals via pack-manifest with internal-only deps.
- **Native lane** — `scripts/form_union_demo.sh` gate 4: a swapped (wide) pack bakes into a **sibling union binary** whose compile mode produces 202 and whose full-source quine still closes. All four gates green locally.
- **`fourth-union.fk`**: `rulefind` packs `op*1000000+arg` (was `op*100+arg`) — gate 4 caught the real collision where operand 100 decoded as op 4 arg 0; wide pack operands now ride.

### Fixed along the way
- **rust-bmf had no int captures at all** — `let-int` lands fully reversible (`rust-int-lit`, `rust-src-int`, emit/source pair, native row), roundtrip-proven in the new band.

### Regression proof
fourth-union-band, language-bmf-bidirectional, bmf-generic-language-scanner-band, language-bmf-program-core, prolog-bmf-reversible — all three-way green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)