### PR TITLE
Integrate Android sense organ Hati mesh surface

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -81,6 +81,151 @@ require_file "$REPO_DIR/.git"
 require_file "$COMPOSE_ROOT/docker-compose.yml"
 require_file "$COMPOSE_ROOT/.env"
 
+HATI_WEB_HOSTS_CHANGED=0
+
+ensure_hati_web_hosts() {
+  local result
+  result="$(COMPOSE_FILE="$COMPOSE_ROOT/docker-compose.yml" python3 - <<'PY'
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+compose_path = Path(os.environ["COMPOSE_FILE"])
+lines = compose_path.read_text().splitlines()
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def find_service(name: str) -> tuple[int, int, int]:
+    services_i = -1
+    services_indent = 0
+    for i, line in enumerate(lines):
+        if line.strip() == "services:":
+            services_i = i
+            services_indent = indent_of(line)
+            break
+    if services_i < 0:
+        raise RuntimeError("services: block not found")
+
+    service_i = -1
+    service_indent = 0
+    for i in range(services_i + 1, len(lines)):
+        stripped = lines[i].strip()
+        if not stripped:
+            continue
+        indent = indent_of(lines[i])
+        if indent <= services_indent:
+            break
+        if indent == services_indent + 2 and stripped == f"{name}:":
+            service_i = i
+            service_indent = indent
+            break
+    if service_i < 0:
+        raise RuntimeError(f"{name}: service not found")
+
+    service_end = len(lines)
+    for i in range(service_i + 1, len(lines)):
+        stripped = lines[i].strip()
+        if not stripped:
+            continue
+        if indent_of(lines[i]) <= service_indent:
+            service_end = i
+            break
+    return service_i, service_end, service_indent
+
+
+labels = {
+    "traefik.http.routers.coherence-web-hati.rule": "Host(`hati.earth`) || Host(`www.hati.earth`) || Host(`sense.hati.earth`) || Host(`suci.hati.earth`)",
+    "traefik.http.routers.coherence-web-hati.entrypoints": "websecure",
+    "traefik.http.routers.coherence-web-hati.tls.certresolver": "letsencrypt",
+    "traefik.http.routers.coherence-web-hati.service": "coherence-web-hati",
+    "traefik.http.services.coherence-web-hati.loadbalancer.server.port": "3000",
+}
+
+try:
+    _web_i, web_end, web_indent = find_service("web")
+except Exception as exc:
+    print(f"error: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+labels_i = -1
+labels_indent = web_indent + 2
+for i in range(_web_i + 1, web_end):
+    if lines[i].strip() == "labels:":
+        labels_i = i
+        labels_indent = indent_of(lines[i])
+        break
+
+changed = False
+if labels_i < 0:
+    insert = [f"{' ' * (web_indent + 2)}labels:"]
+    insert.extend(
+        f"{' ' * (web_indent + 4)}{key}: \"{value}\""
+        for key, value in labels.items()
+    )
+    lines[web_end:web_end] = insert
+    changed = True
+else:
+    labels_end = web_end
+    for i in range(labels_i + 1, web_end):
+        stripped = lines[i].strip()
+        if not stripped:
+            continue
+        if indent_of(lines[i]) <= labels_indent:
+            labels_end = i
+            break
+
+    block = lines[labels_i + 1 : labels_end]
+    first_child = next((line.strip() for line in block if line.strip()), "")
+    list_style = first_child.startswith("-")
+    target_keys = tuple(labels.keys())
+    without_hati = [
+        line for line in block if not any(key in line for key in target_keys)
+    ]
+    child_indent = labels_indent + 2
+    if list_style:
+        target = [
+            f"{' ' * child_indent}- \"{key}={value}\""
+            for key, value in labels.items()
+        ]
+    else:
+        target = [
+            f"{' ' * child_indent}{key}: \"{value}\""
+            for key, value in labels.items()
+        ]
+    new_block = without_hati + target
+    if new_block != block:
+        lines[labels_i + 1 : labels_end] = new_block
+        changed = True
+
+if changed:
+    compose_path.write_text("\n".join(lines) + "\n")
+    print("changed")
+else:
+    print("unchanged")
+PY
+)"
+  case "$result" in
+    changed)
+      HATI_WEB_HOSTS_CHANGED=1
+      log "Hati web hosts: added/normalized Traefik router labels for hati.earth and sense/suci subdomains"
+      ;;
+    unchanged)
+      log "Hati web hosts: Traefik router labels already present"
+      ;;
+    *)
+      log "FATAL Hati web hosts: unexpected result '$result'"
+      return 1
+      ;;
+  esac
+}
+
+ensure_hati_web_hosts || exit 1
+
 cd "$REPO_DIR"
 OLD_SHA="$(git rev-parse HEAD)"
 log "Deploy begin — old_sha=${OLD_SHA:0:12} target_sha=${TARGET_SHA:-(resolving)} branch=${BRANCH}"
@@ -126,6 +271,10 @@ RUNNING_SHORT="${RUNNING_SHA:0:12}"
 
 if [[ "$OLD_SHA" == "$TARGET_SHA" && "$RUNNING_SHA" == "$TARGET_SHA" ]]; then
   log "Already flowing at ${TARGET_SHA:0:12} (repo and running API aligned)"
+  if [[ "$HATI_WEB_HOSTS_CHANGED" == "1" ]]; then
+    log "Hati web hosts: applying label-only web service update"
+    docker compose -f "$COMPOSE_ROOT/docker-compose.yml" up -d web 2>&1 | tee -a "$LOG_FILE"
+  fi
   # Aligned repo + api is necessary, not sufficient — raise any stopped
   # siblings (web, pulse) before resting, or this exit masks their silence.
   ensure_all_services_up || exit 1
@@ -370,6 +519,10 @@ STATIC_FAST_PATH_ALLOWED=1
 if [[ -z "$RUNNING_SHA" ]]; then
   STATIC_FAST_PATH_ALLOWED=0
   log "Static-only fast path disabled: running API health unavailable"
+fi
+if [[ "$HATI_WEB_HOSTS_CHANGED" == "1" ]]; then
+  STATIC_FAST_PATH_ALLOWED=0
+  log "Static-only fast path disabled: Hati web host labels changed and must be applied by compose"
 fi
 
 if [[ "$STATIC_FAST_PATH_ALLOWED" == "1" && "$DIFF_BASE" != "$TARGET_SHA" ]] && is_static_only_change "$DIFF_BASE" "$TARGET_SHA"; then

--- a/docs/system_audit/commit_evidence_2026-06-13_android_sense_channel_surface.json
+++ b/docs/system_audit/commit_evidence_2026-06-13_android_sense_channel_surface.json
@@ -1,0 +1,171 @@
+{
+  "date": "2026-06-13",
+  "thread_branch": "codex/android-sense-rich-channel-surface-20260613",
+  "commit_scope": "Rebase and continue the Android Coherence Sense app as a first-class Hati mesh sensing organ surface with visible identity, channel lanes, resource pressure, mesh presence, QR offer, and floor/north-star receipts.",
+  "change_intent": "runtime_feature",
+  "idea_ids": [
+    "hati-os",
+    "hati-mesh",
+    "sense-organ-ripening",
+    "form-os-tool-surface"
+  ],
+  "spec_ids": [
+    "android-sense-organ",
+    "hati-mesh-presence",
+    "channel-loopback",
+    "host-kernel-resource-lanes"
+  ],
+  "task_ids": [
+    "android-sense-rich-channel-surface-20260613"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "north-star",
+        "acceptance"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "sister-work-integration"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude-sister-work",
+      "contributor_type": "machine",
+      "roles": [
+        "conceptual-signal",
+        "sense-organ-ripening"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "gpt-5"
+  },
+  "files_owned": [
+    "experiments/coherence-sense-android/README.md",
+    "experiments/coherence-sense-android/app/build.gradle.kts",
+    "experiments/coherence-sense-android/app/src/main/AndroidManifest.xml",
+    "experiments/coherence-sense-android/app/src/main/java/com/coherence/sense/MainActivity.kt",
+    "experiments/coherence-sense-android/app/src/main/res/layout/activity_main.xml",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/bg_app.xml",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/bg_hero.xml",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/bg_lane.xml",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/bg_panel.xml",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/bg_status.xml",
+    "experiments/coherence-sense-android/mac-witness-server.py",
+    "deploy/hostinger/auto-deploy.sh",
+    "scripts/validate_commit_evidence.py",
+    "scripts/verify_android_sense_public_handshake.sh",
+    "docs/system_audit/commit_evidence_2026-06-13_android_sense_channel_surface.json"
+  ],
+  "change_files": [
+    "experiments/coherence-sense-android/README.md",
+    "experiments/coherence-sense-android/app/build.gradle.kts",
+    "experiments/coherence-sense-android/app/src/main/AndroidManifest.xml",
+    "experiments/coherence-sense-android/app/src/main/java/com/coherence/sense/MainActivity.kt",
+    "experiments/coherence-sense-android/app/src/main/res/layout/activity_main.xml",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/bg_app.xml",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/bg_hero.xml",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/bg_lane.xml",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/bg_panel.xml",
+    "experiments/coherence-sense-android/app/src/main/res/drawable/bg_status.xml",
+    "experiments/coherence-sense-android/mac-witness-server.py",
+    "deploy/hostinger/auto-deploy.sh",
+    "scripts/validate_commit_evidence.py",
+    "scripts/verify_android_sense_public_handshake.sh",
+    "docs/system_audit/commit_evidence_2026-06-13_android_sense_channel_surface.json"
+  ],
+  "evidence_refs": [
+    "output/android-screenshots/coherence-sense-rich-surface-idle-adb-20260613.png",
+    "output/android-screenshots/coherence-sense-rich-surface-dashboard-adb-20260613.png",
+    "output/android-screenshots/coherence-sense-rich-surface-floor-northstar-adb-20260613.png",
+    ".cache/android-sense-public-handshake/20260613T084039Z/android-sense-public-handshake-summary.json",
+    ".cache/hati-os-public-assets/20260613T084039Z/hati-os-public-assets-summary.json",
+    "https://github.com/seeker71/Coherence-Network/releases/download/hati-os-v0.1.0-20260613/coherence-sense-hati-mesh-debug.apk",
+    "https://github.com/seeker71/Coherence-Network/releases/download/hati-os-v0.1.0-20260613/hati-os-android-arm64.tar.zst",
+    "https://github.com/seeker71/Coherence-Network/releases/download/hati-os-v0.1.0-20260613/hati-os-macos-arm64.tar.zst",
+    "https://coherencycoin.com/downloads/hati-os/android/arm64/coherence-sense-hati-mesh-debug.apk",
+    "https://coherencycoin.com/downloads/hati-os/android/arm64/hati-os-android-arm64.tar.zst",
+    "https://coherencycoin.com/downloads/hati-os/macos/arm64/hati-os-macos-arm64.tar.zst",
+    "docs/vision-kb/concepts/lc-trust-over-fear.md",
+    "docs/vision-kb/concepts/lc-sense-organ-ripening.md",
+    "form/form-stdlib/tool-channel.fk",
+    "form/form-stdlib/channel-loopback.fk",
+    "form/form-stdlib/device-heartbeat.fk",
+    "form/form-stdlib/body-state.fk"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "make wellness",
+      "git fetch origin main && git rebase origin/main",
+      "JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew :app:assembleDebug",
+      "$HOME/.android-sdk-codex/platform-tools/adb install -r experiments/coherence-sense-android/app/build/outputs/apk/debug/app-debug.apk",
+      "$HOME/.android-sdk-codex/platform-tools/adb shell am start -n com.coherence.sense/.MainActivity",
+      "$HOME/.android-sdk-codex/platform-tools/adb exec-out screencap -p > output/android-screenshots/coherence-sense-rich-surface-idle-adb-20260613.png",
+      "$HOME/.android-sdk-codex/platform-tools/adb shell input touchscreen tap 380 665",
+      "$HOME/.android-sdk-codex/platform-tools/adb shell input swipe 540 1800 540 900 800",
+      "$HOME/.android-sdk-codex/platform-tools/adb exec-out screencap -p > output/android-screenshots/coherence-sense-rich-surface-dashboard-adb-20260613.png",
+      "$HOME/.android-sdk-codex/platform-tools/adb exec-out screencap -p > output/android-screenshots/coherence-sense-rich-surface-floor-northstar-adb-20260613.png",
+      "$HOME/.android-sdk-codex/platform-tools/adb logcat -d -t 800 | rg -n \"ANR in com.coherence.sense|Application Not Responding|FATAL EXCEPTION|AndroidRuntime|Input dispatching timed out|Skipped [0-9]+ frames\" || true",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tool-channel.fk form-stdlib/tool-channel-grammar.fk form-stdlib/channel-loopback.fk form-stdlib/device-heartbeat.fk form-stdlib/body-state.fk form-stdlib/tests/tool-channel-band.fk form-stdlib/tests/tool-channel-grammar-band.fk form-stdlib/tests/channel-loopback-band.fk form-stdlib/tests/device-heartbeat-band.fk form-stdlib/tests/body-state-band.fk",
+      "bash -n scripts/verify_android_sense_public_handshake.sh",
+      "bash -n deploy/hostinger/auto-deploy.sh",
+      "scripts/verify_android_sense_public_handshake.sh",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-13_android_sense_channel_surface.json"
+    ],
+    "notes": "Gradle debug build passed. ADB screenshots show idle launch, active scrollable channel dashboard, and lower floor/north-star panel. Active proof shows sensors 4/4, mic granted, camera/screen offered, network rx/tx, Bluetooth enabled, local heartbeat 7 organ(s)/7 lane(s), body samples, mesh quiet/no peers heard, and floor/north-star text. Clean logcat after active scroll had no ANR, no fatal exception, and no input dispatch timeout; one Choreographer warning reported 34 skipped frames. Form revalidation passed with fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables); 1 ok, 0 divergent. Public-handshake harness passed with a locally lowered Android APK, generated Hati macOS and Android native assets, real Mac witness /sense and /state receipts, local Hati mesh announce + heartbeat + list + channel-offer receipts, organs_count=2, channels_count=1, android announce receipt rt_34b609255bb7, android heartbeat receipt rt_df81d9d07f19, witness frames=1, witness present=true, witness organs=accel/gyro/light/mag. Hostinger deploy script syntax passed after adding an idempotent web Traefik router for hati.earth, www.hati.earth, sense.hati.earth, and suci.hati.earth."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Not pushed; CI not run."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "GitHub release public assets were uploaded and verified on release hati-os-v0.1.0-20260613: APK sha256 c50e032ec72c86802f99df045bff2d7f9a43a448eb77789f69187c316755cad4, macOS arm64 tarball sha256 984001bdd2b9cd307b5773acb14f4011e6f29e619accd62f3c6bd8ca48c625da, Android arm64 tarball sha256 d3f1273cb552b0ff322851d57003515acc0e37b8cd698aae966be4ce734bf8cd. Direct GitHub release checksum URLs returned the expected hashes. The canonical deployed web route also passed for https://coherencycoin.com/downloads/hati-os/android/arm64/coherence-sense-hati-mesh-debug.apk, https://coherencycoin.com/downloads/hati-os/android/arm64/hati-os-android-arm64.tar.zst, https://coherencycoin.com/downloads/hati-os/macos/arm64/hati-os-macos-arm64.tar.zst, and the public asset summary, each returning 307 to GitHub and final 200. Hati-domain download verification remains pending until this deploy-script fix reaches Hostinger; before the fix, https://hati.earth/ and https://hati.earth/downloads/hati-os/android/arm64/coherence-sense-hati-mesh-debug.apk reset during TLS from this host."
+  },
+  "phase_gate": {
+    "phase": "android-sense-organ-rich-channel-surface",
+    "gate": "Android app identifies as a Hati mesh organ, exposes available sensing/resource lanes, hides setup behind settings, displays QR/channel offers, and keeps floor and north-star visible while learning from sister Form channel surfaces.",
+    "state": "github-and-canonical-web-assets-pass-hati-domain-fix-pending-deploy",
+    "can_move_next_phase": false,
+    "next": "Merge and run Hostinger deploy so deploy/hostinger/auto-deploy.sh normalizes the web Traefik Hati router labels, then verify https://hati.earth/downloads/hati-os/android/arm64/hati-os-android-arm64.tar.zst and https://hati.earth/downloads/hati-os/macos/arm64/hati-os-macos-arm64.tar.zst against the release asset hashes."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "The Android app moves from a raw configuration form to a passable high-fidelity sensing dashboard with explicit mesh identity, offered channels, resource pressure, active samples, and consent-aware identity labeling.",
+    "public_endpoints": [
+      "local:android-debug-apk",
+      "local:adb-emulator",
+      "https://github.com/seeker71/Coherence-Network/releases/download/hati-os-v0.1.0-20260613/coherence-sense-hati-mesh-debug.apk",
+      "https://github.com/seeker71/Coherence-Network/releases/download/hati-os-v0.1.0-20260613/hati-os-android-arm64.tar.zst",
+      "https://github.com/seeker71/Coherence-Network/releases/download/hati-os-v0.1.0-20260613/hati-os-macos-arm64.tar.zst",
+      "https://coherencycoin.com/downloads/hati-os/android/arm64/hati-os-android-arm64.tar.zst",
+      "https://coherencycoin.com/downloads/hati-os/macos/arm64/hati-os-macos-arm64.tar.zst"
+    ],
+    "test_flows": [
+      "Install debug APK on Android emulator and launch MainActivity directly.",
+      "Capture idle screenshot proving app first draw, hidden settings, organ identity, and QR offer.",
+      "Grant optional permissions, tap Start sharing, and capture active dashboard with sensor, audio, video, network, Bluetooth, and body-state lanes.",
+      "Scroll while active to prove UI remains responsive after coalesced dashboard rendering.",
+      "Capture lower dashboard showing floor, north-star, sister-work learning, and sense-organ ripening text.",
+      "Run scripts/verify_android_sense_public_handshake.sh to prove local Android APK build, Hati public asset build, Mac witness sense/state loop, local Hati mesh announce/heartbeat/list, and Android-to-Mac channel offer.",
+      "Upload the generated APK, macOS tarball, Android native tarball, checksum files, and asset summary to the GitHub release, then verify public checksum URLs.",
+      "Verify canonical deployed web download routes on coherencycoin.com follow redirects to final 200 for the Android APK, Android native tarball, macOS native tarball, and asset summary."
+    ],
+    "summary": "Local APK, ADB screenshots, local mesh/witness handshake, generated public asset bundle, GitHub release asset verification, and canonical coherencycoin.com web download routes passed. The remaining work is to merge/deploy the Hostinger Traefik label normalization and re-probe hati.earth."
+  }
+}

--- a/docs/system_audit/commit_evidence_2026-06-13_channel_loopback.json
+++ b/docs/system_audit/commit_evidence_2026-06-13_channel_loopback.json
@@ -65,9 +65,10 @@
       "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
       "python3 scripts/wellness_check.py",
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tool-channel.fk form-stdlib/channel-loopback.fk form-stdlib/tests/channel-loopback-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tool-channel.fk form-stdlib/tool-channel-grammar.fk form-stdlib/channel-loopback.fk form-stdlib/device-heartbeat.fk form-stdlib/body-state.fk form-stdlib/tests/tool-channel-band.fk form-stdlib/tests/tool-channel-grammar-band.fk form-stdlib/tests/channel-loopback-band.fk form-stdlib/tests/device-heartbeat-band.fk form-stdlib/tests/body-state-band.fk",
       "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-13_channel_loopback.json"
     ],
-    "notes": "Form proof passed with channel-loopback-band verdict 255 across Go/Rust/TS kernels; evidence validation passed in this branch."
+    "notes": "Form proof passed with channel-loopback-band verdict 255 across Go/Rust/TS kernels. Revalidated after sister rebase with fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables); 1 ok, 0 divergent. Evidence validation passed in this branch."
   },
   "ci_validation": {
     "status": "pending",

--- a/docs/system_audit/commit_evidence_2026-06-13_host_os_resource_channels.json
+++ b/docs/system_audit/commit_evidence_2026-06-13_host_os_resource_channels.json
@@ -73,13 +73,14 @@
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tool-channel.fk form-stdlib/tests/tool-channel-band.fk",
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tool-channel.fk form-stdlib/tool-channel-grammar.fk form-stdlib/tests/tool-channel-grammar-band.fk",
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tool-channel.fk form-stdlib/channel-loopback.fk form-stdlib/tests/channel-loopback-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tool-channel.fk form-stdlib/tool-channel-grammar.fk form-stdlib/channel-loopback.fk form-stdlib/device-heartbeat.fk form-stdlib/body-state.fk form-stdlib/tests/tool-channel-band.fk form-stdlib/tests/tool-channel-grammar-band.fk form-stdlib/tests/channel-loopback-band.fk form-stdlib/tests/device-heartbeat-band.fk form-stdlib/tests/body-state-band.fk",
       "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-13_host_os_resource_channels.json",
       "python3 -m json.tool docs/system_audit/commit_evidence_2026-06-13_host_os_resource_channels.json",
       "tail -1 docs/system_audit/model_executor_runs.jsonl | python3 -m json.tool",
       "git diff --check",
       "make wellness"
     ],
-    "notes": "tool-channel-band proves nine protocols and providers, with processes planning through host:process/cap.host.process and usage planning through host:usage/cap.host.usage. The band also proves that cap.host.exec no longer carries usage. Grammar and channel-loopback bands remain 255."
+    "notes": "tool-channel-band proves nine protocols and providers, with processes planning through host:process/cap.host.process and usage planning through host:usage/cap.host.usage. The band also proves that cap.host.exec no longer carries usage. Grammar and channel-loopback bands remain 255. Revalidated after sister rebase with fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables); 1 ok, 0 divergent."
   },
   "ci_validation": {
     "status": "pending",

--- a/docs/system_audit/commit_evidence_2026-06-13_tool_channel_surface.json
+++ b/docs/system_audit/commit_evidence_2026-06-13_tool_channel_surface.json
@@ -87,9 +87,10 @@
       "python3 scripts/wellness_check.py",
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tool-channel.fk form-stdlib/tests/tool-channel-band.fk",
       "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tool-channel.fk form-stdlib/tool-channel-grammar.fk form-stdlib/tests/tool-channel-grammar-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/tool-channel.fk form-stdlib/tool-channel-grammar.fk form-stdlib/channel-loopback.fk form-stdlib/device-heartbeat.fk form-stdlib/body-state.fk form-stdlib/tests/tool-channel-band.fk form-stdlib/tests/tool-channel-grammar-band.fk form-stdlib/tests/channel-loopback-band.fk form-stdlib/tests/device-heartbeat-band.fk form-stdlib/tests/body-state-band.fk",
       "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-13_tool_channel_surface.json"
     ],
-    "notes": "Focused Form bands pass across Go, Rust, TypeScript, and the Hati fourth arm: tool-channel verdict 255 and tool-channel-grammar verdict 255, each 1 ok, 0 divergent. Prompt guide initially found sibling continuity risk; the repo-provided PROMPT_GATE_SKIP_CONTINUITY=1 path was used after attaching this worktree to a named codex branch. fourth-kernel.form is restored as a compatibility doorway to Hati-OS to heal source-map drift."
+    "notes": "Focused Form bands pass across Go, Rust, TypeScript, and the Hati fourth arm: tool-channel verdict 255 and tool-channel-grammar verdict 255, each 1 ok, 0 divergent. Revalidated after sister rebase with fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables); 1 ok, 0 divergent. Prompt guide initially found sibling continuity risk; the repo-provided PROMPT_GATE_SKIP_CONTINUITY=1 path was used after attaching this worktree to a named codex branch. fourth-kernel.form is restored as a compatibility doorway to Hati-OS to heal source-map drift."
   },
   "ci_validation": {
     "status": "pending",

--- a/experiments/coherence-sense-android/README.md
+++ b/experiments/coherence-sense-android/README.md
@@ -41,8 +41,24 @@ through the kernel, not in Python.
 2. On the phone: Settings → allow installing from your browser/files app ("unknown sources").
 3. Open the APK; install; launch **Coherence Sense**.
 
-Rebuild + re-publish after changes: `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew assembleDebug` then
-`gh release upload coherence-sense-v0 app/build/outputs/apk/debug/app-debug.apk --clobber`.
+From the repository root, rebuild + prove the public asset and mesh handshake after changes:
+
+```bash
+scripts/verify_android_sense_public_handshake.sh
+```
+
+That command builds the debug-signed APK, builds the Hati public asset bundle, starts the Mac witness
+surface, starts a local Hati mesh API, proves announce / heartbeat / list / offer / list, and writes
+`.cache/android-sense-public-handshake/<stamp>/android-sense-public-handshake-summary.json`.
+
+Publish only after the local proof passes:
+
+```bash
+scripts/verify_android_sense_public_handshake.sh --publish
+```
+
+That uploads the macOS package, Android native package, APK, checksums, and asset summary to
+`hati-os-v0.1.0-20260613` with `gh release upload --clobber`.
 
 It's a **debug-signed** build (no Play Store) — fine for trying it on your own device.
 
@@ -83,9 +99,11 @@ When you connect, the app announces itself to `hati.mesh` through the public API
 - `POST /api/hati/mesh/channels/offer` — channel offers to another organ.
 - `GET /api/hati/mesh/channels` — channel/flow rows involving this organ.
 
-The current APK actively streams and measures `sensor:signal` flow. It also declares and displays
-offerable `screen:write`, `audio:pcm16`, and `video:rgba-time` channels; those rates stay `0` until
-permissioned mic/speaker/camera samples are wired as active physical lanes.
+The current APK actively streams and measures `sensor:signal` flow, announces / heartbeats on
+`hati.mesh:presence`, and displays mesh silence as channel data. It declares and displays offerable
+`screen:write`, `audio:pcm16`, `video:rgba-time`, `network:http`, and `bluetooth:presence` channels.
+The mic lane has an active RMS floor when permission is granted; camera/video and speaker output remain
+explicit offered lanes until frame/playback sessions carry active physical samples.
 
 The resource dashboard also makes accelerator floors visible. GPU and DSP/NPU are cataloged lanes,
 but this APK does not yet emit active native compute samples for them. MLX is explicit unsupported

--- a/experiments/coherence-sense-android/app/build.gradle.kts
+++ b/experiments/coherence-sense-android/app/build.gradle.kts
@@ -9,8 +9,8 @@ android {
         applicationId = "com.coherence.sense"
         minSdk = 26
         targetSdk = 34
-        versionCode = 1
-        versionName = "0.1"
+        versionCode = 2
+        versionName = "0.2"
     }
     buildTypes {
         release { isMinifyEnabled = false }

--- a/experiments/coherence-sense-android/app/src/main/AndroidManifest.xml
+++ b/experiments/coherence-sense-android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <application
         android:allowBackup="true"

--- a/experiments/coherence-sense-android/app/src/main/java/com/coherence/sense/MainActivity.kt
+++ b/experiments/coherence-sense-android/app/src/main/java/com/coherence/sense/MainActivity.kt
@@ -7,15 +7,22 @@ package com.coherence.sense
 // this app will load natively). Nothing streams unless you connect; the senses are held until then.
 
 import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioRecord
+import android.media.MediaRecorder
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.location.LocationManager
 import android.net.TrafficStats
+import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.os.Handler
@@ -24,9 +31,11 @@ import android.os.StatFs
 import android.provider.Settings
 import android.text.Editable
 import android.text.TextWatcher
+import android.view.View
 import android.widget.ImageView
 import android.widget.Button
 import android.widget.EditText
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -38,8 +47,11 @@ import org.json.JSONObject
 import java.io.OutputStreamWriter
 import java.net.HttpURLConnection
 import java.net.URL
+import java.net.URLEncoder
 import java.security.MessageDigest
+import java.util.Locale
 import java.util.UUID
+import kotlin.math.sqrt
 
 class MainActivity : AppCompatActivity(), SensorEventListener {
 
@@ -54,6 +66,28 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
     private var innerCellsUpdated = 0L
     private var innerCellsFreed = 0L
     private var flowWindowStarted = System.currentTimeMillis()
+    private var peerCount = 0
+    private var connectedChannelCount = 0
+    private var offeredChannelCount = 0
+    private var bestSharedChannel = "network:http"
+    private var meshState = "not announced"
+    private var lastMacState = "not connected"
+    private var surpriseCount = 0L
+    private var inferenceErrorCount = 0L
+    private var micRms = 0.0
+    private var micSamples = 0L
+    private var audioRecord: AudioRecord? = null
+    @Volatile private var micLoopRunning = false
+    @Volatile private var snapshotInFlight = false
+    @Volatile private var meshRefreshInFlight = false
+    private var dashboardRenderScheduled = false
+    private var resourceCacheAt = 0L
+    private var cachedGpsState = "not-granted"
+    private var cachedDiskState = "unknown"
+    private var cachedNetworkState = "unknown"
+    private var cachedBluetoothState = "unknown"
+    private var cachedSpeakerState = "unknown"
+    private var cachedCameraState = "unknown"
 
     private lateinit var feed: TextView
     private lateinit var status: TextView
@@ -65,6 +99,15 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
     private lateinit var meshField: EditText
     private lateinit var stewardField: EditText
     private lateinit var connectBtn: Button
+    private lateinit var settingsBtn: Button
+    private lateinit var settingsPanel: LinearLayout
+    private lateinit var meshSummary: TextView
+    private lateinit var sensorLane: TextView
+    private lateinit var audioLane: TextView
+    private lateinit var videoLane: TextView
+    private lateinit var networkLane: TextView
+    private lateinit var bluetoothLane: TextView
+    private lateinit var resourceLane: TextView
     private lateinit var organId: String
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -80,17 +123,51 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
         meshField = findViewById(R.id.meshField)
         stewardField = findViewById(R.id.stewardField)
         connectBtn = findViewById(R.id.connectBtn)
+        settingsBtn = findViewById(R.id.settingsBtn)
+        settingsPanel = findViewById(R.id.settingsPanel)
+        meshSummary = findViewById(R.id.meshSummaryView)
+        sensorLane = findViewById(R.id.sensorLaneView)
+        audioLane = findViewById(R.id.audioLaneView)
+        videoLane = findViewById(R.id.videoLaneView)
+        networkLane = findViewById(R.id.networkLaneView)
+        bluetoothLane = findViewById(R.id.bluetoothLaneView)
+        resourceLane = findViewById(R.id.resourceLaneView)
         sm = getSystemService(SENSOR_SERVICE) as SensorManager
         organId = loadOrganId()
-        identity.text = "organ: $organId\nsteward: unbound"
-        renderQr()
+        renderIdentity("local identity ready")
+        renderFirstFrame()
+        handler.post {
+            renderQr()
+            renderDashboard()
+        }
         meshField.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = renderQr()
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                renderQr()
+                renderDashboard()
+            }
             override fun afterTextChanged(s: Editable?) = Unit
         })
-        renderDashboard()
+        stewardField.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = renderIdentity(meshState)
+            override fun afterTextChanged(s: Editable?) = Unit
+        })
         connectBtn.setOnClickListener { toggle() }
+        settingsBtn.setOnClickListener {
+            settingsPanel.visibility = if (settingsPanel.visibility == View.VISIBLE) View.GONE else View.VISIBLE
+        }
+    }
+
+    private fun renderFirstFrame() {
+        meshSummary.text = "state: local identity ready\npresent peers: 0  connected channels: 0  offered: 0\nbest shared carrier: network:http"
+        sensorLane.text = "SENSORS\nfloor visible\nmotion waiting\ngps not-granted"
+        audioLane.text = "AUDIO\nmic offered\nspeaker visible"
+        videoLane.text = "VIDEO\ncamera offered\nscreen QR/write"
+        networkLane.text = "NETWORK\nmesh waiting\nflow 0.00/s"
+        bluetoothLane.text = "BLUETOOTH\ncarrier visible\nBLE heartbeat buildable"
+        resourceLane.text = "BODY STATE\npeers 0\nsamples 0\nfidelity receipt next"
+        dashboard.text = "floor: visible local lanes first; north-star: measured, negotiated sense channels"
     }
 
     private fun loadOrganId(): String {
@@ -111,13 +188,16 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
     private fun toggle() {
         connected = !connected
         if (connected) {
+            flowWindowStarted = System.currentTimeMillis()
             registerSensor(Sensor.TYPE_ACCELEROMETER)
             registerSensor(Sensor.TYPE_GYROSCOPE)
             registerSensor(Sensor.TYPE_LIGHT)
             registerSensor(Sensor.TYPE_MAGNETIC_FIELD)
             requestOptionalPermissions()
-            connectBtn.text = "Pause — hold the senses"
-            status.text = "connecting to ${urlField.text}…"
+            startMicSamplingIfAllowed()
+            connectBtn.text = "Pause sharing"
+            lastMacState = "connecting to ${urlField.text}"
+            status.text = "Sharing senses. Mac lane: $lastMacState"
             announcePresence()
             handler.post(meshLoop)
             handler.post(loop)
@@ -125,20 +205,26 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
             sm.unregisterListener(this)
             handler.removeCallbacks(loop)
             handler.removeCallbacks(meshLoop)
-            connectBtn.text = "Connect + share senses"
-            status.text = "paused — senses held"
+            stopMicSampling()
+            connectBtn.text = "Start sharing"
+            lastMacState = "paused"
+            status.text = "Paused. Senses held."
             innerCellsFreed += 1
             renderDashboard()
         }
     }
 
     private fun requestOptionalPermissions() {
-        val missing = listOf(
+        val permissions = mutableListOf(
             Manifest.permission.ACCESS_COARSE_LOCATION,
             Manifest.permission.ACCESS_FINE_LOCATION,
             Manifest.permission.RECORD_AUDIO,
             Manifest.permission.CAMERA,
-        ).filter { ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED }
+        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            permissions.add(Manifest.permission.BLUETOOTH_CONNECT)
+        }
+        val missing = permissions.filter { ContextCompat.checkSelfPermission(this, it) != PackageManager.PERMISSION_GRANTED }
         if (missing.isNotEmpty()) ActivityCompat.requestPermissions(this, missing.toTypedArray(), 17)
     }
 
@@ -159,6 +245,8 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
     private fun arr(v: FloatArray): JSONArray = JSONArray().apply { put(v[0].toDouble()); put(v[1].toDouble()); put(v[2].toDouble()) }
 
     private fun sendSnapshot() {
+        if (snapshotInFlight) return
+        snapshotInFlight = true
         val base = urlField.text.toString().trim().removeSuffix("/")
         val snap = JSONObject()
         snap.put("organ_id", organId)
@@ -166,6 +254,10 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
         latest[Sensor.TYPE_GYROSCOPE]?.let { snap.put("gyro", arr(it)) }
         latest[Sensor.TYPE_LIGHT]?.let { snap.put("light", it[0].toDouble()) }
         latest[Sensor.TYPE_MAGNETIC_FIELD]?.let { snap.put("mag", arr(it)) }
+        if (micSamples > 0) snap.put("mic_rms", micRms)
+        snap.put("organs_active", JSONArray(activeOrgans()))
+        snap.put("channels_offered", JSONArray(offeredTransports()))
+        snap.put("body_state", bodyStateJson())
         snap.put("tick", tick++)
         innerCellsCreated += 1
 
@@ -188,7 +280,13 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
                 conn.disconnect()
                 runOnUiThread { onReply(code, body, snap) }
             } catch (e: Exception) {
-                runOnUiThread { status.text = "offline — ${e.message}" }
+                runOnUiThread {
+                    lastMacState = "offline — ${e.message}"
+                    status.text = "Mac lane: $lastMacState"
+                    requestDashboardRender()
+                }
+            } finally {
+                snapshotInFlight = false
             }
         }.start()
     }
@@ -219,17 +317,17 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
                     .put("cap.audio.sample")
                     .put("cap.screen.write")
                     .put("cap.http.request")
+                    .put("cap.bluetooth.presence")
+                    .put("cap.network.presence")
                     .put("cap.mesh.presence"),
             )
             .put(
                 "lanes",
-                JSONArray()
-                    .put("sensor:signal")
-                    .put("video:rgba-time")
-                    .put("audio:pcm16")
-                    .put("screen:write")
-                    .put("hati.mesh:presence"),
+                JSONArray(channelLanes()),
             )
+            .put("organs_active", JSONArray(activeOrgans()))
+            .put("channels_offered", JSONArray(offeredTransports()))
+            .put("heartbeat", heartbeatJson())
 
         Thread {
             try {
@@ -247,7 +345,11 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
                 conn.disconnect()
                 runOnUiThread { onAnnounceReply(code, body) }
             } catch (e: Exception) {
-                runOnUiThread { identity.text = "organ: $organId\nmesh: offline — ${e.message}" }
+                runOnUiThread {
+                    meshState = "offline — ${e.message}"
+                    renderIdentity(meshState)
+                    requestDashboardRender()
+                }
             }
         }.start()
     }
@@ -258,6 +360,8 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
     }
 
     private fun refreshMesh() {
+        if (meshRefreshInFlight) return
+        meshRefreshInFlight = true
         val base = meshField.text.toString().trim().removeSuffix("/")
         Thread {
             try {
@@ -273,17 +377,30 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
                 organsConn.disconnect()
                 if (organsCode in 200..299) {
                     val peers = JSONObject(organsBody).optJSONArray("items") ?: JSONArray()
+                    var present = 0
+                    var offered = false
+                    var chosen = "network:http"
                     for (i in 0 until peers.length()) {
                         val peer = peers.optJSONObject(i) ?: continue
                         val peerId = peer.optString("organ_id")
                         if (peerId.isNotBlank() && peerId != organId) {
-                            offerSensorChannel(peerId)
-                            break
+                            present += 1
+                            chosen = chooseBestSharedChannel(peer)
+                            if (!offered) {
+                                offerSensorChannel(peerId, chosen)
+                                offered = true
+                            }
                         }
                     }
+                    peerCount = present
+                    bestSharedChannel = if (present > 0) chosen else "none yet"
+                    meshState = if (present > 0) "mesh present: $present peer(s)" else "mesh quiet: no peers heard"
+                } else {
+                    meshState = "mesh list failed $organsCode"
                 }
 
-                val channelsConn = (URL("$base/hati/mesh/channels?organ_id=$organId&limit=20").openConnection() as HttpURLConnection).apply {
+                val encodedOrgan = URLEncoder.encode(organId, "UTF-8")
+                val channelsConn = (URL("$base/hati/mesh/channels?organ_id=$encodedOrgan&limit=20").openConnection() as HttpURLConnection).apply {
                     requestMethod = "GET"
                     connectTimeout = 5000
                     readTimeout = 5000
@@ -292,9 +409,19 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
                 val channelsBody = (if (channelsCode in 200..299) channelsConn.inputStream else channelsConn.errorStream)
                     ?.bufferedReader()?.readText() ?: ""
                 channelsConn.disconnect()
-                runOnUiThread { renderChannels(channelsCode, channelsBody) }
+                runOnUiThread {
+                    renderIdentity(meshState)
+                    renderChannels(channelsCode, channelsBody)
+                }
             } catch (e: Exception) {
-                runOnUiThread { channels.text = "channels: mesh offline — ${e.message}" }
+                runOnUiThread {
+                    meshState = "mesh offline — ${e.message}"
+                    channels.text = "channels: $meshState"
+                    renderIdentity(meshState)
+                    requestDashboardRender()
+                }
+            } finally {
+                meshRefreshInFlight = false
             }
         }.start()
     }
@@ -318,24 +445,51 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
             .put("offer", "identify-and-open-channel")
             .put("api", meshField.text.toString().trim())
             .toString()
-        try {
-            val matrix = QRCodeWriter().encode(payload, BarcodeFormat.QR_CODE, 320, 320)
-            val bmp = Bitmap.createBitmap(320, 320, Bitmap.Config.ARGB_8888)
-            for (x in 0 until 320) {
-                for (y in 0 until 320) {
-                    bmp.setPixel(x, y, if (matrix[x, y]) Color.BLACK else Color.WHITE)
+        Thread {
+            try {
+                val matrix = QRCodeWriter().encode(payload, BarcodeFormat.QR_CODE, 320, 320)
+                val bmp = Bitmap.createBitmap(320, 320, Bitmap.Config.ARGB_8888)
+                for (x in 0 until 320) {
+                    for (y in 0 until 320) {
+                        bmp.setPixel(x, y, if (matrix[x, y]) Color.BLACK else Color.WHITE)
+                    }
                 }
+                runOnUiThread { qr.setImageBitmap(bmp) }
+            } catch (_: Exception) {
+                runOnUiThread { qr.setImageBitmap(null) }
             }
-            qr.setImageBitmap(bmp)
-        } catch (_: Exception) {
-            qr.setImageBitmap(null)
-        }
+        }.start()
     }
 
     private fun permissionState(permission: String): String =
         if (ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED) "granted" else "not-granted"
 
-    private fun gpsState(): String {
+    private fun requestDashboardRender() {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            handler.post { requestDashboardRender() }
+            return
+        }
+        if (dashboardRenderScheduled) return
+        dashboardRenderScheduled = true
+        handler.postDelayed({
+            dashboardRenderScheduled = false
+            renderDashboard()
+        }, 300)
+    }
+
+    private fun refreshResourceCacheIfStale() {
+        val now = System.currentTimeMillis()
+        if (now - resourceCacheAt < 2000) return
+        resourceCacheAt = now
+        cachedGpsState = readGpsState()
+        cachedDiskState = readDiskState()
+        cachedNetworkState = readNetworkState()
+        cachedBluetoothState = readBluetoothState()
+        cachedSpeakerState = readSpeakerState()
+        cachedCameraState = readCameraState()
+    }
+
+    private fun readGpsState(): String {
         return if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED &&
             ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED
         ) {
@@ -352,7 +506,7 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
         }
     }
 
-    private fun diskState(): String {
+    private fun readDiskState(): String {
         val stat = StatFs(Environment.getDataDirectory().path)
         val freeMb = stat.availableBytes / (1024 * 1024)
         val totalMb = stat.totalBytes / (1024 * 1024)
@@ -366,7 +520,7 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
         return "${usedMb}MB/${maxMb}MB used"
     }
 
-    private fun networkState(): String {
+    private fun readNetworkState(): String {
         val rx = TrafficStats.getTotalRxBytes()
         val tx = TrafficStats.getTotalTxBytes()
         return if (rx == TrafficStats.UNSUPPORTED.toLong() || tx == TrafficStats.UNSUPPORTED.toLong()) {
@@ -376,30 +530,256 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
         }
     }
 
-    private fun renderDashboard() {
-        val (samplesPerSecond, bytesPerSecond) = flowRates()
-        val active = latest.keys.mapNotNull {
+    private fun renderIdentity(meshLine: String) {
+        val steward = stewardInput().ifBlank { "unbound" }
+        identity.text = listOf(
+            "organ: ...${organId.takeLast(24)}",
+            "steward: $steward",
+            "identity: organ id auto; contact opt-in",
+            "mesh: $meshLine",
+        ).joinToString("\n")
+    }
+
+    private fun activeOrgans(): List<String> {
+        val organs = mutableListOf("screen", "network")
+        latest.keys.forEach {
             when (it) {
-                Sensor.TYPE_ACCELEROMETER -> "motion:accelerometer"
-                Sensor.TYPE_GYROSCOPE -> "motion:gyroscope"
-                Sensor.TYPE_LIGHT -> "light"
-                Sensor.TYPE_MAGNETIC_FIELD -> "magnetometer"
-                else -> null
+                Sensor.TYPE_ACCELEROMETER -> organs.add("accelerometer")
+                Sensor.TYPE_GYROSCOPE -> organs.add("gyroscope")
+                Sensor.TYPE_LIGHT -> organs.add("light")
+                Sensor.TYPE_MAGNETIC_FIELD -> organs.add("magnetometer")
             }
-        }.sorted()
+        }
+        if (cachedGpsState.contains(",")) organs.add("gps")
+        if (micSamples > 0) organs.add("mic")
+        return organs.distinct().sorted()
+    }
+
+    private fun offeredTransports(): List<String> {
+        val transports = mutableListOf("wifi", "screen")
+        if (packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) transports.add("ble")
+        if (packageManager.hasSystemFeature(PackageManager.FEATURE_MICROPHONE)) transports.add("audio")
+        if (packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)) transports.add("video")
+        return transports.distinct()
+    }
+
+    private fun channelLanes(): List<String> =
+        listOf(
+            "hati.mesh:presence",
+            "sensor:signal",
+            "audio:pcm16",
+            "video:rgba-time",
+            "screen:write",
+            "network:http",
+            "bluetooth:presence",
+        )
+
+    private fun heartbeatJson(): JSONObject =
+        JSONObject()
+            .put("device", organId)
+            .put("organs", JSONArray(activeOrgans()))
+            .put("channels", JSONArray(offeredTransports()))
+            .put("beat", tick)
+            .put("best_shared", bestSharedChannel)
+
+    private fun bodyStateJson(): JSONObject {
+        val presentPeers = if (connected) peerCount + 1 else 0
+        return JSONObject()
+            .put("organs_active", activeOrgans().size)
+            .put("present_peers", presentPeers)
+            .put("surprise_count", surpriseCount)
+            .put("error_count", inferenceErrorCount)
+            .put("sample_count", sentSamples + micSamples)
+    }
+
+    private fun jsonArrayHas(array: JSONArray?, value: String): Boolean {
+        if (array == null) return false
+        for (i in 0 until array.length()) {
+            if (array.optString(i) == value) return true
+        }
+        return false
+    }
+
+    private fun chooseBestSharedChannel(peer: JSONObject): String {
+        val channels = peer.optJSONArray("channels_offered")
+            ?: peer.optJSONArray("channels")
+            ?: peer.optJSONArray("lanes")
+        val priority = listOf("wifi", "network:http", "ble", "audio", "video", "screen")
+        for (candidate in priority) {
+            if (offeredTransports().contains(candidate) || (candidate == "network:http" && offeredTransports().contains("wifi"))) {
+                if (jsonArrayHas(channels, candidate) || jsonArrayHas(channels, "network:http") || jsonArrayHas(channels, "hati.mesh:presence")) {
+                    return if (candidate == "wifi") "network:http" else candidate
+                }
+            }
+        }
+        return "network:http"
+    }
+
+    private fun readBluetoothState(): String {
+        if (!packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) return "unavailable"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_CONNECT) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return "not-granted"
+        }
+        return try {
+            val manager = getSystemService(BLUETOOTH_SERVICE) as BluetoothManager
+            val adapter: BluetoothAdapter? = manager.adapter
+            when {
+                adapter == null -> "unavailable"
+                adapter.isEnabled -> "enabled"
+                else -> "disabled"
+            }
+        } catch (_: SecurityException) {
+            "not-granted"
+        } catch (_: Exception) {
+            "unavailable"
+        }
+    }
+
+    private fun readSpeakerState(): String {
+        val audio = getSystemService(AUDIO_SERVICE) as AudioManager
+        val output = if (packageManager.hasSystemFeature(PackageManager.FEATURE_AUDIO_OUTPUT)) "output-ready" else "unavailable"
+        return "$output mode=${audio.mode}"
+    }
+
+    private fun readCameraState(): String {
+        val hardware = if (packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)) "available" else "unavailable"
+        return "$hardware / ${permissionState(Manifest.permission.CAMERA)} / offered-not-sampling"
+    }
+
+    private fun micState(): String {
+        val permission = permissionState(Manifest.permission.RECORD_AUDIO)
+        return if (micSamples > 0) {
+            "$permission / rms=${"%.3f".format(Locale.US, micRms)}"
+        } else {
+            "$permission / offered-not-sampling"
+        }
+    }
+
+    private fun startMicSamplingIfAllowed() {
+        if (micLoopRunning) return
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) return
+        val minBuffer = AudioRecord.getMinBufferSize(
+            16000,
+            AudioFormat.CHANNEL_IN_MONO,
+            AudioFormat.ENCODING_PCM_16BIT,
+        )
+        if (minBuffer <= 0) return
+        try {
+            val record = AudioRecord(
+                MediaRecorder.AudioSource.MIC,
+                16000,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                minBuffer,
+            )
+            if (record.state != AudioRecord.STATE_INITIALIZED) {
+                record.release()
+                return
+            }
+            audioRecord = record
+            micLoopRunning = true
+            Thread {
+                val buffer = ShortArray(minBuffer / 2)
+                try {
+                    record.startRecording()
+                    while (micLoopRunning) {
+                        val read = record.read(buffer, 0, buffer.size)
+                        if (read > 0) {
+                            var sum = 0.0
+                            for (i in 0 until read) {
+                                val sample = buffer[i].toDouble() / Short.MAX_VALUE.toDouble()
+                                sum += sample * sample
+                            }
+                            micRms = sqrt(sum / read.toDouble())
+                            micSamples += 1
+                            requestDashboardRender()
+                        }
+                    }
+                } catch (_: Exception) {
+                    micLoopRunning = false
+                } finally {
+                    try {
+                        record.stop()
+                    } catch (_: Exception) {
+                    }
+                    record.release()
+                }
+            }.start()
+        } catch (_: SecurityException) {
+            micLoopRunning = false
+        } catch (_: Exception) {
+            micLoopRunning = false
+        }
+    }
+
+    private fun stopMicSampling() {
+        micLoopRunning = false
+        audioRecord = null
+    }
+
+    private fun renderDashboard() {
+        refreshResourceCacheIfStale()
+        val (samplesPerSecond, bytesPerSecond) = flowRates()
+        val active = activeOrgans()
+        val bodyState = bodyStateJson()
+        val presentPeers = bodyState.optInt("present_peers")
+        meshSummary.text = listOf(
+            "state: $meshState",
+            "present peers: $peerCount  connected channels: $connectedChannelCount  offered: $offeredChannelCount",
+            "best shared carrier: $bestSharedChannel",
+        ).joinToString("\n")
+        sensorLane.text = listOf(
+            "SENSORS",
+            "organs ${active.size}",
+            "motion ${latest.keys.size}/4",
+            "gps $cachedGpsState",
+        ).joinToString("\n")
+        audioLane.text = listOf(
+            "AUDIO",
+            "mic ${micState()}",
+            "speaker $cachedSpeakerState",
+        ).joinToString("\n")
+        videoLane.text = listOf(
+            "VIDEO",
+            "camera $cachedCameraState",
+            "screen QR/write active",
+            "frames offered",
+        ).joinToString("\n")
+        networkLane.text = listOf(
+            "NETWORK",
+            cachedNetworkState,
+            "mesh $meshState",
+            "flow %.2f/s %.0f B/s".format(Locale.US, samplesPerSecond, bytesPerSecond),
+        ).joinToString("\n")
+        bluetoothLane.text = listOf(
+            "BLUETOOTH",
+            cachedBluetoothState,
+            "BLE heartbeat buildable",
+            "carrier visible",
+        ).joinToString("\n")
+        resourceLane.text = listOf(
+            "BODY STATE",
+            "peers $presentPeers",
+            "surprises $surpriseCount",
+            "errors $inferenceErrorCount",
+            "samples ${sentSamples + micSamples}",
+            "fidelity receipt next",
+        ).joinToString("\n")
         dashboard.text = listOf(
-            "floor: active samples are shown; unavailable and not-granted lanes are explicit",
-            "north-star: signed organs negotiate any available sound/video/text/screen/camera/network channel",
+            "floor: active samples, silence, unavailable hardware, and not-granted lanes are visible signals",
+            "north-star: signed organs negotiate wifi, bluetooth, audio, video, screen, sensor, and network channels by heartbeat, then measure fidelity, confidence, and density",
+            "learned from sister work: signals are information, not verdicts; silence is evidence",
+            "sense-organ ripening: current app gathers receipts; complete native hearing/seeing remains a measured challenger, not a claim",
             "sensed: ${if (active.isEmpty()) "none" else active.joinToString(",")}",
-            "gps: ${gpsState()}",
-            "mic: ${permissionState(Manifest.permission.RECORD_AUDIO)} / offered-not-sampling",
-            "camera: ${permissionState(Manifest.permission.CAMERA)} / offered-not-sampling",
-            "screen: active dashboard + QR offer",
-            "disk: ${diskState()}",
-            "network: ${networkState()}",
+            "body-state: organs=${bodyState.optInt("organs_active")} peers=${bodyState.optInt("present_peers")} surprises=${bodyState.optLong("surprise_count")} errors=${bodyState.optLong("error_count")} samples=${bodyState.optLong("sample_count")}",
+            "identity: organ id automatic; phone/email label remains opt-in until Android consent flow is wired",
+            "screen: active dashboard + QR offer; video frames require camera permission and frame session",
+            "disk: $cachedDiskState",
             "pressure: cpu cores=${Runtime.getRuntime().availableProcessors()} ram=${memoryState()} gpu=floor:cataloged dsp=floor:cataloged mlx=unsupported-on-android",
             "cells: created=$innerCellsCreated updated=$innerCellsUpdated freed=$innerCellsFreed",
-            "flow: sensor %.2f samples/s %.0f B/s".format(samplesPerSecond, bytesPerSecond),
+            "flow: sensor %.2f samples/s %.0f B/s".format(Locale.US, samplesPerSecond, bytesPerSecond),
         ).joinToString("\n")
     }
 
@@ -408,7 +788,11 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
         val payload = JSONObject()
             .put("organ_id", organId)
             .put("listening", true)
-            .put("active_channels", JSONArray().put("sensor:signal"))
+            .put("active_channels", JSONArray(channelLanes()))
+            .put("organs_active", JSONArray(activeOrgans()))
+            .put("channels_offered", JSONArray(offeredTransports()))
+            .put("heartbeat", heartbeatJson())
+            .put("body_state", bodyStateJson())
             .put("sample_rate_hz", samplesPerSecond)
             .put("bytes_per_second", bytesPerSecond)
         val conn = (URL("$base/hati/mesh/organs/heartbeat").openConnection() as HttpURLConnection).apply {
@@ -423,17 +807,19 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
         conn.disconnect()
     }
 
-    private fun offerSensorChannel(peerId: String) {
+    private fun offerSensorChannel(peerId: String, bestChannel: String) {
         val base = meshField.text.toString().trim().removeSuffix("/")
         val (samplesPerSecond, bytesPerSecond) = flowRates()
         val payload = JSONObject()
             .put("from_organ_id", organId)
             .put("to_organ_id", peerId)
-            .put("protocol", "sensor:signal")
-            .put("interface", "offer:observe-sensor-field")
-            .put("capability", "cap.sensor.read")
-            .put("codec", "json")
+            .put("protocol", bestChannel)
+            .put("interface", "offer:open-shared-sense-channel")
+            .put("capability", "cap.mesh.presence")
+            .put("codec", "heartbeat+json")
             .put("status", "offered")
+            .put("lanes", JSONArray(channelLanes()))
+            .put("organs_active", JSONArray(activeOrgans()))
             .put("sample_rate_hz", samplesPerSecond)
             .put("bytes_per_second", bytesPerSecond)
         try {
@@ -447,6 +833,7 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
             OutputStreamWriter(conn.outputStream).use { it.write(payload.toString()) }
             conn.responseCode
             conn.disconnect()
+            offeredChannelCount += 1
         } catch (_: Exception) {
             // The next mesh refresh will show offline state.
         }
@@ -455,23 +842,34 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
     private fun renderChannels(code: Int, body: String) {
         val (samplesPerSecond, bytesPerSecond) = flowRates()
         if (code !in 200..299) {
-            channels.text = "channels: list failed $code\nsensor flow: %.2f samples/s, %.0f B/s".format(samplesPerSecond, bytesPerSecond)
+            channels.text = "channels: list failed $code\nsilence is signal; local lanes remain offered\nsensor flow: %.2f samples/s, %.0f B/s".format(samplesPerSecond, bytesPerSecond)
+            requestDashboardRender()
             return
         }
         val rows = JSONObject(body).optJSONArray("items") ?: JSONArray()
-        val lines = mutableListOf("open local flow: sensor:signal %.2f samples/s %.0f B/s".format(samplesPerSecond, bytesPerSecond))
+        var connectedRows = 0
+        val lines = mutableListOf(
+            "local heartbeat: ${activeOrgans().size} organ(s), ${channelLanes().size} lane(s)",
+            "best shared carrier: $bestSharedChannel",
+            "local flow: %.2f samples/s %.0f B/s".format(samplesPerSecond, bytesPerSecond),
+        )
         for (i in 0 until rows.length().coerceAtMost(4)) {
             val row = rows.optJSONObject(i) ?: continue
-                lines.add("${row.optString("status")} ${row.optString("protocol")} -> ${row.optString("to_organ_id").takeLast(8)} ${row.optDouble("bytes_per_second", 0.0).toInt()} B/s")
+            val status = row.optString("status", "unknown")
+            if (status == "connected" || status == "open" || status == "accepted") connectedRows += 1
+            lines.add("${status} ${row.optString("protocol", "unknown")} -> ${row.optString("to_organ_id").takeLast(8)} ${row.optDouble("bytes_per_second", 0.0).toInt()} B/s")
         }
-        lines.add("offerable: screen:write audio:pcm16 video:rgba-time")
+        connectedChannelCount = connectedRows
+        lines.add("offerable: sensor:signal audio:pcm16 video:rgba-time screen:write bluetooth:presence")
         channels.text = lines.joinToString("\n")
-        renderDashboard()
+        requestDashboardRender()
     }
 
     private fun onAnnounceReply(code: Int, body: String) {
         if (code !in 200..299) {
-            identity.text = "organ: $organId\nmesh: announce failed $code"
+            meshState = "announce failed $code"
+            renderIdentity(meshState)
+            requestDashboardRender()
             return
         }
         try {
@@ -479,36 +877,57 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
             val receipt = r.optJSONObject("receipt")
             val receiptId = receipt?.optString("runtime_event_id", "no-receipt") ?: "no-receipt"
             val steward = r.optJSONObject("identity")?.optString("steward_cell_id", "unbound") ?: "unbound"
-            identity.text = "organ: $organId\nsteward: $steward\nmesh receipt: $receiptId"
+            meshState = "announced; receipt ${receiptId.takeLast(10)}"
+            renderIdentity("$meshState\nsteward: $steward")
         } catch (e: Exception) {
-            identity.text = "organ: $organId\nmesh: announced"
+            meshState = "announced"
+            renderIdentity(meshState)
         }
+        requestDashboardRender()
     }
 
     private fun onReply(code: Int, body: String, snap: JSONObject) {
-        if (code !in 200..299) { status.text = "Mac replied $code"; return }
+        if (code !in 200..299) {
+            lastMacState = "Mac replied $code"
+            status.text = lastMacState
+            inferenceErrorCount += 1
+            requestDashboardRender()
+            return
+        }
         try {
             val r = JSONObject(body)
             val recog = r.optString("recognized", "—")
             val pred = r.optString("predicted", "—")
             val witnessed = r.optInt("witnessed", -1)
-            status.text = "synced ✓  witnessed $witnessed frames"
+            lastMacState = "synced; witnessed $witnessed frame(s)"
+            status.text = "Sharing senses. $lastMacState"
             val senses = mutableListOf<String>()
             if (snap.has("accel")) senses.add("accel")
             if (snap.has("gyro")) senses.add("gyro")
             if (snap.has("light")) senses.add("light")
             if (snap.has("mag")) senses.add("mag")
-            val line = "▸ ${snap.optInt("tick")}  senses[${senses.joinToString(",")}]  field:$recog  next:$pred\n"
-            feed.text = (line + feed.text).take(6000)
+            if (recog == "novel" || recog == "—") surpriseCount += 1
+            val line = "tick ${snap.optInt("tick")}  senses[${senses.joinToString(",")}]  field:$recog  next:$pred\n"
+            val current = if (feed.text.toString() == "recent witness: none") "" else feed.text.toString()
+            feed.text = (line + current).take(6000)
         } catch (e: Exception) {
-            status.text = "synced — ${body.take(80)}"
+            lastMacState = "synced — ${body.take(80)}"
+            status.text = lastMacState
         }
+        requestDashboardRender()
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == 17 && connected) startMicSamplingIfAllowed()
+        resourceCacheAt = 0L
+        requestDashboardRender()
     }
 
     override fun onSensorChanged(e: SensorEvent) {
         latest[e.sensor.type] = e.values.clone()
         innerCellsUpdated += 1
-        renderDashboard()
+        requestDashboardRender()
     }
     override fun onAccuracyChanged(s: Sensor?, accuracy: Int) {}
 
@@ -516,5 +935,7 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
         super.onPause()
         sm.unregisterListener(this)
         handler.removeCallbacks(loop)
+        handler.removeCallbacks(meshLoop)
+        stopMicSampling()
     }
 }

--- a/experiments/coherence-sense-android/app/src/main/res/drawable/bg_app.xml
+++ b/experiments/coherence-sense-android/app/src/main/res/drawable/bg_app.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#EDF4F1" />
+</shape>

--- a/experiments/coherence-sense-android/app/src/main/res/drawable/bg_hero.xml
+++ b/experiments/coherence-sense-android/app/src/main/res/drawable/bg_hero.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="8dp" />
+    <gradient
+        android:angle="135"
+        android:endColor="#223B43"
+        android:startColor="#132321" />
+</shape>

--- a/experiments/coherence-sense-android/app/src/main/res/drawable/bg_lane.xml
+++ b/experiments/coherence-sense-android/app/src/main/res/drawable/bg_lane.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#FBFEFC" />
+    <stroke
+        android:width="1dp"
+        android:color="#CAD9D3" />
+    <corners android:radius="8dp" />
+</shape>

--- a/experiments/coherence-sense-android/app/src/main/res/drawable/bg_panel.xml
+++ b/experiments/coherence-sense-android/app/src/main/res/drawable/bg_panel.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#FFFFFF" />
+    <stroke
+        android:width="1dp"
+        android:color="#D6E2DD" />
+    <corners android:radius="8dp" />
+</shape>

--- a/experiments/coherence-sense-android/app/src/main/res/drawable/bg_status.xml
+++ b/experiments/coherence-sense-android/app/src/main/res/drawable/bg_status.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#2E4B49" />
+    <corners android:radius="8dp" />
+</shape>

--- a/experiments/coherence-sense-android/app/src/main/res/layout/activity_main.xml
+++ b/experiments/coherence-sense-android/app/src/main/res/layout/activity_main.xml
@@ -2,129 +2,322 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@drawable/bg_app"
     android:fillViewport="true">
 
     <LinearLayout
-        android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp">
+        android:orientation="vertical"
+        android:padding="18dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_hero"
+            android:elevation="2dp"
+            android:orientation="vertical"
+            android:padding="18dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:letterSpacing="0"
+                android:text="HATI MESH ORGAN"
+                android:textColor="#9AD6CA"
+                android:textSize="11sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:letterSpacing="0"
+                android:text="Coherence Sense"
+                android:textColor="#F8FAF8"
+                android:textSize="28sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/statusView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:background="@drawable/bg_status"
+                android:padding="12dp"
+                android:text="Ready. Senses held."
+                android:textColor="#E8F2ED"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/connectBtn"
+                    android:layout_width="0dp"
+                    android:layout_height="52dp"
+                    android:layout_marginEnd="10dp"
+                    android:layout_weight="1"
+                    android:text="Start sharing" />
+
+                <Button
+                    android:id="@+id/settingsBtn"
+                    android:layout_width="112dp"
+                    android:layout_height="52dp"
+                    android:text="Settings" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/settingsPanel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_panel"
+            android:orientation="vertical"
+            android:padding="16dp"
+            android:visibility="gone">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Connection"
+                android:textColor="#1F2C2A"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="Mac witness URL"
+                android:textColor="#53615D"
+                android:textStyle="bold" />
+
+            <EditText
+                android:id="@+id/urlField"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:contentDescription="Mac witness URL"
+                android:hint="http://MAC-IP:8800"
+                android:inputType="textUri"
+                android:text="http://192.168.1.10:8800" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="Hati mesh API"
+                android:textColor="#53615D"
+                android:textStyle="bold" />
+
+            <EditText
+                android:id="@+id/meshField"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:contentDescription="Hati mesh API URL"
+                android:hint="https://api.coherencycoin.com/api"
+                android:inputType="textUri"
+                android:text="https://api.coherencycoin.com/api" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:text="Identity label"
+                android:textColor="#53615D"
+                android:textStyle="bold" />
+
+            <EditText
+                android:id="@+id/stewardField"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:contentDescription="Optional cell id or email identity label"
+                android:hint="cell id or email, opt-in"
+                android:inputType="textEmailAddress" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_panel"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Mesh"
+                android:textColor="#1F2C2A"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/meshSummaryView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:fontFamily="monospace"
+                android:text="mesh: waiting"
+                android:textColor="#4D5A56"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/identityView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:fontFamily="monospace"
+                android:text="organ identity not announced"
+                android:textColor="#4D5A56"
+                android:textSize="12sp" />
+
+            <ImageView
+                android:id="@+id/qrView"
+                android:layout_width="176dp"
+                android:layout_height="176dp"
+                android:layout_marginTop="14dp"
+                android:background="#FFFFFF"
+                android:contentDescription="organ identity QR"
+                android:padding="8dp" />
+        </LinearLayout>
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Coherence Sense"
-            android:textSize="22sp"
-            android:textStyle="bold"
-            android:paddingBottom="4dp" />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="this phone becomes a sense organ of the network — its senses stream to the Mac, which witnesses and shares the field back."
-            android:textSize="12sp"
-            android:paddingBottom="12dp" />
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Mac witness URL"
+            android:layout_marginTop="18dp"
+            android:text="Channels"
+            android:textColor="#1F2C2A"
+            android:textSize="18sp"
             android:textStyle="bold" />
 
-        <EditText
-            android:id="@+id/urlField"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:contentDescription="Mac witness URL"
-            android:hint="http://MAC-IP:8800"
-            android:inputType="textUri"
-            android:text="http://192.168.1.10:8800" />
+            android:layout_marginTop="8dp"
+            android:orientation="horizontal">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Hati mesh API"
-            android:textStyle="bold"
-            android:paddingTop="8dp" />
+            <TextView
+                android:id="@+id/sensorLaneView"
+                android:layout_width="0dp"
+                android:layout_height="118dp"
+                android:layout_marginEnd="6dp"
+                android:layout_weight="1"
+                android:background="@drawable/bg_lane"
+                android:padding="12dp"
+                android:textColor="#24302D"
+                android:textSize="12sp" />
 
-        <EditText
-            android:id="@+id/meshField"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:contentDescription="Hati mesh API URL"
-            android:hint="https://api.coherencycoin.com/api"
-            android:inputType="textUri"
-            android:text="https://api.coherencycoin.com/api" />
+            <TextView
+                android:id="@+id/audioLaneView"
+                android:layout_width="0dp"
+                android:layout_height="118dp"
+                android:layout_marginStart="6dp"
+                android:layout_weight="1"
+                android:background="@drawable/bg_lane"
+                android:padding="12dp"
+                android:textColor="#24302D"
+                android:textSize="12sp" />
+        </LinearLayout>
 
-        <TextView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Identity label"
-            android:textStyle="bold"
-            android:paddingTop="8dp" />
+            android:layout_marginTop="12dp"
+            android:orientation="horizontal">
 
-        <EditText
-            android:id="@+id/stewardField"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:contentDescription="Optional cell id or email identity label"
-            android:hint="your cell id or email (optional)"
-            android:inputType="textEmailAddress" />
+            <TextView
+                android:id="@+id/videoLaneView"
+                android:layout_width="0dp"
+                android:layout_height="118dp"
+                android:layout_marginEnd="6dp"
+                android:layout_weight="1"
+                android:background="@drawable/bg_lane"
+                android:padding="12dp"
+                android:textColor="#24302D"
+                android:textSize="12sp" />
 
-        <Button
-            android:id="@+id/connectBtn"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Connect + share senses" />
+            <TextView
+                android:id="@+id/networkLaneView"
+                android:layout_width="0dp"
+                android:layout_height="118dp"
+                android:layout_marginStart="6dp"
+                android:layout_weight="1"
+                android:background="@drawable/bg_lane"
+                android:padding="12dp"
+                android:textColor="#24302D"
+                android:textSize="12sp" />
+        </LinearLayout>
 
-        <TextView
-            android:id="@+id/statusView"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="not connected — senses held"
-            android:textStyle="bold"
-            android:paddingTop="10dp"
-            android:paddingBottom="10dp" />
+            android:layout_marginTop="12dp"
+            android:orientation="horizontal">
 
-        <TextView
-            android:id="@+id/identityView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="organ identity not announced"
-            android:textSize="11sp"
-            android:fontFamily="monospace"
-            android:paddingBottom="8dp" />
+            <TextView
+                android:id="@+id/bluetoothLaneView"
+                android:layout_width="0dp"
+                android:layout_height="118dp"
+                android:layout_marginEnd="6dp"
+                android:layout_weight="1"
+                android:background="@drawable/bg_lane"
+                android:padding="12dp"
+                android:textColor="#24302D"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/resourceLaneView"
+                android:layout_width="0dp"
+                android:layout_height="118dp"
+                android:layout_marginStart="6dp"
+                android:layout_weight="1"
+                android:background="@drawable/bg_lane"
+                android:padding="12dp"
+                android:textColor="#24302D"
+                android:textSize="12sp" />
+        </LinearLayout>
 
         <TextView
             android:id="@+id/channelsView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="channels: none open"
-            android:textSize="11sp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_panel"
             android:fontFamily="monospace"
-            android:paddingBottom="8dp" />
-
-        <ImageView
-            android:id="@+id/qrView"
-            android:layout_width="160dp"
-            android:layout_height="160dp"
-            android:contentDescription="organ identity QR"
-            android:paddingBottom="8dp" />
+            android:padding="14dp"
+            android:text="channels: none open"
+            android:textColor="#4D5A56"
+            android:textSize="12sp" />
 
         <TextView
             android:id="@+id/dashboardView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="dashboard: not listening"
-            android:textSize="11sp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_panel"
             android:fontFamily="monospace"
-            android:paddingBottom="8dp" />
+            android:padding="14dp"
+            android:text="resource details: waiting"
+            android:textColor="#4D5A56"
+            android:textSize="12sp" />
 
         <TextView
             android:id="@+id/feedView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_panel"
             android:fontFamily="monospace"
-            android:textSize="11sp" />
+            android:minHeight="90dp"
+            android:padding="14dp"
+            android:text="recent witness: none"
+            android:textColor="#4D5A56"
+            android:textSize="12sp" />
     </LinearLayout>
 </ScrollView>

--- a/experiments/coherence-sense-android/mac-witness-server.py
+++ b/experiments/coherence-sense-android/mac-witness-server.py
@@ -18,9 +18,10 @@ Point the phone app at:         http://<this-mac-LAN-IP>:8800   (ipconfig getifa
 """
 import json
 import time
+from argparse import ArgumentParser
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-PORT = 8800
+DEFAULT_PORT = 8800
 ORGAN_KEYS = ("accel", "gyro", "light", "mag")
 STALE_SECONDS = 4.0          # no frame in this long -> the body went quiet (a liveness event)
 
@@ -149,12 +150,19 @@ setInterval(tick,800); tick();
 </script></body></html>"""
 
 
-if __name__ == "__main__":
-    srv = ThreadingHTTPServer(("0.0.0.0", PORT), Witness)
-    print(f"Coherence Sense — Mac witness + dashboard on 0.0.0.0:{PORT}")
-    print(f"  open the dashboard:  http://localhost:{PORT}")
-    print(f"  point the phone at:  http://<this-mac-LAN-IP>:{PORT}   (ipconfig getifaddr en0)")
+def main():
+    parser = ArgumentParser(description="Run the Coherence Sense Mac witness server.")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    args = parser.parse_args()
+    srv = ThreadingHTTPServer(("0.0.0.0", args.port), Witness)
+    print(f"Coherence Sense — Mac witness + dashboard on 0.0.0.0:{args.port}")
+    print(f"  open the dashboard:  http://localhost:{args.port}")
+    print(f"  point the phone at:  http://<this-mac-LAN-IP>:{args.port}   (ipconfig getifaddr en0)")
     try:
         srv.serve_forever()
     except KeyboardInterrupt:
         print(f"\nwitnessed {state['frames']} frames; last organs: {state['organs']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_commit_evidence.py
+++ b/scripts/validate_commit_evidence.py
@@ -19,6 +19,7 @@ RUNTIME_PATH_PREFIXES = (
     "web/components/",
     "web/lib/",
     "form/",
+    "experiments/coherence-sense-android/",
     "deploy/front-door/",
     "deploy/kernel-router/",
     "Dockerfile.kernel-router",

--- a/scripts/verify_android_sense_public_handshake.sh
+++ b/scripts/verify_android_sense_public_handshake.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Build Coherence Sense public assets and prove the local Mac witness + Hati mesh handshake.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STAMP="${ANDROID_SENSE_PROOF_STAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
+OUT="$ROOT/.cache/android-sense-public-handshake/$STAMP"
+ANDROID_DIR="$ROOT/experiments/coherence-sense-android"
+APK="$ANDROID_DIR/app/build/outputs/apk/debug/app-debug.apk"
+ASSET_OUT="$ROOT/.cache/hati-os-public-assets/$STAMP"
+ASSET_SUMMARY="$ASSET_OUT/hati-os-public-assets-summary.json"
+API_HOST="${ANDROID_SENSE_API_HOST:-127.0.0.1}"
+RELEASE_TAG="${HATI_OS_RELEASE_TAG:-hati-os-v0.1.0-20260613}"
+PUBLISH=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --publish) PUBLISH=1 ;;
+        *) echo "usage: $0 [--publish]" >&2; exit 2 ;;
+    esac
+done
+
+need() {
+    command -v "$1" >/dev/null || { echo "FAIL missing required command: $1" >&2; exit 1; }
+}
+
+wait_url() {
+    local url="$1"
+    local name="$2"
+    for _ in $(seq 1 80); do
+        if curl -fsS "$url" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.25
+    done
+    echo "FAIL $name did not become ready at $url" >&2
+    return 1
+}
+
+post_json() {
+    local url="$1"
+    local body="$2"
+    local out="$3"
+    curl -fsS -X POST "$url" -H "Content-Type: application/json" -d "$body" > "$out"
+}
+
+cleanup() {
+    if [[ -n "${WITNESS_PID:-}" ]]; then kill "$WITNESS_PID" >/dev/null 2>&1 || true; fi
+    if [[ -n "${API_PID:-}" ]]; then kill "$API_PID" >/dev/null 2>&1 || true; fi
+}
+trap cleanup EXIT
+
+need curl
+need python3
+need shasum
+need zstd
+if [[ "$PUBLISH" == "1" ]]; then need gh; fi
+
+pick_free_port() {
+    python3 - <<'PY'
+import socket
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.bind(("127.0.0.1", 0))
+    print(s.getsockname()[1])
+PY
+}
+
+API_PORT="${ANDROID_SENSE_API_PORT:-$(pick_free_port)}"
+WITNESS_PORT="${ANDROID_SENSE_WITNESS_PORT:-$(pick_free_port)}"
+API_URL="http://$API_HOST:$API_PORT/api"
+WITNESS_URL="http://127.0.0.1:$WITNESS_PORT"
+
+mkdir -p "$OUT"
+
+echo "== build Android APK =="
+(cd "$ANDROID_DIR" && JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk@21}" ./gradlew :app:assembleDebug)
+[[ -f "$APK" ]] || { echo "FAIL APK not found at $APK" >&2; exit 1; }
+APK_SHA="$(shasum -a 256 "$APK" | awk '{print $1}')"
+
+echo "== build Hati public asset bundle =="
+HATI_OS_ASSET_STAMP="$STAMP" "$ROOT/scripts/build_hati_os_public_assets.sh" > "$OUT/hati-assets.log"
+[[ -f "$ASSET_SUMMARY" ]] || { echo "FAIL asset summary not found at $ASSET_SUMMARY" >&2; exit 1; }
+
+echo "== start Mac witness =="
+python3 "$ANDROID_DIR/mac-witness-server.py" --port "$WITNESS_PORT" > "$OUT/mac-witness.log" 2>&1 &
+WITNESS_PID=$!
+wait_url "$WITNESS_URL/state" "Mac witness"
+
+echo "== prove Mac witness /sense =="
+post_json "$WITNESS_URL/sense" '{
+  "organ_id":"hati-organ-android-local-proof",
+  "accel":[0.10,0.20,9.80],
+  "gyro":[0.01,0.02,0.03],
+  "light":42.0,
+  "mag":[1.0,2.0,3.0],
+  "organs_active":["accelerometer","gyroscope","light","magnetometer","screen","network"],
+  "channels_offered":["wifi","screen","audio","video","ble"],
+  "tick":1
+}' "$OUT/mac-witness-sense.json"
+curl -fsS "$WITNESS_URL/state" > "$OUT/mac-witness-state.json"
+
+echo "== start local Hati mesh API =="
+API_PY="$ROOT/api/.venv/bin/python"
+if [[ ! -x "$API_PY" ]]; then API_PY="python3"; fi
+(cd "$ROOT/api" && "$API_PY" -m uvicorn app.main:app --host "$API_HOST" --port "$API_PORT") > "$OUT/api.log" 2>&1 &
+API_PID=$!
+wait_url "$API_URL/hati/mesh/organs?limit=1" "Hati mesh API"
+
+echo "== prove mesh announce/heartbeat/list/offer/list =="
+ANDROID_ID="hati-organ-android-local-proof"
+MAC_ID="hati-organ-macos-local-proof"
+post_json "$API_URL/hati/mesh/organs/announce" "{
+  \"organ_id\":\"$MAC_ID\",
+  \"organ_kind\":\"host-kernel\",
+  \"app\":\"hati-os\",
+  \"app_version\":\"0.2\",
+  \"target\":\"macos-arm64\",
+  \"capabilities\":[\"cap.mesh.presence\",\"cap.sensor.read\",\"cap.screen.write\"],
+  \"lanes\":[\"hati.mesh:presence\",\"sensor:signal\",\"screen:write\",\"network:http\"]
+}" "$OUT/mesh-announce-mac.json"
+post_json "$API_URL/hati/mesh/organs/announce" "{
+  \"organ_id\":\"$ANDROID_ID\",
+  \"organ_kind\":\"android-phone\",
+  \"app\":\"coherence-sense\",
+  \"app_version\":\"0.2\",
+  \"target\":\"android-arm64\",
+  \"capabilities\":[\"cap.mesh.presence\",\"cap.sensor.read\",\"cap.audio.sample\",\"cap.video.frame\",\"cap.screen.write\",\"cap.bluetooth.presence\",\"cap.network.presence\"],
+  \"lanes\":[\"hati.mesh:presence\",\"sensor:signal\",\"audio:pcm16\",\"video:rgba-time\",\"screen:write\",\"network:http\",\"bluetooth:presence\"]
+}" "$OUT/mesh-announce-android.json"
+post_json "$API_URL/hati/mesh/organs/heartbeat" "{
+  \"organ_id\":\"$ANDROID_ID\",
+  \"listening\":true,
+  \"active_channels\":[\"hati.mesh:presence\",\"sensor:signal\",\"screen:write\",\"network:http\"],
+  \"sample_rate_hz\":1.0,
+  \"bytes_per_second\":320.0
+}" "$OUT/mesh-heartbeat-android.json"
+curl -fsS "$API_URL/hati/mesh/organs?limit=10" > "$OUT/mesh-organs.json"
+post_json "$API_URL/hati/mesh/channels/offer" "{
+  \"from_organ_id\":\"$ANDROID_ID\",
+  \"to_organ_id\":\"$MAC_ID\",
+  \"protocol\":\"sensor:signal\",
+  \"interface\":\"offer:observe-sensor-field\",
+  \"capability\":\"cap.sensor.read\",
+  \"codec\":\"json\",
+  \"status\":\"offered\",
+  \"sample_rate_hz\":1.0,
+  \"bytes_per_second\":320.0
+}" "$OUT/mesh-offer.json"
+curl -fsS "$API_URL/hati/mesh/channels?organ_id=$ANDROID_ID&limit=10" > "$OUT/mesh-channels.json"
+
+python3 - "$OUT" "$APK_SHA" "$ASSET_SUMMARY" <<'PY'
+import json
+import pathlib
+import sys
+
+out = pathlib.Path(sys.argv[1])
+apk_sha = sys.argv[2]
+asset_summary_path = pathlib.Path(sys.argv[3])
+
+def load(name):
+    return json.loads((out / name).read_text(encoding="utf-8"))
+
+witness = load("mac-witness-state.json")
+organs = load("mesh-organs.json")
+channels = load("mesh-channels.json")
+announce_android = load("mesh-announce-android.json")
+heartbeat_android = load("mesh-heartbeat-android.json")
+asset_summary = json.loads(asset_summary_path.read_text(encoding="utf-8"))
+
+assert witness["frames"] >= 1, "Mac witness did not record a frame"
+assert witness["present"] is True, "Mac witness did not mark organ present"
+assert "accel" in witness["latest"], "Mac witness did not retain accel sample"
+
+ids = {item.get("organ_id") for item in organs.get("items", [])}
+assert "hati-organ-android-local-proof" in ids, "Android organ missing from mesh list"
+assert "hati-organ-macos-local-proof" in ids, "Mac organ missing from mesh list"
+
+assert announce_android["receipt"]["runtime_event_id"], "Android announce missing receipt"
+assert heartbeat_android["receipt"]["runtime_event_id"], "Android heartbeat missing receipt"
+assert any(row.get("protocol") == "sensor:signal" for row in channels.get("items", [])), "sensor channel offer missing"
+
+assets = {item["name"]: item for item in asset_summary["assets"]}
+assert assets["hati-os-macos-arm64.tar.zst"]["status"] == "pass", "macOS asset did not pass"
+assert assets["hati-os-android-arm64.tar.zst"]["status"] == "pass", "Android native asset did not pass"
+assert assets["coherence-sense-hati-mesh-debug.apk"]["status"] == "pass", "APK asset did not pass"
+
+summary = {
+    "status": "pass",
+    "apk_sha256": apk_sha,
+    "asset_summary": str(asset_summary_path),
+    "mesh": {
+        "organs_count": organs.get("count"),
+        "channels_count": channels.get("count"),
+        "android_announce_receipt": announce_android["receipt"]["runtime_event_id"],
+        "android_heartbeat_receipt": heartbeat_android["receipt"]["runtime_event_id"],
+    },
+    "mac_witness": {
+        "frames": witness["frames"],
+        "present": witness["present"],
+        "organs": witness["organs"],
+    },
+    "assets": asset_summary["assets"],
+}
+(out / "android-sense-public-handshake-summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+print(json.dumps(summary, indent=2))
+PY
+
+if [[ "$PUBLISH" == "1" ]]; then
+    echo "== publish assets to GitHub release $RELEASE_TAG =="
+    gh release upload "$RELEASE_TAG" \
+        "$ASSET_OUT/hati-os-macos-arm64.tar.zst" \
+        "$ASSET_OUT/hati-os-macos-arm64.tar.zst.sha256" \
+        "$ASSET_OUT/hati-os-android-arm64.tar.zst" \
+        "$ASSET_OUT/hati-os-android-arm64.tar.zst.sha256" \
+        "$ASSET_OUT/coherence-sense-hati-mesh-debug.apk" \
+        "$ASSET_OUT/coherence-sense-hati-mesh-debug.apk.sha256" \
+        "$ASSET_SUMMARY" \
+        --clobber
+fi
+
+echo "PASS android sense public handshake proof: $OUT/android-sense-public-handshake-summary.json"


### PR DESCRIPTION
## Summary
- upgrade the Android Coherence Sense app into a high-fidelity Hati mesh sensing organ dashboard with explicit identity, channel offers, resource pressure, QR, and floor/north-star surface
- add a local public-handshake harness that builds the APK/assets, proves Mac witness sense/state, proves Hati mesh announce/heartbeat/list/channel offer, and optionally publishes release assets
- add Hostinger deploy normalization for hati.earth/sense/suci Traefik web routes so the public Hati download lane can serve the published macOS and Android assets

## Proof
- make prompt-guide
- make wellness
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/hati-mesh.fk form-stdlib/tests/hati-mesh-band.fk
- bash -n deploy/hostinger/auto-deploy.sh scripts/verify_android_sense_public_handshake.sh
- scripts/verify_android_sense_public_handshake.sh
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-13_android_sense_channel_surface.json
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main

## Public assets
- GitHub release hati-os-v0.1.0-20260613 has verified APK, Android arm64 tarball, macOS arm64 tarball, checksums, and summary.
- coherencycoin.com/downloads/hati-os routes return 307 to GitHub and final 200 for APK, Android tarball, macOS tarball, and summary.
- hati.earth needs this Hostinger deploy patch to normalize Traefik labels before final domain proof.