### PR TITLE
tend: arctangent completes the inverse-trig surface, four-way

### DIFF
--- a/form/form-stdlib/tests/trig-atan-band.fk
+++ b/form/form-stdlib/tests/trig-atan-band.fk
@@ -1,0 +1,52 @@
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk
+;
+; trig-atan-band — arctangent as a Form recipe (fatan/fatan2), the inverse-trig surface,
+; proven four-way. The strange-minimal test is the compass: atan2 walks the eight octants
+; and must land on the eight multiples of 45deg; fatan reproduces the 30/45/60 triad; the
+; x>1 range-reduction path is exercised by large arguments; and a round-trip through the
+; already-proven fsin/fcos closes the loop (atan2(sin θ, cos θ) = θ). Radians convert to
+; integer degrees via ×(180/π) then round, so last-bit float display never touches the proof.
+;
+; Verdict 1111111 (127) when every claim lands across all four kernels.
+;   atan2 NE/E octants:   atan2(1,1)=45,  atan2(1,0)=90            → 1
+;   atan2 NW/S octants:   atan2(1,-1)=135, atan2(0,-1)=180         → 10
+;   atan2 lower half:     atan2(-1,-1)=-135, (-1,0)=-90, (-1,1)=-45 → 100
+;   atan2 on the +x axis: atan2(0,1)=0,   atan2(0,5)=0             → 1000
+;   the 30/45/60 triad:   atan(1/√3)=30, atan(1)=45, atan(√3)=60   → 10000
+;   x>1 reduction path:   atan(10)=84,    atan(1000)=90            → 100000
+;   round-trip vs fsin/fcos: atan2(sin30,cos30)=30                 → 1000000
+;
+
+(do
+    ;; ×(180/π): radians → degrees
+    ;; --- 1. the east/northeast octants -------------------------------
+    (let c0 (if (eq (round (mul (fatan2 1.0 1.0) 57.29577951308232)) 45)
+                (if (eq (round (mul (fatan2 1.0 0.0) 57.29577951308232)) 90) 1 0) 0))
+
+    ;; --- 2. the northwest octant and the −x axis ---------------------
+    (let c1 (if (eq (round (mul (fatan2 1.0 -1.0) 57.29577951308232)) 135)
+                (if (eq (round (mul (fatan2 0.0 -1.0) 57.29577951308232)) 180) 10 0) 0))
+
+    ;; --- 3. the lower half: negative angles --------------------------
+    (let c2 (if (eq (round (mul (fatan2 -1.0 -1.0) 57.29577951308232)) -135)
+                (if (eq (round (mul (fatan2 -1.0 0.0) 57.29577951308232)) -90)
+                    (if (eq (round (mul (fatan2 -1.0 1.0) 57.29577951308232)) -45) 100 0) 0) 0))
+
+    ;; --- 4. on the +x axis, any magnitude reads 0 --------------------
+    (let c3 (if (eq (round (mul (fatan2 0.0 1.0) 57.29577951308232)) 0)
+                (if (eq (round (mul (fatan2 0.0 5.0) 57.29577951308232)) 0) 1000 0) 0))
+
+    ;; --- 5. the 30/45/60 triad through fatan -------------------------
+    (let c4 (if (eq (round (mul (fatan 0.5773502691896258) 57.29577951308232)) 30)
+                (if (eq (round (mul (fatan 1.0) 57.29577951308232)) 45)
+                    (if (eq (round (mul (fatan 1.7320508075688772) 57.29577951308232)) 60) 10000 0) 0) 0))
+
+    ;; --- 6. the x>1 reduction path (atan(x)=π/2−atan(1/x)) -----------
+    (let c5 (if (eq (round (mul (fatan 10.0) 57.29577951308232)) 84)
+                (if (eq (round (mul (fatan 1000.0) 57.29577951308232)) 90) 100000 0) 0))
+
+    ;; --- 7. round-trip vs the already-proven fsin/fcos ---------------
+    ;; atan2(sin 30°, cos 30°) = 30°  (30° = π/6 = 0.5235987755982988 rad)
+    (let c6 (if (eq (round (mul (fatan2 (fsin 0.5235987755982988) (fcos 0.5235987755982988)) 57.29577951308232)) 30) 1000000 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/form-stdlib/trig.fk
+++ b/form/form-stdlib/trig.fk
@@ -59,3 +59,36 @@
 ; one — and as a recipe over already-four-way primitives it crosses the fourth arm with
 ; no new native tag (the same posture as fsin/fcos/fsqrt). b must be > 0; b <= 0 → 0.0.
 (defn fpow (b e) (if (le b 0.0) 0.0 (math_exp (mul e (fln b)))))
+
+; --- fatan/fatan2: arctangent as a Form recipe — the inverse-trig surface that completes
+; sin/cos/sqrt/ln/exp/pow. Same posture: a recipe over the four-way primitives, no kernel
+; native. Range-reduce any x to |z| <= tan(15deg): first x>1 → π/2 − atan(1/x), then
+; x>tan15 → π/6 + atan((x√3−1)/(x+√3)) — where the Taylor series atan(z)=z−z³/3+z⁵/5−…
+; reaches fp64 depth in 16 terms. fatan2 places the angle in the right quadrant in (−π,π].
+; This is what every geocentric longitude, ascendant, and coordinate transform needs.
+(defn PI () 3.141592653589793)
+(defn PI-6 () 0.5235987755982988)
+(defn TAN15 () 0.26794919243112270)
+(defn SQRT3 () 1.7320508075688772)
+; Taylor for small |z|: term_{k+1} = term_k · (−z²) · (2k+1)/(2k+3)
+(defn atan-ser (z2 term k acc n)
+  (if (ge k n) acc
+      (atan-ser z2
+                (div (mul (mul term (mul -1.0 z2)) (add (mul 2 k) 1)) (add (mul 2 k) 3))
+                (add k 1) (add acc term) n)))
+(defn atan-small (z) (atan-ser (mul z z) z 0 0.0 16))
+(defn atan-unit (x)
+  (if (gt x (TAN15))
+      (add (PI-6) (atan-small (div (sub (mul x (SQRT3)) 1.0) (add x (SQRT3)))))
+      (atan-small x)))
+(defn atan-pos (x)
+  (if (gt x 1.0) (sub (HALF-PI) (atan-unit (div 1.0 x))) (atan-unit x)))
+(defn fatan (x)
+  (if (lt x 0.0) (mul -1.0 (atan-pos (mul -1.0 x))) (atan-pos (mul x 1.0))))
+(defn fatan2 (y x)
+  (if (gt x 0.0) (fatan (div (mul y 1.0) x))
+  (if (lt x 0.0)
+      (do (let a (fatan (div (mul y 1.0) x)))
+          (if (ge y 0.0) (add a (PI)) (sub a (PI))))
+  (if (gt y 0.0) (HALF-PI)
+  (if (lt y 0.0) (mul -1.0 (HALF-PI)) 0.0)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -227,6 +227,7 @@ jit-oracle-learning fks 1023
 jit-tensor-emit fks 7
 float-conversions fks 31
 trig fks 127
+trig-atan fks 1111111
 tensor-quant fks 4095
 transcendental-natives fks 16
 learning-arc fks 127


### PR DESCRIPTION
`trig.fk` carried `fsin`/`fcos`/`fsqrt`/`fln`/`flog10`/`fpow` but **no arctangent** — no way to recover an angle from a ratio, the operation every geocentric longitude, ascendant, and coordinate transform needs. `fatan`/`fatan2` close that gap as Form recipes over the already-four-way primitives — no kernel native added, same posture as `fsin`/`fcos`.

**How it computes**
- `fatan` range-reduces any `x` to `|z| ≤ tan(15°)`: first `x>1 → π/2 − atan(1/x)`, then `x>tan15 → π/6 + atan((x√3−1)/(x+√3))`, where the Taylor series `atan(z)=z−z³/3+z⁵/5−…` reaches fp64 depth in 16 terms.
- `fatan2` places the angle in the correct quadrant in `(−π,π]`.

**Proof — the compass.** `trig-atan-band` walks `atan2` through the eight octants (the eight multiples of 45°), reproduces the 30/45/60 triad through `fatan`, exercises the `x>1` reduction path (`atan(10)=84`, `atan(1000)=90`), and closes the loop back through the already-proven `fsin`/`fcos` (`atan2(sin 30°, cos 30°) = 30°`).

Verdict **`1111111`** four-way (Go/Rust/TS/fkwu), 0 divergent. Registered `trig-atan fks 1111111`. No dependent regressed — `trig` `127` and `ephemeris-sun` `1111111` still cross four-way.

This unblocks the next breath: placing the planets from Keplerian orbital elements (heliocentric → geocentric ecliptic longitude is an `atan2`), one engine with the planets as data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)