### PR TITLE
attune: the fourth arm is a kernel — a divergence is a bug, not a gap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,10 +110,26 @@ data, framebuffer traces, carrier-tissue reads, edge-category counts,
 wellness output, and source repetition as introspection. Lift only with proof:
 a Form/BML band, a native route trace, or an evidence record that shows the old
 low-level shape is now carried by a simpler reusable cell. Form/BML runtime
-proof walks toward the four-kernel floor: Go, Rust, TypeScript, and the emitted
-`fkwu` arm when `form/fourth-arm-bands.txt` covers the band. Evidence names its
-level exactly: `fourth arm: ... four-way` for covered bands, or `3-kernel only`
-with the fourth-arm gap that keeps the band out of the manifest.
+proof walks the four-kernel floor: Go, Rust, TypeScript, and the emitted `fkwu`
+arm. Run every new band on all four arms before shipping — the fourth is a
+kernel, not a footnote; a band that never touched it is not proven. When fkwu
+disagrees, name which kind it is, because they are not the same and only one is
+acceptable to ship:
+- A **divergence** — fkwu HAS the ops but computes a DIFFERENT answer than the
+  three walkers — means one of our four kernels is wrong. It is a correctness
+  bug and a hard gate: diagnose it to root cause and resolve it to four-way (fix
+  the recipe shape, or the walker) before merge. Never ship a divergence as a
+  "named gap," and never hide it by leaving the band out of the manifest — that
+  buries the disagreement instead of resolving it. If the real fix is deeper
+  than the change at hand (e.g. a walker-emitter change), the divergence is
+  still root-caused, owned, and tracked to a specific fix — never waved at.
+- An **unsupported op** — fkwu lacks the op FAMILY (the node/substrate, host-io,
+  and multi-line standing walls named in `form/fourth-arm-bands.txt`) — is a
+  known limitation, not a wrong answer. `3-kernel only` is honest here, and only
+  here, with the specific missing op named.
+Evidence names the level exactly: `fourth arm: ... four-way` for covered bands,
+or `3-kernel only — <unsupported op>` with that op named. A divergence dressed
+as a gap is the precise shape this rule forbids.
 
 **Connected tissue stays aligned.** The same north star should read coherently
 from sister nodes: `form/fourth-arm-bands.txt`, substrate `.form` north-star

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -17,6 +17,14 @@
 # the milestone proofs the first rows crossed through. A band leaves this
 # file only when its source moves outside the walker's op families.
 #
+# A band is out of this manifest for exactly ONE honest reason: it uses an op
+# FAMILY fkwu does not yet carry (the standing walls below). A *divergence* —
+# fkwu has the ops but computes a different answer than Go/Rust/TS — is NEVER a
+# reason to leave a band unregistered. That is a correctness bug: one kernel is
+# wrong. Root-cause it and resolve to four-way (recipe shape or walker) before
+# the work ships; if the fix is a deeper walker-emitter change, the divergence
+# is still owned and tracked to that fix, never buried by omission here.
+#
 # The standing walls (what keeps a band out today, by blocked-band count):
 #   remaining node/substrate family — generated bp table parity beyond the
 #     current literal registry floor, the symbol wire sibling constructor,


### PR DESCRIPTION
**Why.** The floor language let `3-kernel only with the fourth-arm gap` cover two very different situations as if they were one — and a real correctness divergence (the planet engine: fkwu computes venus/mars longitude *wrong*) rode out under wording meant for a known limitation. This tightens the rule so that can't happen again.

**The distinction the rule now makes:**
- A **divergence** — fkwu *has* the ops but computes a **different answer** than Go/Rust/TS — means one of our four kernels is wrong. Correctness bug, **hard gate**: diagnose to root cause and resolve to four-way (recipe shape or walker) before merge. Never ship as a "named gap"; never bury it by leaving the band unregistered. A deeper walker-emitter fix is still owned and **tracked to a specific fix**, not waved at.
- An **unsupported op** — fkwu lacks the op *family* (node/substrate, host-io, multi-line standing walls) — is a known limitation, not a wrong answer. `3-kernel only` is honest here, and only here, with the missing op named.

Plus: **run every new band on all four arms before shipping** — the fourth is a kernel, not a footnote; a band that never touched it is not proven. Reinforced in the `fourth-arm-bands.txt` header.

Changes `CLAUDE.md` (Core lift floor language) + the manifest header. No code; governance/guide tissue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)