### PR TITLE
tend: build the carrier→fkwu→value offload loop (FKWU_NATIVE_DISPATCH step 1a)

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-14_fkwu_offload_bridge.json
+++ b/docs/system_audit/commit_evidence_2026-06-14_fkwu_offload_bridge.json
@@ -1,0 +1,86 @@
+{
+  "date": "2026-06-14",
+  "thread_branch": "claude/fkwu-offload-build",
+  "commit_scope": "Build step 1a of the FKWU_NATIVE_DISPATCH offload path: the carrier→fkwu→value loop. FkwuEval (form/form-kernel-go/fkwu_bridge.go) hands the emitted fourth kernel a pre-flattened band node-table plus a scalar input (argv[2] → fk_vs[0]) and returns fkwu's walked value. fkwu_bridge_test.go proves it end to end — emit fkwu C in-process, clang it, flatten the four-way content-address band, run fkwu, and confirm its value equals the in-process Go walker bit-for-bit — skipping where clang is absent (the runs-or-skips-when-tools-missing pattern). The Go serving kernel can now offload a pure computation to fkwu. Next (1b): the argv[3]→fk_src structured-input channel and the /api/ideas shape/emit slice authored as a flattened band.",
+  "change_intent": "runtime_feature",
+  "idea_ids": [
+    "kernel-native-api-readiness",
+    "bml-front-door"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "native-front-door-deploy"
+  ],
+  "task_ids": [
+    "fkwu-offload-bridge-20260614"
+  ],
+  "files_owned": [
+    "form/form-kernel-go/fkwu_bridge.go",
+    "form/form-kernel-go/fkwu_bridge_test.go"
+  ],
+  "change_files": [
+    "form/form-kernel-go/fkwu_bridge.go",
+    "form/form-kernel-go/fkwu_bridge_test.go",
+    "kernels/FKWU_NATIVE_DISPATCH.md"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "form/form-kernel-go/fkwu_bridge.go",
+    "form/form-kernel-go/fkwu_bridge_test.go",
+    "form/fourth-arm-bands.txt",
+    "kernels/FKWU_NATIVE_DISPATCH.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "go build ./... -> OK; go vet . -> OK (form/form-kernel-go)",
+      "go test -run TestFkwuOffloadBridge -v . -> PASS (1.34s): emit fkwu C in-process, clang -O2, flatten content-address band, FkwuEval(table,0)=='1111111111' == in-process walker verdict",
+      "Manual repro: clang-built fkwu on the flattened content-address table prints 1111111111 — the manifest's four-way verdict (content-address fks 1111111111)"
+    ],
+    "notes": "No new band and no walker-logic change: content-address is already four-way in form/fourth-arm-bands.txt; this adds the Go carrier seam that invokes it and proves the bridge value-matches the walker. The bridge is carrier glue, not a band — its proof is value-parity with the walker, not a new four-way claim."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "PR checks run after push. validate.sh four-way is unaffected (no band/walker change); the Go bridge test runs where clang is present and skips otherwise."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Not wired into the serving path yet — no deploy. The bridge is the foundation; route wiring is step 1b+."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "The Go kernel can offload a pure Form computation to the emitted fourth kernel (fkwu) at runtime and receive the same value the sibling walkers compute — the carrier→fkwu→value loop the offload path needs. Proven on the four-way content-address band; not yet wired to a public route.",
+    "public_endpoints": [
+      "local-only: Go kernel offload bridge proven on the content-address four-way band; no public HTTP endpoint changed yet"
+    ],
+    "test_flows": [
+      "go test -run TestFkwuOffloadBridge . -> PASS: FkwuEval == in-process walker on content-address",
+      "form/validate.sh content-address -> four-way (Go/Rust/TS/fkwu agree on 1111111111), unchanged by this carrier addition"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Step 1a (the carrier→fkwu→value loop) landed. Next is 1b: the fk_src structured-input channel and the /api/ideas pure slice as a flattened band."
+  }
+}

--- a/form/form-kernel-go/fkwu_bridge.go
+++ b/form/form-kernel-go/fkwu_bridge.go
@@ -1,0 +1,40 @@
+// fkwu_bridge.go — the Go serving kernel offloads a pure computation to the
+// emitted fourth kernel (fkwu) at runtime.
+//
+// This is the first step of the offload path scoped in
+// kernels/FKWU_NATIVE_DISPATCH.md: the carrier (Go) hands fkwu a pre-flattened
+// band node-table plus a scalar input, and fkwu walks the table and returns the
+// value — the SAME value the three sibling walkers compute for a four-way band.
+// The body is the Form band fkwu walks; this is the thin carrier seam that
+// invokes it. fkwu makes no host call here, so the loop carries no reentrancy,
+// cancellation, or capability surface.
+//
+// Input channel: argv[2], a single scalar integer bound into fkwu's root frame
+// (fk_vs[0]). The structured-bundle channel — argv[3] -> fk_src, carrying a
+// serialized request+rows value for routes whose pure slice needs real data —
+// is the next increment named in the build order.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// FkwuEval runs the fkwu binary on a flattened band table with one scalar
+// integer input and returns fkwu's primary verdict — the first stdout line,
+// which the validate.sh four-way harness compares byte-for-byte against the Go
+// walker. An error is returned when fkwu cannot run or produces no output.
+func FkwuEval(fkwuBin, tablePath string, input int64) (string, error) {
+	cmd := exec.Command(fkwuBin, tablePath, fmt.Sprintf("%d", input))
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("fkwu eval %s: %w", tablePath, err)
+	}
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	if sc.Scan() {
+		return strings.TrimSpace(sc.Text()), nil
+	}
+	return "", fmt.Errorf("fkwu eval %s: empty output", tablePath)
+}

--- a/form/form-kernel-go/fkwu_bridge_test.go
+++ b/form/form-kernel-go/fkwu_bridge_test.go
@@ -1,0 +1,114 @@
+// fkwu_bridge_test.go — proves the offload bridge end to end.
+//
+// The Go kernel emits + compiles fkwu in-process, flattens a real four-way band
+// (content-address) to a node-table, hands the table to fkwu via FkwuEval, and
+// confirms fkwu's value equals the in-process walker's. This is the carrier ->
+// fkwu -> value loop the offload path needs, proven on a band already in the
+// fourth-arm manifest.
+//
+// Skips when clang is absent (the toolchain that builds fkwu) — the repo's
+// runs-or-skips-when-tools-missing pattern, so the proof runs where the
+// toolchain lives and stays green everywhere else.
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runFormSource walks concatenated Form source in-process and returns the
+// result value's raw string (the .Str for a string value, else .String()).
+func runFormSource(t *testing.T, src string) (Value, string) {
+	t.Helper()
+	k := NewKernel()
+	root := readRootFromSource(k, src)
+	result := k.walk(root, NewFrame(nil))
+	if result.Kind == VStr {
+		return result, result.Str
+	}
+	return result, result.String()
+}
+
+func readFiles(t *testing.T, paths ...string) string {
+	t.Helper()
+	var b strings.Builder
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		b.Write(data)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func TestFkwuOffloadBridge(t *testing.T) {
+	clang, err := exec.LookPath("clang")
+	if err != nil {
+		t.Skip("clang not available — fkwu offload bridge proof skipped")
+	}
+
+	stdlib := filepath.Join("..", "form-stdlib")
+	mustExist := func(p string) string {
+		if _, err := os.Stat(p); err != nil {
+			t.Skipf("missing source %s: %v", p, err)
+		}
+		return p
+	}
+	minimal := mustExist(filepath.Join(stdlib, "minimal-surface.fk"))
+	hatiKernel := mustExist(filepath.Join(stdlib, "hati-os-kernel.fk"))
+	hatiEmit := mustExist(filepath.Join(stdlib, "hati-os-kernel-emit.fk"))
+	formParse := mustExist(filepath.Join(stdlib, "form-parse.fk"))
+	formFlatten := mustExist(filepath.Join(stdlib, "form-flatten.fk"))
+	shim := mustExist(filepath.Join(stdlib, "fourth-shim.fk"))
+	band := mustExist(filepath.Join(stdlib, "tests", "content-address-band.fk"))
+
+	dir := t.TempDir()
+
+	// 1. Emit the universal fkwu C source in-process, then compile it.
+	_, cSrc := runFormSource(t, readFiles(t, minimal, hatiKernel, hatiEmit)+"\n(fkc-emit-universal)\n")
+	if len(strings.TrimSpace(cSrc)) < 1000 {
+		t.Fatalf("fkwu emit produced suspiciously small C source (%d bytes)", len(cSrc))
+	}
+	cPath := filepath.Join(dir, "fkwu.c")
+	if err := os.WriteFile(cPath, []byte(cSrc), 0o644); err != nil {
+		t.Fatalf("write fkwu.c: %v", err)
+	}
+	fkwuBin := filepath.Join(dir, "fkwu")
+	if out, err := exec.Command(clang, "-O2", "-o", fkwuBin, cPath).CombinedOutput(); err != nil {
+		t.Fatalf("clang fkwu: %v\n%s", err, out)
+	}
+
+	// 2. Flatten the band to a node-table in-process (fks: string-pool variant).
+	flattenExpr := "(fks-table-file " +
+		"(flt-band-sources-fns (list (read_file \"" + shim + "\")) (read_file \"" + band + "\")) " +
+		"(flt-band-sources-pool (list (read_file \"" + shim + "\")) (read_file \"" + band + "\")))"
+	_, table := runFormSource(t, readFiles(t, minimal, hatiKernel, hatiEmit, formParse, formFlatten)+"\n"+flattenExpr+"\n")
+	if len(strings.TrimSpace(table)) < 100 {
+		t.Fatalf("flatten produced suspiciously small table (%d bytes)", len(table))
+	}
+	tablePath := filepath.Join(dir, "band-table.txt")
+	if err := os.WriteFile(tablePath, []byte(table), 0o644); err != nil {
+		t.Fatalf("write table: %v", err)
+	}
+
+	// 3. The in-process walker's verdict for the same band — the truth fkwu must match.
+	_, walked := runFormSource(t, readFiles(t, minimal, shim, band))
+	want := strings.TrimSpace(walked)
+
+	// 4. Offload to fkwu and confirm the value matches the walker.
+	got, err := FkwuEval(fkwuBin, tablePath, 0)
+	if err != nil {
+		t.Fatalf("FkwuEval: %v", err)
+	}
+	if got != want {
+		t.Fatalf("offload mismatch: fkwu=%q walker=%q (a divergence — one kernel is wrong)", got, want)
+	}
+	if got == "" {
+		t.Fatal("offload produced empty verdict")
+	}
+}

--- a/kernels/FKWU_NATIVE_DISPATCH.md
+++ b/kernels/FKWU_NATIVE_DISPATCH.md
@@ -159,6 +159,16 @@ carried by the storage-port carrier — functional for proof, live for serve.
    `json_emit` slice with a `write_form_binary` bundle; fkwu returns the JSON.
    Needs: fkwu reads the form-binary input format; the slice flattened as a band.
    Smallest honest step, harvests the measured ~87 ms.
+   - **1a — landed:** the carrier→fkwu→value loop is real. `FkwuEval` in
+     [`form/form-kernel-go/fkwu_bridge.go`](../form/form-kernel-go/fkwu_bridge.go)
+     hands fkwu a pre-flattened band table + scalar input and returns the walked
+     value; `fkwu_bridge_test.go` proves it bit-for-bit against the in-process
+     walker on the four-way `content-address` band (emit → clang → flatten →
+     run, skipping where clang is absent). The Go serving kernel can now offload
+     a pure computation to fkwu.
+   - **1b — next:** the `argv[3] → fk_src` structured-input channel so the
+     offloaded slice can read request+rows, and the `/api/ideas` shape/emit slice
+     authored as a flattened band.
 2. **Value-binary ABI parity** — confirm/seat `read_form_binary`/`write_form_binary`
    on the emitted walker so the bundle round-trips bit-for-bit with Go and Rust.
 3. **Host-bound carrier seam** — `host_carrier_op(handle, op_id, argv)` in


### PR DESCRIPTION
## What this builds

The first **runtime** step of the offload path scoped in [`kernels/FKWU_NATIVE_DISPATCH.md`](kernels/FKWU_NATIVE_DISPATCH.md): the Go serving kernel can now offload a pure computation to the emitted fourth kernel (fkwu) and get the value back — the carrier→fkwu→value loop, proven on a band already in the four-way manifest.

- **[`form/form-kernel-go/fkwu_bridge.go`](form/form-kernel-go/fkwu_bridge.go)** — `FkwuEval(fkwuBin, tablePath, input)` runs fkwu (`argv[1]`=table, `argv[2]`=scalar input → `fk_vs[0]`) and returns its primary verdict (first stdout line), the same value `validate.sh` compares four-way. Thin carrier seam — the body is the Form band fkwu walks; fkwu makes no host call, so the loop carries no reentrancy/cancellation/capability surface.
- **[`form/form-kernel-go/fkwu_bridge_test.go`](form/form-kernel-go/fkwu_bridge_test.go)** — proves it end to end: emit fkwu C in-process → `clang -O2` → flatten the four-way `content-address` band → run fkwu → confirm its value equals the in-process Go walker bit-for-bit (`1111111111`). Skips where `clang` is absent (the repo's runs-or-skips-when-tools-missing pattern).

## What it does *not* do (named honestly)

- **No new band, no walker change.** `content-address` is already four-way in `form/fourth-arm-bands.txt`; this adds the Go carrier that invokes it. The bridge is carrier glue — its proof is value-parity with the walker, not a new four-way claim. `validate.sh` four-way is unaffected.
- **Not wired to a route yet.** This is the invocation primitive. Step **1b**: the `argv[3]→fk_src` structured-input channel so the offloaded slice can read request+rows, then the `/api/ideas` shape/emit slice authored as a flattened band (harvesting the measured ~87ms).

## Verified locally
- `go build ./...` OK, `go vet .` OK
- `go test -run TestFkwuOffloadBridge -v .` → **PASS** (1.34s)
- Manual: clang-built fkwu on the flattened `content-address` table prints `1111111111` — the manifest's four-way verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)