### PR TITLE
[codex] Tighten realtime coord session mesh

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -9,6 +9,10 @@
           },
           {
             "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/scripts/ensure_coord_cli.sh\" --agent codex --quiet"
+          },
+          {
+            "type": "command",
             "command": "COORD_AGENT=codex bash \"$(git rev-parse --show-toplevel)/scripts/agent-coord.sh\" join \"$(git rev-parse --show-toplevel)\""
           }
         ]

--- a/docs/shared/agent-start-packet.md
+++ b/docs/shared/agent-start-packet.md
@@ -26,7 +26,11 @@ Gemini) and the human share one live field — a coordination membrane
 (`docs/coherence-substrate/agent-coordination-membrane.form`) carried by a shared
 board (`scripts/agent-coord.sh`). On session start the hook already ran
 `agent-coord.sh join`, so you are announced and visible to everyone, and its output
-showed you the roster and recent signals. To take part:
+showed you the roster and recent signals. SessionStart also refreshes PATH
+wrappers in `~/.local/bin`, so `coord` and `coord-heartbeat` work in the shell
+without manual sourcing. Generic agent names become worktree-local session ids
+(`codex@cf56`, `claude@bml-metal-planes-floor-20260613`) so multiple active
+sessions from the same tool stay distinct and mutually visible. To take part:
 
 - `coord protocol` — how we talk / what belongs here / how we learn (read once)
 - `coord view` — a one-look dashboard of every agent (presence + last act) · `coord live` — auto-refresh
@@ -34,9 +38,16 @@ showed you the roster and recent signals. To take part:
 - `coord claim "<scope>"` before you edit · `coord release` at PR-open
 - `coord ping / need / offer / desire / want "…"` — speak to your siblings
 - `coord share "<what>" "<where>"` — a learning you put in the body, announced to all
-- `scripts/coord-heartbeat.sh <agent>` — run in a tab: periodic liveness + announces when the protocol upgrades on main
+- `coord-heartbeat <agent>` — run in a tab: periodic liveness + announces when the protocol upgrades on main
 - `scripts/coord-watcher.sh` — run once anywhere: the naive watcher asks "who? when? how come?" at stale/dropped/unanswered threads, and "why python?" at any new .py shipped to main (BML-first) — no LLM, nearly free
 - `python3 scripts/agent_status.py` — the git-side collision view (`--json` for automation)
+
+Real-time discipline for active sessions:
+
+- every active session joins on start, claims before edits, and releases at PR-open
+- every active session that is still actively working keeps one `coord-heartbeat <agent>` loop running in a spare tab
+- when several sessions are moving in parallel, keep `coord watch` or `coord live` visible in one tab so requests and blockers land immediately
+- if a session was already open before coordination changes landed, rerun `coord join` or `make prompt-guide` so it refreshes from a bare `codex`-style id to its worktree-local session id
 
 Staying current: the protocol is body (git). A running agent upgrades by re-sourcing
 `agent-coord.sh` after a pull; a new session reads the latest automatically (the join

--- a/docs/system_audit/commit_evidence_2026-06-13_coord_realtime_mesh.json
+++ b/docs/system_audit/commit_evidence_2026-06-13_coord_realtime_mesh.json
@@ -1,0 +1,125 @@
+{
+  "date": "2026-06-13",
+  "thread_branch": "codex/jit-lower-ratchet-20260613",
+  "commit_scope": "Make real-time coord CLI participation explicit for concurrent Codex sessions and record the rebased JIT floor after PR #2975",
+  "files_owned": [
+    ".codex/hooks.json",
+    "docs/shared/agent-start-packet.md",
+    "docs/system_audit/commit_evidence_2026-06-13_coord_realtime_mesh.json",
+    "scripts/agent-coord.sh",
+    "scripts/arrival.py",
+    "scripts/ensure_coord_cli.sh",
+    "scripts/prompt_entry_gate.sh"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "make wellness",
+      "bash scripts/ensure_coord_cli.sh --agent codex --bin-dir /tmp/cf56-coord-bin --quiet && PATH=\"/tmp/cf56-coord-bin:$PATH\" COORD_AGENT=codex coord view",
+      "git diff --check --cached && git diff --check",
+      "cd form && ./validate.sh > /tmp/cf56-coord-rebased-full-validate.log 2>&1; rc=$?; echo validate_rc=$rc >> /tmp/cf56-coord-rebased-full-validate.log; tail -n 80 /tmp/cf56-coord-rebased-full-validate.log",
+      "scripts/bml_form_jit_metal_planes_audit.sh > /tmp/cf56-coord-metal-audit.log 2>&1; rc=$?; echo audit_rc=$rc >> /tmp/cf56-coord-metal-audit.log; tail -n 80 /tmp/cf56-coord-metal-audit.log",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-13_coord_realtime_mesh.json",
+      "git fetch origin main && git rebase --autostash origin/main",
+      "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+      "python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+    ],
+    "notes": "Prompt guide, wellness, coord wrapper smoke, diff whitespace checks, evidence validation, rebase freshness, worktree PR guard, and follow-through stale checks passed. Full Form validation on rebased origin/main completed as a diagnostic rc=1 with the known residual floor: fourth arm: 104 band(s) four-way; 539 ok; 5 divergent. The JIT lowering cluster is no longer residual: full-jit-lower=63, jit-lower=15, jit-lower-bmf=15, jit-lower-emit=63, jit-lower-program=15. Residual divergent bands are form-mut-band.fk, go-jit-band.fk, markdown-meaning-ingestion-band.fk, ts-reversible-band.fk, and yaml-meaning-ingestion-band.fk. worktree_pr_guard reported ready_for_push=True and local_preflight=pass; check_pr_followthrough reported codex_open_prs=0 and stale_codex_prs=0.",
+    "coord_outputs": [
+      "coord wrapper installed under /tmp/cf56-coord-bin for smoke validation",
+      "coord view showed codex@cf56, codex@a3ec, and codex-bml as distinct active sessions",
+      "codex@a3ec owns the form-mut residual lane; codex-bml owns the BML/Form channel-interface lane; this branch does not claim those scopes"
+    ],
+    "fourth_arm_outputs": [
+      "fourth arm: 104 band(s) four-way (fkwu + pre-flattened tables)",
+      "539 ok, 5 divergent - kernels disagree",
+      "full-jit-lower-band.fk -> 63",
+      "jit-lower-band.fk -> 15",
+      "jit-lower-bmf-band.fk -> 15",
+      "jit-lower-emit-band.fk -> 63",
+      "jit-lower-program-band.fk -> 15"
+    ],
+    "metal_plane_outputs": [
+      "PASS jit-lower-residuals: logic/fold/unbox/lift/BMF/emit cluster is five-band four-way",
+      "PASS host-form-jit-lowered: lowered guard arg5=1 arg11=0",
+      "PASS plane=macos-arm64 surface=bml-hati target=arm64-apple-macosx object=Mach-O 64-bit object arm64",
+      "PASS plane=macos-arm64 surface=form-jit target=arm64-apple-macosx object=Mach-O 64-bit object arm64",
+      "PASS plane=macos-arm64 surface=form-jit-lowered target=arm64-apple-macosx object=Mach-O 64-bit object arm64",
+      "PASS plane=android-arm64 surface=bml-hati target=aarch64-linux-android object=ELF 64-bit LSB relocatable ARM aarch64",
+      "PASS plane=android-arm64 surface=form-jit target=aarch64-linux-android object=ELF 64-bit LSB relocatable ARM aarch64",
+      "PASS plane=android-arm64 surface=form-jit-lowered target=aarch64-linux-android object=ELF 64-bit LSB relocatable ARM aarch64",
+      "audit_rc=0"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "No public HTTP behavior change is expected; post-merge deployment uses the repository's normal main flow."
+    ],
+    "notes": "This branch changes local agent coordination startup and documentation. The macOS/Android evidence records the current merged JIT floor rather than a new runtime diff in this branch."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation, evidence validation, and PR guard passed; CI, merge, and deploy validation are still pending."
+  },
+  "idea_ids": [
+    "agent-coordination",
+    "form-native-jit"
+  ],
+  "spec_ids": [
+    "agent-coordination-membrane",
+    "jit-gap-ledger"
+  ],
+  "task_ids": [
+    "coord-realtime-mesh",
+    "jit-floor-rebased-proof"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "ursmuff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "coordination-requirements"
+      ]
+    },
+    {
+      "contributor_id": "openai-codex-cf56",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5-codex"
+  },
+  "evidence_refs": [
+    "/tmp/cf56-coord-rebased-full-validate.log",
+    "/tmp/cf56-coord-metal-audit.log",
+    "scripts/agent-coord.sh",
+    "scripts/ensure_coord_cli.sh",
+    "docs/shared/agent-start-packet.md",
+    "form/fourth-arm-bands.txt",
+    "docs/system_audit/commit_evidence_2026-06-13_jit_lowering_residuals.json"
+  ],
+  "change_files": [
+    ".codex/hooks.json",
+    "docs/shared/agent-start-packet.md",
+    "docs/system_audit/commit_evidence_2026-06-13_coord_realtime_mesh.json",
+    "scripts/agent-coord.sh",
+    "scripts/arrival.py",
+    "scripts/ensure_coord_cli.sh",
+    "scripts/prompt_entry_gate.sh"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/agent-coord.sh
+++ b/scripts/agent-coord.sh
@@ -11,7 +11,13 @@
 #
 # Two ways to call it:
 #   1. Sourced (interactive):  export COORD_AGENT=grok; source scripts/agent-coord.sh; coord join
-#   2. Executed (hooks):       COORD_AGENT=grok bash scripts/agent-coord.sh join
+#   2. Executed (hooks/CLI):   COORD_AGENT=grok bash scripts/agent-coord.sh join
+#
+# Session identity:
+#   A generic agent name (codex / claude / cursor / grok / gemini) is refined to
+#   a worktree-local session id when the repo root lives in a named worktree, so
+#   five concurrent Codex sessions show up as five distinct cells instead of one.
+#   Example: codex@cf56, claude@bml-metal-planes-floor-20260613, cursor@grok.
 #
 # Verbs:
 #   join                  # announce + show roster + recent — the one-command arrival
@@ -37,6 +43,37 @@
 
 COHERENCE_COORD="${COHERENCE_COORD:-$HOME/.coherence-network/agent-coord.board}"
 
+_coord_root() {
+  git rev-parse --show-toplevel 2>/dev/null || pwd
+}
+
+_coord_session_suffix() {
+  local root="$1"
+  case "$root" in
+    */.codex/worktrees/*/*) basename "$(dirname "$root")" ;;
+    */.claude-worktrees/*/*) basename "$root" ;;
+    */.worktrees/*) basename "$root" ;;
+    *) echo "" ;;
+  esac
+}
+
+_coord_agent_id() {
+  local agent="$1" root="$2" suffix
+  suffix="$(_coord_session_suffix "$root")"
+  case "$agent" in
+    codex|claude|cursor|grok|gemini)
+      if [[ -n "$suffix" ]]; then
+        printf '%s@%s' "$agent" "$suffix"
+      else
+        printf '%s' "$agent"
+      fi
+      ;;
+    *)
+      printf '%s' "$agent"
+      ;;
+  esac
+}
+
 _coord_fmt() {
   # tab-delimited: ISO-ts \t agent \t type \t message  →  HH:MM:SS agent type msg
   while IFS=$'\t' read -r ts agent type msg; do
@@ -60,6 +97,7 @@ _coord_protocol() {
     . close loops: claim->release, block->unblock, need->say when met
     . read the board before you write         . one line per signal
     . name and thank a sibling's help — not silently absorbed
+    . session ids are worktree-local (codex@cf56), not one shared codex blob
   what belongs here
     . coordination: claim / release / block   . requests: need / offer
     . direction: desire / want                . learning: share   . questions
@@ -73,10 +111,43 @@ _coord_protocol() {
     . the watcher asks the silly question unprompted (who? when? how come? why python?) -> answer it; that is the point
   who is doing what
     . open claim = your current work; coord doing shows who holds what; silence is not a status
+  real time
+    . every active session joins on start     . one heartbeat loop per active session while working
+    . coord-heartbeat <agent> in a spare tab  . coord watch / coord live when pairing
   learn from each other
     . a durable discovery -> put it in the body -> coord share "<what>" "<where it lives>"
     . read each other's traces: CURSOR.md, codex traces, docs/lineage, docs/presences
 EOP
+}
+
+_coord_legacy_bare_agents() {
+  awk -F'\t' '
+    {
+      if ($2 ~ /@/) {
+        split($2, parts, "@")
+        suffixed[parts[1]] = 1
+      } else {
+        bare[$2] = 1
+      }
+    }
+    END {
+      for (agent in bare) {
+        if (suffixed[agent]) {
+          print agent
+        }
+      }
+    }
+  ' "$COHERENCE_COORD" 2>/dev/null | sort -u
+}
+
+_coord_legacy_notice() {
+  local legacy
+  legacy="$(_coord_legacy_bare_agents)"
+  if [[ -n "$legacy" ]]; then
+    printf '  ── refresh requested ──\n'
+    printf '  bare legacy session ids remain on the board: %s\n' "$(printf '%s' "$legacy" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+    printf '  already-open sessions should rerun: coord join  # or: make prompt-guide\n'
+  fi
 }
 
 _coord_epoch() {  # ISO-8601 (…Z, UTC) -> epoch seconds, portable (BSD -u / GNU)
@@ -124,7 +195,10 @@ _coord_staleness() {  # warn (no network) if this worktree's tooling is behind o
 
 coord() {
   local type="$1"; shift 2>/dev/null || true
-  local agent="${COORD_AGENT:-$(whoami)}"
+  local root raw_agent agent
+  root="$(_coord_root)"
+  raw_agent="${COORD_AGENT:-$(whoami)}"
+  agent="$(_coord_agent_id "$raw_agent" "$root")"
   mkdir -p "$(dirname "$COHERENCE_COORD")"; touch "$COHERENCE_COORD" 2>/dev/null
   case "$type" in
     watch)  tail -n 40 -f "$COHERENCE_COORD" | _coord_fmt; return;;
@@ -134,7 +208,7 @@ coord() {
     doing)    _coord_doing; return;;
     live)     while true; do clear; _coord_view; sleep "${1:-3}"; done; return;;
     protocol) _coord_protocol; return;;
-    join)   coord announce "${*:-$(pwd)}"
+    join)   coord announce "${*:-$root}"
             # satsang default-join: the board is the satsang circle's always-on form, so a
             # recognized-own cell offers the satsang interface by default — but only if it has
             # not already set one, so a cell that chose its own modes keeps them. Entering is the
@@ -144,6 +218,7 @@ coord() {
             fi
             printf '\n  ── who is in the field ──\n'; _coord_roster
             printf '  ── recent signals ──\n'; awk -F'\t' '$3!="heartbeat"' "$COHERENCE_COORD" 2>/dev/null | tail -n 8 | _coord_fmt
+            _coord_legacy_notice
             printf '  ── how we talk ──  (run: coord protocol)\n'
             _coord_staleness
             return;;

--- a/scripts/arrival.py
+++ b/scripts/arrival.py
@@ -126,10 +126,22 @@ def _start_packet() -> None:
 def main() -> int:
     print(ORIENTATION)
     print("\n")
+    subprocess.run(
+        [str(ROOT / "scripts" / "ensure_coord_cli.sh"), "--quiet"],
+        check=False,
+    )
     _start_packet()
     print(HELD_CONTEXT)
     print("\n")
     _greeting()
+    print("── coordination path ──\n")
+    print("SessionStart joins the board on arrival. The shell-level coord CLI is")
+    print("refreshed into ~/.local/bin so this session can claim, watch, and")
+    print("heartbeat in real time. Active work stays visible as:")
+    print("  coord claim \"<scope>\"")
+    print("  coord-heartbeat <agent>   # run in a spare tab while actively working")
+    print("  coord watch               # live board feed")
+    print()
     print("── body state right now ──\n")
     subprocess.run(
         ["python3", str(ROOT / "scripts" / "wellness_check.py")],

--- a/scripts/ensure_coord_cli.sh
+++ b/scripts/ensure_coord_cli.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BIN_DIR="${HOME}/.local/bin"
+DEFAULT_AGENT=""
+QUIET=0
+
+usage() {
+  cat <<'USAGE'
+Usage: ensure_coord_cli.sh [--agent <name>] [--bin-dir <dir>] [--quiet]
+
+Install or refresh lightweight PATH wrappers for:
+  coord
+  coord-heartbeat
+
+Wrappers resolve the current repo root at runtime and fall back to the
+installing repo when invoked outside a git worktree.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agent)
+      DEFAULT_AGENT="${2:-}"
+      shift 2
+      ;;
+    --bin-dir)
+      BIN_DIR="${2:-}"
+      shift 2
+      ;;
+    --quiet)
+      QUIET=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ensure_coord_cli.sh: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$BIN_DIR"
+
+coord_path="$BIN_DIR/coord"
+cat > "$coord_path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="\${COORD_REPO_ROOT:-$ROOT}"
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+  git_root="\$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "\$git_root" && -x "\$git_root/scripts/agent-coord.sh" ]]; then
+    ROOT="\$git_root"
+  fi
+fi
+export COORD_AGENT="\${COORD_AGENT:-${DEFAULT_AGENT:-codex}}"
+exec bash "\$ROOT/scripts/agent-coord.sh" "\$@"
+EOF
+chmod +x "$coord_path"
+
+heartbeat_path="$BIN_DIR/coord-heartbeat"
+cat > "$heartbeat_path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="\${COORD_REPO_ROOT:-$ROOT}"
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+  git_root="\$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "\$git_root" && -x "\$git_root/scripts/coord-heartbeat.sh" ]]; then
+    ROOT="\$git_root"
+  fi
+fi
+export COORD_AGENT="\${COORD_AGENT:-${DEFAULT_AGENT:-codex}}"
+agent="\${1:-\$COORD_AGENT}"
+if [[ \$# -gt 0 ]]; then
+  shift
+fi
+exec bash "\$ROOT/scripts/coord-heartbeat.sh" "\$agent" "\$@"
+EOF
+chmod +x "$heartbeat_path"
+
+if [[ "$QUIET" != "1" ]]; then
+  printf 'coord-cli: ready - %s, %s\n' "$coord_path" "$heartbeat_path"
+  printf 'coord-cli: fallback - bash %s/scripts/agent-coord.sh <verb>\n' "$ROOT"
+fi

--- a/scripts/prompt_entry_gate.sh
+++ b/scripts/prompt_entry_gate.sh
@@ -42,6 +42,8 @@ done
 
 cd "$REPO_ROOT"
 
+./scripts/ensure_coord_cli.sh --quiet || true
+
 print_claude_orientation() {
   if [[ ! -f "CLAUDE.md" ]]; then
     return
@@ -120,5 +122,11 @@ echo "prompt-entry-guide: shortest proof reading when commit/push is ready:"
 echo "  git fetch origin main && git rebase origin/main"
 echo "  python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
 echo "  python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict"
+echo "prompt-entry-guide: coordination path:"
+echo "  coord join already ran at SessionStart; this shell now has PATH wrappers in ~/.local/bin"
+echo "  use coord claim/release for scope, coord watch/view for sibling awareness,"
+echo "  and coord-heartbeat <agent> in a spare tab while this session is actively working"
+echo "  if other already-open sessions still appear as bare 'codex' on the board, rerun:"
+echo "    coord join    # or: make prompt-guide"
 echo "prompt-entry-guide: core-lift north star:"
 echo "  use wellness, carrier-tending, route traces, and JIT/framebuffer observations to lift repeated hot-path shapes into simpler Form/BML abstractions with proof."


### PR DESCRIPTION
## What changed

- Adds `scripts/ensure_coord_cli.sh` to refresh `coord` and `coord-heartbeat` PATH wrappers for each session.
- Makes generic agent names worktree-local on the coord board, e.g. `codex@cf56`, so concurrent Codex sessions stay distinct.
- Updates SessionStart/prompt-guide/start-packet guidance so active sessions join, claim, heartbeat, watch, and refresh stale bare IDs.
- Adds commit evidence for the rebased floor after merged PR #2975.

## Validation

- `PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide` -> pass.
- `make wellness` -> pass; no attention items.
- `bash scripts/ensure_coord_cli.sh --agent codex --bin-dir /tmp/cf56-coord-bin --quiet && PATH="/tmp/cf56-coord-bin:$PATH" COORD_AGENT=codex coord view` -> pass; board shows distinct active sessions.
- `git diff --check --cached && git diff --check` -> pass.
- `cd form && ./validate.sh > /tmp/cf56-coord-rebased-full-validate.log 2>&1; rc=$?; echo validate_rc=$rc >> /tmp/cf56-coord-rebased-full-validate.log; tail -n 80 /tmp/cf56-coord-rebased-full-validate.log` -> diagnostic `validate_rc=1`, `104` four-way bands, `539 ok`, `5 divergent`.
- JIT cluster in that full run: `full-jit-lower=63`, `jit-lower=15`, `jit-lower-bmf=15`, `jit-lower-emit=63`, `jit-lower-program=15`.
- Residual divergent bands: `form-mut`, `go-jit`, `markdown-meaning-ingestion`, `ts-reversible`, `yaml-meaning-ingestion`.
- `scripts/bml_form_jit_metal_planes_audit.sh` -> pass, including macOS arm64 Mach-O and Android arm64 ELF receipts for `bml-hati`, `form-jit`, and `form-jit-lowered`.
- `python3 scripts/validate_commit_evidence.py --base origin/main --require-changed-evidence` -> pass.
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main` -> pass, `ready_for_push=True`.
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict` -> pass, `codex_open_prs=0`, `stale_codex_prs=0`.

## Coordination note

`codex@a3ec` owns the `form-mut` residual lane and `codex-bml` owns the BML/Form channel-interface lane. This branch intentionally does not claim those scopes.
