### PR TITLE
Print Hati string results as native stdout

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-13_bml_native_string_stdout_abi.json
+++ b/docs/system_audit/commit_evidence_2026-06-13_bml_native_string_stdout_abi.json
@@ -1,0 +1,105 @@
+{
+  "date": "2026-06-13",
+  "thread_branch": "codex/bml-native-string-abi-20260613",
+  "commit_scope": "Close the Hati fourth-kernel native stdout ABI gap so BML string and char results print user-facing string bytes instead of string-pool ids while numeric output stays unchanged.",
+  "files_owned": [
+    "docs/system_audit/commit_evidence_2026-06-13_bml_native_string_stdout_abi.json",
+    "form/form-stdlib/hati-os-kernel-emit.fk",
+    "form/form-stdlib/tests/hati-os-band.fk",
+    "scripts/bml_hati_native_compiler_probe.sh"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "make wellness",
+      "scripts/bml_hati_native_compiler_probe.sh",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-hati-native-compiler-proof.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/tests/hati-os-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/form-parse.fk form-stdlib/form-flatten.fk form-stdlib/tests/form-flatten-strings-band.fk",
+      "cd form && ./validate.sh form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/bmf-mini.fk form-stdlib/fourth-union.fk form-stdlib/tests/fourth-union-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/champion-challenger.fk form-stdlib/tests/melt-hot-swap-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/tests/crystallization-wire-band.fk"
+    ],
+    "notes": "Native probe emits a 23,025-byte universal C walker and a 36,048-byte binary. The BML char case now prints stdout_first=A with empty stderr and rc=0. Numeric cases stay unchanged: INT=3, FLOAT=1.5, ADD=3, CHOOSE=8. Final medians were approximately 2.45-2.62 ms. Hati OS source shape returns 15, string flattening returns 63, fourth-union returns 31, melt-hot-swap returns 31, crystallization-wire returns 31, and the BML native compiler proof returns 39."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Pending rebase, worktree guard, push, PR, and GitHub checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Pending merge and public deployment verification."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "A BML program compiled to a Hati loadable table can return a string/char result and have the native universal binary print the string bytes on stdout, not the internal string-pool index.",
+    "public_endpoints": [
+      "https://coherencycoin.com/substrate/form",
+      "https://api.coherencycoin.com/api/health"
+    ],
+    "test_flows": [
+      "scripts/bml_hati_native_compiler_probe.sh -> CHAR stdout_first=A, stderr='', rc=0",
+      "scripts/bml_hati_native_compiler_probe.sh -> INT=3, FLOAT=1.5, ADD=3, CHOOSE=8, stderr=''",
+      "cd form && ./validate.sh ... bml-hati-native-compiler-proof.fk -> 39",
+      "cd form && ./validate.sh ... hati-os-band.fk -> 15",
+      "cd form && ./validate.sh ... form-flatten-strings-band.fk -> 63",
+      "cd form && ./validate.sh ... fourth-union-band.fk -> 31",
+      "cd form && ./validate.sh ... melt-hot-swap-band.fk -> 31",
+      "cd form && ./validate.sh ... crystallization-wire-band.fk -> 31"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local string stdout ABI proof passes; CI, merge, and public deploy verification are pending."
+  },
+  "idea_ids": [
+    "form-native-runtime",
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "bml-native-compiler",
+    "form-fourth-kernel"
+  ],
+  "task_ids": [
+    "bml-native-string-stdout-abi-20260613"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "north-star requirement for BML/BMF/Form native binaries"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "binary probe"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "OpenAI Codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "scripts/bml_hati_native_compiler_probe.sh -> binary bytes=36048, universal C bytes=23025, INT=3, FLOAT=1.5, CHAR=A, ADD=3, CHOOSE=8, stderr=''",
+    "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/grammars/bml.fk form-stdlib/tests/bml-hati-native-compiler-proof.fk -> 39",
+    "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/tests/hati-os-band.fk -> 15",
+    "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/form-parse.fk form-stdlib/form-flatten.fk form-stdlib/tests/form-flatten-strings-band.fk -> 63",
+    "cd form && ./validate.sh form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/bmf-mini.fk form-stdlib/fourth-union.fk form-stdlib/tests/fourth-union-band.fk -> 31",
+    "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/champion-challenger.fk form-stdlib/tests/melt-hot-swap-band.fk -> 31",
+    "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/tests/crystallization-wire-band.fk -> 31"
+  ],
+  "change_files": [
+    "form/form-stdlib/hati-os-kernel-emit.fk",
+    "form/form-stdlib/tests/hati-os-band.fk",
+    "scripts/bml_hati_native_compiler_probe.sh"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/hati-os-kernel-emit.fk
+++ b/form/form-stdlib/hati-os-kernel-emit.fk
@@ -343,16 +343,24 @@
     (str_concat (fkc-carrier-decl-text)
                 (fkc-melt-text))))))))))
 
+(defn fkc-typed-stdout-text ()
+    "static long long fk_str_root_depth(long long i, long long d) { if (d > 64 || i < 0 || i >= fk_node_count) { return 0; } long long t = fk_node[i][0]; if (t == 24 || t == 27 || t == 29 || t == 32 || t == 33 || t == 62 || t == 63) { return 1; } if (t == 6) { if (fk_str_root_depth(fk_node[i][2], d + 1) && fk_str_root_depth(fk_node[i][3], d + 1)) { return 1; } return 0; } if (t == 12) { long long f = fk_node[i][1]; if (f >= 0 && f < fk_fn_count) { return fk_str_root_depth(fk_fn[f], d + 1); } return 0; } if (t == 69) { return fk_str_root_depth(fk_node[i][2], d + 1); } return 0; } static void fk_psv(long long v) { long long sa = v >> 1; if (sa >= 0 && sa < fk_sp) { long long j = 0; while (j < fk_sl[sa]) { putchar((int)(unsigned char)fk_sb[fk_so[sa] + j]); j = j + 1; } putchar(10); } else { fk_pv(v); } } static void fk_pv_root(long long root, long long v) { if (fk_str_root_depth(root, 0)) { fk_psv(v); } else { fk_pv(v); } } ")
+
 (defn fkc-decl-many-text (rows roots)
     (str_concat (fkc-arena-decl-text)
-    (str_concat "static const long long fk_fn["
+    (str_concat "static long long fk_fn_count = "
+    (str_concat (int_to_str (len roots))
+    (str_concat "; static long long fk_node_count = "
+    (str_concat (int_to_str (len rows))
+    (str_concat "; static const long long fk_fn["
     (str_concat (int_to_str (len roots))
     (str_concat "] = { "
     (str_concat (fkc-fn-text roots)
     (str_concat " }; static const long long fk_node["
     (str_concat (int_to_str (len rows))
     (str_concat "][4] = { "
-    (str_concat (fkc-rows-text rows) " }; "))))))))))
+    (str_concat (fkc-rows-text rows)
+                (str_concat " }; " (fkc-typed-stdout-text))))))))))))))))
 
 ; the shared arms (8..23) under the frame-pointer discipline: fp indexes
 ; fk_vs (never a value in C), CALL pushes its evaluated argument and
@@ -399,7 +407,7 @@
                 (fkc-arms-many-text)))
 
 (defn fkc-main-many-text ()
-    "extern int atoi(const char *); int main(int argc, char **argv) { long long a = 0; if (argc > 1) { a = atoi(argv[1]) << 1; } fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } return 0; }")
+    "extern int atoi(const char *); int main(int argc, char **argv) { long long a = 0; if (argc > 1) { a = atoi(argv[1]) << 1; } fk_vs[0] = a; fk_vsp = 1; fk_pv_root(fk_fn[0], fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } return 0; }")
 
 (defn fkc-emit-many2 (flat)
     (str_concat (fkc-pr-text)
@@ -449,7 +457,7 @@
 ; captured bytes land in fk_src (the same buffer the universal loader fills),
 ; so op 17 BUF and the streaming cursor read a LIVE subprocess.
 (defn fkc-driver-main-text ()
-    "extern int pipe(int *); extern int fork(void); extern int dup2(int,int); extern int close(int); extern long long read(int,void*,unsigned long); extern int execvp(const char*, char* const*); extern void _exit(int); extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fds[2]; if (pipe(fds) < 0) { return 2; } int pid = fork(); if (pid == 0) { dup2(fds[1], 1); close(fds[0]); close(fds[1]); execvp(argv[1], &argv[1]); _exit(127); } close(fds[1]); long long total = 0; long long g; while ((g = read(fds[0], fk_src + total, 262143 - total)) > 0) { total = total + g; } fk_src[total] = 0; close(fds[0]); fk_vs[0] = 0; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); return 0; }")
+    "extern int pipe(int *); extern int fork(void); extern int dup2(int,int); extern int close(int); extern long long read(int,void*,unsigned long); extern int execvp(const char*, char* const*); extern void _exit(int); extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fds[2]; if (pipe(fds) < 0) { return 2; } int pid = fork(); if (pid == 0) { dup2(fds[1], 1); close(fds[0]); close(fds[1]); execvp(argv[1], &argv[1]); _exit(127); } close(fds[1]); long long total = 0; long long g; while ((g = read(fds[0], fk_src + total, 262143 - total)) > 0) { total = total + g; } fk_src[total] = 0; close(fds[0]); fk_vs[0] = 0; fk_vsp = 1; fk_pv_root(fk_fn[0], fk_walk(fk_fn[0], 0)); return 0; }")
 
 (defn fkc-emit-driver2 (flat)
     (str_concat (fkc-pr-text)
@@ -515,7 +523,7 @@
 
 (defn fkc-decl-universal-text ()
     (str_concat (fkc-arena-decl-text)
-                "static long long fk_fn[256]; static long long fk_node[16384][4]; static char fk_buf[262144]; static long long fk_pos; extern int open(const char *, int, ...); extern long long read(int, void *, unsigned long); static long long fk_next() { long long sg = 1; while (fk_buf[fk_pos] != 0) { if (fk_buf[fk_pos] == 45 && fk_buf[fk_pos + 1] >= 48 && fk_buf[fk_pos + 1] <= 57) { sg = 0 - 1; fk_pos = fk_pos + 1; break; } if (fk_buf[fk_pos] >= 48) { if (fk_buf[fk_pos] <= 57) { break; } } fk_pos = fk_pos + 1; } long long v = 0; while (fk_buf[fk_pos] >= 48 && fk_buf[fk_pos] <= 57) { v = v * 10 + (fk_buf[fk_pos] - 48); fk_pos = fk_pos + 1; } return sg * v; } "))
+                "static long long fk_fn_count; static long long fk_node_count; static long long fk_fn[256]; static long long fk_node[16384][4]; static char fk_buf[262144]; static long long fk_pos; extern int open(const char *, int, ...); extern long long read(int, void *, unsigned long); static long long fk_next() { long long sg = 1; while (fk_buf[fk_pos] != 0) { if (fk_buf[fk_pos] == 45 && fk_buf[fk_pos + 1] >= 48 && fk_buf[fk_pos + 1] <= 57) { sg = 0 - 1; fk_pos = fk_pos + 1; break; } if (fk_buf[fk_pos] >= 48) { if (fk_buf[fk_pos] <= 57) { break; } } fk_pos = fk_pos + 1; } long long v = 0; while (fk_buf[fk_pos] >= 48 && fk_buf[fk_pos] <= 57) { v = v * 10 + (fk_buf[fk_pos] - 48); fk_pos = fk_pos + 1; } return sg * v; } "))
 
 ; the table file's STRING SECTION rides after the rows: count, then per
 ; string length + bytes (plain ints, the loader's digit cursor unchanged);
@@ -523,31 +531,33 @@
 ; loader appends VERBATIM: the flattener is the interner and pool indices
 ; in SLIT rows must stay stable.
 (defn fkc-main-universal-text ()
-    (str_concat "extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; long long nf = fk_next(); long long k = 0; while (k < nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long ns = fk_next(); long long si = 0; while (si < ns) { long long sl = fk_next(); fk_so[fk_sp] = fk_sbp; fk_sl[fk_sp] = sl; long long bj = 0; while (bj < sl) { fk_sb[fk_sbp] = (char)fk_next(); fk_sbp = fk_sbp + 1; bj = bj + 1; } fk_sp = fk_sp + 1; si = si + 1; } long long a = 0; if (argc > 2) { a = atoi(argv[2]) << 1; } if (argc > 3) { int sfd = open(argv[3], 0); if (sfd >= 0) { long long sg = read(sfd, fk_src, 262143); if (sg >= 0) { fk_src[sg] = 0; } } } fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= "
+    (str_concat "extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; long long nf = fk_next(); fk_fn_count = nf; long long k = 0; while (k < nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); fk_node_count = nr; long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long ns = fk_next(); long long si = 0; while (si < ns) { long long sl = fk_next(); fk_so[fk_sp] = fk_sbp; fk_sl[fk_sp] = sl; long long bj = 0; while (bj < sl) { fk_sb[fk_sbp] = (char)fk_next(); fk_sbp = fk_sbp + 1; bj = bj + 1; } fk_sp = fk_sp + 1; si = si + 1; } long long a = 0; if (argc > 2) { a = atoi(argv[2]) << 1; } if (argc > 3) { int sfd = open(argv[3], 0); if (sfd >= 0) { long long sg = read(sfd, fk_src, 262143); if (sg >= 0) { fk_src[sg] = 0; } } } fk_vs[0] = a; fk_vsp = 1; fk_pv_root(fk_fn[0], fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= "
     (str_concat (int_to_str (sub (fkc-arm-slots) 1))
                 ") { fk_pr(fk_arms[t]); t = t + 1; } return 0; }")))
 
 (defn fkc-emit-universal ()
     (str_concat (fkc-pr-text)
     (str_concat (fkc-decl-universal-text)
+    (str_concat (fkc-typed-stdout-text)
     (str_concat (fkc-walk-many-text)
-                (fkc-main-universal-text)))))
+                (fkc-main-universal-text))))))
 
 (defn fkc-decl-server-universal-text ()
     (str_concat (fkc-arena-decl-text)
-                "static long long fk_fn[256]; static long long fk_node[16384][4]; static char fk_buf[262144]; static long long fk_pos; extern int open(const char *, int, ...); extern long long read(int, void *, unsigned long); extern int socket(int,int,int); extern int bind(int,const void*,unsigned int); extern int listen(int,int); extern long accept(int,void*,void*); extern int close(int); extern int dup2(int,int); extern int fflush(void*); extern int fork(void); extern void _exit(int); extern int setsockopt(int,int,int,const void*,unsigned int); extern int shutdown(int,int); static long long fk_next() { long long sg = 1; while (fk_buf[fk_pos] != 0) { if (fk_buf[fk_pos] == 45 && fk_buf[fk_pos + 1] >= 48 && fk_buf[fk_pos + 1] <= 57) { sg = 0 - 1; fk_pos = fk_pos + 1; break; } if (fk_buf[fk_pos] >= 48) { if (fk_buf[fk_pos] <= 57) { break; } } fk_pos = fk_pos + 1; } long long v = 0; while (fk_buf[fk_pos] >= 48 && fk_buf[fk_pos] <= 57) { v = v * 10 + (fk_buf[fk_pos] - 48); fk_pos = fk_pos + 1; } return sg * v; } "))
+                "static long long fk_fn_count; static long long fk_node_count; static long long fk_fn[256]; static long long fk_node[16384][4]; static char fk_buf[262144]; static long long fk_pos; extern int open(const char *, int, ...); extern long long read(int, void *, unsigned long); extern int socket(int,int,int); extern int bind(int,const void*,unsigned int); extern int listen(int,int); extern long accept(int,void*,void*); extern int close(int); extern int dup2(int,int); extern int fflush(void*); extern int fork(void); extern void _exit(int); extern int setsockopt(int,int,int,const void*,unsigned int); extern int shutdown(int,int); static long long fk_next() { long long sg = 1; while (fk_buf[fk_pos] != 0) { if (fk_buf[fk_pos] == 45 && fk_buf[fk_pos + 1] >= 48 && fk_buf[fk_pos + 1] <= 57) { sg = 0 - 1; fk_pos = fk_pos + 1; break; } if (fk_buf[fk_pos] >= 48) { if (fk_buf[fk_pos] <= 57) { break; } } fk_pos = fk_pos + 1; } long long v = 0; while (fk_buf[fk_pos] >= 48 && fk_buf[fk_pos] <= 57) { v = v * 10 + (fk_buf[fk_pos] - 48); fk_pos = fk_pos + 1; } return sg * v; } "))
 
 ; universal dynamic server: load a table file once, then serve fn 0 over the
 ; net organ forever. Each accepted request is staged into fk_src before the
 ; walk, so the loaded program can branch on live request bytes through fk-buf.
 (defn fkc-main-server-universal-text ()
-    "extern int atoi(const char *); struct fk_sa { unsigned char len; unsigned char fam; unsigned char p[2]; unsigned int addr; unsigned char z[8]; }; int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; long long nf = fk_next(); long long k = 0; while (k < nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long ns = fk_next(); long long si = 0; while (si < ns) { long long sl = fk_next(); fk_so[fk_sp] = fk_sbp; fk_sl[fk_sp] = sl; long long bj = 0; while (bj < sl) { fk_sb[fk_sbp] = (char)fk_next(); fk_sbp = fk_sbp + 1; bj = bj + 1; } fk_sp = fk_sp + 1; si = si + 1; } long long port = 8080; if (argc > 2) { port = atoi(argv[2]); } int sfd = socket(2, 1, 0); int yes = 1; setsockopt(sfd, 65535, 4, &yes, 4); struct fk_sa a; a.len = 16; a.fam = 2; a.p[0] = (port >> 8) & 255; a.p[1] = port & 255; a.addr = 0; for (int z = 0; z < 8; z = z + 1) { a.z[z] = 0; } if (bind(sfd, &a, 16) < 0) { return 4; } listen(sfd, 16); while (1) { long cfd = accept(sfd, 0, 0); if (cfd < 0) { continue; } if (fork() == 0) { long rg = read((int)cfd, fk_src, 262143); if (rg < 0) { rg = 0; } fk_src[rg] = 0; dup2((int)cfd, 1); fk_vs[0] = 0; fk_vsp = 1; fk_walk(fk_fn[0], 0); fflush(0); shutdown((int)cfd, 2); _exit(0); } close((int)cfd); } return 0; }")
+    "extern int atoi(const char *); struct fk_sa { unsigned char len; unsigned char fam; unsigned char p[2]; unsigned int addr; unsigned char z[8]; }; int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; long long nf = fk_next(); fk_fn_count = nf; long long k = 0; while (k < nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); fk_node_count = nr; long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long ns = fk_next(); long long si = 0; while (si < ns) { long long sl = fk_next(); fk_so[fk_sp] = fk_sbp; fk_sl[fk_sp] = sl; long long bj = 0; while (bj < sl) { fk_sb[fk_sbp] = (char)fk_next(); fk_sbp = fk_sbp + 1; bj = bj + 1; } fk_sp = fk_sp + 1; si = si + 1; } long long port = 8080; if (argc > 2) { port = atoi(argv[2]); } int sfd = socket(2, 1, 0); int yes = 1; setsockopt(sfd, 65535, 4, &yes, 4); struct fk_sa a; a.len = 16; a.fam = 2; a.p[0] = (port >> 8) & 255; a.p[1] = port & 255; a.addr = 0; for (int z = 0; z < 8; z = z + 1) { a.z[z] = 0; } if (bind(sfd, &a, 16) < 0) { return 4; } listen(sfd, 16); while (1) { long cfd = accept(sfd, 0, 0); if (cfd < 0) { continue; } if (fork() == 0) { long rg = read((int)cfd, fk_src, 262143); if (rg < 0) { rg = 0; } fk_src[rg] = 0; dup2((int)cfd, 1); fk_vs[0] = 0; fk_vsp = 1; fk_walk(fk_fn[0], 0); fflush(0); shutdown((int)cfd, 2); _exit(0); } close((int)cfd); } return 0; }")
 
 (defn fkc-emit-server-universal ()
     (str_concat (fkc-pr-text)
     (str_concat (fkc-decl-server-universal-text)
+    (str_concat (fkc-typed-stdout-text)
     (str_concat (fkc-walk-many-text)
-                (fkc-main-server-universal-text)))))
+                (fkc-main-server-universal-text))))))
 
 ; ── self-JIT on heat — learned-primitive's crystallize, in the emitted sibling ──
 ; The emitter lowers each pure function FROM ITS CELLS to a native C
@@ -585,7 +595,7 @@
 (defn fkc-main-jit-text (nf)
     (str_concat "extern int atoi(const char *); int main(int argc, char **argv) { long long a = 0; if (argc > 1) { a = atoi(argv[1]) << 1; } fk_hot = 1000000000000; if (argc > 2) { fk_hot = atoi(argv[2]); } "
     (str_concat (fkc-jit-fills 0 nf)
-                "fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } fk_pr(fk_njit); return 0; }")))
+                "fk_vs[0] = a; fk_vsp = 1; fk_pv_root(fk_fn[0], fk_walk(fk_fn[0], 0)); long long t = 1; while (t <= 23) { fk_pr(fk_arms[t]); t = t + 1; } fk_pr(fk_njit); return 0; }")))
 
 (defn fkc-emit-jit2 (fns flat)
     (str_concat (fkc-pr-text)
@@ -725,7 +735,7 @@
     (str_concat "extern int atoi(const char *); int main(int argc, char **argv) { long long a = 0; if (argc > 1) { a = atoi(argv[1]) << 1; } fk_hot = 1000000000000; if (argc > 2) { fk_hot = atoi(argv[2]); } "
     (str_concat (fkc-jit-fills 0 (len fns))
     (str_concat (fkc-can-fills (fkc-can-list fns) 0)
-    (str_concat "fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); fk_pr(fk_njit); fk_pr(fk_nmelt); fk_pr(fk_nfreeze); long long f = 0; while (f < "
+    (str_concat "fk_vs[0] = a; fk_vsp = 1; fk_pv_root(fk_fn[0], fk_walk(fk_fn[0], 0)); fk_pr(fk_njit); fk_pr(fk_nmelt); fk_pr(fk_nfreeze); long long f = 0; while (f < "
     (str_concat (int_to_str (len fns))
                 ") { fk_pr(fk_heat[f]); fk_pr(fk_ice[f]); f = f + 1; } return 0; }"))))))
 
@@ -858,11 +868,12 @@
 ; probe: value, njit, nmelt, nfreeze, nwire, then (heat, ice, can) per loaded
 ; function — the foreign thermodynamic state born observable like every sibling
 (defn fkc-main-uwire-text ()
-    "extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; fk_nf = fk_next(); long long k = 0; while (k < fk_nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long ns = fk_next(); long long si = 0; while (si < ns) { long long sl = fk_next(); fk_so[fk_sp] = fk_sbp; fk_sl[fk_sp] = sl; long long bj = 0; while (bj < sl) { fk_sb[fk_sbp] = (char)fk_next(); fk_sbp = fk_sbp + 1; bj = bj + 1; } fk_sp = fk_sp + 1; si = si + 1; } long long a = 0; if (argc > 2) { a = atoi(argv[2]) << 1; } fk_hot = 1000000000000; if (argc > 3) { fk_hot = atoi(argv[3]); } fk_canc(); fk_vs[0] = a; fk_vsp = 1; fk_pv(fk_walk(fk_fn[0], 0)); fk_pr(fk_njit); fk_pr(fk_nmelt); fk_pr(fk_nfreeze); fk_pr(fk_nwire); long long f = 0; while (f < fk_nf) { fk_pr(fk_heat[f]); fk_pr(fk_ice[f]); fk_pr(fk_can[f]); f = f + 1; } return 0; }")
+    "extern int atoi(const char *); int main(int argc, char **argv) { if (argc < 2) { return 1; } int fd = open(argv[1], 0); if (fd < 0) { return 2; } long long got = read(fd, fk_buf, 262143); if (got < 0) { return 3; } fk_buf[got] = 0; fk_nf = fk_next(); fk_fn_count = fk_nf; long long k = 0; while (k < fk_nf) { fk_fn[k] = fk_next(); k = k + 1; } long long nr = fk_next(); fk_node_count = nr; long long r = 0; while (r < nr) { fk_node[r][0] = fk_next(); fk_node[r][1] = fk_next(); fk_node[r][2] = fk_next(); fk_node[r][3] = fk_next(); r = r + 1; } long long ns = fk_next(); long long si = 0; while (si < ns) { long long sl = fk_next(); fk_so[fk_sp] = fk_sbp; fk_sl[fk_sp] = sl; long long bj = 0; while (bj < sl) { fk_sb[fk_sbp] = (char)fk_next(); fk_sbp = fk_sbp + 1; bj = bj + 1; } fk_sp = fk_sp + 1; si = si + 1; } long long a = 0; if (argc > 2) { a = atoi(argv[2]) << 1; } fk_hot = 1000000000000; if (argc > 3) { fk_hot = atoi(argv[3]); } fk_canc(); fk_vs[0] = a; fk_vsp = 1; fk_pv_root(fk_fn[0], fk_walk(fk_fn[0], 0)); fk_pr(fk_njit); fk_pr(fk_nmelt); fk_pr(fk_nfreeze); fk_pr(fk_nwire); long long f = 0; while (f < fk_nf) { fk_pr(fk_heat[f]); fk_pr(fk_ice[f]); fk_pr(fk_can[f]); f = f + 1; } return 0; }")
 
 (defn fkc-emit-uwire ()
     (str_concat (fkc-pr-text)
     (str_concat (fkc-decl-universal-text)
+    (str_concat (fkc-typed-stdout-text)
     (str_concat (fkc-jitmelt-decl-text)
     (str_concat (fkc-wire-decl-text)
     (str_concat (fkc-wire-phrases-text)
@@ -873,4 +884,4 @@
     (str_concat (fkc-epoch-body-text "fk_nf")
     (str_concat (fkc-jd-wire-text)
     (str_concat (fkc-walk-jitmelt-text)
-                (fkc-main-uwire-text))))))))))))))
+                (fkc-main-uwire-text)))))))))))))))

--- a/form/form-stdlib/tests/hati-os-band.fk
+++ b/form/form-stdlib/tests/hati-os-band.fk
@@ -11,29 +11,31 @@
 ; Verdict 15 when the OS face holds:
 ;   1   the table FILE is canonical — ADD(LIT 40, LIT 2) serializes to
 ;       1 2 3 1 40 0 0 1 2 0 0 3 0 1 0 (function count, roots, row count, rows)
-;   2   the universal walker's full emission is 10553 bytes and deterministic —
+;   2   the universal walker's full emission is 23024 bytes and deterministic —
 ;       program-independent constant tissue: loader (sign-aware: table rows
 ;       may carry negative literals), organ arms, the BMF cursor's eye
 ;       (op 17 BUF), the m4e2 arena with its melt door
 ;       (ops 18..23 + fk_arena/fk_mlive/fk_mcopy/fk_melt, melt-on-cool-band),
 ;       the walker-managed value stack (fk_vs — args melt-rooted), the
 ;       string pool with its loader string section (tags 24..28), and the
-;       figure-ops arms (tags 34..42, m4e5)
+;       root-typed stdout bridge that prints string pool bytes at the CLI
+;       boundary while leaving numeric values boxed, plus figure-ops arms
+;       (tags 34..42, m4e5)
 ;   4   the native lowering is faithful text — ADD(LIT 1, ARG) lowers to
-;       (2 + a): literals lower ENCODED (ints even, refs odd — the tagged ABI) — and the jit emission for CALL-fib is 10093 bytes
+;       (2 + a): literals lower ENCODED (ints even, refs odd — the tagged ABI) — and the jit emission for CALL-fib is 22248 bytes
 ;   8   the organ program (RAM roundtrip + clock + entropy, mask 7) flattens
 ;       to its 23 rows with tags 13..16 present in the table
 (do
     (let c0 (if (str_eq (fkc-table-file (list (fk-add (fk-lit 40) (fk-lit 2)))) "1 2 3 1 40 0 0 1 2 0 0 3 0 1 0") 1 0))
 
-    (let c1 (if (eq (str_len (fkc-emit-universal)) 10553)
+    (let c1 (if (eq (str_len (fkc-emit-universal)) 23024)
                 (if (str_eq (fkc-emit-universal) (fkc-emit-universal)) 2 0) 0))
 
     (let fibc (fk-if (fk-le (fk-arg) (fk-lit 1)) (fk-arg)
                      (fk-add (fk-call 0 (fk-sub (fk-arg) (fk-lit 1)))
                              (fk-call 0 (fk-sub (fk-arg) (fk-lit 2))))))
     (let c2 (if (str_eq (fkc-nat-expr (fk-add (fk-lit 1) (fk-arg))) "(2 + a)")
-                (if (eq (str_len (fkc-emit-jit (list fibc))) 10093) 4 0) 0))
+                (if (eq (str_len (fkc-emit-jit (list fibc))) 22248) 4 0) 0))
 
     (let organ (fk-add (fk-if (fk-sub (fk-set (fk-lit 7) (fk-lit 42)) (fk-get (fk-lit 7))) (fk-lit 0) (fk-lit 1))
                (fk-add (fk-if (fk-le (fk-time) (fk-lit 0)) (fk-lit 0) (fk-lit 2))

--- a/scripts/bml_hati_native_compiler_probe.sh
+++ b/scripts/bml_hati_native_compiler_probe.sh
@@ -125,7 +125,7 @@ expected_for() {
   case "$1" in
     INT) echo 3 ;;
     FLOAT) echo 1.5 ;;
-    CHAR) echo 0 ;;
+    CHAR) echo A ;;
     ADD) echo 3 ;;
     CHOOSE) echo 8 ;;
     *) echo "unknown case: $1" >&2; exit 1 ;;
@@ -178,4 +178,4 @@ if ! grep -q "1 1 65" "$char_table"; then
   exit 1
 fi
 
-echo "char_pool_shape=ok literal=A stdout_is_pool_id=0"
+echo "char_pool_shape=ok literal=A stdout=A"


### PR DESCRIPTION
## Summary
- Add root-typed stdout printing to Hati native emitted binaries so string/char results print string-pool bytes instead of pool ids.
- Wire the typed stdout boundary through static, driver, universal loader, server-universal, JIT, JIT+melt, and runtime-wire binary shapes.
- Update the BML native binary probe and Hati OS source-shape sentinels for the new ABI.

## Proof
- scripts/bml_hati_native_compiler_probe.sh -> INT=3, FLOAT=1.5, CHAR=A, ADD=3, CHOOSE=8, stderr=''
- cd form && ./validate.sh ... bml-hati-native-compiler-proof.fk -> 39
- cd form && ./validate.sh ... hati-os-band.fk -> 15
- cd form && ./validate.sh ... form-flatten-strings-band.fk -> 63
- cd form && ./validate.sh ... fourth-union-band.fk -> 31
- cd form && ./validate.sh ... melt-hot-swap-band.fk -> 31
- cd form && ./validate.sh ... crystallization-wire-band.fk -> 31
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main -> local_preflight=pass