### PR TITLE
tend: the fourth sibling joins the suite — covered bands run four-way on pre-compiled tables

### DIFF
--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1,0 +1,63 @@
+# fourth-arm-bands.txt — the bands proven to cross four-way on the emitted
+# fourth kernel (fkwu, the universal walker). One row per band:
+#
+#   <band-stem> <table-emitter> <expected-verdict>
+#
+# table-emitter names the flattener door the band's table file comes through:
+#   fkc — fkc-table-file (flt-band-fns ...)                       no string pool
+#   fks — fks-table-file (flt-band-fns ...) (flt-band-pool ...)   string pool
+#
+# The module source is the band's `; preludes:` header (first non-core
+# prelude), falling back to the same-name convention form-stdlib/<stem>.fk.
+# Provenance: scripts/fourth_kernel_audit.sh sections 19/22/24/25/26 —
+# every row here is gated four-way there before it lands here. A band
+# leaves this file only when its source moves outside the walker's op
+# families (the audit will say so first).
+learning-trend fkc 127
+cooldown fkc 63
+alert-gate fkc 127
+value-execution fkc 7
+anomaly-band fkc 127
+body-state fkc 127
+field-fusion fkc 127
+histogram-peak fkc 127
+model-retire fkc 63
+signal-derivative fkc 127
+feature-vector fkc 127
+active-inference fks 127
+branch-choice-order fks 511
+cell-sync fks 127
+chakra-column fks 127
+champion-challenger fks 127
+classifier-eval fks 63
+confidence-calibrate fks 127
+confidence-weighted-vote fks 127
+device-heartbeat fks 127
+drift-detect fks 63
+ensemble-vote fks 127
+friend-node fks 127
+learned-primitive fks 255
+markov-2 fks 127
+mesh-gradient fks 127
+mesh-relay fks 127
+nearest-shape fks 127
+novelty fks 63
+online-accuracy fks 63
+predictor-train fks 63
+prototype-merge fks 127
+provisioning fks 127
+recognition-router fks 127
+recognition-router-compute fks 63
+recognition-router-vision fks 31
+self-grounding-classifier fks 63
+sequence-predictor fks 127
+shared-sensing fks 127
+surprise-salience fks 127
+temporal-smoothing fks 63
+declared-source fks 127
+transition-detect fks 127
+warm-start fks 127
+adler32 fks 5
+crc32 fks 4
+slice-merge fks 127
+rle fks 12

--- a/form/scripts/fourth-arm.sh
+++ b/form/scripts/fourth-arm.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# fourth-arm.sh — the emitted fourth kernel as a validate.sh leg.
+#
+# Sourced by validate.sh (cwd = form/). The fourth sibling is the universal
+# walker binary (fkwu) whose C source is emitted entirely by Form recipes
+# (fourth-walker-emit.fk, fkc-emit-universal). Bands listed in
+# fourth-arm-bands.txt — each one already gated four-way by
+# scripts/fourth_kernel_audit.sh — run on it as a fourth leg: the band's
+# UNMODIFIED source is flattened once into a node-table file (the
+# pre-compiled artifact), cached by content, and the binary answers in
+# milliseconds. A band's wall time stays max(legs); the fourth witness is
+# effectively free.
+#
+# Everything degrades honestly: no clang, no manifest, or an emission
+# failure simply leaves FKWU/table empty and the band runs three-way as
+# before — the suite never goes red because the fourth arm could not build,
+# only when it DISAGREES.
+
+FOURTH_DIR="form-stdlib/.cache/fourth"
+FOURTH_MANIFEST="fourth-arm-bands.txt"
+# The emitter chain: every file whose content shapes either the fkwu binary
+# or a flattened table. Cache keys hash these so a flattener or walker
+# change rebuilds exactly what it touches.
+FOURTH_CHAIN=(
+    form-stdlib/minimal-surface.fk
+    form-stdlib/fourth-walker.fk
+    form-stdlib/fourth-walker-emit.fk
+    form-stdlib/form-parse.fk
+    form-stdlib/form-flatten.fk
+)
+FKWU=""
+
+fourth_available() { [[ -n "$FKWU" && -x "$FKWU" ]]; }
+
+# build_fourth — the standing fkwu binary, cached by emitter content.
+build_fourth() {
+    [[ -f "$FOURTH_MANIFEST" ]] || return 0
+    command -v clang >/dev/null 2>&1 || return 0
+    mkdir -p "$FOURTH_DIR"
+    local stamp out d
+    stamp="$(cat "${FOURTH_CHAIN[@]}" "$GO_BIN" 2>/dev/null | shasum | cut -c1-16)"
+    out="$FOURTH_DIR/fkwu-$stamp"
+    if [[ ! -x "$out" ]]; then
+        echo "  building fourth kernel (fkwu)..." >&2
+        d="$(mktemp -d "${TMPDIR:-/tmp}/form-fourth.XXXXXX")"
+        cat form-stdlib/minimal-surface.fk form-stdlib/fourth-walker.fk \
+            form-stdlib/fourth-walker-emit.fk > "$d/uni-driver.fk"
+        printf '(print "==UNI==")\n(print (fkc-emit-universal))\n(print "==END==")\n' >> "$d/uni-driver.fk"
+        "$GO_BIN" "$d/uni-driver.fk" 2>/dev/null > "$d/uni.out" || true
+        sed -n '/^==UNI==$/,/^==END==$/p' "$d/uni.out" | sed -e '1d' -e '$d' > "$d/uni.c"
+        if [[ -s "$d/uni.c" ]] && clang -O2 -o "$out.tmp" "$d/uni.c" 2>/dev/null; then
+            mv -f "$out.tmp" "$out"
+        else
+            rm -f "$out.tmp"
+            echo "  fourth kernel build did not land — bands run three-way" >&2
+        fi
+        rm -rf "$d"
+    fi
+    [[ -x "$out" ]] && FKWU="$out"
+    # Compost stale binaries from earlier emitter generations.
+    find "$FOURTH_DIR" -maxdepth 1 -name 'fkwu-*' ! -name "$(basename "$out")" -delete 2>/dev/null || true
+}
+
+# fourth_band_stem — manifest stem for a band file path, or empty.
+fourth_band_stem() {
+    local band="$1" stem
+    stem="$(basename "$band")"
+    stem="${stem%.fk}"
+    stem="${stem%-band}"
+    [[ -f "$FOURTH_MANIFEST" ]] || return 0
+    awk -v b="$stem" '$1==b{print $1; exit}' "$FOURTH_MANIFEST"
+}
+
+# fourth_band_module — the band's module source: first non-core prelude,
+# falling back to the same-name convention.
+fourth_band_module() {
+    local stem="$1" band="form-stdlib/tests/$stem-band.fk" mod
+    mod="$(grep -E '^; preludes:' "$band" 2>/dev/null | head -1 | sed 's/^; preludes://' \
+        | tr ' ' '\n' | grep -v 'core\.fk' | grep . | head -1)"
+    [[ -z "$mod" ]] && mod="form-stdlib/$stem.fk"
+    printf '%s\n' "$mod"
+}
+
+# fourth_table — cached flattened node-table for one band (path on stdout).
+# Emits through the Go walker on a cache miss; empty output means the band
+# runs three-way this time.
+fourth_table() {
+    local stem="$1" kind mod band key out d
+    kind="$(awk -v b="$stem" '$1==b{print $2; exit}' "$FOURTH_MANIFEST")"
+    [[ -n "$kind" ]] || return 0
+    band="form-stdlib/tests/$stem-band.fk"
+    mod="$(fourth_band_module "$stem")"
+    [[ -f "$band" && -f "$mod" ]] || return 0
+    key="$(cat "$mod" "$band" "${FOURTH_CHAIN[@]}" 2>/dev/null | shasum | cut -c1-16)"
+    out="$FOURTH_DIR/t-$stem-$key.txt"
+    if [[ ! -s "$out" ]]; then
+        d="$(mktemp -d "${TMPDIR:-/tmp}/form-fourth-t.XXXXXX")"
+        cat "${FOURTH_CHAIN[@]}" > "$d/driver.fk"
+        if [[ "$kind" == "fks" ]]; then
+            printf '(print (fks-table-file (flt-band-fns (read_file "%s") (read_file "%s")) (flt-band-pool (read_file "%s") (read_file "%s"))))\n' \
+                "$mod" "$band" "$mod" "$band" >> "$d/driver.fk"
+        else
+            printf '(print (fkc-table-file (flt-band-fns (read_file "%s") (read_file "%s"))))\n' \
+                "$mod" "$band" >> "$d/driver.fk"
+        fi
+        "$GO_BIN" "$d/driver.fk" 2>/dev/null > "$out.tmp" && mv -f "$out.tmp" "$out" || rm -f "$out.tmp"
+        rm -rf "$d"
+    fi
+    [[ -s "$out" ]] && printf '%s\n' "$out"
+}
+
+# fourth_table_for_band — the cached table for a band FILE PATH (the last
+# workload argument), or empty when the band is outside the manifest.
+fourth_table_for_band() {
+    local stem
+    stem="$(fourth_band_stem "$1")"
+    [[ -n "$stem" ]] || return 0
+    fourth_table "$stem"
+}
+
+# fourth_prepare_all — batch-emit every missing manifest table in ONE Go
+# walker run (the flattener chain parses once, not once per band). Called
+# before the full suite; single-band runs fall back to fourth_table's
+# per-band miss path.
+fourth_prepare_all() {
+    fourth_available || return 0
+    [[ -f "$FOURTH_MANIFEST" ]] || return 0
+    local d stems=() outs=() stem kind mod band key out missing=0
+    d="$(mktemp -d "${TMPDIR:-/tmp}/form-fourth-all.XXXXXX")"
+    cat "${FOURTH_CHAIN[@]}" > "$d/driver.fk"
+    while read -r stem kind _; do
+        [[ -z "$stem" || "$stem" == \#* ]] && continue
+        band="form-stdlib/tests/$stem-band.fk"
+        mod="$(fourth_band_module "$stem")"
+        [[ -f "$band" && -f "$mod" ]] || continue
+        key="$(cat "$mod" "$band" "${FOURTH_CHAIN[@]}" 2>/dev/null | shasum | cut -c1-16)"
+        out="$FOURTH_DIR/t-$stem-$key.txt"
+        [[ -s "$out" ]] && continue
+        missing=$((missing + 1))
+        stems+=("$stem")
+        outs+=("$out")
+        printf '(print "==T-%s==")\n' "$stem" >> "$d/driver.fk"
+        if [[ "$kind" == "fks" ]]; then
+            printf '(print (fks-table-file (flt-band-fns (read_file "%s") (read_file "%s")) (flt-band-pool (read_file "%s") (read_file "%s"))))\n' \
+                "$mod" "$band" "$mod" "$band" >> "$d/driver.fk"
+        else
+            printf '(print (fkc-table-file (flt-band-fns (read_file "%s") (read_file "%s"))))\n' \
+                "$mod" "$band" >> "$d/driver.fk"
+        fi
+    done < "$FOURTH_MANIFEST"
+    if [[ "$missing" -eq 0 ]]; then
+        rm -rf "$d"
+        return 0
+    fi
+    echo "  flattening $missing band tables for the fourth arm..." >&2
+    printf '(print "==T-END==")\n' >> "$d/driver.fk"
+    "$GO_BIN" "$d/driver.fk" 2>/dev/null > "$d/all.out" || true
+    local i cur=""
+    for ((i = 0; i < ${#stems[@]}; i++)); do
+        cur="${outs[$i]}"
+        if ((i + 1 < ${#stems[@]})); then
+            sed -n "/^==T-${stems[$i]}==\$/,/^==T-${stems[$((i + 1))]}==\$/p" "$d/all.out" | sed -e '1d' -e '$d' > "$cur.tmp"
+        else
+            sed -n "/^==T-${stems[$i]}==\$/,/^==T-END==\$/p" "$d/all.out" | sed -e '1d' -e '$d' > "$cur.tmp"
+        fi
+        if [[ -s "$cur.tmp" ]]; then mv -f "$cur.tmp" "$cur"; else rm -f "$cur.tmp"; fi
+    done
+    rm -rf "$d"
+    # Compost stale tables from earlier source generations.
+    find "$FOURTH_DIR" -maxdepth 1 -name 't-*' -mtime +14 -delete 2>/dev/null || true
+}

--- a/form/validate.sh
+++ b/form/validate.sh
@@ -73,6 +73,14 @@ build_rs &
 build_ts &
 wait
 
+# The fourth sibling — the universal walker binary emitted from Form
+# recipes — joins covered bands as a fourth leg. Built AFTER the Go kernel
+# (its C source is emitted by running the Go walker); everything degrades
+# honestly when clang or the manifest is absent. See scripts/fourth-arm.sh.
+# shellcheck source=scripts/fourth-arm.sh
+source scripts/fourth-arm.sh
+build_fourth
+
 run_ts() {
     local bundle="$TS_DIR/dist/main.mjs"
     local loader="$PWD/$TS_DIR/node_modules/tsx/dist/loader.mjs"
@@ -160,6 +168,14 @@ run_siblings() {
     local label="$1"; shift
     local go_out rs_out ts_out legs
     prepare_sources "$@"
+    # Fourth leg: when the workload's band is in the fourth-arm manifest,
+    # its pre-flattened table runs on the emitted universal walker (fkwu)
+    # alongside the three walkers. Native execution answers in milliseconds,
+    # so max(legs) — the band's wall time — does not move.
+    local fourth_tbl="" fk_out=""
+    if fourth_available; then
+        fourth_tbl="$(fourth_table_for_band "${*: -1}")"
+    fi
     # The three kernels run CONCURRENTLY: a band's wall time is max(leg), not
     # sum — on compiler-heavy bands the Go+Rust legs ride inside the TS leg's
     # shadow for free. Outputs stay byte-compared exactly as before.
@@ -173,12 +189,22 @@ run_siblings() {
     ( TMPDIR="$legs/tmp-go" "$GO_BIN" "${prepared_args[@]}" > "$legs/go" 2>&1 || true ) &
     ( TMPDIR="$legs/tmp-rs" "$RS_BIN" "${prepared_args[@]}" > "$legs/rs" 2>&1 || true ) &
     ( TMPDIR="$legs/tmp-ts" run_ts "${prepared_args[@]}" > "$legs/ts" 2>&1 || true ) &
+    if [[ -n "$fourth_tbl" ]]; then
+        ( "$FKWU" "$fourth_tbl" 0 2>/dev/null | head -1 > "$legs/fk" || true ) &
+    fi
     wait
     go_out=$(cat "$legs/go"); rs_out=$(cat "$legs/rs"); ts_out=$(cat "$legs/ts")
+    if [[ -n "$fourth_tbl" ]]; then fk_out=$(cat "$legs/fk" 2>/dev/null || true); fi
     rm -rf "$legs"
-    if [[ "$go_out" == "$rs_out" && "$go_out" == "$ts_out" ]]; then
+    if [[ "$go_out" == "$rs_out" && "$go_out" == "$ts_out" ]] \
+        && { [[ -z "$fourth_tbl" ]] || [[ "$fk_out" == "$go_out" ]]; }; then
         printf "  ✓  %-30s  → %s\n" "$label" "$go_out"
         ok=$((ok + 1))
+        if [[ -n "$fourth_tbl" ]]; then fourth_ok=$((fourth_ok + 1)); fi
+    elif [[ -n "$fourth_tbl" ]]; then
+        printf "  ✗  %-30s\n      go         = %s\n      rust       = %s\n      typescript = %s\n      fourth     = %s\n" \
+            "$label" "$go_out" "$rs_out" "$ts_out" "$fk_out"
+        fail=$((fail + 1))
     else
         printf "  ✗  %-30s\n      go         = %s\n      rust       = %s\n      typescript = %s\n" \
             "$label" "$go_out" "$rs_out" "$ts_out"
@@ -219,6 +245,7 @@ run_workload() {
 
 ok=0
 fail=0
+fourth_ok=0
 
 # --- explicit mode: validate one file list as one workload --------------
 if [[ $# -gt 0 ]]; then
@@ -233,6 +260,9 @@ if [[ $# -gt 0 ]]; then
     done
     run_workload "$label" "$@"
 else
+    # Pre-flatten every covered band's table in one Go run before the
+    # suite fans out — cold cache pays ~20s once; warm runs skip it.
+    fourth_prepare_all
     # --- form-samples/*.fk: self-contained files ------------------------
     for f in form-samples/*.fk; do
         run_workload "$(basename "$f")" "$f"
@@ -268,6 +298,9 @@ else
 fi
 
 echo ""
+if [[ $fourth_ok -gt 0 ]]; then
+    echo "  fourth arm: $fourth_ok band(s) four-way (fkwu + pre-flattened tables)"
+fi
 if [[ $fail -eq 0 ]]; then
     if [[ $binary_mode -eq 1 ]]; then
         echo "  $ok ok, 0 divergent — kernels agree on every binary artifact."


### PR DESCRIPTION
## What this lands

The emitted fourth kernel (fkwu — the universal walker whose C source is authored entirely by Form recipes) becomes a **standing validate.sh leg**, with **pre-compiled stdlib artifacts** carrying covered bands at native speed.

- **`form/scripts/fourth-arm.sh`** — builds fkwu once, cached by emitter-chain content (34.7 KB binary, ~2s cold / ~0.2s warm), and pre-flattens every covered band's UNMODIFIED source into a node-table file, cached by content (48 tables, ~20s cold, skipped warm). These table files are the pre-compiled stdlib binaries: load-and-run, no parsing.
- **`form/fourth-arm-bands.txt`** — the coverage manifest: the 48 bands `scripts/fourth_kernel_audit.sh` already gates four-way (sections 19/22/24/25/26), lifted into one file. A manifest band's fkwu verdict must equal the three walkers' — disagreement is a suite failure with a fourth output row, never a silent skip.
- **`form/validate.sh`** — the fourth leg rides inside the existing concurrent legs block; the suite summary names the count.

## Measured rows (macOS arm64, this branch)

| ask | result |
|---|---|
| 48 manifest bands on fkwu | **2s aggregate**, all audited verdicts answered |
| table flatten (one-time, content-cached) | 20s for all 48 |
| fkwu build (content-cached) | ~2s cold, 0.2s warm |
| full suite with the arm riding | 1287s, `509 ok, 0 divergent — fourth arm: 48 band(s) four-way` |

Re-verified after rebase onto current main (#2938 era): 48/48.

Honest degradation: no clang, no manifest, or an emission failure leaves bands three-way; the suite reds only on real disagreement. The ratchet (`bands-on-fourth-arm`) climbs by editing the manifest as the audit proves new families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)