### PR TITLE
tend: feed real tool telemetry into the embodiment gate

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -43,11 +43,11 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 147 | Python bridge/API routers — current endpoint carrier and upstream tail while Form-native routes are promoted |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 246 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 58 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 268 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 269 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 237 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 238 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/api/app/services/agent_service_usage_visibility.py
+++ b/api/app/services/agent_service_usage_visibility.py
@@ -39,6 +39,57 @@ def _metadata_bool(value: Any) -> bool:
     return False
 
 
+# Lanes that run inside our own body — no external membrane. Used only to tag a
+# lane local/remote for the Form embodiment gate; the gate (not this tag) decides
+# sovereignty and which lane holds a tool's body.
+_LOCAL_LANES = ("form-native", "form", "ollama", "local", "kernel")
+
+
+def _lane_locality(lane: str) -> str:
+    name = (lane or "").strip().lower()
+    return "local" if any(token in name for token in _LOCAL_LANES) else "remote"
+
+
+def _embodiment_rows_by_tool(recent_runs: list[dict[str, Any]]) -> dict[str, list[list[Any]]]:
+    """Group real per-event telemetry into the rows the Form gate reads.
+
+    One row is [lane, locality, completed, failed, runtime_ms] — exactly what
+    te-embody-lanes (form/form-stdlib/tool-embodiment.fk) consumes, grouped by
+    (tool, lane). Fan-out only: no projection, no verdict. Those stay in Form,
+    served by the kernel over these rows.
+    """
+    grouped: dict[tuple[str, str], dict[str, float]] = {}
+    for run in recent_runs or []:
+        tool = str(run.get("tool") or "").strip() or "unknown"
+        lane = str(run.get("executor") or run.get("provider") or "").strip() or "unknown"
+        cell = grouped.setdefault((tool, lane), {"completed": 0, "failed": 0, "runtime_ms": 0.0})
+        cell["failed" if int(run.get("status_code", 0) or 0) >= 400 else "completed"] += 1
+        cell["runtime_ms"] += float(run.get("runtime_ms", 0.0) or 0.0)
+    rows_by_tool: dict[str, list[list[Any]]] = {}
+    for (tool, lane), cell in grouped.items():
+        rows_by_tool.setdefault(tool, []).append(
+            [lane, _lane_locality(lane), int(cell["completed"]), int(cell["failed"]), int(round(cell["runtime_ms"]))]
+        )
+    return rows_by_tool
+
+
+def _embodiment_block(execution: dict[str, Any]) -> dict[str, Any]:
+    """The /visibility embodiment surface — real rows plus where the verdict lives."""
+    rows = execution.get("embodiment_rows_by_tool")
+    return {
+        "rows_by_tool": rows if isinstance(rows, dict) else {},
+        "row_shape": ["lane", "locality", "completed", "failed", "runtime_ms"],
+        "recipe": "form/form-stdlib/tool-embodiment.fk",
+        "gate": "te-embody-lanes",
+        "note": (
+            "Real per-(tool, lane) telemetry, shaped for the Form embodiment "
+            "gate. The verdict — which lane holds a tool's body, and whether a "
+            "Form-native lane has earned it — is computed by the kernel-served "
+            "recipe over these rows, not reimplemented in Python."
+        ),
+    }
+
+
 def _execution_usage_summary(completed_or_failed_task_ids: list[str]) -> dict[str, Any]:
     tracked_task_ids = set()
     by_executor = {}
@@ -119,6 +170,7 @@ def _execution_usage_summary(completed_or_failed_task_ids: list[str]) -> dict[st
         "by_executor": by_executor,
         "by_agent": by_agent,
         "by_tool": by_tool,
+        "embodiment_rows_by_tool": _embodiment_rows_by_tool(recent_runs),
         "coverage": {
             "completed_or_failed_tasks": len(completed_or_failed_set),
             "tracked_task_runs": len(tracked_set),
@@ -428,6 +480,7 @@ def get_visibility_summary() -> dict[str, Any]:
             "untracked_task_ids": normalized_untracked_ids,
             "health": health,
         },
+        "embodiment": _embodiment_block(execution),
     }
 
 

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 268
+**Total files**: 269
 
 | File | Purpose |
 |---|---|
@@ -253,6 +253,7 @@
 | [test_task_chain_correlation.py](test_task_chain_correlation.py) | Cross-task-outcome-correlation (6 requirements in 3 flows). |
 | [test_task_dedup_service.py](test_task_dedup_service.py) | Tests for the task dedup service — prevents duplicate tasks per idea+phase. |
 | [test_timeout_adaptive_service.py](test_timeout_adaptive_service.py) | _no top-of-file purpose_ |
+| [test_tool_embodiment_rows.py](test_tool_embodiment_rows.py) | Real tool telemetry groups into the rows the Form embodiment gate consumes. |
 | [test_trace_symbol_spaces_form.py](test_trace_symbol_spaces_form.py) | Proof that trace symbol spaces stay grounded in raw field traces. |
 | [test_translations_router.py](test_translations_router.py) | Tests for POST /api/translations and GET /api/translations/{entity_type}/{entity_id}. |
 | [test_utils_breath_balance.py](test_utils_breath_balance.py) | Tests for /api/utils/breath_balance — the first kernel-served route to use a transcendental native (ln). |

--- a/api/tests/test_tool_embodiment_rows.py
+++ b/api/tests/test_tool_embodiment_rows.py
@@ -1,0 +1,67 @@
+"""Real tool telemetry groups into the rows the Form embodiment gate consumes.
+
+The verdict — which lane holds a tool's body — is proven four-way by
+form/form-stdlib/tests/tool-embodiment-band.fk. This test proves the other
+half: the Python fan-out turns real RuntimeEvents into the exact
+[lane, locality, completed, failed, runtime_ms] rows te-embody-lanes reads,
+grouped by (tool, lane), with no embodiment logic on the carrier side.
+"""
+from types import SimpleNamespace
+
+from app.services import runtime_service
+from app.services import agent_service_usage_visibility as viz
+
+
+def _ev(tool: str, executor: str, status: int, ms: float, task_id: str):
+    return SimpleNamespace(
+        source="worker",
+        endpoint=f"tool:{tool}",
+        status_code=status,
+        runtime_ms=ms,
+        id=f"{tool}-{executor}-{status}",
+        recorded_at="2026-06-14T00:00:00Z",
+        metadata={"task_id": task_id, "executor": executor, "provider": executor},
+    )
+
+
+def test_embodiment_rows_group_by_tool_and_lane(monkeypatch):
+    # one tool, two lanes: a local Form-native lane and a remote claude lane.
+    events = []
+    events += [_ev("search", "form-native", 200, 30.0, "t1") for _ in range(8)]
+    events += [_ev("search", "form-native", 500, 30.0, "t1") for _ in range(2)]
+    events += [_ev("search", "claude", 200, 120.0, "t1") for _ in range(9)]
+    events += [_ev("search", "claude", 500, 120.0, "t1") for _ in range(1)]
+    monkeypatch.setattr(runtime_service, "list_events", lambda **_: events)
+
+    summary = viz._execution_usage_summary(["t1"])
+    rows_by_tool = summary["embodiment_rows_by_tool"]
+
+    assert "search" in rows_by_tool
+    rows = {r[0]: r for r in rows_by_tool["search"]}
+
+    # every row is the exact shape te-embody-lanes reads.
+    for r in rows_by_tool["search"]:
+        assert len(r) == 5  # [lane, locality, completed, failed, runtime_ms]
+
+    fn = rows["form-native"]
+    assert fn[1] == "local"      # locality derived, not asserted as sovereignty
+    assert fn[2] == 8 and fn[3] == 2
+    assert fn[4] == 300          # 10 events (8 completed + 2 failed), 30ms each
+
+    cl = rows["claude"]
+    assert cl[1] == "remote"
+    assert cl[2] == 9 and cl[3] == 1
+    assert cl[4] == 1200         # 10 events, 120ms each
+
+
+def test_visibility_summary_surfaces_embodiment(monkeypatch):
+    monkeypatch.setattr(
+        runtime_service,
+        "list_events",
+        lambda **_: [_ev("read_file", "form-native", 200, 5.0, "t2")],
+    )
+    out = viz.get_visibility_summary()
+    assert "embodiment" in out
+    assert out["embodiment"]["row_shape"] == ["lane", "locality", "completed", "failed", "runtime_ms"]
+    assert out["embodiment"]["gate"] == "te-embody-lanes"
+    assert "read_file" in out["embodiment"]["rows_by_tool"]

--- a/docs/coherence-substrate/code-tool-learning.form
+++ b/docs/coherence-substrate/code-tool-learning.form
@@ -62,7 +62,7 @@
   (embodiment
     "tool-embodiment.fk projects REAL per-tool runner telemetry (lane, locality, completed, failed, runtime-ms) into ctl-floor-oracle rows, deriving cost, nutrition, sovereignty, trust, and confidence honestly off measurement, then asks this sideband's proven gate which lane holds the body."
     (recipe form/form-stdlib/tool-embodiment.fk)
-    (proof form/form-stdlib/tests/tool-embodiment-band.fk -> 63 four-way)
+    (proof form/form-stdlib/tests/tool-embodiment-band.fk -> 127 four-way)
     (rule "a Form-native lane embodies — replaces the external tool — only when ctl-fo-ready? clears sovereignty/trust/confidence >= 70 AND it is cheaper than the incumbent; until its measured success rate crosses the gate, the external lane keeps the body. No assertion replaces a tool; only a measured receipt does."))
 
   (next-step

--- a/form/form-stdlib/tests/tool-embodiment-band.fk
+++ b/form/form-stdlib/tests/tool-embodiment-band.fk
@@ -9,7 +9,7 @@
 ; lane keeps the body; above it the Form-native lane embodies. The flip IS
 ; "embodied when vitality asks for it," computed from measurement, not asserted.
 ;
-; Verdict 63 when every claim lands:
+; Verdict 127 when every claim lands:
 ;   1   remote telemetry projects to a costed, low-sovereignty oracle row
 ;   2   local telemetry projects to a zero-token, high-sovereignty oracle row
 ;   4   a Form-native lane below the trust gate has NOT earned embodiment
@@ -17,6 +17,8 @@
 ;   16  the verdict flips external -> form-native exactly as trust crosses the gate
 ;   32  the multi-lane winner (te-verdict) agrees: incumbent keeps the body
 ;       under a young challenger, the ripe challenger takes it
+;   64  the carrier entry te-embody-lanes — fed RAW (lane locality completed
+;       failed runtime-ms) rows, the exact runner telemetry shape — flips too
 (do
     ; one external incumbent: 9/10 terminal successes, 1200ms, remote membrane.
     (let ext (te-telemetry-oracle "external:claude" "remote" 9 1 1200))
@@ -54,5 +56,20 @@
                 (str_eq (te-embodied-path (list ext fn-young)) "external:claude")
                 (str_eq (te-embodied-path (list ext fn-ripe)) "form-native:search"))
             32 0))
+    ; 64 — the carrier entry: RAW telemetry rows (the shape the Python fan-out
+    ;      hands over) project + decide entirely in Form, flipping at the gate.
+    (let raw-young
+        (list
+            (list "external:claude" "remote" 9 1 1200)
+            (list "form-native:search" "local" 6 4 400)))
+    (let raw-ripe
+        (list
+            (list "external:claude" "remote" 9 1 1200)
+            (list "form-native:search" "local" 8 2 400)))
+    (let c6
+        (if (and
+                (str_eq (te-embody-lanes raw-young) "external:claude")
+                (str_eq (te-embody-lanes raw-ripe) "form-native:search"))
+            64 0))
 
-    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/form-stdlib/tool-embodiment.fk
+++ b/form/form-stdlib/tool-embodiment.fk
@@ -85,3 +85,23 @@
 ; ready, cheaper challenger displaces it.
 (defn te-verdict (rows) (ctl-floor-winner rows))
 (defn te-embodied-path (rows) (ctl-fo-path (te-verdict rows)))
+
+; --- carrier entry: consume the (tool, lane) telemetry rows the runner emits ---
+; The live agent runner, grouped per lane, yields one row per lane shaped
+;   (lane locality completed failed runtime-ms)
+; — exactly RuntimeEvent telemetry summed by (tool, executor). The carrier
+; (Python fan-out) only groups the events into these rows; the projection and
+; the verdict stay here in Form. te-row->oracle lifts one raw row; te-rows lifts
+; a whole list; te-embody-lanes returns which lane holds the body; and
+; te-lanes-ready? says whether that lane is a sovereign (ready) one.
+(defn te-row->oracle (r)
+    (te-telemetry-oracle (nth r 0) (nth r 1) (nth r 2) (nth r 3) (nth r 4)))
+; explicit monomorphic recursion — NOT (map te-row->oracle rows): a function
+; passed to map does not cross the fourth arm (fkwu) yet, so the walk names its
+; callee directly and stays four-way.
+(defn te-rows (rows)
+    (if (nil? rows)
+        (empty)
+        (cons (te-row->oracle (head rows)) (te-rows (tail rows)))))
+(defn te-embody-lanes (rows) (te-embodied-path (te-rows rows)))
+(defn te-lanes-ready? (rows) (te-ready? (te-verdict (te-rows rows))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -90,7 +90,7 @@ choice-receipt fks 4294967295
 choice-receipt-learning fks 255
 choice-outcome-learning fks 32767
 code-tool-learning fks 131071
-tool-embodiment fks 63
+tool-embodiment fks 127
 text-summary-learning fks 262143
 llm-feature-channel-floor fks 131071
 android-mesh-learning fks 4095

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 237
+**Total files**: 238
 
 | File | Purpose |
 |---|---|
@@ -13,6 +13,7 @@
 | [add_task_cards_to_specs.py](add_task_cards_to_specs.py) | Add Task Card and Research Inputs sections to spec files that don't have them. |
 | [agent-coord.sh](agent-coord.sh) | agent-coord.sh — the carrier for agent-coordination-membrane.form. |
 | [agent_status.py](agent_status.py) | Show active work across all coding agents (worktrees + tasks). |
+| [android_mesh_learning_receipt.py](android_mesh_learning_receipt.py) | Record a Mac + Android mesh-learning receipt from a real adb device. |
 | [archive_view_events.py](archive_view_events.py) | Move days of asset_view_events into cold-tier storage. |
 | [arrival.py](arrival.py) | Arrival — read first, sense the body, then begin. |
 | [asm_pl_human_demo.sh](asm_pl_human_demo.sh) | asm_pl_human_demo.sh — an assembly -> programming language -> human language |


### PR DESCRIPTION
## What

The real-data half of the embodiment wire ([#3046](https://github.com/seeker71/Coherence-Network/pull/3046) proved the gate over fixtures). The gate now consumes the exact shape live telemetry takes, and real `RuntimeEvent`s are grouped into it.

## Form (the decision stays here)

`tool-embodiment.fk` gains carrier entry points — `te-row->oracle` / `te-rows` / `te-embody-lanes` / `te-lanes-ready?` — that take RAW telemetry rows `(lane locality completed failed runtime-ms)`, the exact runner shape, and run the proven projection + gate. `te-rows` is explicit monomorphic recursion, **not** `(map f …)`: a function-as-argument doesn't cross the fourth arm (`fkwu`) yet, so the walk names its callee directly and stays four-way.

**Band → 127, four-way** (Go / Rust / TS / `fkwu`). Claim 64 feeds raw telemetry rows and confirms the embodiment flip end-to-end.

## Carrier (fan-out only — no embodiment logic in Python)

`agent_service_usage_visibility` groups real `RuntimeEvent`s by `(tool, lane)` into `[lane, locality, completed, failed, runtime_ms]` rows, surfaced on `/visibility` under `embodiment`. `test_tool_embodiment_rows` proves the grouping + row shape.

## Honest engineering finding

The live **verdict** is *not* a Python bridge call. The stdlib chain is BML-dialect and not raw-kernel-loadable, so calling `te-embody-lanes` from Python would mean duplicating the proven recipe into a self-contained file — the exact anti-pattern we avoid. The verdict belongs in a **native kernel route** (where the stdlib is already loaded). That's the north-star carrier and the named next step; this PR lands the verifiable fan-out + the proven Form entry points it will consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)