### PR TITLE
Complete IEEE float support in the native kernels (TS abs/pow); map the fourth-arm gap

### DIFF
--- a/form/form-kernel-ts/src/kernel.ts
+++ b/form/form-kernel-ts/src/kernel.ts
@@ -1441,8 +1441,10 @@ export class Kernel {
     // (pow base exp) → base**exp. Negative exponents return 0 (Python's
     // int**-n is a float; floats on this path are a later breath).
     this.registerNative("pow", catMethod(), (_k, args) => {
-      const base = argInt(args, 0);
-      const exp = argInt(args, 1);
+      // integer power; float args coerce to int (truncate) to match Go/Rust
+      // AsInt() — pow is the integer power, math_pow the IEEE float power.
+      const base = Math.trunc(argFloat(args, 0));
+      const exp = Math.trunc(argFloat(args, 1));
       if (exp < 0) return { kind: "int", int: 0 };
       let result = 1;
       for (let i = 0; i < exp; i++) result *= base;
@@ -2074,6 +2076,13 @@ export class Kernel {
       return { kind: "int", int: 0 };
     });
     this.registerNative("abs", catMethod(), (_k, args) => {
+      // abs preserves type — float in, float out; int in, int out — sibling-parity
+      // with Go (VFloat -> math.Abs) and Rust (Value::Float(f) -> f.abs()). IEEE
+      // float abs is core, not a special case routed around.
+      const v = args[0];
+      if (v?.kind === "f64" || v?.kind === "f32") {
+        return { kind: "f64", float: Math.abs(v.float) };
+      }
       const n = argInt(args, 0);
       return { kind: "int", int: n < 0 ? -n : n };
     });

--- a/form/form-stdlib/tests/ieee-float-ops-band.fk
+++ b/form/form-stdlib/tests/ieee-float-ops-band.fk
@@ -1,0 +1,36 @@
+; tests/ieee-float-ops-band.fk — the IEEE float-op surface across the native kernels.
+;
+; Float support is core, not a special case to route around. This pins the float ops —
+; the rounding family, the transcendentals (sqrt/exp/log), float arithmetic, compare,
+; and remainder — so any recipe may reach for them. Proven three-way on Go/Rust/TS.
+;
+; FOURTH-ARM STATUS (named, not hidden): the emitted walker fkwu does not yet carry a
+; float-op band — it returns 0 wholesale on this one. Two reasons, both real: (1) the
+; flatten tag space is full (form-flatten.fk uses tags 0..99; fkc-arm-slots = 100), so
+; abs and math_pow have no tag at all; (2) the walker bails on the float-heavy band even
+; for already-tagged ops, a structural gap above the per-op tags. Completing the fourth
+; arm — expanding the dispatch slot count, adding abs/math_pow dispatch in
+; hati-os-kernel-emit.fk, and resolving the walker's float-band handling — is the named
+; next row. Kept 3-kernel-only with the blocker named (the AUTHORING convention) rather
+; than registered red.
+;
+; Verdict 1111111 (127) when every claim holds across Go/Rust/TS.
+;   floor: 3.7->3, -2.3->-3                                       -> 1
+;   ceil: 3.2->4, -2.7->-2                                        -> 10
+;   trunc: -3.7->-3, 3.7->3                                       -> 100
+;   round half-away-from-zero: 2.5->3, -2.5->-3                   -> 1000
+;   abs preserves type: |-4.2|->4.2 (x10=42), |-7 int|->7        -> 10000
+;   sqrt/exp/log: sqrt2 (x1000)=1414, e (x1000)=2718, ln(e^5)=5  -> 100000
+;   float div/mod/compare/pow: 22/7 (x100)=314, 7 mod 3=1, 2^10  -> 1000000
+;
+; preludes: form-stdlib/core.fk
+;
+(do
+    (let floor-ok (if (eq (round (floor 3.7)) 3) (if (eq (round (floor (sub 0.0 2.3))) -3) 1 0) 0))
+    (let ceil-ok  (if (eq (round (ceil 3.2)) 4) (if (eq (round (ceil (sub 0.0 2.7))) -2) 10 0) 0))
+    (let trunc-ok (if (eq (round (trunc (sub 0.0 3.7))) -3) (if (eq (round (trunc 3.7)) 3) 100 0) 0))
+    (let round-ok (if (eq (round 2.5) 3) (if (eq (round (sub 0.0 2.5)) -3) 1000 0) 0))
+    (let abs-ok   (if (eq (round (mul 10.0 (abs (sub 0.0 4.2)))) 42) (if (eq (round (abs (sub 0 7))) 7) 10000 0) 0))
+    (let trans-ok (if (eq (round (mul 1000.0 (math_sqrt 2.0))) 1414) (if (eq (round (mul 1000.0 (math_exp 1.0))) 2718) (if (eq (round (math_log (math_exp 5.0))) 5) 100000 0) 0) 0))
+    (let arith-ok (if (eq (round (mul 100.0 (div 22.0 7.0))) 314) (if (eq (round (mod 7.0 3.0)) 1) (if (eq (round (pow 2.0 10.0)) 1024) 1000000 0) 0) 0))
+    (sum (list floor-ok ceil-ok trunc-ok round-ok abs-ok trans-ok arith-ok)))


### PR DESCRIPTION
Following the directive that float support is core. Probing the float-op surface across all kernels surfaced — and fixed — two real parity bugs, and precisely mapped the remaining fourth-arm gap.

## Two real bugs fixed (TS kernel rejected floats Go/Rust accept)

- **`abs` crashed on a float** — `expected int-like, got f64`. Now preserves type (float→float, int→int), matching Go (`VFloat → math.Abs`) and Rust (`Value::Float(f) → f.abs()`).
- **`pow` rejected float args** — now coerces to int like Go/Rust `AsInt()` (`pow` is the integer power; `math_pow` is the IEEE float power).

The three native kernels now agree on the full IEEE float-op surface — floor, ceil, trunc, round, abs, sqrt, exp, log, pow, mod, arithmetic — `tests/ieee-float-ops-band.fk → 1111111`, three-way, 0 divergent.

## The fourth-arm gap, mapped (not hidden)

The emitted walker `fkwu` returns `0` wholesale on a float-op band. Two real reasons, both documented in the band header as the named next row:
1. **Tag space is full** — `form-flatten.fk` uses tags 0..99 and `fkc-arm-slots = 100`, so `abs` and `math_pow` have no tag at all.
2. **The walker bails structurally** on a float-heavy band even for already-tagged ops.

Completing it — expanding the dispatch slot count, adding `abs`/`math_pow` dispatch in `hati-os-kernel-emit.fk`, resolving the walker's float-band handling — is careful core surgery in a walker that's actively being worked; the band is kept **3-kernel-only with the blocker named** (the AUTHORING convention) rather than registered red.

## Regression

`abs`/`pow` int paths are unchanged. Confirmed unchanged: `float-natives` (28), `numeric` (208), `celestial-pole` (1111111), `primitive-registry`, `python-bmf-arithmetic` (25304).

## Note

This edits the TS *kernel* (a sibling walker implementing a core primitive to match Go/Rust) — kernel-parity work, not TS-as-logic. The float `abs`/`pow` semantics are the body; the kernel must implement them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)