### PR TITLE
tend: higher-order map/filter/foldl with function args cross the fourth arm

### DIFF
--- a/form/form-stdlib/fourth-shim.fk
+++ b/form/form-stdlib/fourth-shim.fk
@@ -8,9 +8,17 @@
 ; Two lanes live here:
 ;   · core mirrors — nil?/sum/append/abs/min2/max2/range/take/drop/
 ;     reverse/maximum/minimum/product, each the first-order image of the
-;     core.fk definition (foldl-shaped originals rewritten as direct
-;     recursion; higher-order core stays outside the walker's reach until
-;     defunctionalization)
+;     core.fk definition
+;   · higher-order core — map/filter/foldl/foldr (and the even?/odd?/zero?
+;     predicates they pair with), the EXACT generic recipes core.fk runs on
+;     the three reference kernels. A function name in argument position
+;     lowers to a function-ref value (flt-fref: cons of (fn-index, arity)),
+;     and the combinator's call to its function PARAMETER lowers to an
+;     indirect call (tag 44) that reads (fn-index, arity) and dispatches —
+;     arity 1 reads the single arg, arity ≥ 2 rides the packed-args list
+;     like a direct call. No defunctionalization, no per-call-site monomorph;
+;     one engine carries the function-value through map/filter's forward
+;     recursion and foldl's two-arg step.
 ;   · string stones — substring/int_to_str/str_to_int/str_find composed
 ;     from char_at (the BYTE2S∘SCHAR lowering), str_concat, and ord:
 ;     tags 24..29 carry every byte; these recipes carry the shapes
@@ -39,6 +47,21 @@
     (defn maximum (xs) (if (nil? (tail xs)) (head xs) (max2 (head xs) (maximum (tail xs)))))
     (defn minimum (xs) (if (nil? (tail xs)) (head xs) (min2 (head xs) (minimum (tail xs)))))
     (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))
+    ; ── higher-order core (function-as-argument, indirect call tag 44) ──
+    ; The same generic recipes as core.fk's map/filter/foldl/foldr. The
+    ; function parameter (f/pred) arrives as a function-ref value; the body's
+    ; (f ...) / (pred ...) calls lower to indirect calls the walker dispatches.
+    (defn even? (n) (eq (mod n 2) 0))
+    (defn odd? (n) (eq (mod n 2) 1))
+    (defn zero? (n) (eq n 0))
+    (defn map (f xs) (if (nil? xs) (empty) (cons (f (head xs)) (map f (tail xs)))))
+    (defn filter (pred xs)
+        (if (nil? xs) (empty)
+            (if (pred (head xs))
+                (cons (head xs) (filter pred (tail xs)))
+                (filter pred (tail xs)))))
+    (defn foldl (f init xs) (if (nil? xs) init (foldl f (f init (head xs)) (tail xs))))
+    (defn foldr (f init xs) (if (nil? xs) init (f (head xs) (foldr f init (tail xs)))))
     (defn range (start end) (if (ge start end) (empty) (cons start (range (add start 1) end))))
     (defn take (n xs) (if (or (le n 0) (nil? xs)) (empty) (cons (head xs) (take (sub n 1) (tail xs)))))
     (defn drop (n xs) (if (le n 0) xs (if (nil? xs) (empty) (drop (sub n 1) (tail xs)))))

--- a/form/form-stdlib/tests/higher-order-fn-arg-band.fk
+++ b/form/form-stdlib/tests/higher-order-fn-arg-band.fk
@@ -1,0 +1,51 @@
+; higher-order-fn-arg-band.fk — the higher-order wall, crossed four-way.
+;
+; preludes: form-stdlib/core.fk
+;
+; The named wall (fourth-arm-bands.txt): "higher-order calls — foldl/map/
+; filter with function arguments." A higher-order recipe takes a function as
+; an ARGUMENT and calls it inside its body. The three reference kernels run
+; core.fk's generic map/filter/foldl directly; this band proves the SAME
+; generic recipes also walk on the emitted fourth kernel (fkwu), with no
+; special-casing — one engine.
+;
+; How it crosses: a band-local function name in argument position lowers to a
+; function-ref value (cons of (fn-index, arity)) via the flattener's flt-fref
+; path; the higher-order body's call to its function PARAMETER lowers to an
+; indirect call (tag 44), which evaluates the function-value, reads
+; (fn-index, arity), and dispatches — arity 1 reads the single arg, arity ≥ 2
+; rides the packed-args list exactly like a direct call. map/filter pass the
+; function-value forward through self-recursion; foldl calls it with two args.
+;
+; Verdict 1111 when every higher-order shape holds across all four kernels:
+;   map with a 1-arg function argument        (dbl over a list)       →    1
+;   filter with a 1-arg predicate argument     (evenp over a list)     →   10
+;   foldl with a 2-arg function argument        (plus2 reducing)        →  100
+;   map composed with filter (function args threaded twice)            → 1000
+
+(do
+    ;; band-local functions passed BY NAME into the generic higher-order
+    ;; recipes from core.fk (map/filter/foldl). Each name in argument
+    ;; position lowers to a function-ref the indirect-call arm dispatches.
+    (defn dbl (n) (mul n 2))
+    (defn evenp (n) (if (eq (mod n 2) 0) 1 0))
+    (defn plus2 (a b) (add a b))
+
+    ;; map: a 1-arg function applied across a list, rebuilt by cons.
+    ;; (dbl 1)+(dbl 2)+(dbl 3) = 2+4+6 = 12
+    (let map-score (if (eq (sum (map dbl (list 1 2 3))) 12) 1 0))
+
+    ;; filter: a 1-arg predicate selects elements.
+    ;; even of 1..6 = 2+4+6 = 12
+    (let filter-score (if (eq (sum (filter evenp (list 1 2 3 4 5 6))) 12) 10 0))
+
+    ;; foldl: a 2-arg function reduces the list (the packed-args indirect call).
+    ;; 0+1+2+3+4+5 = 15
+    (let foldl-score (if (eq (foldl plus2 0 (list 1 2 3 4 5)) 15) 100 0))
+
+    ;; map ∘ filter: the function argument threads through two higher-order
+    ;; layers — double every even of 1..6 = 2*(2+4+6) = 24
+    (let compose-score
+        (if (eq (sum (map dbl (filter evenp (list 1 2 3 4 5 6)))) 24) 1000 0))
+
+    (add map-score (add filter-score (add foldl-score compose-score))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -24,10 +24,20 @@
 #     surfaces beyond the explicit make_nodeid, category/pkg/level/type/inst
 #     projection, and generic/doc/concept/dns/session floor
 #   host io family        — read_file, write_file_text, file_mtime, scan_run
-#   higher-order calls    — foldl/map/filter with function arguments
-#     (wants defunctionalization: monomorphic copies per call site)
 #   multi-line output     — bands that print mid-walk (the walker answers
 #     one value through fk_pr)
+#
+# Crossed walls (kept here as named precedent, not standing blockers):
+#   higher-order calls    — foldl/map/filter with function arguments now CROSS
+#     four-way (higher-order-fn-arg row). No defunctionalization was needed:
+#     the flattener already lowers a function name in argument position to a
+#     function-ref value (flt-fref: cons of (fn-index, arity)), and a call to
+#     a param-bound function lowers to the indirect-call arm (tag 44), which
+#     reads (fn-index, arity) and dispatches — arity 1 reads the single arg,
+#     arity ≥ 2 rides the packed-args list like a direct call. The only gap
+#     was the standing shim: map/filter/foldl/foldr (and even?/odd?/zero?)
+#     are now carried as the EXACT generic recipes core.fk runs, so a band
+#     reaching them resolves ordinary function rows that walk through tag 44.
 #
 # Current floor (2026-06-14 content-address + sibling-node floor): the admitted
 # manifest carries content-address, durable substrate-core, and the doc-xpath,
@@ -91,6 +101,7 @@ signal-derivative fkc 127
 feature-vector fkc 127
 active-inference fks 127
 indirect-call-runtime-probe fks 7
+higher-order-fn-arg fks 1111
 branch-choice-order fks 511
 channel-interface fks 127
 channel-flow fks 8388607


### PR DESCRIPTION
## The wall, crossed

The named **higher-order calls** wall in `form/fourth-arm-bands.txt` — *foldl/map/filter with function arguments* — now crosses four-way (Go, Rust, TypeScript, and the emitted universal walker `fkwu`), with **no defunctionalization**.

## What grounded the wall

Authoring a minimal higher-order band and tracing the flattened table showed the flattener + walker **already carry the shape**:

- A function name in **argument position** lowers to a function-ref value via `flt-fref` — a cons of `(fn-index, arity)`.
- A call to a **param-bound function** inside a higher-order body lowers to the indirect-call arm (**tag 44**), which evaluates the function-value, reads `(fn-index, arity)`, and dispatches: arity 1 reads the single arg, arity ≥ 2 rides the packed-args list exactly like a direct call.

The map/filter/foldl shapes (including a 2-arg step function and function-args threaded through two higher-order layers) all returned correct verdicts on `fkwu` once the combinators were *defined*. The only gap was the standing shim.

## The fix (one engine, not parallel paths)

`form/form-stdlib/fourth-shim.fk` deliberately omitted the higher-order combinators (`; higher-order core stays outside the walker's reach until defunctionalization`), so a band reaching `map`/`filter`/`foldl` resolved an **undefined** call that lowered to a zero verdict.

This PR carries `map`/`filter`/`foldl`/`foldr` (plus `even?`/`odd?`/`zero?`) in the shim as the **exact generic recipes `core.fk` runs on the three reference kernels** — not a per-call-site monomorphic copy. The function-value threads through map/filter's forward recursion and foldl's two-arg step via the same tag-44 the carrier-dispatch floor already used.

## Proof

`form/form-stdlib/tests/higher-order-fn-arg-band.fk` (manifest: `higher-order-fn-arg fks 1111`):

| shape | bit |
|---|---|
| `map` with a 1-arg function argument | 1 |
| `filter` with a 1-arg predicate argument | 10 |
| `foldl` with a 2-arg function argument (packed-args indirect call) | 100 |
| `map ∘ filter` (function arg threaded through two layers) | 1000 |

Focused four-way gate:

```
  ✓  core.fk+higher-order-fn-arg-band.fk  → 1111

  fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
  1 ok, 0 divergent — kernels agree on every sample.
```

Existing shim-touching bands re-validated individually after the shim change (the shim re-hashes every cached table): `indirect-call-runtime-probe → 7`, `substrate-core → 11111`, `feature-vector → 127`, `base64 → 12`, `learning-trend → 127`, `slice-merge → 127`, `sha256 → 2` — all `0 divergent` four-way.

## Scope

Touched only the flattener's standing prelude (the shim), the manifest row + wall narrative, and the new band — per the lane constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)