### PR TITLE
tend: heal /api/ideas 500 — read model tolerates empty description

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -44,7 +44,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 147 | Python bridge/API routers — current endpoint carrier and upstream tail while Form-native routes are promoted |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 246 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 58 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 270 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 271 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |

--- a/api/app/models/idea.py
+++ b/api/app/models/idea.py
@@ -159,7 +159,12 @@ class IdeaQuestionCreate(BaseModel):
 class Idea(BaseModel):
     id: str = Field(min_length=1)
     name: str = Field(min_length=1)
-    description: str = Field(min_length=1)
+    # description is optional in real data: ~15% of ideas carry none. The read
+    # model tolerates empty so the native /api/ideas projection (IdeaWithScore)
+    # serves them instead of hard-failing the whole list (the strict min_length=1
+    # 500'd the Go native route while Python skipped). Creation stays strict via
+    # IdeaCreate.
+    description: str = Field(default="")
     potential_value: float = Field(ge=0.0)
     actual_value: float = Field(default=0.0, ge=0.0)
     estimated_cost: float = Field(ge=0.0)

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 270
+**Total files**: 271
 
 | File | Purpose |
 |---|---|
@@ -120,6 +120,7 @@
 | [test_hati_mesh.py](test_hati_mesh.py) | _no top-of-file purpose_ |
 | [test_homepage_contrast.py](test_homepage_contrast.py) | WCAG AA contrast tests for homepage CSS palette (ux-homepage-readability). |
 | [test_household_service_board.py](test_household_service_board.py) | Flow test for the household resident-service board (api/app/routers/household.py). |
+| [test_idea_empty_description.py](test_idea_empty_description.py) | Idea read model tolerates empty description (real data: ~15% of ideas have none). |
 | [test_idea_lifecycle_closure.py](test_idea_lifecycle_closure.py) | Tests for idea lifecycle closure (spec: idea-lifecycle-closure). |
 | [test_idea_scoring.py](test_idea_scoring.py) | Tests for idea_scoring (spec: ideas-prioritization). |
 | [test_idea_standing_questions.py](test_idea_standing_questions.py) | Tests for idea_standing_questions (spec: standing-questions-roi-and-next-task-generation). |

--- a/api/tests/test_idea_empty_description.py
+++ b/api/tests/test_idea_empty_description.py
@@ -1,0 +1,48 @@
+"""Idea read model tolerates empty description (real data: ~15% of ideas have none).
+
+The strict `description: min_length=1` made the ideas listing hard-fail on real
+nodes that carry no description; the read model now accepts empty so the listing
+serves them. Creation stays strict via IdeaCreate.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.idea import Idea, IdeaWithScore, IdeaCreate
+
+
+def _base_kwargs(**over):
+    kw = dict(
+        id="idea-x",
+        name="An idea",
+        description="",
+        potential_value=1.0,
+        estimated_cost=0.1,
+    )
+    kw.update(over)
+    return kw
+
+
+def test_idea_accepts_empty_description():
+    idea = Idea(**_base_kwargs())
+    assert idea.description == ""
+
+
+def test_idea_with_score_inherits_tolerance():
+    # IdeaWithScore is the shape the native /api/ideas projection emits.
+    iws = IdeaWithScore(**_base_kwargs(coherence_score=0.0, free_energy_score=0.0, value_gap=0.0))
+    assert iws.description == ""
+
+
+def test_idea_still_requires_name_and_id():
+    with pytest.raises(ValidationError):
+        Idea(**_base_kwargs(name=""))
+    with pytest.raises(ValidationError):
+        Idea(**_base_kwargs(id=""))
+
+
+def test_creation_stays_strict():
+    # IdeaCreate is a separate write model — new ideas must still carry a description.
+    with pytest.raises(ValidationError):
+        IdeaCreate(name="An idea", description="")

--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -1,7 +1,7 @@
 # The Living Collective — Knowledge Base
 
 > AI-maintained markdown wiki. Read this file first. Drill into linked files for detail.
-> **Last maintained**: 2026-06-13 | **Concepts**: 188 | **Status**: 4 expanding, 127 seed, 55 deepening, 1 living, 1 gas | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
+> **Last maintained**: 2026-06-13 | **Concepts**: 189 | **Status**: 4 expanding, 127 seed, 55 deepening, 1 living, 2 gas | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
 
 ## How to use this KB
 


### PR DESCRIPTION
## Production incident
GET `/api/ideas` returned **500** (`{"error":"persistence","detail":"idea query failed"}`). Root cause: the strict `Idea` read model required `description` min_length=1, but **~452 of 3083 real ideas (~15%) carry no description** — the listing hard-failed on them. (web + `/api/health` were fine; this was the flagship native route.)

## Fix
`Idea.description` (read model) → `Field(default="")`. The listing now serves every idea; `IdeaWithScore` (the native projection shape) inherits the tolerance. **Creation stays strict** via the separate `IdeaCreate` model. Test covers: empty desc accepted on read, id/name still required, IdeaCreate still strict.

## Already done (your approved cleanup)
Removed **1536 external-proof test nodes + 4478 revisions** from prod (the `External Proof Test Idea [auto-cleanup]` / `Native default idea` pollution). Cleanup alone didn't clear the 500 — the 452 real empty-desc ideas needed this read heal.

## Next (recurrence — flagged)
The native-default external-proof CREATE runs every few minutes, re-inserting `idea:native-default` with a **deterministic revision id** → duplicate-key failures + fresh test nodes. That's a scheduled-harness/idempotency issue, separate from this read heal — the next fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)