### PR TITLE
Sequence bare do-statements on the fourth arm (effect-once, part 1)

### DIFF
--- a/form/form-stdlib/form-flatten.fk
+++ b/form/form-stdlib/form-flatten.fk
@@ -220,8 +220,12 @@
     (if (ge pos (fp-len s)) (list val pos)
     (if (eq (fp-at s pos) 41) (list val (add pos 1))
     (if (str_eq (flt-peek s pos) "let") (flt-do-let s pos fns env val)
-        (flt-do-e s (flt-expr s pos fns env) fns env)))))
-(defn flt-do-e (s ee fns env) (flt-do2 s (fp-skip s (nth ee 1)) fns env (nth ee 0)))
+        (flt-do-e s (flt-expr s pos fns env) fns env val)))))
+; A bare do-statement is an EFFECT, not dead weight: sequence the running value
+; before the new expression (t==69 walks the left for effect, returns the right),
+; so every statement fires exactly once in order and the last is the do's value.
+; The initial (fk-lit 0) sentinel rides as a harmless first left-walk.
+(defn flt-do-e (s ee fns env val) (flt-do2 s (fp-skip s (nth ee 1)) fns env (flt-sequence val (nth ee 0))))
 
 ; (let name value) inside a do — value parses under the CURRENT env, then
 ; binds for the remaining items (shadowing outer bindings by name)
@@ -422,8 +426,11 @@
     (if (eq (fp-at s pos) 41) (list fns rbodies main (add pos 1) env)
     (if (str_eq (flt-peek s pos) "defn") (flt-defn s pos fns rbodies env main)
     (if (str_eq (flt-peek s pos) "let") (flt-let s pos fns rbodies env main)
-        (flt-main s (flt-expr s pos fns env) fns rbodies env))))))
-(defn flt-main (s ee fns rbodies env) (flt-items s (nth ee 1) fns rbodies env (nth ee 0)))
+        (flt-main s (flt-expr s pos fns env) fns rbodies env main))))))
+; Top-level bare statements are effects too: sequence the running main before the
+; new expression so a do-block's intermediate statements fire once in order and
+; the last is the program value (same discipline as flt-do-e for nested do).
+(defn flt-main (s ee fns rbodies env main) (flt-items s (nth ee 1) fns rbodies env (flt-sequence main (nth ee 0))))
 
 ; (defn name (p0 p1 ...) body) — pos arrives at the form's '('. The param
 ; LIST reads whole first so the function row carries (name index arity)

--- a/form/form-stdlib/tests/do-effect-seq-band.fk
+++ b/form/form-stdlib/tests/do-effect-seq-band.fk
@@ -1,0 +1,17 @@
+; do-effect-seq-band.fk — bare do-statements must each fire exactly once, in order.
+;
+; preludes: form-stdlib/core.fk
+;
+; fkwu's flattener kept only a do-block's LAST expression and dropped the bare
+; statements before it, so their side effects vanished. The three reference
+; kernels sequence them. This band writes two bytes through two bare append
+; statements (after a clean-slate remove) and reads the length back — only 2 if
+; every bare statement was walked exactly once, in order. Deterministic: the
+; remove gives a clean slate so reruns return 2.
+(do
+    (let dir (temp_dir))
+    (let path (str_concat dir "/fk-do-effect-seq.txt"))
+    (fs_remove path)
+    (file_append_bytes path (list 65))
+    (file_append_bytes path (list 66))
+    (str_len (read_file path)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -312,12 +312,16 @@ substrate-core fks 11111
 # real filesystem io was 3-kernel-only (the named "host io" wall). temp_dir is
 # now a native fkwu arm (tag 101, fk_tempdir reads $TMPDIR), joining the existing
 # fs carriers (tags 55..63). hostio-roundtrip writes "ABC" then reads it back
-# over the live filesystem and crosses four-way deterministically. The remaining
-# wall is effect-once semantics: fkwu inlines let and drops bare do-statements,
-# and eq/and walk an operand twice, so a side-effecting op re-fires unless walked
-# exactly once — write_file_text/file_mtime/scan_run and the segmented-FILE and
-# Postgres carriers wait on let-effect-once / do-sequencing reaching fkwu.
+# over the live filesystem and crosses four-way deterministically. Effect-once
+# is the remaining ground, and one piece of it is now crossed: bare do-statements
+# (top-level and nested) sequence through tag 69, so each fires exactly once in
+# order (do-effect-seq writes two bytes through two bare appends and reads len 2).
+# Still open: fkwu inlines let (re-walks a bound value at every use) and flt-eq/
+# flt-lt lower an operand twice — so write_file_text/file_mtime/scan_run and the
+# segmented-FILE and Postgres carriers wait on let-effect-once and single-walk
+# eq/lt reaching fkwu.
 hostio-roundtrip fks 111
+do-effect-seq fks 2
 doc-xpath fks 10
 concept-xpath fks 9
 dns fks 5


### PR DESCRIPTION
## What

The host-io lane named **effect-once** as the wall behind durable real carriers. This lands the first piece.

fkwu's flattener kept only a do-block's **last** expression and dropped the bare statements before it, so their side effects vanished (the three reference kernels sequence them — any multi-effect body diverged). `flt-do-e` (nested `do`) and `flt-main` (top-level `do`) now sequence the running value before each new statement through the existing sequence node (tag 69): walk the left for effect, return the right — every bare statement fires exactly once, in order, and the last is the do's value.

New `do-effect-seq` band: clean-slate remove → two bare appends → read length — crosses four-way at **2** only if each bare statement walked exactly once.

## Proof

`cd form && ./validate.sh` → **202 bands four-way, 603 ok, 0 divergent.** The sequence wrap is transparent to every existing do-block (single-expression do returns the same value; verdicts unchanged).

## Floor → north star

Floor: bare do-statements dropped (effects vanish). This crosses one slice of effect-once. **Still open** toward the durable-carrier north star: let-effect-once (fkwu inlines `let`, re-walking a bound value at each use) and single-walk eq/lt (`flt-eq`/`flt-lt` lower an operand twice). Named in the manifest as the remaining ground for `write_file_text`/segmented-FILE/Postgres carriers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)