### PR TITLE
tend: form_cli ask — the front door agents call first

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -44,7 +44,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 147 | Python bridge/API routers — current endpoint carrier and upstream tail while Form-native routes are promoted |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 246 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 58 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 272 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 273 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 272
+**Total files**: 273
 
 | File | Purpose |
 |---|---|
@@ -105,6 +105,7 @@
 | [test_flow_reactions.py](test_flow_reactions.py) | Flow tests for reactions — emoji + comment across any entity. |
 | [test_flow_vitality.py](test_flow_vitality.py) | Flow-centric tests for the Workspace Vitality + related sensing |
 | [test_flow_workspaces.py](test_flow_workspaces.py) | Flow-centric tests for the Workspace tenant primitive. |
+| [test_form_cli_ask.py](test_form_cli_ask.py) | form_cli `ask` front door: serve Form-native, route the rest, capture for learning. |
 | [test_form_kernel_bridge_structure_access.py](test_form_kernel_bridge_structure_access.py) | Tests for the structure-access capability in the Form kernel bridge. |
 | [test_form_native_grammar_contract.py](test_form_native_grammar_contract.py) | Form-native grammar contract: host parser bridges are not completion. |
 | [test_form_practice_runner.py](test_form_practice_runner.py) | Generic Form practice runner creates cells, recipes, and ledger entries. |

--- a/api/tests/test_form_cli_ask.py
+++ b/api/tests/test_form_cli_ask.py
@@ -1,0 +1,62 @@
+"""form_cli `ask` front door: serve Form-native, route the rest, capture for learning.
+
+The usable entry an agent asks first. These tests cover the routing decision and
+the io-match capture without requiring the kernel; the Form-native compute path is
+exercised when the kernel binary is present (skipped otherwise).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+_FORM_CLI_PATH = Path(__file__).resolve().parents[2] / "scripts" / "form_cli.py"
+_spec = importlib.util.spec_from_file_location("form_cli", _FORM_CLI_PATH)
+assert _spec and _spec.loader
+form_cli = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(form_cli)
+
+_KERNEL = form_cli._KERNEL_BIN
+_HAVE_KERNEL = _KERNEL.is_file() and os.access(_KERNEL, os.X_OK)
+
+
+def test_is_form_expr_routing():
+    assert form_cli._is_form_expr("(mul 17 23)") is True
+    assert form_cli._is_form_expr("  (add 1 2)") is True
+    assert form_cli._is_form_expr("write me a poem") is False
+
+
+def test_non_form_request_routes_to_oracle():
+    res = form_cli.ask_handle("summarize this document")
+    assert res["lane"] == "oracle"
+    assert res["outcome"] == "route"
+    assert res["tokens"] is None
+
+
+def test_capture_writes_io_match_record(tmp_path, monkeypatch):
+    cap = tmp_path / "cap.jsonl"
+    monkeypatch.setattr(form_cli, "_ASK_CAPTURE", cap)
+    res = {"result": "391", "lane": "form-native:compute", "outcome": "success", "tokens": 0}
+    form_cli.ask_capture("(mul 17 23)", res)
+    rec = json.loads(cap.read_text().strip())
+    # content-addressed in/out (sha256), lane + outcome carried.
+    assert rec["input_sig"] == form_cli._io_sig("(mul 17 23)")
+    assert rec["output_sig"] == form_cli._io_sig("391")
+    assert rec["lane"] == "form-native:compute" and rec["outcome"] == "success" and rec["tokens"] == 0
+
+
+def test_same_input_same_sig():
+    assert form_cli._io_sig("(mul 17 23)") == form_cli._io_sig("(mul 17 23)")
+    assert form_cli._io_sig("(mul 17 23)") != form_cli._io_sig("(mul 17 24)")
+
+
+@pytest.mark.skipif(not _HAVE_KERNEL, reason="form-kernel-rust binary not built in this env")
+def test_compute_lane_runs_form_native():
+    res = form_cli.ask_handle("(mul 17 23)")
+    assert res["lane"] == "form-native:compute"
+    assert res["outcome"] == "success"
+    assert res["tokens"] == 0
+    assert res["result"] == "391"

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -76,7 +76,7 @@
 | [form-convert.sh](form-convert.sh) | form-convert — the machine-native kernel-cli for the goal Urs named: |
 | [form_asm_conviction_demo.sh](form_asm_conviction_demo.sh) | form_asm_conviction_demo.sh — the byte-conviction gate that licenses dropping |
 | [form_branch_demo.sh](form_branch_demo.sh) | form_branch_demo.sh — the FULL asm-pl-human program, compiled by Form and run on |
-| [form_cli.py](form_cli.py) | form_cli.py — Form-native CLI: generate, execute, convert. |
+| [form_cli.py](form_cli.py) | form_cli.py — Form-native CLI: ask, generate, execute, convert. |
 | [form_cli_demo.sh](form_cli_demo.sh) | form_cli_demo.sh — exercise every form_cli subcommand end-to-end. |
 | [form_debug_demo.sh](form_debug_demo.sh) | form_debug_demo.sh — LIVE DEBUGGING: the value trace joined with provenance. |
 | [form_diagnose_demo.sh](form_diagnose_demo.sh) | form_diagnose_demo.sh — the live-diagnosis organ on REAL channels. One fib |

--- a/scripts/form_cli.py
+++ b/scripts/form_cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""form_cli.py — Form-native CLI: generate, execute, convert.
+"""form_cli.py — Form-native CLI: ask, generate, execute, convert.
 
 The CLI Urs named: kernel + binary library + Language cells, end-to-end.
 Uses ONLY the seedbank/local-llm-cell-v0/form_native.py recipes and
@@ -9,6 +9,16 @@ through the Form-native composition (Newton sqrt, Taylor exp, recursive
 list ops) verified by parity_check.py.
 
 Subcommands:
+
+    form_cli ask <request...>
+        The front door — ask this FIRST. Serves the request Form-native when it
+        can (v0: a Form expression is computed on the kernel, zero tokens, no
+        python), else routes to an oracle (the agent's own LLM / agent CLI) with
+        exit code 3. Every call is captured as an io-match record so usage
+        becomes learning. Benefit twice: tokens saved now, capability next time.
+            form_cli ask '(mul 17 23)'        # -> 391  (Form-native, 0 tokens)
+            form_cli ask "summarize this"     # -> route: oracle (exit 3)
+        Agents script it as:  form_cli ask "$req" || <handle with my LLM>
 
     form_cli list <library>
         Print library meta + per-recipe summary.
@@ -43,9 +53,14 @@ Examples:
 from __future__ import annotations
 
 import argparse
+import datetime
+import hashlib
 import json
+import os
 import re
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -941,6 +956,110 @@ def cmd_generate(args: argparse.Namespace) -> int:
     return 0
 
 
+# ─── subcommand: ask (the front door) ────────────────────────────────────
+#
+# The thing an agent asks FIRST. Before reaching for its own LLM, an agent asks
+# the form-cli to handle a request. The form-cli serves what it can Form-native
+# (v0: Form-expression compute via the kernel — math + logic, zero tokens, no
+# python, no external interpreter) and routes the rest to an oracle (the agent's
+# own LLM / agent CLI), so capabilities are never lost. Every call is captured as
+# an io-match record (content-addressed in/out + lane + outcome), so usage
+# becomes learning and the local lane grows over time. We benefit twice: tokens
+# saved on what runs locally now, capability gained for next time.
+#
+# This is the bootstrap front door; the routing decision (form-cli-loop.fk), the
+# compute (the Form kernel), and the learning shape (io-match.fk) are Form. The
+# destination is the native form-macho binary running this loop directly
+# (docs/coherence-substrate/form-cli-north-star.form).
+
+_KERNEL_BIN = Path(
+    os.environ.get("FORM_KERNEL_RUST_BIN")
+    or (REPO_ROOT / "form" / "form-kernel-rust" / "target" / "release" / "form-kernel-rust")
+)
+_ASK_CAPTURE = Path(
+    os.environ.get("FORM_CLI_CAPTURE") or (REPO_ROOT / "logs" / "form_cli_io_match.jsonl")
+)
+
+
+def _io_sig(text: str) -> str:
+    """Content-address a request or result — the same sha256 io-match.fk uses."""
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def _is_form_expr(request: str) -> bool:
+    """v0 local-handler test: a Form expression is the compute lane."""
+    return request.strip().startswith("(")
+
+
+def _kernel_eval(expr: str) -> tuple[str | None, str | None]:
+    """Evaluate a Form expression on the kernel (builtins: math, logic, lists).
+    Returns (value, None) on success or (None, reason) on failure."""
+    if not (_KERNEL_BIN.is_file() and os.access(_KERNEL_BIN, os.X_OK)):
+        return None, "kernel-unavailable"
+    with tempfile.NamedTemporaryFile("w", suffix=".fk", delete=False) as f:
+        f.write(f"(do {expr})\n")
+        path = f.name
+    try:
+        proc = subprocess.run([str(_KERNEL_BIN), path], capture_output=True, text=True, timeout=10)
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return None, f"kernel-error:{e}"
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip().splitlines()
+        return None, stderr[-1] if stderr else "kernel-error"
+    out = (proc.stdout or "").rstrip("\n").splitlines()
+    return (out[-1] if out else ""), None
+
+
+def ask_handle(request: str) -> dict:
+    """Serve Form-native if we can; else route to the oracle. Never lose capability."""
+    if _is_form_expr(request):
+        value, err = _kernel_eval(request)
+        if err is None:
+            return {"result": value, "lane": "form-native:compute", "outcome": "success", "tokens": 0}
+        return {"result": None, "lane": "oracle", "outcome": "route", "tokens": None,
+                "note": f"local compute failed ({err}); route to oracle"}
+    return {"result": None, "lane": "oracle", "outcome": "route", "tokens": None,
+            "note": "no local handler; route to oracle (agent's LLM / agent CLI)"}
+
+
+def ask_capture(request: str, res: dict) -> dict:
+    """Record the call as an io-match row so usage becomes learning."""
+    rec = {
+        "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "input_sig": _io_sig(request),
+        "output_sig": _io_sig(str(res.get("result") or "")),
+        "lane": res.get("lane"),
+        "outcome": res.get("outcome"),
+        "tokens": res.get("tokens"),
+    }
+    _ASK_CAPTURE.parent.mkdir(parents=True, exist_ok=True)
+    with _ASK_CAPTURE.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+    return rec
+
+
+def cmd_ask(args: argparse.Namespace) -> int:
+    request = " ".join(args.request).strip()
+    if not request and not sys.stdin.isatty():
+        request = sys.stdin.read().strip()
+    if not request:
+        _die("ask: empty request (give a Form expr to compute, or any request to route)")
+    res = ask_handle(request)
+    if not args.no_capture:
+        ask_capture(request, res)
+    if str(res["lane"]).startswith("form-native"):
+        print(res["result"])
+        print(f"[form-cli] served Form-native ({res['lane']}, {res['tokens']} tokens)", file=sys.stderr)
+        return 0
+    print(f"[form-cli] route: {res['lane']} — {res.get('note', '')}", file=sys.stderr)
+    return 3  # caller should handle via its own LLM / agent CLI
+
+
 # ─── argparser ───────────────────────────────────────────────────────────
 
 
@@ -979,6 +1098,14 @@ def main() -> int:
     p_gen.add_argument("--name", help="library name (default: source stem)")
     p_gen.add_argument("--out", help="output .recipelib path")
     p_gen.set_defaults(func=cmd_generate)
+
+    p_ask = sub.add_parser(
+        "ask",
+        help="the front door: serve Form-native if possible, else route to oracle; capture for learning",
+    )
+    p_ask.add_argument("request", nargs="+", help="a Form expr to compute, or any request to route")
+    p_ask.add_argument("--no-capture", action="store_true", help="do not write an io-match capture record")
+    p_ask.set_defaults(func=cmd_ask)
 
     args = parser.parse_args()
     return args.func(args)


### PR DESCRIPTION
## Something usable, now
The form-cli already runs Form-native recipes (generate/execute/convert). This adds the **`ask` front door** an agent calls *before* reaching for its own LLM:

```
form_cli ask '(mul 17 23)'      -> 391   (Form-native compute, 0 tokens, exit 0)
form_cli ask 'summarize this'   -> route: oracle (exit 3; caller uses its LLM)
```

- **Serves Form-native** what it can (v0: a Form expression computed on the kernel — math + logic, **zero tokens, no python, no external interpreter**).
- **Routes the rest** to the agent's own LLM / agent CLI (exit 3), so capabilities are never lost.
- **Captures every call** as an io-match record (content-addressed in/out + lane + outcome) — usage becomes learning, the local lane grows.

**Benefit twice:** tokens saved on what runs locally now, capability gained for next time. Agents script it as `form_cli ask "$req" || <my LLM>`.

## Discipline
Bootstrap front door: routing (`form-cli-loop.fk`), compute (the Form kernel), and learning shape (`io-match.fk`) are Form; this dispatches and captures. Destination is the native form-macho binary running the loop directly.

## Proof
`test_form_cli_ask.py` — 5 pass (routing, capture record + content-addressing, same-input-same-sig, and the live kernel compute path). Maintainability gate: no regression.

## Next
More local handlers (NL→Form grammar, learned recipes that persist across sessions) shift more requests off the oracle; unify this capture into the shared io-match telemetry the embodiment gate already reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)