### PR TITLE
Fourth-arm band merges skip the api rebuild (deploy-churn fast path)

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -414,6 +414,14 @@ is_static_only_change() {
       proof.fk) ;;
       we.fkb) ;;
       PROOF.md) ;;
+      # Fourth-arm validation tissue: test bands and the fkwu manifest are run
+      # only by validate.sh, never loaded by the api/web runtime (the api serves
+      # routes through form-stdlib MODULES, which stay outside this allowlist and
+      # still force a rebuild). So a pure band-admission merge skips the heavy
+      # rebuild+force-recreate that was straining the witness on every fourth-arm
+      # commit — deployed_sha still advances on the fast path.
+      form/form-stdlib/tests/*) ;;
+      form/fourth-arm-bands.txt) ;;
       *) return 1 ;;
     esac
   done <<< "$changed"


### PR DESCRIPTION
## What

Every main push touching `form/form-stdlib/**` triggers the Hostinger deploy, and `services_to_rebuild` maps `form/form-stdlib/* → api` — so a pure fourth-arm **band-admission** merge (a test band + the `fourth-arm-bands.txt` manifest) forced a full api rebuild + `--force-recreate`. With the field merging fourth-arm work rapidly, those stacked/cancelled rebuilds are the recurring **witness strain** (page_vitality/neo4j transients on nearly every commit).

Test bands and the fkwu manifest are validation tissue run only by `validate.sh` — the api serves routes through form-stdlib **modules**, never the test bands or the manifest (confirmed: no `api/`, `web/`, or `deploy/` reference to either). So they now ride `is_static_only_change`'s allowlist: a pure band-admission merge takes the fast path (no rebuild, no force-recreate; `deployed_sha` still advances), while any merge that also touches a form module, the fkwu emitter, or api/web code stays outside the allowlist and rebuilds as before.

`is_static_only_change` requires **every** changed file to be in the allowlist, so the conservatism is structural — one api-relevant file anywhere in the diff falls back to the full rebuild.

## Verified classification

| Merge shape | Result |
|---|---|
| test band + manifest | skip rebuild ✓ |
| test band + emitter | rebuild ✓ |
| form module (`arrival.fk`) | rebuild ✓ |
| api code | rebuild ✓ |

(`bash -n` clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)