### PR TITLE
tend: project real tool telemetry into the proven embodiment gate

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -43,11 +43,11 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 147 | Python bridge/API routers — current endpoint carrier and upstream tail while Form-native routes are promoted |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 246 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 58 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 266 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 268 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 236 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 237 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 266
+**Total files**: 268
 
 | File | Purpose |
 |---|---|
@@ -142,6 +142,7 @@
 | [test_mcp_substrate_tools.py](test_mcp_substrate_tools.py) | MCP exposure for the coherence-substrate: every sibling agent reaches Form. |
 | [test_meeting_resonance_capture.py](test_meeting_resonance_capture.py) | Meeting resonance capture flow tests. |
 | [test_modality_blueprints.py](test_modality_blueprints.py) | Tests for the cross-modal canonical-shape interner. |
+| [test_model_executor_proof_ledger.py](test_model_executor_proof_ledger.py) | _no top-of-file purpose_ |
 | [test_monitor_pipeline_stale_running.py](test_monitor_pipeline_stale_running.py) | Stale-running pipeline monitoring tests. |
 | [test_monitor_resolution.py](test_monitor_resolution.py) | Tests for heal-completion-issue-resolution spec (047). |
 | [test_morning_coherence_brief.py](test_morning_coherence_brief.py) | _no top-of-file purpose_ |
@@ -270,6 +271,7 @@
 | [test_utils_weighted_average.py](test_utils_weighted_average.py) | Tests for /api/utils/weighted_average — transmuted under the habit pattern. |
 | [test_value_lineage.py](test_value_lineage.py) | Tests for the value lineage and payout attribution API. |
 | [test_verification.py](test_verification.py) | Flow-centric tests for the public verification framework. |
+| [test_view_recipe_library_choice.py](test_view_recipe_library_choice.py) | _no top-of-file purpose_ |
 | [test_views_and_wallets.py](test_views_and_wallets.py) | Flow-centric tests for view tracking, wallet integration, and discovery rewards. |
 | [test_vision_content.py](test_vision_content.py) | _no top-of-file purpose_ |
 | [test_wellness_chain_duplicates.py](test_wellness_chain_duplicates.py) | Regression test: the chain organ tolerates duplicate ``test:`` keys. |

--- a/docs/coherence-substrate/code-tool-learning.form
+++ b/docs/coherence-substrate/code-tool-learning.form
@@ -59,5 +59,11 @@
     (sovereignty "whether the result keeps capability choice explicit and locally ownable")
     (trust "whether the result has enough receipt evidence to learn from or execute"))
 
+  (embodiment
+    "tool-embodiment.fk projects REAL per-tool runner telemetry (lane, locality, completed, failed, runtime-ms) into ctl-floor-oracle rows, deriving cost, nutrition, sovereignty, trust, and confidence honestly off measurement, then asks this sideband's proven gate which lane holds the body."
+    (recipe form/form-stdlib/tool-embodiment.fk)
+    (proof form/form-stdlib/tests/tool-embodiment-band.fk -> 63 four-way)
+    (rule "a Form-native lane embodies — replaces the external tool — only when ctl-fo-ready? clears sovereignty/trust/confidence >= 70 AND it is cheaper than the incumbent; until its measured success rate crosses the gate, the external lane keeps the body. No assertion replaces a tool; only a measured receipt does."))
+
   (next-step
-    "Attach this sideband to the agent execution loop so each real patch/tool/proof turn emits a code-tool receipt, then train heldout lanes for search/edit/proof/review/deploy before routing any important flow to a Form-native candidate by default."))
+    "tool-embodiment.fk turns the live runner's per-tool telemetry into a measured embodiment verdict. The remaining carrier is a read door that runs te-verdict over the current get_usage_summary() by-tool rows, then trains heldout lanes for search/edit/proof/review/deploy before routing any important flow to a Form-native candidate by default."))

--- a/form/form-stdlib/tests/tool-embodiment-band.fk
+++ b/form/form-stdlib/tests/tool-embodiment-band.fk
@@ -1,0 +1,58 @@
+; preludes: form-stdlib/core.fk form-stdlib/nearest-shape.fk form-stdlib/classifier-eval.fk form-stdlib/tool-channel.fk form-stdlib/choice-receipt.fk form-stdlib/branch-choice-order.fk form-stdlib/choice-receipt-learning.fk form-stdlib/oracle-catalog.fk form-stdlib/code-tool-learning.fk form-stdlib/tool-embodiment.fk
+;
+; tool-embodiment-band — real per-tool telemetry, projected into the proven
+; embodiment gate, decides WHEN a Form-native lane replaces an external tool.
+;
+; The strange-minimal edge: one tool ("search"), two lanes — a remote
+; incumbent and a Form-native challenger — and the moment the challenger's
+; measured success rate crosses the trust gate (70). Below it the external
+; lane keeps the body; above it the Form-native lane embodies. The flip IS
+; "embodied when vitality asks for it," computed from measurement, not asserted.
+;
+; Verdict 63 when every claim lands:
+;   1   remote telemetry projects to a costed, low-sovereignty oracle row
+;   2   local telemetry projects to a zero-token, high-sovereignty oracle row
+;   4   a Form-native lane below the trust gate has NOT earned embodiment
+;   8   the same lane above the trust gate HAS earned embodiment
+;   16  the verdict flips external -> form-native exactly as trust crosses the gate
+;   32  the multi-lane winner (te-verdict) agrees: incumbent keeps the body
+;       under a young challenger, the ripe challenger takes it
+(do
+    ; one external incumbent: 9/10 terminal successes, 1200ms, remote membrane.
+    (let ext (te-telemetry-oracle "external:claude" "remote" 9 1 1200))
+    ; the same tool's Form-native challenger, two ripeness states (local lane).
+    ; young: 6/10 -> trust 60 (below gate). ripe: 8/10 -> trust 80 (above gate).
+    (let fn-young (te-telemetry-oracle "form-native:search" "local" 6 4 400))
+    (let fn-ripe  (te-telemetry-oracle "form-native:search" "local" 8 2 400))
+
+    ; 1 — remote projection: terminal 10 * 60 tokens, sovereignty 40 (borrowed).
+    (let c0
+        (if (and (eq (ctl-fo-tokens ext) 600) (eq (ctl-fo-sovereignty ext) 40))
+            1 0))
+    ; 2 — local projection: zero external tokens, sovereignty 90 (own body).
+    (let c1
+        (if (and (eq (ctl-fo-tokens fn-ripe) 0) (eq (ctl-fo-sovereignty fn-ripe) 90))
+            2 0))
+    ; 4 — a young Form-native lane (trust 60) has not earned readiness.
+    (let c2
+        (if (eq (te-ready? fn-young) 0) 4 0))
+    ; 8 — the ripe Form-native lane (trust 80, conf 80, sov 90) is ready.
+    (let c3
+        (if (eq (te-ready? fn-ripe) 1) 8 0))
+    ; 16 — the embodiment decision flips as trust crosses the gate:
+    ;      young challenger does NOT embody; ripe challenger DOES.
+    (let c4
+        (if (and
+                (eq (te-embodies? ext fn-young) 0)
+                (eq (te-embodies? ext fn-ripe) 1))
+            16 0))
+    ; 32 — the multi-lane winner over [incumbent, challenger] agrees with the
+    ;      pairwise gate: young challenger leaves the body with the incumbent;
+    ;      the ripe challenger takes it.
+    (let c5
+        (if (and
+                (str_eq (te-embodied-path (list ext fn-young)) "external:claude")
+                (str_eq (te-embodied-path (list ext fn-ripe)) "form-native:search"))
+            32 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/form/form-stdlib/tool-embodiment.fk
+++ b/form/form-stdlib/tool-embodiment.fk
@@ -1,0 +1,87 @@
+; tool-embodiment.fk — project REAL per-tool telemetry into the proven
+; embodiment gate, so a Form-native lane replaces an external tool only
+; when its measured receipts earn it.
+;
+; preludes: form-stdlib/core.fk form-stdlib/nearest-shape.fk form-stdlib/classifier-eval.fk form-stdlib/tool-channel.fk form-stdlib/choice-receipt.fk form-stdlib/branch-choice-order.fk form-stdlib/choice-receipt-learning.fk form-stdlib/oracle-catalog.fk form-stdlib/code-tool-learning.fk
+;
+; The live agent runner already emits, per real tool call, a RuntimeEvent
+; (endpoint "tool:<name>", status_code, runtime_ms, model). Summed per lane
+; that is (lane, locality, completed, failed, runtime-ms). code-tool-learning.fk
+; proved the embodiment GATE over hand-written floor-oracle rows; the missing
+; link was a recipe that DERIVES those rows from real measurement. This file is
+; that link: it turns one telemetry lane-row into a ctl-floor-oracle row —
+; the six axes (cost, nutrition, sovereignty, trust, confidence) read honestly
+; off telemetry — then asks the proven gate whether a Form-native challenger
+; has earned embodiment over the incumbent it would replace.
+;
+; The discipline is "embodied when vitality asks": a Form-native lane displaces
+; an external tool only when ctl-fo-ready? (sovereignty/trust/confidence >= 70)
+; AND it is cheaper than the incumbent. Until its measured success rate crosses
+; the gate, the external lane keeps the body. No assertion replaces a tool;
+; only a measured receipt does.
+;
+; Proven by: form-stdlib/tests/tool-embodiment-band.fk
+
+; floor token cost charged to each REMOTE invocation; local lanes spend none.
+; Exact provider tokens come from automation_usage later; this is the honest
+; structural floor — a remote membrane costs tokens, a local recipe does not.
+(defn te-token-unit () 60)
+; wall-clock ms that count as one unit of energy (measured runtime / unit).
+(defn te-energy-unit () 100)
+
+(defn te-local? (locality) (if (str_eq locality "local") 1 0))
+
+; terminal outcomes are the honest denominator — completed work, not in-flight.
+(defn te-terminal (completed failed) (add completed failed))
+
+; success rate in 0..100 from measured terminal outcomes (guarded for none).
+(defn te-success-rate (completed failed)
+    (if (eq (te-terminal completed failed) 0)
+        0
+        (div (mul completed 100) (te-terminal completed failed))))
+
+; confidence grows with evidence volume: full weight needs >= 5 terminal runs,
+; so a 100%-but-tiny sample cannot vault a lane through the gate on one lucky call.
+(defn te-min5 (n) (if (gt n 5) 5 n))
+(defn te-confidence (completed failed)
+    (div
+        (mul (te-success-rate completed failed) (te-min5 (te-terminal completed failed)))
+        5))
+
+; project one telemetry lane-row into a measured floor-oracle row.
+;   tokens      0 for local lanes; terminal * token-unit for remote membranes
+;   energy      measured runtime-ms / energy-unit
+;   nutrition   terminal invocations consumed (cost tie-break)
+;   sovereignty structural: local 90, remote 40 (a membrane is borrowed sense)
+;   trust       measured success rate
+;   confidence  success rate weighted by evidence volume
+(defn te-telemetry-oracle (lane locality completed failed runtime-ms)
+    (ctl-floor-oracle
+        lane
+        (if (eq (te-local? locality) 1)
+            0
+            (mul (te-terminal completed failed) (te-token-unit)))
+        (div runtime-ms (te-energy-unit))
+        (te-terminal completed failed)
+        (if (eq (te-local? locality) 1) 90 40)
+        (te-success-rate completed failed)
+        (te-confidence completed failed)))
+
+; has THIS lane, on its own measured axes, cleared the readiness gate?
+(defn te-ready? (row) (ctl-fo-ready? row))
+
+; the pairwise embodiment decision: does the challenger EARN the body the
+; incumbent currently holds? Ready on its own axes AND cheaper than incumbent.
+; Order is explicit (incumbent first) — no reliance on list position.
+(defn te-embodies? (incumbent challenger)
+    (if (and
+            (eq (ctl-fo-ready? challenger) 1)
+            (eq (ctl-fo-lower-cost? challenger incumbent) 1))
+        1
+        0))
+
+; the embodiment verdict over many lanes for one tool. Order the list
+; incumbent-first; the proven ctl-floor-winner keeps the incumbent until a
+; ready, cheaper challenger displaces it.
+(defn te-verdict (rows) (ctl-floor-winner rows))
+(defn te-embodied-path (rows) (ctl-fo-path (te-verdict rows)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -84,6 +84,7 @@ choice-receipt fks 4294967295
 choice-receipt-learning fks 255
 choice-outcome-learning fks 32767
 code-tool-learning fks 131071
+tool-embodiment fks 63
 text-summary-learning fks 262143
 llm-feature-channel-floor fks 131071
 bml-route-source-object fks 2047

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 236
+**Total files**: 237
 
 | File | Purpose |
 |---|---|
@@ -137,6 +137,7 @@
 | [migrate_ideas_to_fractal.py](migrate_ideas_to_fractal.py) | Wire existing DB ideas into the fractal structure. |
 | [migrate_spec_slugs.py](migrate_spec_slugs.py) | Migrate spec slugs: strip numeric prefixes from spec IDs everywhere. |
 | [minimal_kernel_census.sh](minimal_kernel_census.sh) | minimal_kernel_census.sh — count the Go kernel's registered natives by the four |
+| [model_executor_proof_ledger.py](model_executor_proof_ledger.py) | Validate and export native model executor proof-run records. |
 | [morning_coherence_brief.py](morning_coherence_brief.py) | Collect a morning Coherence brief from live network signals. |
 | [native_route_goal_loop.py](native_route_goal_loop.py) | Rank web-used API routes for native high-grammar promotion. |
 | [opt_out_contributor.py](opt_out_contributor.py) | Honour a contributor's opt-out across the network's body of evidence. |


### PR DESCRIPTION
## What

Agent host tools (bash, read/write file, git, python-for-math, web-search) are 3rd-party channels. The body already named the north star — `tool-channel.form`, `lc-tools-as-form-cells`, `code-tool-learning.form` — and the embodiment **gate** (cost / nutrition / sovereignty / trust) was already proven (`ctl-floor-oracle` + `ctl-floor-winner`, band 131071 four-way).

The missing link: the gate had only ever judged hand-written rows. Real per-tool receipts already flow from the live agent runner (`RuntimeEvent`: `tool:<name>`, status, `runtime_ms`, model) but nothing projected them into the gate. **`tool-embodiment.fk` is that projection.**

## How it measures (honestly, off real telemetry)

From `(lane, locality, completed, failed, runtime-ms)`:
- **cost** — local lanes spend 0 external tokens; remote membranes cost `terminal × token-unit`; energy = measured `runtime-ms / unit`
- **nutrition** — terminal invocations consumed (cost tie-break)
- **sovereignty** — structural: local 90, remote 40 (a membrane is borrowed sense)
- **trust** — measured success rate
- **confidence** — success rate weighted by evidence volume (a tiny lucky sample can't vault the gate)

**Embodiment rule:** a Form-native lane replaces the external tool only when `ctl-fo-ready?` clears sovereignty/trust/confidence ≥ 70 **and** it is cheaper than the incumbent. Until its measured success rate crosses the gate, the external lane keeps the body. *No assertion replaces a tool; only a measured receipt does.*

## Proof

`tool-embodiment-band.fk` → **verdict 63, four-way** (Go / Rust / TS / emitted `fkwu`). Strange-minimal edge: one tool, two lanes, the embodiment flip at the trust threshold (young 6/10 keeps the external lane; ripe 8/10 embodies the Form-native one).

## Next (named, not built — carrier is authored last)

A read door that runs `te-verdict` over the live `get_usage_summary()` by-tool rows, then trains heldout lanes for search/edit/proof/review/deploy before routing any important flow to a Form-native candidate by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)