### PR TITLE
tend: the visible planets, placed by one Keplerian engine (three-way)

### DIFF
--- a/form/form-stdlib/ephemeris-planets.fk
+++ b/form/form-stdlib/ephemeris-planets.fk
@@ -1,0 +1,134 @@
+; ephemeris-planets.fk — the visible planets, placed natively by ONE Keplerian engine.
+;
+; The north star made literal: there is no per-planet code. A planet IS a row of orbital
+; elements (data); a single recipe solves Kepler's equation, lifts the body into the J2000
+; ecliptic, subtracts Earth's position, and reads the geocentric longitude as an atan2.
+; Mercury, Venus, Mars, Jupiter, Saturn (and Earth, the observer) all flow through the same
+; planet-helio-xy / planet-geo-lon — they differ only as data. Add a planet by adding a row.
+;
+; Elements are the attested JPL low-precision set (Standish, "Keplerian Elements for
+; Approximate Positions of the Major Planets", valid 1800–2050): for each body, the six
+; elements at J2000 and their rates per Julian century —
+;   a (au)  e  I(deg)  L(deg)  ϖ longitude-of-perihelion(deg)  Ω longitude-of-node(deg)
+; held as a 12-list (six values, then six rates). Earth's row is the Earth-Moon barycentre.
+;
+;   T          = (JD − 2451545)/36525           Julian centuries past J2000
+;   M          = L − ϖ                           mean anomaly  (then folded to ±180°)
+;   M = E − e*·sin E                              Kepler's equation (e* = (180/π)·e), Newton-solved
+;   x' = a(cos E − e),  y' = a√(1−e²) sin E       heliocentric, orbital plane
+;   (rotate by ω=ϖ−Ω, I, Ω) → heliocentric ecliptic (x,y)
+;   geocentric = planet − Earth;  λ = atan2(yg, xg)   ecliptic longitude in [0,360)
+;
+;   (mars-longitude y m d)        -> Mars's geocentric ecliptic longitude (float deg)
+;   (mars-sign-tropical y m d)    -> its zodiac sign (→ celestial-pole-channel reductions)
+;   (kepler-sun-longitude y m d)  -> the Sun via Earth's orbit (Earth helio λ + 180): the
+;                                    cross-check against the independently-built ephemeris-sun
+;
+; Proof: three-way (Go/Rust/TS). The fourth arm (fkwu) waits on the let-inlining re-walk fix —
+; planet-geo-lon reads two let-bound planet-helio-xy lists twice each, and fkwu's in-defn let
+; re-walk diverges there for some bodies. The recipe is correct; the three walkers agree.
+;
+; preludes: form-stdlib/core.fk form-stdlib/guidance-channel.fk form-stdlib/celestial-pole-channel.fk form-stdlib/trig.fk form-stdlib/ephemeris-sun.fk
+;
+
+(do
+    ;; --- orbital element rows (data) — six elements, then six per-century rates --------
+    ;;                         a            e            I            L              ϖ            Ω
+    (defn mercury-elements () (list 0.38709927  0.20563593  7.00497902  252.25032350  77.45779628  48.33076593
+                                    0.00000037  0.00001906 -0.00594749  149472.67411175 0.16047689 -0.12534081))
+    (defn venus-elements ()   (list 0.72333566  0.00677672  3.39467605  181.97909950  131.60246718 76.67984255
+                                    0.00000390 -0.00004107 -0.00078890  58517.81538729  0.00268329 -0.27769418))
+    (defn earth-elements ()   (list 1.00000261  0.01671123 -0.00001531  100.46457166  102.93768193  0.0
+                                    0.00000562 -0.00004392 -0.01294668  35999.37244981  0.32327364  0.0))
+    (defn mars-elements ()    (list 1.52371034  0.09339410  1.84969142  -4.55343205  -23.94362959  49.55953891
+                                    0.00001847  0.00007882 -0.00813131  19140.30268499  0.44441088 -0.29257343))
+    (defn jupiter-elements () (list 5.20288700  0.04838624  1.30439695  34.39644051   14.72847983  100.47390909
+                                   -0.00011607 -0.00013253 -0.00183714  3034.74612775   0.21252668  0.20469106))
+    (defn saturn-elements ()  (list 9.53667594  0.05386179  2.48599187  49.95424423   92.59887831  113.66242448
+                                   -0.00125060 -0.00050991  0.00193609  1222.49362201  -0.41897216 -0.28867794))
+
+    ;; --- the engine ------------------------------------------------------------------
+    (defn planet-T (y m d) (div (mul (ephem-n y m d) 1.0) 36525.0))
+    (defn el-at (els i T) (add (nth els i) (mul (nth els (add i 6)) T)))    ; element + rate·T
+    (defn deg-norm180 (d) (sub d (mul 360.0 (round (div d 360.0)))))        ; fold to (−180,180]
+
+    ;; Kepler: solve E (deg) from M (deg), e — Newton, fixed iterations.
+    ;;   ΔE = (M − (E − e*·sin E)) / (1 − e·cos E),  e* = (180/π)·e
+    (defn kepler-iter (M e estar E n)
+      (if (eq n 0) E
+          (kepler-iter M e estar
+                       (add E (div (sub M (sub E (mul estar (fsin (deg2rad E)))))
+                                   (sub 1.0 (mul e (fcos (deg2rad E))))))
+                       (sub n 1))))
+    (defn kepler-E (M e)
+      (do (let estar (mul 57.29577951308232 e))
+          (kepler-iter M e estar (add M (mul estar (fsin (deg2rad M)))) 10)))
+
+    ;; heliocentric ecliptic (x,y), J2000 — returns a 2-list
+    (defn planet-helio-xy (els T)
+      (do
+        (let a  (el-at els 0 T))
+        (let e  (el-at els 1 T))
+        (let I  (el-at els 2 T))
+        (let L  (el-at els 3 T))
+        (let vp (el-at els 4 T))
+        (let om (el-at els 5 T))
+        (let w  (sub vp om))                          ; argument of perihelion (deg)
+        (let M  (deg-norm180 (sub L vp)))             ; mean anomaly (deg)
+        (let E  (kepler-E M e))
+        (let Er (deg2rad E))
+        (let xp (mul a (sub (fcos Er) e)))
+        (let yp (mul a (mul (fsqrt (sub 1.0 (mul e e))) (fsin Er))))
+        (let wr (deg2rad w)) (let Ir (deg2rad I)) (let Or (deg2rad om))
+        (let cw (fcos wr)) (let sw (fsin wr))
+        (let cO (fcos Or)) (let sO (fsin Or))
+        (let cI (fcos Ir))
+        (let xe (add (mul (sub (mul cw cO) (mul (mul sw sO) cI)) xp)
+                     (mul (sub (mul -1.0 (mul sw cO)) (mul (mul cw sO) cI)) yp)))
+        (let ye (add (mul (add (mul cw sO) (mul (mul sw cO) cI)) xp)
+                     (mul (add (mul -1.0 (mul sw sO)) (mul (mul cw cO) cI)) yp)))
+        (list xe ye)))
+
+    ;; geocentric ecliptic longitude (deg [0,360)): planet − Earth, then atan2
+    (defn planet-geo-lon (els T)
+      (do
+        (let p (planet-helio-xy els T))
+        (let g (planet-helio-xy (earth-elements) T))
+        (let xg (sub (head p) (head g)))
+        (let yg (sub (nth p 1) (nth g 1)))
+        (fnorm360 (mul (fatan2 yg xg) 57.29577951308232))))
+
+    (defn planet-longitude (els y m d) (planet-geo-lon els (planet-T y m d)))
+
+    ;; the Sun, via Earth's own orbit: Earth's heliocentric longitude + 180 — the
+    ;; independent witness that the engine agrees with ephemeris-sun.fk.
+    (defn kepler-sun-longitude (y m d)
+      (do (let g (planet-helio-xy (earth-elements) (planet-T y m d)))
+          (fnorm360 (add (mul (fatan2 (nth g 1) (head g)) 57.29577951308232) 180.0))))
+
+    ;; heliocentric distance r = a(1 − e·cos E) (au) — orbital geometry sanity
+    (defn planet-distance (els T)
+      (do (let a (el-at els 0 T)) (let e (el-at els 1 T))
+          (let M (deg-norm180 (sub (el-at els 3 T) (el-at els 4 T))))
+          (mul a (sub 1.0 (mul e (fcos (deg2rad (kepler-E M e))))))))
+
+    ;; --- named bodies: each is its element row through the one engine ----------------
+    (defn mercury-longitude (y m d) (planet-longitude (mercury-elements) y m d))
+    (defn venus-longitude (y m d)   (planet-longitude (venus-elements) y m d))
+    (defn mars-longitude (y m d)    (planet-longitude (mars-elements) y m d))
+    (defn jupiter-longitude (y m d) (planet-longitude (jupiter-elements) y m d))
+    (defn saturn-longitude (y m d)  (planet-longitude (saturn-elements) y m d))
+
+    (defn mars-sign-tropical (y m d)    (tropical-sign-of (mars-longitude y m d)))
+    (defn mars-sign-sidereal (y m d)    (sidereal-sign-of (mars-longitude y m d) (lahiri-ayanamsa-2000)))
+    (defn jupiter-sign-tropical (y m d) (tropical-sign-of (jupiter-longitude y m d)))
+    (defn saturn-sign-tropical (y m d)  (tropical-sign-of (saturn-longitude y m d)))
+
+    ;; angular difference on the circle (deg), 0..180
+    (defn abs-deg (d) (if (lt d 0.0) (mul -1.0 d) d))
+    (defn ang-diff (a b) (do (let d (abs-deg (sub a b))) (if (gt d 180.0) (sub 360.0 d) d)))
+    (defn lon-wf (lon) (if (ge lon 0.0) (if (lt lon 360.0) 1 0) 0))    ; longitude in [0,360)?
+
+    (defn ephemeris-planets-teaching () "lc-cross-modal-unity")
+
+    0)

--- a/form/form-stdlib/tests/ephemeris-planets-band.fk
+++ b/form/form-stdlib/tests/ephemeris-planets-band.fk
@@ -1,0 +1,69 @@
+; tests/ephemeris-planets-band.fk — the Keplerian planet engine, proven native, four-way.
+;
+; The engine carries no external almanac value to assert; instead it proves itself against
+; physics and the body's own already-proven Sun. Two witnesses do the heavy lifting:
+;   · the SUN, computed through Earth's own orbit (Earth helio λ + 180), must agree with the
+;     independently-built ephemeris-sun.fk to within a degree, all the way around the year —
+;     that validates the full chain: Kepler solve → heliocentric coords → ecliptic rotation
+;     → atan2 → normalisation, on the one body whose answer we can check.
+;   · MARS at its documented 2003-08-28 opposition must sit ~180° from the Sun — opposition
+;     MEANS opposite the Sun, so this validates the geocentric subtraction (planet − Earth)
+;     for an outer body without asserting a fabricated longitude.
+; Angles compare as integer degrees (round); within-tolerance checks round the angular gap.
+;
+; Proof level: THREE-KERNEL (Go/Rust/TS), verdict 1111111. The fourth arm (fkwu) is a named
+; gap, not in the manifest: planet-geo-lon binds two planet-helio-xy list results and reads
+; each twice, and fkwu re-walks those let-bound calls (top-level band lets snapshot, but lets
+; inside a defn re-walk) — the deep re-walk diverges for some bodies (venus/mars at J2000 read
+; 0 where the three walkers agree, while mercury and the Earth-orbit Sun cross cleanly). The
+; recipe is correct — three independent kernels agree bit-for-bit — and this band is a clean
+; reproducer for the fkwu let-inlining re-walk fix; it crosses four-way once that lands.
+;
+; Verdict 1111111 (127) when every claim holds across Go/Rust/TS.
+;   Kepler inverts: solve E for (M=30,e=0.2), then E−e*·sinE = 30          → 1
+;   Sun via Earth's orbit = ephemeris-sun at spring equinox (≤1°)          → 10
+;   …and at the summer solstice (≤1°)                                      → 100
+;   …and at the autumn equinox AND winter solstice (≤1°)                   → 1000
+;   the engine's Sun lands in the same zodiac sign as ephemeris-sun        → 10000
+;   Mars at the 2003-08-28 opposition is ~180° from the Sun (≤5°)          → 100000
+;   all six bodies compute a well-formed longitude in [0,360)              → 1000000
+;
+; preludes: form-stdlib/core.fk form-stdlib/guidance-channel.fk form-stdlib/celestial-pole-channel.fk form-stdlib/trig.fk form-stdlib/ephemeris-sun.fk form-stdlib/ephemeris-planets.fk
+;
+
+(do
+    ;; --- 1. Kepler's equation inverts: M → E → M --------------------------------------
+    (let E30 (kepler-E 30.0 0.2))
+    (let kep-ok (if (eq (round (sub E30 (mul (mul 57.29577951308232 0.2) (fsin (deg2rad E30))))) 30) 1 0))
+
+    ;; --- 2. the Sun through Earth's orbit = ephemeris-sun, spring equinox -------------
+    (let spring-ok (if (le (round (ang-diff (kepler-sun-longitude 2000 3 20) (sun-longitude 2000 3 20))) 1) 10 0))
+
+    ;; --- 3. …summer solstice ----------------------------------------------------------
+    (let summer-ok (if (le (round (ang-diff (kepler-sun-longitude 2000 6 21) (sun-longitude 2000 6 21))) 1) 100 0))
+
+    ;; --- 4. …autumn equinox AND winter solstice (the far half of the orbit) -----------
+    (let autumn-ok (le (round (ang-diff (kepler-sun-longitude 2000 9 22) (sun-longitude 2000 9 22))) 1))
+    (let winter-ok (le (round (ang-diff (kepler-sun-longitude 2000 12 21) (sun-longitude 2000 12 21))) 1))
+    (let far-ok (if autumn-ok (if winter-ok 1000 0) 0))
+
+    ;; --- 5. the engine's Sun lands in the same sign as ephemeris-sun ------------------
+    (let ks (tropical-sign-of (kepler-sun-longitude 2000 1 1)))
+    (let es (tropical-sign-of (sun-longitude 2000 1 1)))
+    (let sign-ok (if (eq ks es) (if (eq es 9) 10000 0) 0))
+
+    ;; --- 6. Mars at the 2003-08-28 opposition is ~180° from the Sun -------------------
+    ;; opposition ⇒ geocentric Mars and Sun are 180° apart; this exercises planet − Earth.
+    (let mars-opp (ang-diff (mars-longitude 2003 8 28) (fnorm360 (add (sun-longitude 2003 8 28) 180.0))))
+    (let opp-ok (if (le (round mars-opp) 5) 100000 0))
+
+    ;; --- 7. every body computes a well-formed longitude in [0,360) -------------------
+    (let wf-count (add (lon-wf (mercury-longitude 2000 1 1))
+                  (add (lon-wf (venus-longitude 2000 1 1))
+                  (add (lon-wf (mars-longitude 2000 1 1))
+                  (add (lon-wf (jupiter-longitude 2000 1 1))
+                  (add (lon-wf (saturn-longitude 2000 1 1))
+                       (lon-wf (kepler-sun-longitude 2000 1 1))))))))
+    (let wf-ok (if (eq wf-count 6) 1000000 0))
+
+    (add kep-ok (add spring-ok (add summer-ok (add far-ok (add sign-ok (add opp-ok wf-ok)))))))


### PR DESCRIPTION
The north star made literal: **no per-planet code**. A planet IS a row of orbital elements (the attested JPL low-precision set, Standish, valid 1800–2050). One recipe solves Kepler's equation by Newton iteration, lifts the body into the J2000 ecliptic, subtracts Earth's position, and reads the geocentric longitude as an `atan2` (the inverse-trig from [#3080](https://github.com/seeker71/Coherence-Network/pull/3080)). Mercury, Venus, Mars, Jupiter, Saturn, and Earth all flow through the same `planet-helio-xy` / `planet-geo-lon` — they differ only as data. Add a planet by adding a row; each then receives the existing sign/sidereal reductions for free.

**Proof carries no fabricated almanac value** — it leans on physics and the body's own already-proven Sun:
- The Sun computed *through Earth's orbit* (Earth helio λ + 180) agrees with the independently-built `ephemeris-sun` all the way around the year (≤1°) and lands in the same zodiac sign — validating the whole chain (Kepler solve → heliocentric → ecliptic rotation → `atan2`).
- **Mars at its documented 2003-08-28 opposition sits ~180° from the Sun** (≤5°) — opposition *means* opposite the Sun, so this validates the geocentric subtraction for an outer body with no asserted longitude.

**Proof level: three-kernel (Go/Rust/TS), verdict `1111111`, 0 divergent.** The fourth arm (fkwu) is a **named gap**, not in the manifest: `planet-geo-lon` binds two `planet-helio-xy` list results and reads each twice, and fkwu re-walks let-bound calls *inside a defn* (top-level band lets snapshot) — the deep re-walk diverges for some bodies (venus/mars at J2000 read 0 where the three walkers agree; mercury and the Earth-orbit Sun cross cleanly). The recipe is correct — three independent kernels agree bit-for-bit — and this band is a clean reproducer for the fkwu **let-inlining re-walk** fix already in flight; it crosses four-way once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)