### PR TITLE
tend: io-match — make LLM/tool usage learnable, not just paid for

### DIFF
--- a/docs/coherence-substrate/code-tool-learning.form
+++ b/docs/coherence-substrate/code-tool-learning.form
@@ -65,5 +65,12 @@
     (proof form/form-stdlib/tests/tool-embodiment-band.fk -> 127 four-way)
     (rule "a Form-native lane embodies — replaces the external tool — only when ctl-fo-ready? clears sovereignty/trust/confidence >= 70 AND it is cheaper than the incumbent; until its measured success rate crosses the gate, the external lane keeps the body. No assertion replaces a tool; only a measured receipt does."))
 
+  (capture-and-learn
+    "io-match.fk closes the loop the embodiment gate needs a source for: it makes real LLM/tool usage LEARNABLE instead of only paid for. One captured call is an io-match record (input-sig output-sig lane tokens outcome) — content-addressed in/out (sha256.fk over the real prompt and completion; substrate Blueprint equivalence is the richer match). A Form-native candidate is REPLAYED on the same input-sig and scored by whether it reproduces the LLM's output-sig; its match-rate becomes its trust in tool-embodiment.fk (completed = matches, failed = mismatches). A lane that learns to match — cheaper and sovereign — earns the body and replaces the LLM it learned from."
+    (recipe form/form-stdlib/io-match.fk)
+    (proof form/form-stdlib/tests/io-match-band.fk -> 31 four-way)
+    (carrier "the Mac binary channel — form-macho.fk emits the native arm64 binary — intercepts the agent's real reasoning/tool calls for input/output matching and writes io-match records; that interception carrier is authored last, the learning body is here")
+    (why "the model cost is not maintainable; switching tool and LLM use to Form-native, learned from real usage, is how we keep access to the highest-value capability when the external lane is no longer affordable"))
+
   (next-step
-    "tool-embodiment.fk turns the live runner's per-tool telemetry into a measured embodiment verdict. The remaining carrier is a read door that runs te-verdict over the current get_usage_summary() by-tool rows, then trains heldout lanes for search/edit/proof/review/deploy before routing any important flow to a Form-native candidate by default."))
+    "io-match.fk turns captured I/O into a learnable match score that feeds the embodiment gate; the remaining carrier is the Mac binary channel (form-macho.fk) that intercepts the agent's real reasoning/tool calls and writes io-match records, plus the read door that runs te-verdict over live rows — then heldout lanes for search/edit/proof/review/deploy graduate to Form-native by match-rate, cost, and sovereignty before any important flow routes to them by default."))

--- a/form/form-stdlib/io-match.fk
+++ b/form/form-stdlib/io-match.fk
@@ -1,0 +1,69 @@
+; io-match.fk — content-addressed input/output capture so LLM/tool usage becomes
+; LEARNABLE, not just paid for.
+;
+; preludes: form-stdlib/core.fk form-stdlib/nearest-shape.fk form-stdlib/classifier-eval.fk form-stdlib/tool-channel.fk form-stdlib/choice-receipt.fk form-stdlib/branch-choice-order.fk form-stdlib/choice-receipt-learning.fk form-stdlib/oracle-catalog.fk form-stdlib/code-tool-learning.fk form-stdlib/tool-embodiment.fk
+;
+; Today usage is paid for and discarded: automation_usage counts tokens, the
+; learning sample carries only a feature-vector — never the actual (input,
+; output) pair. So we cannot LEARN to reproduce what the LLM did; we just pay
+; for it again. This file closes that: one captured call is an io-match record
+;   (input-sig output-sig lane tokens outcome)
+; where input-sig / output-sig are content addresses (sha256.fk over the real
+; prompt and completion bytes; structural equivalence via the substrate is the
+; richer match). The Mac binary channel (form-macho.fk emits the native arm64
+; binary) is the carrier that intercepts the agent's real reasoning/tool calls
+; and writes these records; this recipe is the body that turns them into learning.
+;
+; The bridge to embodiment: a Form-native candidate is REPLAYED on the same
+; input-sig, and scored by whether it reproduces the LLM's output-sig. Its
+; match-rate becomes its trust in the embodiment gate (tool-embodiment.fk):
+; completed = outputs that matched the LLM, failed = mismatches. A lane that
+; learns to match — cheaper (0 external tokens) and sovereign (local) — earns
+; the body and replaces the LLM it learned from. That is how we keep the
+; capability when the model cost is no longer maintainable.
+;
+; Proven by: form-stdlib/tests/io-match-band.fk
+
+; one captured call: content-addressed in/out, the lane, its cost, its outcome.
+(defn iom-record (input-sig output-sig lane tokens outcome)
+    (list input-sig output-sig lane tokens outcome))
+(defn iom-in (r) (nth r 0))
+(defn iom-out (r) (nth r 1))
+(defn iom-lane (r) (nth r 2))
+(defn iom-tokens (r) (nth r 3))
+(defn iom-outcome (r) (nth r 4))
+
+; did a candidate reproduce the recorded output? exact content match is the
+; floor; substrate Blueprint equivalence is the richer match the carrier can use.
+(defn iom-match? (candidate-out recorded-out)
+    (if (str_eq candidate-out recorded-out) 1 0))
+
+; over a candidate's outputs for ONE input, how many matched the LLM's output.
+; explicit recursion (named callee, no function-as-argument) so it crosses the
+; fourth arm.
+(defn iom-matches (recorded-out candidate-outs)
+    (if (nil? candidate-outs)
+        0
+        (add (iom-match? (head candidate-outs) recorded-out)
+             (iom-matches recorded-out (tail candidate-outs)))))
+(defn iom-attempts (candidate-outs) (len candidate-outs))
+(defn iom-mismatches (recorded-out candidate-outs)
+    (sub (iom-attempts candidate-outs) (iom-matches recorded-out candidate-outs)))
+
+; the bridge: a candidate lane's match record becomes a telemetry row the
+; embodiment gate reads — (lane locality completed failed runtime-ms) — where
+; completed = matches against the LLM, failed = mismatches. Its match-rate IS
+; its measured trust.
+(defn iom-candidate-row (lane locality recorded-out candidate-outs runtime-ms)
+    (list lane locality
+        (iom-matches recorded-out candidate-outs)
+        (iom-mismatches recorded-out candidate-outs)
+        runtime-ms))
+
+; the full verdict: given the LLM incumbent's own row and a learned candidate's
+; match record, which lane holds the body now? (te-embody-lanes runs the proven
+; gate; the LLM keeps the body until the candidate learns to match cheaply and
+; sovereignly.)
+(defn iom-embodied-path (llm-row lane locality recorded-out candidate-outs runtime-ms)
+    (te-embody-lanes
+        (list llm-row (iom-candidate-row lane locality recorded-out candidate-outs runtime-ms))))

--- a/form/form-stdlib/tests/io-match-band.fk
+++ b/form/form-stdlib/tests/io-match-band.fk
@@ -1,0 +1,48 @@
+; preludes: form-stdlib/core.fk form-stdlib/nearest-shape.fk form-stdlib/classifier-eval.fk form-stdlib/tool-channel.fk form-stdlib/choice-receipt.fk form-stdlib/branch-choice-order.fk form-stdlib/choice-receipt-learning.fk form-stdlib/oracle-catalog.fk form-stdlib/code-tool-learning.fk form-stdlib/tool-embodiment.fk form-stdlib/io-match.fk
+;
+; io-match-band — captured LLM I/O becomes learning, and a candidate that learns
+; to reproduce the output earns the body.
+;
+; The strange-minimal edge: one input, one recorded LLM output ("OUT"), and a
+; Form-native candidate replayed on that input. When the candidate reproduces
+; "OUT" 8 of 10 times (local, cheap) it takes the body from the costly remote
+; LLM; at 6 of 10 the LLM keeps it. The flip is the moment usage stops being
+; only paid for and starts being learned from.
+;
+; Verdict 31 when every claim lands:
+;   1   exact content match scores 1, a miss scores 0
+;   2   matches are counted across a candidate's replayed outputs
+;   4   a candidate's match record becomes a (lane locality completed failed rt) row
+;   8   a candidate that matches 8/10 — cheaper and sovereign — takes the body
+;   16  a candidate that matches 6/10 leaves the body with the LLM
+(do
+    (let recorded "OUT")
+    ; the LLM incumbent's own row: it always matches itself (10/0), but remote and costly.
+    (let llm-row (list "external:claude" "remote" 10 0 1200))
+    ; a learned candidate replayed on the same input — two ripeness states.
+    (let ripe  (list "OUT" "OUT" "OUT" "OUT" "OUT" "OUT" "OUT" "OUT" "X" "X"))
+    (let young (list "OUT" "OUT" "OUT" "OUT" "OUT" "OUT" "X" "X" "X" "X"))
+
+    ; 1 — exact content match.
+    (let c0
+        (if (and (eq (iom-match? "OUT" recorded) 1) (eq (iom-match? "X" recorded) 0))
+            1 0))
+    ; 2 — matches counted across replayed outputs.
+    (let c1
+        (if (and (eq (iom-matches recorded ripe) 8) (eq (iom-matches recorded young) 6))
+            2 0))
+    ; 3 — match record becomes a 5-field telemetry row (completed = matches).
+    (let row (iom-candidate-row "form-native:gen" "local" recorded ripe 400))
+    (let c2
+        (if (and (eq (len row) 5) (and (eq (nth row 2) 8) (eq (nth row 3) 2)))
+            4 0))
+    ; 8 — a candidate that learned to match 8/10, cheaper and sovereign, embodies.
+    (let c3
+        (if (str_eq (iom-embodied-path llm-row "form-native:gen" "local" recorded ripe 400) "form-native:gen")
+            8 0))
+    ; 16 — a candidate that matches only 6/10 has not earned it; the LLM keeps the body.
+    (let c4
+        (if (str_eq (iom-embodied-path llm-row "form-native:gen" "local" recorded young 400) "external:claude")
+            16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -105,6 +105,7 @@ choice-receipt-learning fks 255
 choice-outcome-learning fks 32767
 code-tool-learning fks 131071
 tool-embodiment fks 127
+io-match fks 31
 text-summary-learning fks 262143
 llm-feature-channel-floor fks 131071
 android-mesh-learning fks 4095


### PR DESCRIPTION
## Why (highest priority)

The model cost is not maintainable. Switching tool **and LLM** use to Form-native — learned from real usage — is how we keep access to the highest-value capability when the external lane is no longer affordable. Today usage is paid for and discarded: `automation_usage` counts tokens, the learning sample carries only a feature-vector, never the actual **(input, output) pair**. So we cannot learn to reproduce what the LLM did; we pay for it again.

## What this closes

`io-match.fk` is the keystone between **capture** and **embodiment**. One captured call is an io-match record:

```
(input-sig  output-sig  lane  tokens  outcome)
```

content-addressed in/out (`sha256.fk` over the real prompt + completion; substrate Blueprint equivalence is the richer match). A Form-native candidate is **replayed on the same input-sig** and scored by whether it reproduces the LLM's output-sig. Its **match-rate becomes its trust** in the embodiment gate (`tool-embodiment.fk`): completed = matches, failed = mismatches. A lane that learns to match — cheaper (0 external tokens) and sovereign (local) — **earns the body and replaces the LLM it learned from.**

## Proof

`io-match-band.fk` → **31, four-way** (Go/Rust/TS/`fkwu`). The learning flip: a candidate matching 8/10 of the LLM's outputs takes the body; at 6/10 the LLM keeps it.

## The loop, now whole in Form

| stage | cell | status |
|---|---|---|
| capture (Mac binary channel) | `form-macho.fk` emits the native arm64 interceptor | substrate exists; **interception carrier is the next step** |
| content-address I/O | `sha256.fk` | exists |
| **learn from usage** | **`io-match.fk`** | **this PR, four-way** |
| embody when learned + cheaper + sovereign | `tool-embodiment.fk` | [#3051](https://github.com/seeker71/Coherence-Network/pull/3051) |

## Next (carrier, authored last)

The Mac binary channel itself: `form-macho.fk` emits the native arm64 binary that intercepts the agent's real reasoning/tool calls for input/output matching and writes io-match records. The learning body is proven; the interception carrier is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)