### PR TITLE
tend: witness flags native routes served by the python fan-out fallback

### DIFF
--- a/pulse/pulse_app/analysis.py
+++ b/pulse/pulse_app/analysis.py
@@ -251,15 +251,24 @@ def latency_percentiles(samples: list[Sample]) -> tuple[int | None, int | None]:
 
 # --- current status -------------------------------------------------------
 
+# Detail prefixes that mark an ok=True sample as "strained" rather than fully
+# breathing: the surface answered, but a measured signal is off. Producers live
+# in probe.py / organs.py:
+#   "slow: "      — latency over the organ threshold (also reused for recent
+#                   5xx/4xx pressure on the api organ)
+#   "fell back: " — a native-promoted route served by the Python fan-out
+#                   instead of its kernel-router carrier (x-form-router check)
+STRAIN_DETAIL_PREFIXES = ("slow: ", "fell back: ")
+
+
 def status_from_last_sample(sample: Sample | None) -> str:
     if sample is None:
         return "unknown"
     if not sample.ok:
         return "silent"
-    # A successful probe with a "slow:" detail was flagged by probe._apply
-    # because its latency crossed the organ's threshold. It breathes, but
-    # it's straining.
-    if sample.detail and sample.detail.startswith("slow: "):
+    # A successful probe whose detail begins with a strain marker breathes,
+    # but it's straining (see STRAIN_DETAIL_PREFIXES).
+    if sample.detail and sample.detail.startswith(STRAIN_DETAIL_PREFIXES):
         return "strained"
     return "breathing"
 

--- a/pulse/pulse_app/organs.py
+++ b/pulse/pulse_app/organs.py
@@ -59,6 +59,19 @@ class Organ:
                                        # detail is set, so the current
                                        # status reads as "strained" while
                                        # the historical uptime stays at 100%
+    expected_router: str | None = None  # When set, the organ's response must
+                                       # carry `x-form-router: <this>` (e.g.
+                                       # "native-kernel"). A native route served
+                                       # by the Python fan-out fallback (kernel-
+                                       # router unhealthy → Traefik failover)
+                                       # still returns 200 with a valid body, so
+                                       # status+shape checks miss it; this makes
+                                       # probe._apply flag a "fell back: …"
+                                       # strain naming the carrier actually seen.
+                                       # Declarative like latency_threshold_ms —
+                                       # the check lives once in _apply, so a new
+                                       # native-promoted route opts in with one
+                                       # field, no per-extractor code.
 
 
 # --- upstream labels ------------------------------------------------------
@@ -278,7 +291,13 @@ def extract_web_vitality(r: "UpstreamResult") -> OrganVerdict:
 
 
 def extract_api_ideas(r: "UpstreamResult") -> OrganVerdict:
-    """/api/ideas returns a dict with an 'ideas' list (the prod shape)."""
+    """/api/ideas returns a dict with an 'ideas' list (the prod shape).
+
+    The carrier-path check (native-kernel vs fanout-python via the
+    `x-form-router` header) is applied generically by probe._apply from the
+    organ's `expected_router`, not here — so it covers any native-promoted
+    route without per-extractor code.
+    """
     if not _is_ok(r.status):
         return OrganVerdict(False, f"HTTP {r.status}")
     body = _require_body(r)
@@ -445,6 +464,13 @@ ORGANS: list[Organ] = [
         upstream=UPSTREAM_API_IDEAS,
         extractor=extract_api_ideas,
         latency_threshold_ms=1500,
+        # /api/ideas is a native-promoted route — its body runs in the Go
+        # form-kernel and the response carries `x-form-router: native-kernel`.
+        # If the kernel-router is unhealthy, Traefik fails over to the Python
+        # fan-out (`x-form-router: fanout-python`), which returns 200 and masks
+        # a native-route regression (the #3087 boolean::bigint 500). Declaring
+        # the expected carrier makes the witness flag that failover as strain.
+        expected_router="native-kernel",
     ),
     Organ(
         name="endpoint_vitality",

--- a/pulse/pulse_app/probe.py
+++ b/pulse/pulse_app/probe.py
@@ -16,7 +16,7 @@ shape, or rendered text markers.
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Iterable
 
 import httpx
@@ -38,6 +38,9 @@ class UpstreamResult:
     text: str | None              # Raw response text when kind=text, else None
     latency_ms: int
     error: str | None             # Transport error text, or None
+    headers: dict[str, str] = field(default_factory=dict)  # response headers,
+                                  # keys lowercased. Extractors and _apply read
+                                  # these for carrier-path checks (x-form-router).
 
 
 async def _probe_upstream(
@@ -66,6 +69,7 @@ async def _probe_upstream(
         else:
             resp = await client.get(url)
         elapsed = int((time.perf_counter() - start) * 1000)
+        headers = {k.lower(): v for k, v in resp.headers.items()}
         body: dict[str, Any] | None = None
         text: str | None = None
         if kind == "json":
@@ -86,6 +90,7 @@ async def _probe_upstream(
             text=text,
             latency_ms=elapsed,
             error=None,
+            headers=headers,
         )
     except httpx.HTTPError as exc:
         elapsed = int((time.perf_counter() - start) * 1000)
@@ -106,6 +111,40 @@ def _short_error(exc: BaseException) -> str:
 
 _SLOW_PREFIX = "slow: "
 
+# Native-promoted routes stamp their response with an `x-form-router` header
+# naming the carrier that served them: "native-kernel" (the Form kernel-router,
+# the body's actual carrier) or "fanout-python" (the Python fan-out fallback).
+# When the kernel-router container is unhealthy, Traefik fails over to the
+# Python `api` container, which still returns 200 with a valid body — so a
+# native-route regression (e.g. the boolean::bigint 500 fixed in #3087) is
+# invisible to status+shape checks alone: the witness probes the Python 200 and
+# reads "breathing" while the native route is down. An organ that declares
+# `expected_router` makes _apply compare the carrier seen and flag a strain
+# when the route was served by anything but its native carrier. Strain, not
+# silence: the surface still breathes, and a brief deploy-window failover
+# self-heals without scarring uptime.
+_FORM_ROUTER_HEADER = "x-form-router"
+_FALLBACK_PREFIX = "fell back: "
+
+
+def _router_fallback_detail(organ: Organ, result: UpstreamResult) -> str | None:
+    """Strain detail when a native-promoted route was served off its carrier.
+
+    Returns None when the organ declares no expected router or the carrier the
+    response named matches. Otherwise returns a "fell back: " strain detail
+    naming the actual carrier seen, so status_from_last_sample reads 'strained'
+    while uptime stays whole. A missing header counts as a fallback too — the
+    native carrier didn't stamp the response.
+    """
+    expected = organ.expected_router
+    if not expected:
+        return None
+    seen = result.headers.get(_FORM_ROUTER_HEADER)
+    if seen == expected:
+        return None
+    seen_label = seen if seen else "no router header"
+    return f"{_FALLBACK_PREFIX}expected {expected}, got {seen_label}"
+
 
 def _apply(organ: Organ, result: UpstreamResult, ts: str) -> Sample:
     if result.error is not None:
@@ -118,18 +157,24 @@ def _apply(organ: Organ, result: UpstreamResult, ts: str) -> Sample:
         )
     verdict = organ.extractor(result)
     detail = verdict.detail
-    # Post-verdict threshold check: a probe that passed content assertions
-    # can still be "slow" — detail is set but ok stays True. The current
-    # status then reads as "strained" via status_from_last_sample while
-    # the historical uptime stays at 100% (nothing was wrong, just slow).
-    if (
-        verdict.ok
-        and organ.latency_threshold_ms
-        and result.latency_ms > organ.latency_threshold_ms
-    ):
-        detail = (
-            f"{_SLOW_PREFIX}{result.latency_ms}ms > {organ.latency_threshold_ms}ms threshold"
-        )
+    # Post-verdict strain checks: a probe that passed content assertions can
+    # still be degraded — detail is set but ok stays True. The current status
+    # then reads as "strained" via status_from_last_sample while historical
+    # uptime stays at 100% (nothing failed, just strained). Carrier-path
+    # fallback takes precedence over slowness: a native route served by the
+    # Python fan-out is the more significant signal (and is usually slower
+    # anyway).
+    if verdict.ok:
+        fallback = _router_fallback_detail(organ, result)
+        if fallback is not None:
+            detail = fallback
+        elif (
+            organ.latency_threshold_ms
+            and result.latency_ms > organ.latency_threshold_ms
+        ):
+            detail = (
+                f"{_SLOW_PREFIX}{result.latency_ms}ms > {organ.latency_threshold_ms}ms threshold"
+            )
     return Sample(
         ts=ts,
         organ=organ.name,

--- a/pulse/tests/test_analysis.py
+++ b/pulse/tests/test_analysis.py
@@ -75,6 +75,19 @@ def test_status_last_sample_slow_is_strained():
     assert status_from_last_sample(slow_sample) == "strained"
 
 
+def test_status_last_sample_fell_back_is_strained():
+    """A native route served by the Python fan-out reads as strained, not silent:
+    the surface breathed (ok=True), but off its native carrier."""
+    fell_back = Sample(
+        ts=iso_utc(),
+        organ="endpoint_ideas",
+        ok=True,
+        latency_ms=120,
+        detail="fell back: expected native-kernel, got fanout-python",
+    )
+    assert status_from_last_sample(fell_back) == "strained"
+
+
 def test_status_last_sample_detail_other_than_slow_is_still_breathing():
     weird_sample = Sample(
         ts=iso_utc(),

--- a/pulse/tests/test_probe.py
+++ b/pulse/tests/test_probe.py
@@ -7,6 +7,7 @@ import json
 import httpx
 import pytest
 
+from pulse_app.analysis import status_from_last_sample
 from pulse_app.probe import probe_all
 
 
@@ -125,6 +126,9 @@ def _handler(
     ready_status=200,
     ideas_body=None,
     ideas_status=200,
+    ideas_headers=None,  # None → default native-kernel carrier header;
+                         # pass {} for a response with no x-form-router header,
+                         # or {"x-form-router": "fanout-python"} for failover.
     vitality_api_body=None,
     vitality_api_status=200,
     web_status=200,
@@ -153,10 +157,15 @@ def _handler(
                 headers={"content-type": "application/json"},
             )
         if path == "/api/ideas":
+            router_headers = (
+                {"x-form-router": "native-kernel"}
+                if ideas_headers is None
+                else ideas_headers
+            )
             return httpx.Response(
                 ideas_status,
                 content=json.dumps(ideas_body if ideas_body is not None else HEALTHY_IDEAS),
-                headers={"content-type": "application/json"},
+                headers={"content-type": "application/json", **router_headers},
             )
         if path == "/api/workspaces/coherence-network/vitality":
             return httpx.Response(
@@ -470,6 +479,53 @@ async def test_endpoint_ideas_http_error():
     by = await _run(_handler(ideas_status=500))
     assert by["endpoint_ideas"].ok is False
     assert "500" in (by["endpoint_ideas"].detail or "")
+
+
+@pytest.mark.asyncio
+async def test_endpoint_ideas_native_kernel_breathes_clean():
+    """The healthy carrier path: native-kernel served it, no strain detail."""
+    by = await _run(_handler())  # default headers carry x-form-router: native-kernel
+    sample = by["endpoint_ideas"]
+    assert sample.ok is True
+    assert sample.detail is None
+    assert status_from_last_sample(sample) == "breathing"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_ideas_fanout_python_fallback_strains():
+    """The #3087 blindness: the native route regressed, Traefik failed over to
+    the Python fan-out, which returned a 200 with a valid 'ideas' list. Status
+    and shape both pass — the only tell is the x-form-router header. The witness
+    must now read this as strained (breathing surface, wrong carrier), not as a
+    clean breath.
+    """
+    by = await _run(_handler(ideas_headers={"x-form-router": "fanout-python"}))
+    sample = by["endpoint_ideas"]
+    # The surface still answers, so the probe itself succeeded — strain, not silence.
+    assert sample.ok is True
+    assert sample.detail is not None
+    assert sample.detail.startswith("fell back: ")
+    assert "native-kernel" in sample.detail
+    assert "fanout-python" in sample.detail
+    # End-to-end: the strain detail makes the current status read 'strained'.
+    assert status_from_last_sample(sample) == "strained"
+    # Sibling organs are untouched — this is a carrier-path sensing win.
+    assert by["api"].ok is True
+    assert by["endpoint_vitality"].ok is True
+
+
+@pytest.mark.asyncio
+async def test_endpoint_ideas_missing_router_header_strains():
+    """No x-form-router header at all means the native carrier never stamped the
+    response — treat it as a fallback too, naming what was (not) seen."""
+    by = await _run(_handler(ideas_headers={}))
+    sample = by["endpoint_ideas"]
+    assert sample.ok is True
+    assert sample.detail is not None
+    assert sample.detail.startswith("fell back: ")
+    assert "native-kernel" in sample.detail
+    assert "no router header" in sample.detail
+    assert status_from_last_sample(sample) == "strained"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## The blindness

The `endpoint_ideas` witness organ asserts HTTP status (`< 300`) and body shape (an `ideas` list), but **not which router served the response**. The public `GET /api/ideas` can be served by either:

- the native Form kernel-router → `x-form-router: native-kernel` (the body's actual carrier), or
- the Python fan-out fallback → `x-form-router: fanout-python` (Traefik failover when the kernel-router container is unhealthy).

Both return `200` with a valid `ideas` list. So when the native route regressed — e.g. the `boolean::bigint` 500 fixed in [#3087](https://github.com/seeker71/Coherence-Network/pull/3087) — Traefik failed over and the witness probed the Python 200, reading **"breathing"** the entire time the native route was 500ing. The original ask ("assert status < 500") didn't reach this; the probe already asserts status. The real blindness is **router-path masking via the unhealthy-kernel-router failover**.

Confirmed against prod: `GET https://api.coherencycoin.com/api/ideas` currently returns `x-form-router: native-kernel`.

## The change

- **`probe.UpstreamResult` now carries response `headers`** (keys lowercased); `_probe_upstream` captures them. They were not exposed to the extractor layer before.
- **`Organ` gains a declarative `expected_router` field**, parallel to `latency_threshold_ms`. `probe._apply` checks `x-form-router` **once, generically** — any native-promoted route opts in with one field, no per-extractor code (core-abstraction-first: the carrier expectation is data on the organ, the check is one engine).
- A carrier mismatch (or a missing header) flags a **`fell back: expected native-kernel, got fanout-python`** strain — naming the carrier actually seen, per the ask. **Strain, not silence**: the surface still breathes (200 + valid shape) and a brief deploy-window failover self-heals without scarring uptime. This rides the same channel as the existing `extract_api` 5xx strain.
- `status_from_last_sample` recognizes the generalized strain prefixes (`STRAIN_DETAIL_PREFIXES = ("slow: ", "fell back: ")`); existing `slow: ` behavior unchanged.
- `endpoint_ideas` declares `expected_router="native-kernel"`.

## Proof

`pulse/tests/` — 77 passed. New tests:
- `test_endpoint_ideas_fanout_python_fallback_strains` — the #3087 scenario: 200 + valid `ideas` list + `x-form-router: fanout-python` → `ok=True`, detail `fell back: …`, `status_from_last_sample == "strained"` end-to-end; sibling organs untouched.
- `test_endpoint_ideas_missing_router_header_strains` — no header → strain naming `no router header`.
- `test_endpoint_ideas_native_kernel_breathes_clean` — native-kernel → clean breath, no detail.
- `test_status_last_sample_fell_back_is_strained` (analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)