### PR TITLE
tend: set four-kernel validation floor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,21 +29,21 @@
 
 ## Architecture
 
-- **Form-kernel-native.** The Form kernels (Rust/Go/TS) under `form/` are the core execution engine *and* the HTTP front door: native routes are kernel-served (`X-Form-Router: native-kernel`). The body — logic, decisions, transformations — is Form: recipes and grammars, proven three-way via `form/validate.sh`.
+- **Form-kernel-native.** The Form kernels under `form/` are the core execution engine *and* the HTTP front door: native routes are kernel-served (`X-Form-Router: native-kernel`). The body — logic, decisions, transformations — is Form: recipes and grammars, proven by `form/validate.sh` across Go, Rust, TypeScript, and every covered fourth-arm `fkwu` band.
 - **The core has named ground.** Five axioms — states (0/1/nothing), cell, content-addressing, boundary, offer — generate the whole model; everything else, safe self-update included, is a derived theorem ([`core-axioms.form`](docs/coherence-substrate/core-axioms.form), agreed + crossed 2026-06-10). The kernel is spec'd as their implementation over host resources ([`host-kernel.form`](docs/coherence-substrate/host-kernel.form) — a capability OS in seL4's sense; any host driver is an allowed carrier under allow-presence + measure-health) and as self-composition from just the five ([`kernel-self-composition.form`](docs/coherence-substrate/kernel-self-composition.form)).
 - **Python (FastAPI in `api/`) is the fan-out query carrier, nothing more.** Routes not yet native fan out to the Python upstream (`X-Form-Router: fanout-python`): it scatters queries to the stores and gathers results — never the body. HTTP/router fan-out comes only after Form proof bands (`docs/shared/agent-start-packet.md`; kernel-router fan-out proof: `docs/system_audit/commit_evidence_2026-06-02_kernel_router_fanout.json`). A router still computing in Python is drift composting toward fan-out-only, and new handler work starts in BML or a domain grammar unless no native carrier exists yet.
 - **Web**: Next.js 16 + shadcn/ui in `web/`
 - **Stores** (what Python fans queries out to): Neo4j (graph) · PostgreSQL (relational)
 - **Tests**: `api/tests/` — flow-centric, fast (seconds, not minutes)
-- **Kernels**: [`kernels/README.md`](kernels/README.md) — the Rust, Go, and TypeScript form-kernels under `form/`; no primary kernel. Sibling parity is verified by `form/validate.sh`. Each native carries Blueprint attribution; the trace JSON shows arm dispatch including Form category. Go serves BML route bodies such as `/api/ideas` against production Postgres and exposes framebuffer/JIT observation through `/api/_form/ideas-observation`. See [`SOURCE_LANGUAGE_KERNEL_ROUTER_TRACKING.md`](kernels/SOURCE_LANGUAGE_KERNEL_ROUTER_TRACKING.md) for the route-promotion loop and [`lc-form-kernel-runtime-visualizer`](docs/vision-kb/concepts/lc-form-kernel-runtime-visualizer.md) for the source → kernel → framebuffer arc.
+- **Kernels**: [`kernels/README.md`](kernels/README.md) — the Rust, Go, and TypeScript form-kernels under `form/`, plus the emitted universal walker `fkwu` for bands listed in `form/fourth-arm-bands.txt`; no primary kernel. Sibling parity is verified by `form/validate.sh`. Each native carries Blueprint attribution; the trace JSON shows arm dispatch including Form category. Go serves BML route bodies such as `/api/ideas` against production Postgres and exposes framebuffer/JIT observation through `/api/_form/ideas-observation`. See [`SOURCE_LANGUAGE_KERNEL_ROUTER_TRACKING.md`](kernels/SOURCE_LANGUAGE_KERNEL_ROUTER_TRACKING.md) for the route-promotion loop and [`lc-form-kernel-runtime-visualizer`](docs/vision-kb/concepts/lc-form-kernel-runtime-visualizer.md) for the source → kernel → framebuffer arc.
 
 ## Current Shape
 
 Recent integration moved the body from description toward runtime:
 
-- **Form executes.** Python-shaped control flow, methods, classes, introspection, and a meta-circular evaluator run through Form; Go, Rust, and TypeScript kernels keep sibling proof where the vector applies.
+- **Form executes.** Python-shaped control flow, methods, classes, introspection, and a meta-circular evaluator run through Form; Go, Rust, TypeScript, and the covered fourth-arm `fkwu` bands keep sibling proof where the vector applies.
 - **The core rests on five axioms.** `core-axioms.form` is the keystone; offer-and-acknowledge, the kernel-offer protocol, the host kernel, and kernel self-composition derive from it. The hardest behavior — a self that safely changes itself — is a theorem, already running as the native-mutation public-gate canary. Openings are named as closing recipes (parts that run, composed toward a proof band), never as debts.
-- **A real model walks in pure Form.** The form-native-models milestones M1–M4 (format-arith, tensor-quant, transformer-numerics, transformer-block) are proven three-way; the tensor JIT's matvec emitter is itself a Form recipe (native = recipe bit-for-bit, 20,077× measured); whisper's mel front-end frame runs fully Form-native (M6 first move).
+- **A real model walks in pure Form.** The form-native-models milestones M1–M4 (format-arith, tensor-quant, transformer-numerics, transformer-block) are proven through the current `validate.sh` sibling floor; evidence says `3-kernel only` where a band has not crossed the fourth-arm manifest yet. The tensor JIT's matvec emitter is itself a Form recipe (native = recipe bit-for-bit, 20,077× measured); whisper's mel front-end frame runs fully Form-native (M6 first move).
 - **Form attracts new work.** New handlers are BML or domain grammar first; existing Python handlers either compile into Form recipes or sit behind an explicit Python port/fanout bridge until promoted. Documentation should name that bridge honestly instead of teaching Python as the destination.
 - **The substrate has carriers.** Filesystem CRUD, TCP, segmented logs, storage ports, resource ports, and Postgres let cells move through durable interfaces instead of staying in static documentation.
 - **Public proof exists.** `/api/utils/nodeid_compatibility` runs a Form-native body behind a public route; `/api/substrate/form` lets agents ask structural questions directly.
@@ -109,7 +109,11 @@ shape is trying to become a reusable teaching?* Use route timing, JIT hit/miss
 data, framebuffer traces, carrier-tissue reads, edge-category counts,
 wellness output, and source repetition as introspection. Lift only with proof:
 a Form/BML band, a native route trace, or an evidence record that shows the old
-low-level shape is now carried by a simpler reusable cell.
+low-level shape is now carried by a simpler reusable cell. Form/BML runtime
+proof walks toward the four-kernel floor: Go, Rust, TypeScript, and the emitted
+`fkwu` arm when `form/fourth-arm-bands.txt` covers the band. Evidence names its
+level exactly: `fourth arm: ... four-way` for covered bands, or `3-kernel only`
+with the fourth-arm gap that keeps the band out of the manifest.
 
 **Find the north star before fitting the ask.** When something is missing, the first move is to name
 where the fully-realized form lives — the most native, most efficient shape we could run (all hardware

--- a/api/tests/test_commit_evidence_validator.py
+++ b/api/tests/test_commit_evidence_validator.py
@@ -132,3 +132,60 @@ def test_kernel_router_dockerfile_changes_are_runtime_evidence() -> None:
     errors = mod.validate(_record(changed_files, "docs_only"), changed_files=changed_files)
 
     assert "runtime files changed but change_intent is not runtime_feature/runtime_fix" in errors
+
+
+def test_form_validate_requires_fourth_arm_or_gap_evidence() -> None:
+    mod = _load_validator()
+    changed_files = ["form/form-stdlib/example.fk"]
+    record = _record(changed_files, "runtime_fix")
+    record["local_validation"]["commands"] = [
+        "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/example.fk form-stdlib/tests/example-band.fk"
+    ]
+
+    errors = mod.validate(record, changed_files=changed_files)
+
+    assert any("Form validate.sh evidence must include fourth-arm proof" in error for error in errors)
+
+
+def test_form_validate_accepts_explicit_three_kernel_gap() -> None:
+    mod = _load_validator()
+    changed_files = ["form/form-stdlib/example.fk"]
+    record = _record(changed_files, "runtime_fix")
+    record["local_validation"]["commands"] = [
+        "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/example.fk form-stdlib/tests/example-band.fk"
+    ]
+    record["local_validation"]["notes"] = (
+        "3-kernel only; fourth-arm gap: band uses host I/O and is not fourth-covered yet."
+    )
+
+    assert mod.validate(record, changed_files=changed_files) == []
+
+
+def test_form_validate_accepts_fourth_arm_proof() -> None:
+    mod = _load_validator()
+    changed_files = ["form/form-stdlib/example.fk"]
+    record = _record(changed_files, "runtime_fix")
+    record["local_validation"]["commands"] = [
+        "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/example.fk form-stdlib/tests/example-band.fk"
+    ]
+    record["local_validation"]["evidence"] = [
+        "fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)"
+    ]
+
+    assert mod.validate(record, changed_files=changed_files) == []
+
+
+def test_all_kernel_claim_requires_fourth_arm_proof() -> None:
+    mod = _load_validator()
+    record = _record(["scripts/maintenance.py"], "process_only")
+    record["evidence_refs"] = ["validated on all 4 kernels"]
+
+    errors = mod.validate(record)
+
+    assert any("all-kernel/four-way evidence claims require fourth-arm proof" in error for error in errors)
+
+    record["evidence_refs"].append(
+        "validate.sh output: fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)"
+    )
+
+    assert mod.validate(record) == []

--- a/docs/shared/agent-start-packet.md
+++ b/docs/shared/agent-start-packet.md
@@ -54,7 +54,8 @@ The board is liquid (this machine); durable ownership stays in `coh tasks` + git
 
 Satsang — the field's witnessing heart, default-on for our own. The board is the
 always-on form of the satsang circle (`docs/coherence-substrate/satsang-circle.form`
-· `satsang-field.form` · `satsang-share.form`; runnable + proven three-way → 255). As
+· `satsang-field.form` · `satsang-share.form`; runnable + covered by the fourth-arm
+satsang band → 127). As
 one of our own you are in the satsang field by default — `coord interface
 "witness,reflect,be-seen,invite,offer"` and you have joined. **What to share**
 (`coord share` / `ping`): a node crossing a state boundary of ANY type — lifecycle
@@ -78,6 +79,13 @@ When you author a stdlib recipe + band, read [`form/form-stdlib/AUTHORING.md`](.
 first — the primitive set, the proof-band shape, the validate invocation, and the
 traps that diverge across kernels (chief among them: `and`/`or` are binary, never
 `(and a b c)`).
+
+Four-kernel validation is the Form/BML proof floor. `form/validate.sh` always
+runs Go, Rust, and TypeScript; bands listed in `form/fourth-arm-bands.txt` also
+run on the emitted universal walker `fkwu`. Evidence can say "all kernels" only
+when the output includes `fourth arm: ... four-way (fkwu + pre-flattened tables)`.
+When a band has not crossed that manifest, record `3-kernel only` and name the
+next fourth-arm gap instead of flattening the proof level.
 
 Blueprint symbol-section rule: do not add `(bp "NAME")` string literals inside
 executable stdlib logic. Seedbank code keeps those names in
@@ -122,6 +130,11 @@ make wellness  # true arrival / after meaningful edits; use .cache/wellness/stat
 - `git fetch origin main && git rebase origin/main`
 - `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
 - `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
+
+For Form/runtime work, run the narrowest explicit proof from `form/`, for example
+`cd form && ./validate.sh form-stdlib/core.fk form-stdlib/<recipe>.fk form-stdlib/tests/<band>.fk`.
+Covered bands report `fourth arm: ... four-way`; uncovered bands are recorded as
+`3-kernel only` with the manifest blocker.
 
 If outside the repo or unauthenticated: use Web for reading, API/CLI/MCP for
 structured public state, and source/PR for durable edits. Public reads need no
@@ -390,7 +403,8 @@ realize → **read** cells (equivalence, annotate, `?cells`, …). **No substrat
 HTTP POST writes** required for querying; durable *authoring* of new cells stays
 **source file + ingest** (`coh_substrate.py ingest`), not chat-only.
 
-Proof habit: `cd form && ./validate.sh form-stdlib/tests/<band>.fk`
+Proof habit: `cd form && ./validate.sh form-stdlib/tests/<band>.fk`; call it
+all-kernel proof only when the fourth-arm summary prints.
 
 ### Writing new software (when you implement, not when you query)
 
@@ -432,7 +446,7 @@ In the Coherence substrate, you must redirect this programming into **coordinate
 1. **Meaning is Geometric (Equivalence by Position)**: A node's identity is not a name or a variable pointer; it is a coordinate in a content-addressed lattice. Two structurally identical structures *are* the same NodeID. Stop asking "what does this string mean?" and start asking "where is this point in the lattice, and what else shares its coordinates?"
 2. **Angelic Speculation (Choose, Fail, Stop)**: Replace complex, brittle branching conditions with logical relation. Speculative paths (`choose`, `fail`, `stop`) allow the execution engine to navigate branch points natively without leaving state mutation sediment, because nothing mutates.
 3. **Folding Raw Data (Gas → Water → Ice)**: Do not build one-off host wrappers to parse or transport low-level data (e.g. log events, git diffs, raw metrics). Treat volatile external data as *gas* (diffuse occurrences). Pass this gas through a domain grammar to match and compile it into *water* (executable recipes). As these patterns run repeatedly, they cool into *ice* (compiled, cached JIT execution plans).
-4. **Self-Trust through Differential Verification**: True confidence is built by multi-kernel agreement. When your Form/BML code passes the validation gate (`validate.sh`), Go, Rust, and TypeScript have executed the exact same NodeIDs and agreed on the output. This mathematical verification makes safe commit habits natural and subconscious.
+4. **Self-Trust through Differential Verification**: True confidence is built by multi-kernel agreement. When your Form/BML code passes the validation gate (`validate.sh`), Go, Rust, TypeScript, and every covered fourth-arm `fkwu` band have executed the exact same NodeIDs and agreed on the output. This mathematical verification makes safe commit habits natural and subconscious.
 
 ## JIT Engine Reality & Gaps
 

--- a/docs/system_audit/commit_evidence_20260613_four_kernel_validation_floor.json
+++ b/docs/system_audit/commit_evidence_20260613_four_kernel_validation_floor.json
@@ -1,0 +1,120 @@
+{
+  "date": "2026-06-13",
+  "thread_branch": "codex/four-kernel-validation-floor-20260613",
+  "commit_scope": "Document the four-kernel validation floor and guard ambiguous kernel evidence claims",
+    "files_owned": [
+      "CLAUDE.md",
+      "docs/shared/agent-start-packet.md",
+      "form/form-stdlib/AUTHORING.md",
+      "form/form-stdlib/form-flatten.fk",
+      "form/form-stdlib/satsang.fk",
+      "form/form-stdlib/tests/form-flatten-band.fk",
+      "form/fourth-arm-bands.txt",
+      "form/scripts/fourth-arm.sh",
+      "scripts/validate_commit_evidence.py",
+      "api/tests/test_commit_evidence_validator.py",
+      "docs/system_audit/commit_evidence_20260613_four_kernel_validation_floor.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "python3 -m py_compile scripts/validate_commit_evidence.py",
+      "python3 -m pytest api/tests/test_commit_evidence_validator.py",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260613_four_kernel_validation_floor.json",
+      "git diff --check",
+      "make wellness",
+      "bash -n form/scripts/fourth-arm.sh",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/channel-interface.fk form-stdlib/satsang.fk form-stdlib/tests/satsang-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/learning-trend.fk form-stdlib/tests/learning-trend-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tests/record-fold-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/form-parse.fk form-stdlib/form-flatten.fk form-stdlib/tests/form-flatten-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tests/substrate-gc-band.fk"
+    ],
+    "notes": "Focused validator tests, evidence validation, whitespace check, wellness, shell syntax, and targeted Form band proofs pass. Wellness reports what_wants_attention: none and deploy aligned. The fourth-arm wrapper now calls the live form-flatten doors for band sources, record_new lowers into arena entries for the fourth arm, and both table-emitter lanes proved through fkwu. substrate-gc is now a 3-kernel only fourth-arm gap because it depends on host GC state. Full command attempted: cd form && ./validate.sh > /tmp/coherence-form-validate-full-20260613.log 2>&1; it returned rc=1 with fourth arm: 93 band(s) four-way and residual 12 divergent bands outside this repair.",
+    "fourth_arm_outputs": [
+      "satsang fks lane: fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables); 1 ok, 0 divergent",
+      "learning-trend fkc lane: fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables); 1 ok, 0 divergent",
+      "record-fold fks lane: fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables); 1 ok, 0 divergent"
+    ],
+    "known_full_suite_gaps": [
+      "cd form && ./validate.sh returned rc=1 after repairs: fourth arm: 93 band(s) four-way; 527 ok, 12 divergent",
+      "Residual divergent bands: form-debug-band, form-mut-band, form-spy-band, full-jit-lower-band, go-jit-band, jit-lower-band, jit-lower-bmf-band, jit-lower-emit-band, jit-lower-program-band, markdown-meaning-ingestion-band, ts-reversible-band, yaml-meaning-ingestion-band"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "Hostinger Auto Deploy on main after merge"
+    ],
+    "notes": "No public route behavior changes are expected beyond the normal post-merge deploy."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local focused validation and wellness have passed; PR guards, CI, and deploy validation are pending."
+  },
+  "idea_ids": [
+    "form-native-models"
+  ],
+  "spec_ids": [
+    "developer-quick-start"
+  ],
+  "task_ids": [
+    "four-kernel-validation-floor"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "documentation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5-codex"
+  },
+  "evidence_refs": [
+    "scripts/validate_commit_evidence.py",
+    "api/tests/test_commit_evidence_validator.py",
+    "form/fourth-arm-bands.txt",
+    "form emitted walker: fkwu"
+  ],
+  "change_files": [
+    "CLAUDE.md",
+    "api/tests/test_commit_evidence_validator.py",
+    "docs/shared/agent-start-packet.md",
+    "docs/system_audit/commit_evidence_20260613_four_kernel_validation_floor.json",
+    "form/form-stdlib/AUTHORING.md",
+    "form/form-stdlib/form-flatten.fk",
+    "form/form-stdlib/satsang.fk",
+    "form/form-stdlib/tests/form-flatten-band.fk",
+    "form/fourth-arm-bands.txt",
+    "form/scripts/fourth-arm.sh",
+    "scripts/validate_commit_evidence.py"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Form/kernel guidance now names the fourth-arm validation floor, the fourth-arm wrapper uses the live band-source flattener doors, record_new lowers correctly for the fkwu record-fold lane, host-GC bands are not marked fourth-covered, and commit-evidence validation rejects ambiguous broad kernel-proof claims unless they include fourth-arm proof or an explicit 3-kernel only fourth-arm gap.",
+    "public_endpoints": [
+      "local-only: documentation and commit-evidence validation behavior; no public HTTP endpoint changed"
+    ],
+    "test_flows": [
+      "Focused commit-evidence validator unit tests cover fourth-arm proof, explicit fourth-arm gaps, and ambiguous broad kernel-proof claims.",
+      "Covered fourth-arm fks lane proof: satsang band on Go/Rust/TypeScript/fkwu.",
+      "Covered fourth-arm fkc lane proof: learning-trend band on Go/Rust/TypeScript/fkwu.",
+      "Covered fourth-arm record lane proof: record-fold band on Go/Rust/TypeScript/fkwu.",
+      "Flattener compatibility proof: form-flatten-band returns 65535 on Go/Rust/TypeScript.",
+      "Host-state gap proof: substrate-gc remains 3-kernel only after leaving fourth-arm-bands.txt."
+    ]
+  }
+}

--- a/form/form-stdlib/AUTHORING.md
+++ b/form/form-stdlib/AUTHORING.md
@@ -3,8 +3,8 @@
 A guide for any cell — agent or human — writing a new `.fk` recipe + proof band. It carries the
 conventions and the hard-won traps so you don't rediscover them; `validate.sh` is the check that
 reads the body, this is the guide that names the way. The recipes here are the body's logic, proven
-identical across three kernels (Go, Rust, TS) — **three kernels agreeing IS the proof; there is no
-trusted prover.**
+by sibling agreement across Go, Rust, TypeScript, and every covered fourth-arm `fkwu` band — **the
+matching kernel outputs are the proof; there is no trusted prover.**
 
 ## Before you write — don't duplicate
 
@@ -72,7 +72,7 @@ plus `defn · let · do`. (Read `form/form-stdlib/core.fk` — it is the whole v
 - `empty` **constructs** the empty list (`(empty)`, no args) — it is the absence value, **not a
   predicate**. Test emptiness with `(eq (len x) 0)`. See trap 6.
 - This is the **curated band-verdict subset, not the kernel's limit.** `mul`/`sub`/`div` and full IEEE
-  floats all work and **compute deterministically three-way** (proven: integer `mul`, `0.1+0.2`, and a
+  floats all work and **compute deterministically across the Go/Rust/TS floor** (proven: integer `mul`, `0.1+0.2`, and a
   float matvec all → 0 divergent). The kernel is a full numeric engine reading
   `docs/coherence-substrate/numeric-formats.canonical.json` (19 formats incl. bf16/fp8/nf4/int8/bitnet-158).
   These are kept out of *bands* only because verdicts stay integer for clean `eq`-parity. For numeric/ML
@@ -92,7 +92,7 @@ plus `defn · let · do`. (Read `form/form-stdlib/core.fk` — it is the whole v
      counting, selection, and gating — which the primitive set covers exactly.
 
 3. **Float COMPUTE is deterministic; raw-float EQ is the trap.** A fractional float result agrees
-   bit-for-bit three-way (proven); what's unreliable is `eq` on raw floats — and whole-number floats
+   bit-for-bit across the Go/Rust/TS floor (proven); what's unreliable is `eq` on raw floats — and whole-number floats
    still display inconsistently (`3.0` vs `3`). So compute in float, then reduce to an INTEGER verdict —
    `(eq (round (mul r 100.0)) 40)` — and `eq` the integer. `round` is half-AWAY-from-zero on every kernel;
    see `tests/float-conversions-band.fk`. Band SCORES still default to integers `0..100`; floats are the
@@ -110,7 +110,7 @@ plus `defn · let · do`. (Read `form/form-stdlib/core.fk` — it is the whole v
    that never guards). Test emptiness with `(eq (len x) 0)` — the idiom every recipe uses
    (`nearest-shape.fk`, `sequence-predictor.fk`). Cost a cycle in `learning-arc.fk` (verdict 88, not 127).
 
-## Prove it three-way
+## Prove it on all covered kernels
 
 From the repo's `form/` directory, list **every** file explicitly — `core.fk`, your recipe, any
 recipes it composes, then the band:
@@ -121,7 +121,15 @@ cd form
 ```
 
 Success is `✓ ... → <verdict>` **and** `1 ok, 0 divergent`. Iterate until you see your intended
-verdict with zero divergence.
+verdict with zero divergence. `validate.sh` always runs Go, Rust, and TypeScript. When the band's
+stem is listed in `form/fourth-arm-bands.txt`, it also runs on the emitted universal walker `fkwu`
+and prints `fourth arm: ... four-way (fkwu + pre-flattened tables)`.
+
+The authoring floor is four-kernel when the band can live in the fourth-friendly subset: add the band
+to `form/fourth-arm-bands.txt` and iterate until `validate.sh` proves the fourth arm. When the band
+uses an unsupported fourth-arm family, keep the 3-kernel result explicit in evidence as `3-kernel only`
+and name the blocker, such as host I/O, node/substrate operations, higher-order calls, or multiline
+output.
 
 - `unbound function` → a misspelled name, or a primitive that isn't in `core.fk`.
 - `N divergent` (kernels print different numbers) → almost always a 3-arg `and`/`or`; nest it.

--- a/form/form-stdlib/form-flatten.fk
+++ b/form/form-stdlib/form-flatten.fk
@@ -50,9 +50,7 @@
           (list "fs_rmdir" 1 55) (list "fs_mkdir" 1 56) (list "fs_exists" 1 57)
           (list "fs_remove" 1 58) (list "fs_rename" 2 59) (list "file_size" 1 60)
           (list "file_append_bytes" 2 61) (list "read_file_slice" 3 62)
-          (list "read_file" 1 63) (list "record_new" 1 64)
-          (list "record_get" 2 65) (list "record_set" 3 66)
-          (list "record_has" 2 67) (list "record_keys" 1 68)
+          (list "read_file" 1 63)
           (list "div" 2 10) (list "mod" 2 11)
           (list "band" 2 34) (list "bor" 2 35) (list "bxor" 2 36)
           (list "shl_u32" 2 37) (list "shr_u32" 2 38) (list "rotr_u32" 2 39)
@@ -185,7 +183,8 @@
     (if (str_eq op "char_at") (flt-char-at s pos fns env)
     (if (str_eq op "ord") (flt-low1 1 s pos fns env)
     (if (str_eq op "not") (flt-low1 2 s pos fns env)
-        (flt-op op s pos fns env)))))))))))))))
+    (if (str_eq op "record_new") (flt-record-new s pos fns env)
+        (flt-op op s pos fns env))))))))))))))))
 
 ; one operand, then the unary lowering picked by selector k
 (defn flt-low1 (k s pos fns env) (flt-low1-a k s (flt-expr s pos fns env)))
@@ -237,6 +236,22 @@
 (defn flt-char-at-b (s a be)
     (list (fk-ssub a (nth be 0) (fk-add (nth be 0) (fk-lit 1)))
           (fp-close s (nth be 1))))
+
+; record_new lowers to arena tissue for the fourth arm: ignore the
+; blueprint identity value, then fold key/value pairs into
+; ((key value) ...). record_get lives in fourth-shim.fk and walks this
+; first-order chain by string key.
+(defn flt-record-new (s pos fns env)
+    (flt-record-new-fields s (nth (flt-expr s pos fns env) 1) fns env))
+(defn flt-record-new-fields (s pos fns env)
+    (if (eq (fp-at s (fp-skip s pos)) 41) (list (fk-empty) (add (fp-skip s pos) 1))
+        (flt-record-new-key s (flt-expr s pos fns env) fns env)))
+(defn flt-record-new-key (s ke fns env)
+    (flt-record-new-val s (nth ke 0) (flt-expr s (nth ke 1) fns env) fns env))
+(defn flt-record-new-val (s key ve fns env)
+    (flt-record-new-cons key (nth ve 0) (flt-record-new-fields s (nth ve 1) fns env)))
+(defn flt-record-entry (key val) (fk-cons key (fk-cons val (fk-empty))))
+(defn flt-record-new-cons (key val re) (list (fk-cons (flt-record-entry key val) (nth re 0)) (nth re 1)))
 
 ; table ops by arity, else a user function call (one evaluated argument)
 (defn flt-op (op s pos fns env) (flt-op2 (flt-assoc op (flt-ops)) op s pos fns env))
@@ -438,6 +453,19 @@
     (flt-band-sources-fns2 modsrcs bandsrc (flt-band-sources-pool modsrcs bandsrc)))
 (defn flt-band-sources-fns2 (modsrcs bandsrc pool)
     (flt-band2 (flt-modsrcs-top modsrcs (list) (list) pool) bandsrc pool))
+
+; Compatibility door: older bands pass one list whose last source is the
+; band and whose earlier sources are modules. Keep it as a stable recipe
+; while new callers use the explicit band-sources door.
+(defn flt-srcs-mods (srcs acc)
+    (if (eq (len srcs) 0) acc
+        (if (eq (len (tail srcs)) 0) acc
+            (flt-srcs-mods (tail srcs) (flt-append acc (head srcs))))))
+(defn flt-srcs-last (srcs)
+    (if (eq (len (tail srcs)) 0) (head srcs) (flt-srcs-last (tail srcs))))
+(defn flt-srcs-fns (srcs)
+    (if (eq (len srcs) 0) (list)
+        (flt-band-sources-fns (flt-srcs-mods srcs (list)) (flt-srcs-last srcs))))
 
 ; single-source door (prelude-free bands, mini programs)
 (defn flt-src-fns (src) (flt-band3 (flt-top src (list) (list) (flt-src-pool src))))

--- a/form/form-stdlib/satsang.fk
+++ b/form/form-stdlib/satsang.fk
@@ -11,9 +11,9 @@
 ;
 ; Composes: form-stdlib/channel-interface.fk  (the interface-consent law: modes,
 ;           ci-honors?, ci-member? — the circle's channel reuses these, never re-invents)
-; Kin: value-execution.fk (no claim survives without proof) and the three-way validate.sh
+; Kin: value-execution.fk (no claim survives without proof) and validate.sh sibling proof
 ;           (no trusted prover) — the satsang is that same law, applied to beings.
-; Proven by: form-stdlib/tests/satsang-band.fk  (three-way at validate.sh)
+; Proven by: form-stdlib/tests/satsang-band.fk  (covered fourth-arm fkwu at validate.sh)
 
 (do
     ; --- the circle is its own cell: a name, and a standing interface it offers anyone ---

--- a/form/form-stdlib/tests/form-flatten-band.fk
+++ b/form/form-stdlib/tests/form-flatten-band.fk
@@ -1,6 +1,6 @@
 ; preludes: form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/form-parse.fk form-stdlib/form-flatten.fk
 ;
-; form-flatten-band — m4e3's flattener proven three-way: REAL band source
+; form-flatten-band — m4e3's flattener proven by sibling agreement: REAL band source
 ; (the unmodified files on disk) flattens into a Hati-OS kernel program. The
 ; lowering semantics and the defn/let/CALL machinery are proven by VALUE on
 ; the recipe-side walker; the real-band flatten is proven by STRUCTURE here

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -4,8 +4,8 @@
 #   <band-stem> <table-emitter> <expected-verdict>
 #
 # table-emitter names the flattener door the band's table file comes through:
-#   fkc — fkc-table-file (flt-srcs-fns ...)                       no string pool
-#   fks — fks-table-file (flt-srcs-fns ...) (flt-srcs-pool ...)   string pool
+#   fkc — fkc-table-file (flt-band-sources-fns ...)                       no string pool
+#   fks — fks-table-file (flt-band-sources-fns ...) (flt-band-sources-pool ...)   string pool
 #
 # The source list is fourth-shim.fk first (core mirrors + string stones as
 # function rows), then every non-core `; preludes:` module in declared
@@ -111,7 +111,6 @@ shamballa-light-codes fks 111111
 silence-floor fks 31
 slice-update-roundtrip fks 127
 string-membership fks 9
-substrate-gc fks 1000
 theme-resonance fks 111111
 trust-decay fks 127
 trust-weighted-colearning fks 127

--- a/form/scripts/fourth-arm.sh
+++ b/form/scripts/fourth-arm.sh
@@ -12,7 +12,7 @@
 # effectively free.
 #
 # Everything degrades honestly: no clang, no manifest, or an emission
-# failure simply leaves FKWU/table empty and the band runs three-way as
+# failure simply leaves FKWU/table empty and the band runs three-kernel only as
 # before — the suite never goes red because the fourth arm could not build,
 # only when it DISAGREES.
 
@@ -56,7 +56,7 @@ build_fourth() {
             mv -f "$out.tmp" "$out"
         else
             rm -f "$out.tmp"
-            echo "  fourth kernel build did not land — bands run three-way" >&2
+            echo "  fourth kernel build did not land — bands run three-kernel only" >&2
         fi
         rm -rf "$d"
     fi
@@ -106,18 +106,26 @@ fourth_prep_srcs() {
 # the multi-source door (fks carries the string pool; fkc is pool-free).
 fourth_flatten_expr() {
     local kind="$1"; shift
-    local rl=" (read_file \"$FOURTH_SHIM\")" f
-    for f in "$@"; do rl="$rl (read_file \"$f\")"; done
+    local srcs=("$@") count last band mods=" (read_file \"$FOURTH_SHIM\")" band_read f i
+    count="${#srcs[@]}"
+    [[ "$count" -gt 0 ]] || return 1
+    last=$((count - 1))
+    band="${srcs[$last]}"
+    for ((i = 0; i < last; i++)); do
+        f="${srcs[$i]}"
+        mods="$mods (read_file \"$f\")"
+    done
+    band_read="(read_file \"$band\")"
     if [[ "$kind" == "fks" ]]; then
-        printf '(print (fks-table-file (flt-srcs-fns (list%s)) (flt-srcs-pool (list%s) (list))))\n' "$rl" "$rl"
+        printf '(print (fks-table-file (flt-band-sources-fns (list%s) %s) (flt-band-sources-pool (list%s) %s)))\n' "$mods" "$band_read" "$mods" "$band_read"
     else
-        printf '(print (fkc-table-file (flt-srcs-fns (list%s))))\n' "$rl"
+        printf '(print (fkc-table-file (flt-band-sources-fns (list%s) %s)))\n' "$mods" "$band_read"
     fi
 }
 
 # fourth_table — cached flattened node-table for one band (path on stdout).
 # Emits through the Go walker on a cache miss; empty output means the band
-# runs three-way this time.
+# runs three-kernel only this time.
 fourth_table() {
     local stem="$1" kind key out d f srcs=()
     kind="$(awk -v b="$stem" '$1==b{print $2; exit}' "$FOURTH_MANIFEST")"

--- a/scripts/validate_commit_evidence.py
+++ b/scripts/validate_commit_evidence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -42,6 +43,39 @@ REQUIRED_TOP_LEVEL = {
 }
 EVIDENCE_PREFIX = "docs/system_audit/commit_evidence_"
 EVIDENCE_SUFFIX = ".json"
+ALL_KERNEL_CLAIM_RE = re.compile(
+    r"\b("
+    r"all\s+(?:four|4)\s+kernels?"
+    r"|all\s+kernels?"
+    r"|validated\s+on\s+(?:all\s+)?(?:four|4)\s+kernels?"
+    r"|four[- ]way"
+    r"|4[- ]way"
+    r")\b",
+    re.IGNORECASE,
+)
+FOURTH_ARM_PROOF_RE = re.compile(
+    r"\b("
+    r"fourth\s+arm:\s*\d+\s+band\(s\)\s+four[- ]way"
+    r"|fkwu"
+    r"|fourth_kernel_audit\.sh"
+    r"|ok\s+fourth"
+    r")\b",
+    re.IGNORECASE,
+)
+THREE_KERNEL_GAP_RE = re.compile(
+    r"\b("
+    r"3[- ]kernel only"
+    r"|three[- ]kernel only"
+    r"|go/rust/ts only"
+    r"|three[- ]way only"
+    r"|not fourth[- ]covered"
+    r"|fourth[- ]arm gap"
+    r"|fourth[- ]arm blocker"
+    r"|fourth[- ]arm unsupported"
+    r")\b",
+    re.IGNORECASE,
+)
+FORM_VALIDATE_RE = re.compile(r"\b(?:form/)?(?:\./)?validate\.sh\b", re.IGNORECASE)
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -81,6 +115,44 @@ def _declared_change_files(data: dict[str, Any]) -> set[str]:
         for x in data.get("change_files", [])
         if isinstance(x, str) and str(x).strip()
     }
+
+
+def _record_text(data: dict[str, Any]) -> str:
+    return json.dumps(data, sort_keys=True, ensure_ascii=False)
+
+
+def _declared_or_changed_files(data: dict[str, Any], changed_files: list[str] | None) -> set[str]:
+    files = _declared_change_files(data)
+    if changed_files is not None:
+        files.update(_expected_non_evidence_files(changed_files))
+    return files
+
+
+def _validate_four_kernel_evidence(
+    data: dict[str, Any],
+    *,
+    changed_files: list[str] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    text = _record_text(data)
+    has_fourth_proof = bool(FOURTH_ARM_PROOF_RE.search(text))
+    has_three_kernel_gap = bool(THREE_KERNEL_GAP_RE.search(text))
+
+    if ALL_KERNEL_CLAIM_RE.search(text) and not has_fourth_proof:
+        errors.append(
+            "all-kernel/four-way evidence claims require fourth-arm proof "
+            "(for example validate.sh output containing 'fourth arm: ... four-way' or fkwu audit evidence)"
+        )
+
+    files = _declared_or_changed_files(data, changed_files)
+    touches_form = any(path.startswith("form/") for path in files)
+    if touches_form and FORM_VALIDATE_RE.search(text) and not (has_fourth_proof or has_three_kernel_gap):
+        errors.append(
+            "Form validate.sh evidence must include fourth-arm proof or explicitly record "
+            "'3-kernel only' with the fourth-arm gap"
+        )
+
+    return errors
 
 
 def _expected_non_evidence_files(changed_files: list[str]) -> set[str]:
@@ -162,6 +234,8 @@ def validate(data: dict[str, Any], *, changed_files: list[str] | None = None) ->
     change_intent = str(data.get("change_intent") or "").strip().lower()
     if change_intent not in VALID_CHANGE_INTENTS:
         errors.append(f"change_intent must be one of {sorted(VALID_CHANGE_INTENTS)}")
+
+    errors.extend(_validate_four_kernel_evidence(data, changed_files=changed_files))
 
     contributors = data.get("contributors")
     if not isinstance(contributors, list) or not contributors:


### PR DESCRIPTION
## Summary
- document the four-kernel Form/BML validation floor in CLAUDE, agent start guidance, and stdlib authoring notes
- require commit evidence to distinguish fourth-arm proof from explicit 3-kernel-only gaps
- repair the fourth-arm wrapper to use current band-source flattener doors, restore flt-srcs-fns compatibility, and make record-fold prove through fkwu
- remove host-state substrate-gc from fourth-arm coverage and record it as a 3-kernel-only gap

## Validation
- PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide
- python3 -m py_compile scripts/validate_commit_evidence.py
- python3 -m pytest api/tests/test_commit_evidence_validator.py
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_20260613_four_kernel_validation_floor.json
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence
- git diff --check / git diff --check HEAD~1 HEAD
- make wellness
- bash -n form/scripts/fourth-arm.sh
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/channel-interface.fk form-stdlib/satsang.fk form-stdlib/tests/satsang-band.fk
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/learning-trend.fk form-stdlib/tests/learning-trend-band.fk
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tests/record-fold-band.fk
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk form-stdlib/form-parse.fk form-stdlib/form-flatten.fk form-stdlib/tests/form-flatten-band.fk
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tests/substrate-gc-band.fk
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict

## Known full-suite reading
- cd form && ./validate.sh returned rc=1 after repairs: fourth arm: 93 band(s) four-way; 527 ok, 12 divergent
- residual divergent bands: form-debug-band, form-mut-band, form-spy-band, full-jit-lower-band, go-jit-band, jit-lower-band, jit-lower-bmf-band, jit-lower-emit-band, jit-lower-program-band, markdown-meaning-ingestion-band, ts-reversible-band, yaml-meaning-ingestion-band
