### PR TITLE
tend: io-match capture carrier — real tool calls become content-addressed records

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -43,7 +43,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 147 | Python bridge/API routers — current endpoint carrier and upstream tail while Form-native routes are promoted |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 246 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 58 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 269 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 270 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |

--- a/api/scripts/agent_runner.py
+++ b/api/scripts/agent_runner.py
@@ -23,6 +23,7 @@ except ImportError:
 import sys
 if sys.platform != "win32":
     import pwd
+import hashlib
 import socket
 import shlex
 import shutil
@@ -3027,6 +3028,18 @@ def _parse_failure_hint_from_output(output: str) -> dict[str, Any]:
     return hint
 
 
+def _io_match_sig(content: str) -> str:
+    """Content-address a call's input or output — the bootstrap host-native
+    execution of io-match.fk's `iom-capture` (sha256, FIPS 180-4: the same bytes
+    the canonical Form recipe form/form-stdlib/sha256.fk defines). Identity comes
+    for free — identical inputs share a sig, so repeat calls group and dedup; the
+    digest reveals nothing of the content, so a secret in a command never leaks.
+    The native form-cli binary will run iom-capture directly; this feeds the same
+    records until then. Learning logic stays in Form (io-match.fk scoring,
+    tool-embodiment.fk gate, form-cli-loop.fk routing)."""
+    return hashlib.sha256((content or "").encode("utf-8")).hexdigest()
+
+
 def _post_runtime_event(
     client: httpx.Client,
     *,
@@ -3041,6 +3054,8 @@ def _post_runtime_event(
     worker_id: str,
     executor: str,
     is_openai_codex: bool,
+    input_sig: str | None = None,
+    output_sig: str | None = None,
 ) -> None:
     if _cfg_str("pipeline", "tool_telemetry_enabled", "PIPELINE_TOOL_TELEMETRY_ENABLED", "1").strip() in {"0", "false", "False"}:
         return
@@ -3064,6 +3079,14 @@ def _post_runtime_event(
             "is_openai_codex": bool(is_openai_codex),
         },
     }
+    # io-match capture: when the real (input, output) are content-addressed, the
+    # tool telemetry becomes an io-match record — calls group/dedup by input-sig,
+    # and the learning loop (io-match.fk -> tool-embodiment.fk) reads outcome by lane.
+    if input_sig is not None:
+        payload["metadata"]["io_match"] = "1"
+        payload["metadata"]["input_sig"] = input_sig
+        payload["metadata"]["output_sig"] = output_sig or ""
+        payload["metadata"]["outcome"] = "success" if int(returncode) == 0 else "fail"
     try:
         client.post(f"{BASE}/api/runtime/events", json=payload, timeout=5.0)
     except Exception:
@@ -6824,6 +6847,8 @@ def run_one_task(
             worker_id=worker_id,
             executor=executor,
             is_openai_codex=is_openai_codex,
+            input_sig=_io_match_sig(command),
+            output_sig=_io_match_sig(output or ""),
         )
         if status != "completed":
             _post_tool_failure_friction(

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 269
+**Total files**: 270
 
 | File | Purpose |
 |---|---|
@@ -131,6 +131,7 @@
 | [test_instance_pulse.py](test_instance_pulse.py) | Acceptance tests for instance-pulse — per-instance breath sharing. |
 | [test_interest_registration.py](test_interest_registration.py) | Flow-centric tests for interest registration — privacy-first community gathering. |
 | [test_investments.py](test_investments.py) | Flow-centric tests for the investment surface — covers preview, portfolio, |
+| [test_io_match_capture.py](test_io_match_capture.py) | io-match capture carrier: real tool calls become content-addressed records. |
 | [test_ip_registration.py](test_ip_registration.py) | Flow tests for ip_registration_service — story-protocol-integration R1, R7. |
 | [test_kernel_attribution_report.py](test_kernel_attribution_report.py) | Regression tests for kernel attribution parity sensing. |
 | [test_kernel_conformance_harness.py](test_kernel_conformance_harness.py) | Executable kernel conformance harness for Form question effects. |

--- a/api/tests/test_io_match_capture.py
+++ b/api/tests/test_io_match_capture.py
@@ -1,0 +1,79 @@
+"""io-match capture carrier: real tool calls become content-addressed records.
+
+The bootstrap host-native execution of io-match.fk's `iom-capture`. These tests
+prove the carrier stays faithful to the canonical Form recipe — sha256 (FIPS
+180-4) content-addressing, identical inputs sharing a sig — and that the tool
+telemetry carries the io-match fields the learning loop reads. The learning logic
+itself lives in Form (io-match.fk / tool-embodiment.fk), proven four-way there.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_AGENT_RUNNER_PATH = Path(__file__).resolve().parents[1] / "scripts" / "agent_runner.py"
+_spec = importlib.util.spec_from_file_location("agent_runner", _AGENT_RUNNER_PATH)
+assert _spec and _spec.loader
+agent_runner = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(agent_runner)
+
+
+class _CaptureClient:
+    def __init__(self):
+        self.posts = []
+
+    def post(self, url, json=None, timeout=None):
+        self.posts.append({"url": url, "json": json})
+        return None
+
+
+def test_io_match_sig_is_canonical_sha256():
+    # FIPS 180-4 vector: sha256("abc") — the same bytes form-stdlib/sha256.fk defines.
+    assert agent_runner._io_match_sig("abc") == (
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    )
+    # content-addressing: same input -> same sig; different input -> different sig.
+    assert agent_runner._io_match_sig("ls -la") == agent_runner._io_match_sig("ls -la")
+    assert agent_runner._io_match_sig("ls -la") != agent_runner._io_match_sig("ls -lah")
+    # the digest reveals nothing of the content (no secret leak): 64 hex chars, no input.
+    sig = agent_runner._io_match_sig("export TOKEN=sk-secret-123")
+    assert len(sig) == 64 and "secret" not in sig
+
+
+def _post(returncode, **kw):
+    client = _CaptureClient()
+    agent_runner._post_runtime_event(
+        client,
+        tool_name="bash",
+        status_code=200 if returncode == 0 else 500,
+        runtime_ms=12.0,
+        task_id="t1",
+        task_type="impl",
+        model="form-native",
+        returncode=returncode,
+        output_len=3,
+        worker_id="w1",
+        executor="form-native",
+        is_openai_codex=False,
+        **kw,
+    )
+    return client.posts[0]["json"]["metadata"] if client.posts else {}
+
+
+def test_telemetry_carries_io_match_record_when_sigs_present():
+    meta = _post(0, input_sig=agent_runner._io_match_sig("echo hi"), output_sig=agent_runner._io_match_sig("hi"))
+    assert meta["io_match"] == "1"
+    assert meta["input_sig"] == agent_runner._io_match_sig("echo hi")
+    assert meta["output_sig"] == agent_runner._io_match_sig("hi")
+    assert meta["outcome"] == "success"
+
+
+def test_outcome_is_fail_on_nonzero_returncode():
+    meta = _post(1, input_sig=agent_runner._io_match_sig("false"), output_sig="")
+    assert meta["outcome"] == "fail"
+
+
+def test_no_io_match_fields_when_sigs_absent():
+    # backward compatible: telemetry without capture carries no io-match fields.
+    meta = _post(0)
+    assert "io_match" not in meta and "input_sig" not in meta


### PR DESCRIPTION
## The last mile — live capture

The thin carrier the channel was waiting for. At the runner's tool boundary the real `(command, output)` are in hand; `_io_match_sig` content-addresses each with **sha256 (FIPS 180-4 — the same bytes `form-stdlib/sha256.fk` defines)**, and `_post_runtime_event` carries them as `io_match` fields (`input_sig`, `output_sig`, `outcome`) on the telemetry that already flows.

So every tool call becomes an **io-match record**: calls group/dedup by input-sig, and the learning loop (`io-match.fk` efficacy → `tool-embodiment.fk` gate) reads outcome by lane. **The flywheel now turns on live data.**

## Discipline

This is the **bootstrap host-native execution** of `io-match.fk`'s `iom-capture` — the native form-cli binary will run iom-capture directly. All learning logic stays in Form; the carrier only captures and addresses. The digest reveals nothing of the content, so a secret in a command never leaks.

## Safety

- **Additive / backward-compatible**: no `io_match` fields when sigs are absent, so existing telemetry is byte-unchanged (test covers this).
- **Telemetry-only**: does not touch task progression (the existing `_post_runtime_event` contract).
- Persistence reuses the existing `RuntimeEvent` store the #3051 grouping already reads.

## Proof

`test_io_match_capture.py` (4 tests, + existing telemetry test still 7/7): canonical sha256 vector, content-addressing (same input → same sig), no-secret-leak, telemetry round-trip, fail-outcome, backward compatibility. Maintainability gate: no regression.

## Next

The reasoning-call boundary (the LLM API itself) is the higher-value capture — same shim, next extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)