### PR TITLE
attune: the symbol lens knows kernel natives — registration is declaration

### DIFF
--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -390,6 +390,11 @@ def sense_spec_symbols() -> list[str]:
             rf"^\s*(?:const|let|var)\s+{re.escape(sym)}\s*[:=]",
             rf"^\s*form\s+{re.escape(sym)}\b",         # Form shape
             rf"^\s*defn\s+{re.escape(sym)}\b",         # Form definition
+            # Kernel natives — all three sibling kernels declare a native by
+            # REGISTERING its name as a string: Go/TS `registerNative("sym"`,
+            # Rust `register_native("sym"`. The registry is the definition
+            # site; the quoted name is the declaration.
+            rf"register_?[Nn]ative\(\s*\"{re.escape(sym)}\"",
             # Rust — struct, enum, trait, type alias, fn, union, macro
             rf"\b(?:pub(?:\([^)]+\))?\s+)?(?:unsafe\s+)?(?:async\s+)?fn\s+{re.escape(sym)}\b",
             rf"\b(?:pub(?:\([^)]+\))?\s+)?struct\s+{re.escape(sym)}\b",


### PR DESCRIPTION
The wellness symbol resolver covered Python/TS/Form/Rust definition shapes but not the kernels' native-registration shape — all three siblings declare a native by registering its quoted name (`registerNative("sym"` / `register_native("sym"`). The lens now reads that shape; the standing form-intrinsic-casting drift (str_to_int / str_to_float / int_to_str — all live in main.go) resolves. Proof: `make wellness` symbol section reports every claimed symbol resolving (1033 across 123 specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)