### PR TITLE
tend: astrology math runs on full float precision

### DIFF
--- a/form/form-stdlib/celestial-pole-channel.fk
+++ b/form/form-stdlib/celestial-pole-channel.fk
@@ -67,8 +67,10 @@
     ;; ayanamsa to read the fixed (sidereal) stars — so a degree that is
     ;; early Aries to a Western chart is late Pisces to a Vedic one.
     (defn lahiri-ayanamsa-2000 () 24)
-    (defn tropical-sign-of (lon) (div (mod lon 360) 30))
-    (defn sidereal-sign-of (lon ayan) (div (mod (add (sub lon ayan) 360) 360) 30))
+    ;; full-float reduction: floor the FLOAT longitude, never an int-truncated degree, so a
+    ;; body near a sign boundary lands on the right side. floor returns the integer index.
+    (defn tropical-sign-of (lon) (floor (div (mod lon 360.0) 30.0)))
+    (defn sidereal-sign-of (lon ayan) (floor (div (mod (add (sub lon ayan) 360.0) 360.0) 30.0)))
 
     ;; --- the pole star moves: who holds the pole in a given era -------
     ;; Each row is (epoch-year, attested star). Epoch = year of closest

--- a/form/form-stdlib/ephemeris-moon.fk
+++ b/form/form-stdlib/ephemeris-moon.fk
@@ -18,7 +18,7 @@
 ;   lambda = L' + 6.289 sin M + 1.274 sin(2D-M) + 0.658 sin 2D
 ;              + 0.214 sin 2M - 0.186 sin Ms - 0.114 sin 2F
 ;
-;   (moon-longitude y m d)     -> ecliptic longitude, integer deg in [0,360)
+;   (moon-longitude y m d)     -> ecliptic longitude, float deg in [0,360)
 ;   (moon-sign-tropical y m d) -> the Moon's Western sign
 ;   (moon-elongation y m d)    -> Moon - Sun angle: 0 new, 180 full (the lunar phase)
 ;   (moon-phase-octant y m d)  -> 0..7: 0 new, 2 first quarter, 4 full, 6 last quarter
@@ -48,18 +48,19 @@
             (add (mul -0.186 (fsin (deg2rad (moon-Ms d))))
                  (mul -0.114 (fsin (deg2rad (mul 2.0 (moon-F d))))))))))))
 
+    ;; full float, never int-truncated — the sign/gate reductions floor the precise value.
     (defn moon-longitude (y m d)
-        (round (fnorm360 (moon-longitude-raw (ephem-n y m d)))))
+        (fnorm360 (moon-longitude-raw (ephem-n y m d))))
     (defn moon-sign-tropical (y m d) (tropical-sign-of (moon-longitude y m d)))
     (defn moon-sign-sidereal (y m d) (sidereal-sign-of (moon-longitude y m d) (lahiri-ayanamsa-2000)))
 
     ;; --- lunar phase: the Moon-Sun angle, coupling to the proven Sun ----
     (defn moon-elongation (y m d)
-        (round (fnorm360 (sub (moon-longitude-raw (ephem-n y m d))
-                              (sun-longitude-raw (ephem-n y m d))))))
-    ;; phase octant 0..7 (0 new, 2 first quarter, 4 full, 6 last quarter)
+        (fnorm360 (sub (moon-longitude-raw (ephem-n y m d))
+                       (sun-longitude-raw (ephem-n y m d)))))
+    ;; phase octant 0..7 (0 new, 2 first quarter, 4 full, 6 last quarter) — float floor
     (defn moon-phase-octant (y m d)
-        (div (mod (add (moon-elongation y m d) 22) 360) 45))
+        (floor (div (mod (add (moon-elongation y m d) 22.0) 360.0) 45.0)))
 
     (defn ephemeris-moon-teaching () "lc-cross-modal-unity")
 

--- a/form/form-stdlib/ephemeris-nodes.fk
+++ b/form/form-stdlib/ephemeris-nodes.fk
@@ -12,7 +12,7 @@
 ;   Rahu  = Omega        (north node)
 ;   Ketu  = Omega + 180  (south node)
 ;
-;   (rahu-longitude y m d) / (ketu-longitude y m d)   -> integer deg in [0,360)
+;   (rahu-longitude y m d) / (ketu-longitude y m d)   -> float deg in [0,360)
 ;   (rahu-sign-tropical ...) / (rahu-sign-sidereal ...) / (ketu-sign-tropical ...)
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/guidance-channel.fk form-stdlib/celestial-pole-channel.fk form-stdlib/trig.fk form-stdlib/ephemeris-sun.fk
@@ -22,10 +22,11 @@
     ;; the mean ascending node (degrees), retrograde
     (defn node-omega-raw (d) (sub 125.0445 (mul 0.05295377 d)))
 
+    ;; full float, never int-truncated — the sign/gate reductions floor the precise value.
     (defn rahu-longitude (y m d)
-        (round (fnorm360 (node-omega-raw (ephem-n y m d)))))
+        (fnorm360 (node-omega-raw (ephem-n y m d))))
     (defn ketu-longitude (y m d)
-        (round (fnorm360 (add (node-omega-raw (ephem-n y m d)) 180.0))))
+        (fnorm360 (add (node-omega-raw (ephem-n y m d)) 180.0)))
 
     (defn rahu-sign-tropical (y m d) (tropical-sign-of (rahu-longitude y m d)))
     (defn rahu-sign-sidereal (y m d) (sidereal-sign-of (rahu-longitude y m d) (lahiri-ayanamsa-2000)))

--- a/form/form-stdlib/ephemeris-sun.fk
+++ b/form/form-stdlib/ephemeris-sun.fk
@@ -14,7 +14,7 @@
 ;   g = 357.528 + 0.9856003 n     mean anomaly     (deg)
 ;   lambda = L + 1.915 sin g + 0.020 sin 2g        ecliptic longitude (deg)
 ;
-;   (sun-longitude y m d)       -> ecliptic longitude, integer degrees in [0,360)
+;   (sun-longitude y m d)       -> ecliptic longitude, float degrees in [0,360)
 ;   (sun-sign-tropical y m d)   -> Western sign index 0..11 (the season's sign)
 ;   (sun-sign-sidereal y m d)   -> Vedic sign index (the fixed-star sign)
 ;
@@ -49,9 +49,10 @@
             (let r (sub x (mul 360.0 (round (div x 360.0)))))
             (if (lt r 0.0) (add r 360.0) r)))
 
-    ;; the Sun's ecliptic longitude, integer degrees in [0,360)
+    ;; the Sun's ecliptic longitude, in degrees [0,360) — full float, never int-truncated,
+    ;; so the sign and gate reductions floor the precise value (round only for a verdict).
     (defn sun-longitude (y m d)
-        (round (fnorm360 (sun-longitude-raw (ephem-n y m d)))))
+        (fnorm360 (sun-longitude-raw (ephem-n y m d))))
 
     ;; the Sun's sign, in each astrology — the live position feeding the channels
     (defn sun-sign-tropical (y m d) (tropical-sign-of (sun-longitude y m d)))

--- a/form/form-stdlib/hd-mandala-wheel.fk
+++ b/form/form-stdlib/hd-mandala-wheel.fk
@@ -11,16 +11,17 @@
 ; contains 0 deg Aries. Gate 41 begins at 302.000 deg (2 deg Aquarius) — the Human Design
 ; New Year, the canonical anchor.
 ;
-;   (gate-at-longitude lon)  -> the gate at an ecliptic degree (integer-degree resolution)
+;   (gate-at-longitude lon)  -> the gate at an ecliptic longitude (float, sub-degree)
 ;   (sun-gate y m d)         -> the gate the Sun activates on a date (ephemeris -> wheel)
 ;   (sun-gate-speak y m d)   -> that gate's Human Design keynote (-> iching-channel)
 ;
 ; This closes the activation chain end to end: a date becomes the Sun's longitude
 ; (ephemeris-sun.fk), the longitude becomes a gate (this wheel), the gate becomes its
-; attested meaning (iching-channel.fk). The index is exact integer arithmetic in eighths
-; of a degree (5.625 = 45/8, 358.25 = 2866/8), so no float floor is needed and it crosses
-; the fourth arm. Sub-degree boundary precision waits on a finer longitude than the
-; integer ephemeris gives — a named next row.
+; attested meaning (iching-channel.fk). The wheel boundaries are exact (5.625 = 45/8,
+; 358.25 = 2866/8) and the index floors the FULL-FLOAT longitude over them, so a body
+; within a fraction of a degree of a 5.625-deg gate boundary lands on the right gate —
+; the float ephemeris resolves the sub-degree place the boundary needs. It crosses the
+; fourth arm on float floor plus the trig the longitude rides.
 ;
 ; Sources: geodetheseeker/human-design-py (HD_START_DEGREE 358.25); CReizner/
 ; SharpAstrology.HumanDesign; bonniesorsby.com + barneyandflow.com degree tables; Jovian
@@ -37,11 +38,11 @@
               1 43 14 34 9 5 26 11 10 58 38 54 61 60 41 19 13 49 30 55
               37 63 22 36))
 
-    ;; the wheel index for an integer ecliptic degree. Eighths-of-a-degree keeps it
-    ;; exact integer: 5.625 deg = 45 eighths, 358.25 deg = 2866 eighths, 360 = 2880.
-    ;;   index = floor( ((lon*8 - 2866) mod 2880) / 45 )   (integer div floors)
+    ;; the wheel index for an ecliptic degree — full float, never int-truncated, so a body
+    ;; within a fraction of a degree of a 5.625-deg gate boundary lands on the right gate.
+    ;;   index = floor( ((lon - 358.25) mod 360) / 5.625 )    (fnorm360 lifts negatives)
     (defn hd-gate-index (lon)
-        (div (mod (add (sub (mul lon 8) 2866) 2880) 2880) 45))
+        (floor (div (fnorm360 (sub lon 358.25)) 5.625)))
 
     (defn gate-at-longitude (lon) (nth (hd-wheel) (hd-gate-index lon)))
 

--- a/form/form-stdlib/tests/chart-cast-band.fk
+++ b/form/form-stdlib/tests/chart-cast-band.fk
@@ -7,7 +7,7 @@
 ;
 ; Verdict 1111111 (127) when every claim holds across all four kernels.
 ;   Sun:  Gate 38, Capricorn (9)                                   -> 1
-;   Moon: Gate 44, Scorpio (7)                                     -> 10
+;   Moon: Gate 1, Scorpio (7) — float-precise (int 223 wrongly gave 44; 223.3 is Gate 1) -> 10
 ;   Rahu: Gate 31, Leo (4)                                         -> 100
 ;   Ketu: Gate 41, Aquarius (10)                                   -> 1000
 ;   the cast is 4 placements; the accessors read them              -> 10000
@@ -24,7 +24,7 @@
 
     ;; --- 2. the Moon placement ----------------------------------------
     (let m (moon-placement 2000 1 1))
-    (let moon-ok (if (eq (pl-gate m) 44) (if (eq (pl-trop m) 7) 10 0) 0))
+    (let moon-ok (if (eq (pl-gate m) 1) (if (eq (pl-trop m) 7) 10 0) 0))
 
     ;; --- 3. the Rahu placement ----------------------------------------
     (let r (rahu-placement 2000 1 1))

--- a/form/form-stdlib/tests/ephemeris-moon-band.fk
+++ b/form/form-stdlib/tests/ephemeris-moon-band.fk
@@ -20,7 +20,7 @@
 
 (do
     ;; --- 1. longitude -------------------------------------------------
-    (let lon-ok (if (eq (moon-longitude 2000 1 1) 223) 1 0))
+    (let lon-ok (if (eq (round (moon-longitude 2000 1 1)) 223) 1 0))
 
     ;; --- 2. the tropical/sidereal split on the Moon -------------------
     (let trop (eq (moon-sign-tropical 2000 1 1) 7))
@@ -28,7 +28,7 @@
     (let sign-ok (if trop (if sid 10 0) 0))
 
     ;; --- 3. daily motion ~13 deg --------------------------------------
-    (let motion-ok (if (eq (moon-longitude 2000 1 2) 235) 100 0))
+    (let motion-ok (if (eq (round (moon-longitude 2000 1 2)) 235) 100 0))
 
     ;; --- 4. new moon: phase octant 0 ----------------------------------
     (let new-ok (if (eq (moon-phase-octant 2000 1 6) 0) 1000 0))
@@ -38,7 +38,7 @@
 
     ;; --- 6. full moon: octant 4, elongation ~180 ----------------------
     (let full-oct (eq (moon-phase-octant 2000 1 21) 4))
-    (let full-elong (eq (moon-elongation 2000 1 21) 184))
+    (let full-elong (eq (round (moon-elongation 2000 1 21)) 184))
     (let full-ok (if full-oct (if full-elong 100000 0) 0))
 
     ;; --- 7. last quarter: phase octant 6 ------------------------------

--- a/form/form-stdlib/tests/ephemeris-nodes-band.fk
+++ b/form/form-stdlib/tests/ephemeris-nodes-band.fk
@@ -13,7 +13,7 @@
 
 (do
     ;; --- 1. Rahu longitude --------------------------------------------
-    (let rahu-ok (if (eq (rahu-longitude 2000 1 1) 125) 1 0))
+    (let rahu-ok (if (eq (round (rahu-longitude 2000 1 1)) 125) 1 0))
 
     ;; --- 2. Rahu sign in both zodiacs ---------------------------------
     (let rt (eq (rahu-sign-tropical 2000 1 1) 4))
@@ -21,21 +21,21 @@
     (let rsign-ok (if rt (if rs 10 0) 0))
 
     ;; --- 3. Ketu, the opposite node -----------------------------------
-    (let kl (eq (ketu-longitude 2000 1 1) 305))
+    (let kl (eq (round (ketu-longitude 2000 1 1)) 305))
     (let kt (eq (ketu-sign-tropical 2000 1 1) 10))
     (let ketu-ok (if kl (if kt 100 0) 0))
 
     ;; --- 4. the axis is always 180 deg apart --------------------------
     (let axis-ok
-        (if (eq (mod (add (rahu-longitude 2000 1 1) 180) 360) (ketu-longitude 2000 1 1)) 1000 0))
+        (if (eq (round (mod (add (rahu-longitude 2000 1 1) 180.0) 360.0)) (round (ketu-longitude 2000 1 1))) 1000 0))
 
     ;; --- 5. retrograde: a year on, Rahu has moved back ~19 deg --------
-    (let r2001 (rahu-longitude 2001 1 1))
+    (let r2001 (round (rahu-longitude 2001 1 1)))
     (let retro-ok
         (if (eq r2001 106) (if (eq (sub 125 r2001) 19) 10000 0) 0))
 
     ;; --- 6. it keeps regressing: two years on ------------------------
-    (let r2002 (rahu-longitude 2002 1 1))
+    (let r2002 (round (rahu-longitude 2002 1 1)))
     (let keeps-ok (if (eq r2002 86) (if (gt r2001 r2002) 100000 0) 0))
 
     (sum (list rahu-ok rsign-ok ketu-ok axis-ok retro-ok keeps-ok)))

--- a/form/form-stdlib/tests/ephemeris-sun-band.fk
+++ b/form/form-stdlib/tests/ephemeris-sun-band.fk
@@ -1,17 +1,22 @@
 ; tests/ephemeris-sun-band.fk — the Sun's real place, computed native, four-way.
 ;
 ; The proof is the sky itself: from a date and nothing else, the recipe lands the
-; Sun on the four cardinal points of the year — 0 deg Aries at the spring equinox,
-; 90 deg Cancer at the summer solstice, 180 deg Libra at the autumn equinox, 270 deg
-; Capricorn at the winter solstice — and the same computed degree, read through the
-; Vedic ayanamsa, lands one sign back. All on Go/Rust/TS/fkwu: the fourth arm carries
-; the float and trig (trig fks 127), so the ephemeris does too.
+; Sun on the four cardinal degrees of the year — 0, 90, 180, 270 — at the equinoxes and
+; solstices. Read with full float (never int-truncated), the noon Sun resolves to its
+; precise sub-degree place: just *into* Aries at the spring equinox and Cancer at the
+; summer solstice, whose exact moments fall before noon (07:35 and 01:48 UTC in 2000);
+; and at the very *end* of Virgo and Sagittarius in autumn and winter, whose moments fall
+; after noon (17:27 and 13:37 UTC) — the Sun has not yet crossed the cardinal point. The
+; int-rounded degree reads the cardinal point; the unrounded sign reads where the Sun
+; truly is. The same computed degree through the Vedic ayanamsa lands one sign back. All
+; on Go/Rust/TS/fkwu: the fourth arm carries the float and trig (trig fks 127), so the
+; ephemeris does too.
 ;
 ; Verdict 1111111 (127) when every claim holds across all kernels.
-;   spring equinox: longitude 0, tropical sign Aries (0)           → 1
-;   summer solstice: longitude 90, tropical sign Cancer (3)        → 10
-;   autumn equinox: longitude 180, tropical sign Libra (6)         → 100
-;   winter solstice: longitude 270, tropical sign Capricorn (9)    → 1000
+;   spring equinox: rounds to 0, noon sign just into Aries (0)     → 1
+;   summer solstice: rounds to 90, noon sign just into Cancer (3)  → 10
+;   autumn equinox: rounds to 180, noon sign late Virgo (5)        → 100
+;   winter solstice: rounds to 270, noon sign late Sagittarius (8) → 1000
 ;   New Year: the Sun is ~280 deg, in Capricorn                    → 10000
 ;   sidereal: the equinox Sun is tropical Aries but Vedic Pisces   → 100000
 ;   century-stable: New Year 2100 still computes Capricorn (281)   → 1000000
@@ -21,27 +26,31 @@
 
 (do
     ;; --- 1. spring equinox: 0 deg Aries -------------------------------
-    (let mar-lon (eq (sun-longitude 2000 3 20) 0))
+    (let mar-lon (eq (round (sun-longitude 2000 3 20)) 0))
     (let mar-sign (eq (sun-sign-tropical 2000 3 20) 0))
     (let c-spring (if mar-lon (if mar-sign 1 0) 0))
 
     ;; --- 2. summer solstice: 90 deg Cancer ----------------------------
-    (let jun-lon (eq (sun-longitude 2000 6 21) 90))
+    (let jun-lon (eq (round (sun-longitude 2000 6 21)) 90))
     (let jun-sign (eq (sun-sign-tropical 2000 6 21) 3))
     (let c-summer (if jun-lon (if jun-sign 10 0) 0))
 
-    ;; --- 3. autumn equinox: 180 deg Libra -----------------------------
-    (let sep-lon (eq (sun-longitude 2000 9 22) 180))
-    (let sep-sign (eq (sun-sign-tropical 2000 9 22) 6))
+    ;; --- 3. autumn equinox: rounds to 180; noon Sun still late Virgo --
+    ;; the equinox moment (180 deg exact) falls at 17:27 UTC, after noon, so at noon the
+    ;; Sun is at ~29.8 deg Virgo (5) — the float resolves it; int-rounding would read Libra.
+    (let sep-lon (eq (round (sun-longitude 2000 9 22)) 180))
+    (let sep-sign (eq (sun-sign-tropical 2000 9 22) 5))
     (let c-autumn (if sep-lon (if sep-sign 100 0) 0))
 
-    ;; --- 4. winter solstice: 270 deg Capricorn ------------------------
-    (let dec-lon (eq (sun-longitude 2000 12 21) 270))
-    (let dec-sign (eq (sun-sign-tropical 2000 12 21) 9))
+    ;; --- 4. winter solstice: rounds to 270; noon Sun still late Sagittarius
+    ;; the solstice moment falls at 13:37 UTC, after noon, so the noon Sun is at ~29.9 deg
+    ;; Sagittarius (8) — not yet across into Capricorn.
+    (let dec-lon (eq (round (sun-longitude 2000 12 21)) 270))
+    (let dec-sign (eq (sun-sign-tropical 2000 12 21) 8))
     (let c-winter (if dec-lon (if dec-sign 1000 0) 0))
 
     ;; --- 5. New Year: the Sun is ~280 deg, in Capricorn ---------------
-    (let jan-lon (eq (sun-longitude 2000 1 1) 280))
+    (let jan-lon (eq (round (sun-longitude 2000 1 1)) 280))
     (let jan-sign (eq (sun-sign-tropical 2000 1 1) 9))
     (let c-newyear (if jan-lon (if jan-sign 10000 0) 0))
 
@@ -51,7 +60,7 @@
     (let c-sidereal (if sid 100000 0))
 
     ;; --- 7. the float holds a century out on the fourth arm ----------
-    (let far-lon (eq (sun-longitude 2100 1 1) 281))
+    (let far-lon (eq (round (sun-longitude 2100 1 1)) 281))
     (let far-sign (eq (sun-sign-tropical 2100 1 1) 9))
     (let c-century (if far-lon (if far-sign 1000000 0) 0))
 


### PR DESCRIPTION
The ephemeris longitudes and zodiac reductions carried int truncation: sun/moon/node longitudes rounded to whole degrees before the sign/gate/octant floor, and the sign reductions divided integer degrees. With full IEEE float on the fourth arm, there's no reason to throw the fraction away — the recipes now return the precise float longitude and the reductions `floor` it.

**The precision changes real answers:**
- The Moon on 2000-01-01 sits at 223.3°. Int 223 floored to HD Gate 44; 223.3 is Gate **1**. The chart-cast band now reads the true gate.
- The noon Sun at the autumn equinox / winter solstice is at the very *end* of Virgo / Sagittarius (the exact equinox and solstice moments fall after noon UTC — 17:27 and 13:37), not yet across into Libra / Capricorn as the rounded degree implied. The sun band now asserts where the Sun truly is.

**What changed**
- `celestial-pole-channel.fk` — `tropical-sign-of` / `sidereal-sign-of` floor the float (`mod 360.0`, `div 30.0`, `floor`)
- `ephemeris-sun/moon/nodes.fk` — longitudes return float (drop the premature `round`); moon phase octant floors the float
- `hd-mandala-wheel.fk` — gate index floors the full-float longitude; sub-degree boundary precision (previously named a "next row") now lands
- bands round only at the integer-comparison boundary — cardinal degrees still read 0/90/180/270

**Proof** — all six bands cross four-way (Go/Rust/TS/fkwu) at their registered verdicts: `ephemeris-sun` `1111111`, `ephemeris-moon` `1111111`, `ephemeris-nodes` `111111`, `celestial-pole-channel` / `hd-mandala-wheel` / `chart-cast` `1111111`. 0 divergent on every sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)