### PR TITLE
tend: records cross the fourth arm as arena tissue — zero new tags

### DIFF
--- a/form/form-stdlib/form-flatten.fk
+++ b/form/form-stdlib/form-flatten.fk
@@ -130,7 +130,8 @@
     (if (str_eq op "char_at") (flt-low 7 s pos fns env)
     (if (str_eq op "ord") (flt-low1 1 s pos fns env)
     (if (str_eq op "not") (flt-low1 2 s pos fns env)
-        (flt-op op s pos fns env)))))))))))))))
+    (if (str_eq op "record_new") (flt-recnew s pos fns env)
+        (flt-op op s pos fns env))))))))))))))))
 
 ; one operand, then the unary lowering picked by selector k
 (defn flt-low1 (k s pos fns env) (flt-low1-a k s (flt-expr s pos fns env)))
@@ -217,6 +218,30 @@
         (flt-list2 s (flt-expr s pos fns env) fns env)))
 (defn flt-list2 (s ee fns env) (flt-list3 (nth ee 0) (flt-list s (nth ee 1) fns env)))
 (defn flt-list3 (e re) (list (fk-cons e (nth re 0)) (nth re 1)))
+
+; ── (record_new bp k1 v1 k2 v2 ...) — records as ARENA TISSUE (no new tags) ──
+; The blueprint is parsed and DISCARDED: the read-only record family this lane
+; carries never compares types (record_blueprint / node_eq stay outside it,
+; with the mutable-identity family). The key/value pairs right-fold into a
+; cons-chain of PROPER 2-lists (list key val) — the SAME arena the `list`
+; special form builds, so head/tail/nil? walk it and the emitted fkwu binary
+; carries records on the existing arena arms (tags 18..23) with zero new
+; walker tags. (A proper 2-list, never a dotted (cons key val) pair: the host
+; kernels' head/tail want proper lists, the C arena reads either, so the
+; 2-list is the shape that walks identically on all four.) The matching read
+; is record_get (fourth-shim.fk): a recipe that walks the chain comparing the
+; interned key id (str_eq IS content equality, axiom 3).
+(defn flt-recnew (s pos fns env) (flt-recnew-bp s (flt-expr s pos fns env) fns env))
+(defn flt-recnew-bp (s be fns env) (flt-recpairs s (nth be 1) fns env))
+(defn flt-recpairs (s pos fns env)
+    (if (eq (fp-at s (fp-skip s pos)) 41) (list (fk-empty) (add (fp-skip s pos) 1))
+        (flt-recpairs-v s (flt-expr s pos fns env) fns env)))
+(defn flt-recpairs-v (s ke fns env)
+    (flt-recpairs-r (nth ke 0) s (flt-expr s (nth ke 1) fns env) fns env))
+(defn flt-recpairs-r (key s ve fns env)
+    (flt-recpairs-done key (nth ve 0) (flt-recpairs s (nth ve 1) fns env)))
+(defn flt-recpairs-done (key val re)
+    (list (fk-cons (fk-cons key (fk-cons val (fk-empty))) (nth re 0)) (nth re 1)))
 
 ; ── the do-walker: defn registers a function row (name BEFORE body, so
 ;    self-recursion lands), let binds env, the last plain expression is the

--- a/form/form-stdlib/fourth-shim.fk
+++ b/form/form-stdlib/fourth-shim.fk
@@ -70,4 +70,16 @@
     (defn str_find (s needle from)
         (if (gt from (str_len s)) (sub 0 1)
             (fourth-sf-at s needle (max2 from 0))))
+    ; record_get — the portable record READ, paired with form-flatten.fk's
+    ; record_new lowering. A record is a cons-chain of (list key val) entries
+    ; (records as arena tissue); this walks the chain and answers the value of
+    ; the first entry whose interned key matches `field` (str_eq IS content
+    ; equality, axiom 3), or 0 when no entry carries it. record_new (the
+    ; flattener special form) is the matching WRITE; the two are the read-only
+    ; record family the fourth arm carries with zero new walker tags.
+    (defn record_get (rec field)
+        (if (nil? rec) 0
+            (if (str_eq (head (head rec)) field)
+                (head (tail (head rec)))
+                (record_get (tail rec) field))))
     0)

--- a/form/form-stdlib/tests/form-flatten-band.fk
+++ b/form/form-stdlib/tests/form-flatten-band.fk
@@ -8,7 +8,7 @@
 ; in scripts/fourth_kernel_audit.sh — the fourth arm, where the heap ops
 ; live). Same cells, both walkers; content-addressing carries the identity.
 ;
-; Verdict 32767 when the flattener holds:
+; Verdict 65535 when the flattener holds:
 ;   1   the lowerings carry values — gt strict at the tie (gt 4 4 -> 0,
 ;       the learning-trend boundary), ge admits it, eq lands, and gates
 ;   2   defn/let/CALL — a mini band with a function, a let, and a verdict
@@ -52,6 +52,11 @@
 ;        boundaries (base->mid->main = 32), and the REAL base64 module +
 ;        band (shim-first, unmodified from disk) walk BY VALUE to the
 ;        siblings' own verdict 12
+;   32768 records as ARENA TISSUE — record_new lowers to a cons-chain of
+;        (list key val) entries (blueprint discarded), record_get walks it
+;        by interned-key match; the REAL record-fold band (unmodified,
+;        shim-first) folds a named integer field across a list of records
+;        and walks BY VALUE to the siblings' verdict 31 — zero new tags
 (do
     (let c0 (if (and (and (eq (fkm-run (flt-src-fns "(do (gt 5 2))") 0) 1)
                           (eq (fkm-run (flt-src-fns "(do (gt 4 4))") 0) 0))
@@ -114,4 +119,14 @@
                                                        (read_file "form-stdlib/base64.fk")
                                                        (read_file "form-stdlib/tests/base64-band.fk"))) 0) 12))
                  16384 0))
-    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 (add c9 (add c10 (add c11 (add c12 (add c13 c14)))))))))))))))
+    ;; records as ARENA TISSUE — record_new lowers (form-flatten.fk special
+    ;; form, blueprint discarded) to a cons-chain of (list key val) entries;
+    ;; record_get (the shim recipe) walks the chain by interned-key match. No
+    ;; new walker tags: the arena arms 18..23 + the string lane carry it. The
+    ;; REAL record-fold band (read from disk, unmodified, shim-first) folds a
+    ;; named integer field across a LIST of records and walks BY VALUE to the
+    ;; siblings' own verdict 31 (field read at two keys, a list-of-record fold,
+    ;; a field predicate, the empty-fold identity).
+    (let c15 (if (eq (fkm-run (flt-srcs-fns (list shim
+                                                  (read_file "form-stdlib/tests/record-fold-band.fk"))) 0) 31) 32768 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 (add c9 (add c10 (add c11 (add c12 (add c13 (add c14 c15))))))))))))))))

--- a/form/form-stdlib/tests/record-fold-band.fk
+++ b/form/form-stdlib/tests/record-fold-band.fk
@@ -1,0 +1,59 @@
+; tests/record-fold-band.fk — read-only RECORD construction + field read +
+; fold over a LIST of records, proven FOUR-WAY (Go, Rust, TypeScript, and the
+; emitted fourth kernel fkwu).
+;
+; preludes: form-stdlib/core.fk
+;
+; record_new / record_get are kernel natives on the three walkers; on the
+; fourth arm they ride the records-as-arena-tissue carrier — record_new lowers
+; to a cons-chain of (cons key val) entries (form-flatten.fk's special form,
+; blueprint discarded) and record_get is a recipe that walks the chain
+; (fourth-shim.fk). No new walker tags: records reuse the arena arms (18..23)
+; and the string-pool lane (str_eq = content equality). This is the
+; integer-field, identity-free half of the API_KERNEL_READINESS record gate —
+; the float-field and mutable-aliasing halves stay with the float and
+; mutable-cell lanes (grounded-cost / list-of-record / record / method bands).
+;
+; The strange-minimal edge that covers the most: a single record read at two
+; DISTINCT keys (key matching, not position), a fold that READS a named field
+; from each element of a list of records, a field PREDICATE (count under gt),
+; and the empty-fold identity — the four shapes every list-of-record reduction
+; reduces to, in the simplest expression. Each check is one bit of the verdict
+; so a failure names itself.
+;
+; Band verdict: 31 when every assertion holds across all four kernels.
+;   - record reads field "n" (42) and field "tag" (9) off one record  → 1, 2
+;   - sum a named integer field across a list of records (3+7+5 = 15)  → 4
+;   - count elements whose field passes a predicate (tag > 0 → 2)      → 8
+;   - empty-list fold returns the identity accumulator (0)             → 16
+
+(do
+    (let bp (make_nodeid 1 5 4 1))
+
+    (let items (list
+        (record_new bp "n" 3 "tag" 1)
+        (record_new bp "n" 7 "tag" 1)
+        (record_new bp "n" 5 "tag" 0)))
+
+    ;; sum a named integer field across the list (head/tail accumulator fold)
+    (defn sum_n (xs acc)
+        (if (eq (len xs) 0)
+            acc
+            (sum_n (tail xs) (add acc (record_get (head xs) "n")))))
+
+    ;; count elements whose "tag" field is > 0 (a field predicate)
+    (defn count_tag (xs acc)
+        (if (eq (len xs) 0)
+            acc
+            (if (gt (record_get (head xs) "tag") 0)
+                (count_tag (tail xs) (add acc 1))
+                (count_tag (tail xs) acc))))
+
+    (let one (record_new bp "n" 42 "tag" 9))
+    (let s1 (if (eq (record_get one "n") 42) 1 0))
+    (let s2 (if (eq (record_get one "tag") 9) 1 0))
+    (let s3 (if (eq (sum_n items 0) 15) 1 0))
+    (let s4 (if (eq (count_tag items 0) 2) 1 0))
+    (let s5 (if (eq (sum_n (list) 0) 0) 1 0))
+
+    (add s1 (add (mul s2 2) (add (mul s3 4) (add (mul s4 8) (mul s5 16))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -119,3 +119,16 @@ turn-taking fks 127
 ulid fks 4
 witness-theorem fks 31
 witness-to-co-regulate fks 127
+
+# ── records lane — read-only RECORD family as ARENA TISSUE (zero new tags) ──
+# record_new lowers (form-flatten.fk special form, blueprint discarded) to a
+# cons-chain of (list key val) entries; record_get (fourth-shim.fk) walks the
+# chain by interned-key match. Records reuse the arena arms (18..23) + the
+# string-pool lane — no new walker tags claimed (66..69 stay free). The
+# record-fold band proves the integer-field, identity-free half of the
+# API_KERNEL_READINESS record gate: construction, field read at distinct keys,
+# a fold over a LIST of records, a field predicate, the empty-fold identity.
+# The float-field record bands (grounded-cost-*, list-of-record-reduction,
+# record-field-access) wait on the float lane; the mutable-aliasing +
+# blueprint bands (record, method) wait on the mutable-cell + method lanes.
+record-fold fks 31


### PR DESCRIPTION
## What crossed

The read-only **record family** now crosses four-way on the emitted fourth kernel (fkwu), carried entirely as **arena tissue** — **zero new walker tags** (66..69 stay free; `fourth-walker.fk` and `fourth-walker-emit.fk` are untouched).

- `record_new` lowers in `form-flatten.fk` as a variadic special form (like `list`): the blueprint is parsed and **discarded** (the read-only family never compares types), and the key/value pairs right-fold into a cons-chain of **proper 2-lists** `(list key val)` — the same arena the `list` form builds.
- `record_get` rides `fourth-shim.fk` as a recipe that walks the chain by **interned-key match** (`str_eq` IS content equality, axiom 3), answering 0 for an absent key.

A 2-list (never a dotted `(cons key val)` pair) is the shape that walks identically on all four kernels: the host kernels' `head`/`tail` want proper lists; the C arena reads either.

## Proof

- **`form-flatten-band.fk`** grows bit `32768` (verdict `32767 → 65535`): the real `record-fold` band, read from disk unmodified shim-first, walks **by value to 31** on the recipe-side walker. `validate.sh` confirms byte-identical across Go / Rust / TS (and the fourth leg fires).
- **`record-fold-band.fk`** (new witness): record construction, field read at two distinct keys, a fold over a **list of records**, a field predicate (`count` under `gt`), and the empty-fold identity — the four shapes every list-of-record reduction reduces to. **PASS-4WAY** at verdict `31` (the emitted fkwu binary agrees with the three native walkers bit-for-bit).
- Regression: `base64`, `adler32`, `substrate-gc` stay **PASS-4WAY** after the shim grows `record_get` (the shim rides every flatten; the function table holds).

## Tag claims

**None.** Records compose from the existing arena arms (tags 18..23) + the string-pool lane. Tags 66..69 remain unclaimed — the honest north-star answer (compose from the arena, don't grow the tag space when it isn't needed).

## Walls hit (named, not mine to close here)

The existing record-using route bands never need records *in isolation*:
- `grounded-cost-*`, `list-of-record-reduction`, `record-field-access` carry **float fields** — blocked by the integer-only C walker's float wall (the "three-way" in their comments is the three walkers, not the emitted C kernel).
- `record-band` needs **mutable reference identity** (aliasing `r2 = r`, in-place `record_set`) + `node_eq`/`record_blueprint`.
- `method-band` needs **method dispatch + closures** stored on the blueprint.

So this lane lands one focused four-way records witness rather than promoting a float-or-mutation-blocked band. The carrier is ready; the float-field and mutable-aliasing record bands wait on the float and mutable-cell lanes.

> Note: `scripts/fourth_kernel_audit.sh` prints its real verdict `ok — parity held and the rows are real`, then exits non-zero on a **pre-existing** trailing doc-echo bug (`$table` unbound under `set -u`, from commit 814edf555, unrelated to records). Flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)