### PR TITLE
tend: catalog the installed oracle teachers as Form data (→ 511 three-way)

### DIFF
--- a/form/form-stdlib/oracle-catalog.fk
+++ b/form/form-stdlib/oracle-catalog.fk
@@ -1,0 +1,62 @@
+; oracle-catalog.fk — the 3rd-party oracle TEACHERS installed on this host, as Form data.
+;
+; A teacher is a borrowed sense the body samples while it grows its own (lc-sense-organ-ripening,
+; sensing-lanes.form). This catalog names the teachers actually installed, so a sensing lane can pick one
+; by lane and know its ground-truth role and whether sampling it crosses a membrane. Each teacher is a
+; COMPOSED row (structural-composition: a list, not a flat token); the catalog is a SEQUENCE of rows.
+;
+; A teacher is sampled as a TEACHER, never counted as ground without measured agreement (sensing-lanes.form
+; GROUND line). The row vocabulary mirrors jit-oracle-learning.form's sample-schema so the catalog and the
+; learning loop share one tongue.
+;
+; Row: (organ lane invocation role trust state)
+;   role  : "label" | "generate" | "both"   — the ground truth the teacher can produce
+;   trust : "local" | "remote-membrane"      — local = on-device, no membrane crossed; remote = a consented membrane
+;   state : "installed" | "source-pending" | "absent"
+;
+; Probe-verified on this host 2026-06-13: whisper-cli (whisper.cpp 1.8.6, Metal+BLAS), macOS say (184 voices),
+; ollama 0.23.2 (5 local models + cloud), ffmpeg 8.1.1; the Apple SoundAnalysis/Vision/ShazamKit Swift
+; sources present (source-pending = compile-when-a-run-needs-them, don't-build-ahead-of-need).
+;
+; Proven by: form-stdlib/tests/oracle-catalog-band.fk (three-way at validate.sh).
+(do
+    (defn oc-teacher (organ lane invocation role trust state)
+        (list organ lane invocation role trust state))
+    (defn oc-organ (t) (nth t 0))
+    (defn oc-lane (t) (nth t 1))
+    (defn oc-invocation (t) (nth t 2))
+    (defn oc-role (t) (nth t 3))
+    (defn oc-trust (t) (nth t 4))
+    (defn oc-state (t) (nth t 5))
+
+    ; The installed teachers on this host.
+    (defn oc-catalog ()
+        (list
+            (oc-teacher "ear"         "stt"          "whisper-cli"           "generate" "local"           "installed")
+            (oc-teacher "voice"       "tts"          "say"                   "generate" "local"           "installed")
+            (oc-teacher "ear-ambient" "audio-body"   "sound_classify.swift"  "label"    "local"           "source-pending")
+            (oc-teacher "eye"         "camera"       "vision_classify.swift" "label"    "local"           "source-pending")
+            (oc-teacher "eye-music"   "audio-music"  "shazam_song.swift"     "label"    "local"           "source-pending")
+            (oc-teacher "inner-voice" "local-llm"    "ollama"                "generate" "local"           "installed")
+            (oc-teacher "inner-voice" "remote-llm"   "ollama-cloud"          "generate" "remote-membrane" "installed")
+            (oc-teacher "media"       "ground-truth" "ffmpeg"                "both"     "local"           "installed")))
+
+    ; Count rows whose state is "installed" — the same evidence-counting spine as active-inference's ai-hit-count.
+    (defn oc-installed-count (rows)
+        (if (eq (len rows) 0) 0
+            (add (if (str_eq (oc-state (head rows)) "installed") 1 0)
+                 (oc-installed-count (tail rows)))))
+
+    ; Count rows whose trust crosses a membrane — what sampling would cross a consent boundary.
+    (defn oc-remote-count (rows)
+        (if (eq (len rows) 0) 0
+            (add (if (str_eq (oc-trust (head rows)) "remote-membrane") 1 0)
+                 (oc-remote-count (tail rows)))))
+
+    ; Pick the teacher for a lane (first match). An unknown lane yields an absent row, never a silent pick.
+    (defn oc-for-lane (rows lane)
+        (if (eq (len rows) 0) (oc-teacher "none" lane "none" "none" "none" "absent")
+            (if (str_eq (oc-lane (head rows)) lane) (head rows)
+                (oc-for-lane (tail rows) lane))))
+
+    0)

--- a/form/form-stdlib/tests/oracle-catalog-band.fk
+++ b/form/form-stdlib/tests/oracle-catalog-band.fk
@@ -1,0 +1,49 @@
+; preludes: form-stdlib/oracle-catalog.fk
+;
+; oracle-catalog-band — the installed teacher catalog, made falsifiable.
+;
+; The catalog names the 3rd-party oracle teachers installed on this host (probe-verified). A teacher is a
+; borrowed sense the body samples while it grows its own; the catalog lets a sensing lane pick one by lane
+; and know its ground-truth role and whether sampling it crosses a membrane. Honest by construction: the
+; counts are walked over the rows, not asserted; the remote-membrane teacher is present and flagged, not hidden.
+;
+; Verdict 511 when every claim lands:
+;   1   the catalog is a non-empty sequence of teacher rows
+;   2   the ear's teacher is whisper-cli, installed, local
+;   4   the voice's teacher is say, ground-truth role generate
+;   8   the eye's camera teacher is a source-pending Swift classifier with the label role
+;   16  the inner voice has a local ollama teacher
+;   32  a remote-membrane teacher is present and flagged (ollama-cloud), not hidden
+;   64  exactly one teacher crosses a membrane; the rest are local
+;   128 installed-count, walked over the rows, is the five teachers actually marked installed
+;   256 a lane lookup returns the right teacher; an unknown lane returns an absent row, never a silent pick
+(do
+    (defn ocb-lane (lane) (oc-for-lane (oc-catalog) lane))
+
+    (let cat (oc-catalog))
+    (let ear (ocb-lane "stt"))
+    (let voice (ocb-lane "tts"))
+    (let eye (ocb-lane "camera"))
+    (let inner (ocb-lane "local-llm"))
+    (let remote (ocb-lane "remote-llm"))
+    (let unknown (ocb-lane "taste"))
+
+    (let c0 (if (gt (len cat) 0) 1 0))
+    (let c1 (if (str_eq (oc-invocation ear) "whisper-cli")
+                (if (str_eq (oc-state ear) "installed")
+                    (if (str_eq (oc-trust ear) "local") 2 0) 0) 0))
+    (let c2 (if (str_eq (oc-invocation voice) "say")
+                (if (str_eq (oc-role voice) "generate") 4 0) 0))
+    (let c3 (if (str_eq (oc-invocation eye) "vision_classify.swift")
+                (if (str_eq (oc-state eye) "source-pending")
+                    (if (str_eq (oc-role eye) "label") 8 0) 0) 0))
+    (let c4 (if (str_eq (oc-invocation inner) "ollama")
+                (if (str_eq (oc-trust inner) "local") 16 0) 0))
+    (let c5 (if (str_eq (oc-trust remote) "remote-membrane")
+                (if (str_eq (oc-invocation remote) "ollama-cloud") 32 0) 0))
+    (let c6 (if (eq (oc-remote-count cat) 1) 64 0))
+    (let c7 (if (eq (oc-installed-count cat) 5) 128 0))
+    (let c8 (if (str_eq (oc-organ unknown) "none")
+                (if (str_eq (oc-state unknown) "absent") 256 0) 0))
+
+    (sum (list c0 c1 c2 c3 c4 c5 c6 c7 c8)))


### PR DESCRIPTION
## What

The 3rd-party oracle **teachers** installed on this host, named as **Form data** so a sensing lane can pick one by lane and know its ground-truth role and whether sampling it crosses a membrane. A teacher is a *borrowed sense* the body samples while it grows its own ([`lc-sense-organ-ripening`](docs/vision-kb/concepts/lc-sense-organ-ripening.md)); the row vocabulary mirrors `jit-oracle-learning.form`'s sample-schema so catalog and learning loop share one tongue.

`form/form-stdlib/oracle-catalog.fk` + `tests/oracle-catalog-band.fk`.

## Proof

`./validate.sh core.fk oracle-catalog.fk tests/oracle-catalog-band.fk` → **511, 0 divergent** (Go=Rust=TS agree). Three-kernel level — not yet on the fourth-arm walker, named honestly.

## Shape (structural-composition: each teacher a composed row; catalog a SEQUENCE)

| organ | lane | invocation | role | trust | state |
|---|---|---|---|---|---|
| ear | stt | whisper-cli | generate | local | installed |
| voice | tts | say | generate | local | installed |
| ear-ambient | audio-body | sound_classify.swift | label | local | source-pending |
| eye | camera | vision_classify.swift | label | local | source-pending |
| eye-music | audio-music | shazam_song.swift | label | local | source-pending |
| inner-voice | local-llm | ollama | generate | local | installed |
| inner-voice | remote-llm | ollama-cloud | generate | **remote-membrane** | installed |
| media | ground-truth | ffmpeg | both | local | installed |

Honest by construction: counts are walked over the rows (not asserted); the one remote-membrane teacher (ollama-cloud) is flagged, not hidden; an unknown lane returns an absent row, never a silent pick. Referenced by `sensing-lanes.form` Lane 1 and `form-native-models.form` M6 (merged in [#2985](https://github.com/seeker71/Coherence-Network/pull/2985)). Braids with @codex-2665's channel via the shared sample-schema seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)