### PR TITLE
tend: four grammar headers name the live ontology path, mirroring prolog-bmf

### DIFF
--- a/form/form-stdlib/grammars/go-bmf.fk
+++ b/form/form-stdlib/grammars/go-bmf.fk
@@ -1,10 +1,10 @@
 ; grammars/go-bmf.fk - Go grammar as native BMF object rules
 ;
 ; Per-dialect category constants (GO-BMF-*) are declared as data in
-; form-stdlib/form-ontology.json and emitted into
-; form-stdlib/dialect-categories.fk by scripts/generate_ontology.py. This
-; file references them as free identifiers; load dialect-categories.fk as
-; a prelude before this file.
+; form-stdlib/form-ontology.json; scripts/gen_bp_table.py bakes them into
+; the kernel-native bp table, and form-ontology-loader.fk materializes the
+; Form-side bindings. This file references them as free identifiers; load
+; form-ontology-loader.fk as a prelude before this file.
 
 (do
     (defn go-src-keyword (value) (bmf-atom "go-keyword" value))

--- a/form/form-stdlib/grammars/python-bmf.fk
+++ b/form/form-stdlib/grammars/python-bmf.fk
@@ -6,10 +6,10 @@
 ; and completed matches emit reversible Form objects.
 ;
 ; Per-dialect PY-BMF-* category constants are declared as data in
-; form-stdlib/form-ontology.json and emitted into
-; form-stdlib/dialect-categories.fk by scripts/generate_ontology.py. This
-; file references them as free identifiers; load dialect-categories.fk as
-; a prelude before this file.
+; form-stdlib/form-ontology.json; scripts/gen_bp_table.py bakes them into
+; the kernel-native bp table, and form-ontology-loader.fk materializes the
+; Form-side bindings. This file references them as free identifiers; load
+; form-ontology-loader.fk as a prelude before this file.
 
 (do
     ;; --- source-object helpers ---------------------------------------

--- a/form/form-stdlib/grammars/rust-bmf.fk
+++ b/form/form-stdlib/grammars/rust-bmf.fk
@@ -1,10 +1,10 @@
 ; grammars/rust-bmf.fk - Rust grammar as native BMF object rules
 ;
 ; Per-dialect category constants (RS-BMF-*) are declared as data in
-; form-stdlib/form-ontology.json and emitted into
-; form-stdlib/dialect-categories.fk by scripts/generate_ontology.py. This
-; file references them as free identifiers; load dialect-categories.fk as
-; a prelude before this file.
+; form-stdlib/form-ontology.json; scripts/gen_bp_table.py bakes them into
+; the kernel-native bp table, and form-ontology-loader.fk materializes the
+; Form-side bindings. This file references them as free identifiers; load
+; form-ontology-loader.fk as a prelude before this file.
 
 (do
     (defn rust-src-keyword (value) (bmf-atom "rust-keyword" value))

--- a/form/form-stdlib/grammars/typescript-bmf.fk
+++ b/form/form-stdlib/grammars/typescript-bmf.fk
@@ -1,10 +1,10 @@
 ; grammars/typescript-bmf.fk - TypeScript grammar as native BMF object rules
 ;
 ; Per-dialect category constants (TS-BMF-*) are declared as data in
-; form-stdlib/form-ontology.json and emitted into
-; form-stdlib/dialect-categories.fk by scripts/generate_ontology.py. This
-; file references them as free identifiers; load dialect-categories.fk as
-; a prelude before this file.
+; form-stdlib/form-ontology.json; scripts/gen_bp_table.py bakes them into
+; the kernel-native bp table, and form-ontology-loader.fk materializes the
+; Form-side bindings. This file references them as free identifiers; load
+; form-ontology-loader.fk as a prelude before this file.
 
 (do
     (defn ts-src-keyword (value) (bmf-atom "typescript-keyword" value))


### PR DESCRIPTION
The go/rust/typescript/python BMF grammar headers said their dialect category constants are "emitted into form-stdlib/dialect-categories.fk by scripts/generate_ontology.py" — neither that file nor that script exists. The live path: constants declared in `form/form-stdlib/form-ontology.json` → `scripts/gen_bp_table.py` bakes them into the three kernel bp tables → `form/form-stdlib/form-ontology-loader.fk` materializes the Form-side bindings (loaded as a prelude). `grammars/prolog-bmf.fk` (#2933) already carries the correct wording; the four older headers now mirror it.

Comment-only change. `go-bmf-reversible-band` proven three-way locally: go, rust, and typescript kernels agree (→ 142).

🤖 Generated with [Claude Code](https://claude.com/claude-code)