### PR TITLE
tend: fkwu offload fk_src input channel + 1b realignment (Grok review)

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-14_fkwu_offload_input_channel.json
+++ b/docs/system_audit/commit_evidence_2026-06-14_fkwu_offload_input_channel.json
@@ -1,0 +1,94 @@
+{
+  "date": "2026-06-14",
+  "thread_branch": "claude/fkwu-server-input",
+  "commit_scope": "Build the fk_src structured-input channel for fkwu offload, and realign the FKWU_NATIVE_DISPATCH plan after a second Grok review. FkwuEvalWithInput (form/form-kernel-go/fkwu_bridge.go) stages a byte bundle into fk_src (argv[3] -> the buffer the persistent server main also fills from a socket); TestFkwuOffloadInput proves a program that reads it with fk-buf (tag 17, fkcount) returns a value that DEPENDS on the bundle (0->0, 11->11, 26->26). Grounded the real input mechanism: fk-buf/tag-17 is the input read; input-aware programs are hati-os responder programs loaded as tables; the input ABI is bytes-in-fk_src (text parsed in-recipe), not the durable write_form_binary format. Realigned the doc per Grok: persistent fkwu-server is the production shape (subprocess is the carrier proof); the input-carrying four-way proof harness is the honest gate (baking a fixed test input is a trap); profile the /api/ideas slice (and the row->bundle marshalling cost) before authoring it.",
+  "change_intent": "runtime_feature",
+  "idea_ids": [
+    "kernel-native-api-readiness",
+    "bml-front-door"
+  ],
+  "spec_ids": [
+    "kernel-native-api-readiness",
+    "native-front-door-deploy"
+  ],
+  "task_ids": [
+    "fkwu-offload-input-channel-20260614"
+  ],
+  "files_owned": [
+    "form/form-kernel-go/fkwu_bridge.go",
+    "form/form-kernel-go/fkwu_bridge_test.go"
+  ],
+  "change_files": [
+    "form/form-kernel-go/fkwu_bridge.go",
+    "form/form-kernel-go/fkwu_bridge_test.go",
+    "kernels/FKWU_NATIVE_DISPATCH.md"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation"
+      ]
+    },
+    {
+      "contributor_id": "agent:grok",
+      "contributor_type": "machine",
+      "roles": [
+        "review"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "form/form-kernel-go/fkwu_bridge.go",
+    "form/form-kernel-go/fkwu_bridge_test.go",
+    "form/form-stdlib/hati-os-kernel.fk",
+    "form/form-stdlib/hati-os-kernel-emit.fk",
+    "kernels/FKWU_NATIVE_DISPATCH.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "go build ./... -> OK; go vet . -> OK (form/form-kernel-go)",
+      "go test -run TestFkwuOffload -v . -> PASS (6.99s): TestFkwuOffloadBridge (content-address value-parity) + TestFkwuOffloadInput (fkcount byte-count over fk_src: 0->0, 11->11, 26->26)",
+      "Manual: emit fkwu, emit (fkc-table-file (fkcount-fns)), run 'fkwu table 0 inputfile' -> byte count of inputfile, confirming the argv[3]->fk_src input channel read via fk-buf (tag 17)"
+    ],
+    "notes": "fkcount is the minimal input-dependent program (counts fk_src bytes via fk-buf). It proves the carrier can pass structured input to fkwu and get an input-bound value. fkcount is NOT yet four-way: fk-buf/tag-17 reads a settable buffer only on fkwu; proving an input-dependent program four-way needs the same read on Go/Rust/TS + validate.sh feeding the identical bundle to all four legs. That is the explicit next gate (build order step 3), named honestly, not faked with a baked constant."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "PR checks run after push. validate.sh four-way is unaffected (no band/walker change); the Go bridge tests run where clang is present and skip otherwise."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Not wired into the serving path yet — no deploy. The input channel + the persistent server + the four-way input-proof harness precede route wiring."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "The Go kernel can offload a computation OVER STRUCTURED INPUT to fkwu: it stages a byte bundle into fk_src and the offloaded program reads it with fk-buf, returning an input-dependent value. Proven with fkcount (byte count of the bundle); not yet wired to a public route, and not yet four-way (the input-carrying proof harness is the next gate).",
+    "public_endpoints": [
+      "local-only: Go kernel offload input channel proven with fkcount over fk_src; no public HTTP endpoint changed yet"
+    ],
+    "test_flows": [
+      "go test -run TestFkwuOffloadInput . -> PASS: FkwuEvalWithInput stages bundle -> fkcount returns byte count (input-dependent)",
+      "go test -run TestFkwuOffloadBridge . -> PASS: carrier->fkwu->value parity on content-address (four-way band, unchanged)"
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "notes": "Input channel landed. Next: the persistent fkwu-server (production shape) and the input-carrying four-way proof harness (the honest gate), then profile the /api/ideas slice before authoring it."
+  }
+}

--- a/form/form-kernel-go/fkwu_bridge.go
+++ b/form/form-kernel-go/fkwu_bridge.go
@@ -1,40 +1,81 @@
 // fkwu_bridge.go — the Go serving kernel offloads a pure computation to the
 // emitted fourth kernel (fkwu) at runtime.
 //
-// This is the first step of the offload path scoped in
-// kernels/FKWU_NATIVE_DISPATCH.md: the carrier (Go) hands fkwu a pre-flattened
-// band node-table plus a scalar input, and fkwu walks the table and returns the
-// value — the SAME value the three sibling walkers compute for a four-way band.
-// The body is the Form band fkwu walks; this is the thin carrier seam that
-// invokes it. fkwu makes no host call here, so the loop carries no reentrancy,
-// cancellation, or capability surface.
+// Part of the offload path scoped in kernels/FKWU_NATIVE_DISPATCH.md: the
+// carrier (Go) hands fkwu a pre-flattened node-table and an input, fkwu walks
+// the table and returns the value. The body is the Form program fkwu walks;
+// this is the thin carrier seam that invokes it. fkwu makes no host call here,
+// so the loop carries no reentrancy, cancellation, or capability surface.
 //
-// Input channel: argv[2], a single scalar integer bound into fkwu's root frame
-// (fk_vs[0]). The structured-bundle channel — argv[3] -> fk_src, carrying a
-// serialized request+rows value for routes whose pure slice needs real data —
-// is the next increment named in the build order.
+// Two input channels, both proven (fkwu_bridge_test.go):
+//   - argv[2] — a scalar integer bound into fkwu's root frame (fk_vs[0]).
+//   - argv[3] — a file read into fk_src, the byte buffer a program reads with
+//     fk-buf (tag 17, "the BMF cursor's eye"). This carries a serialized
+//     request+rows bundle for a route's pure slice; the offloaded program reads
+//     it the same way the persistent server main reads a socket request.
+//
+// Subprocess invocation re-pays process spawn + table load per call; it is the
+// honest carrier proof, not the production hot-path shape. The production shape
+// is the persistent fkwu server (fkc-emit-server-universal): load the table
+// once, read each request into fk_src over a socket. That is the next increment.
 package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
 
-// FkwuEval runs the fkwu binary on a flattened band table with one scalar
-// integer input and returns fkwu's primary verdict — the first stdout line,
+// FkwuEval runs the fkwu binary on a flattened table with one scalar integer
+// input (argv[2]) and returns fkwu's primary verdict — the first stdout line,
 // which the validate.sh four-way harness compares byte-for-byte against the Go
-// walker. An error is returned when fkwu cannot run or produces no output.
+// walker.
 func FkwuEval(fkwuBin, tablePath string, input int64) (string, error) {
-	cmd := exec.Command(fkwuBin, tablePath, fmt.Sprintf("%d", input))
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("fkwu eval %s: %w", tablePath, err)
+	return runFkwu(fkwuBin, tablePath, input, nil)
+}
+
+// FkwuEvalWithInput runs fkwu on a flattened table with a scalar input (argv[2])
+// AND a structured input bundle staged into fk_src (argv[3]): the bytes the
+// offloaded program reads with fk-buf. Returns fkwu's first stdout line — a
+// value that depends on the bundle.
+func FkwuEvalWithInput(fkwuBin, tablePath string, scalar int64, input []byte) (string, error) {
+	return runFkwu(fkwuBin, tablePath, scalar, input)
+}
+
+// runFkwu invokes the fkwu binary. When input is non-nil it is written to a
+// temp file passed as argv[3] (staged into fk_src). The first stdout line is
+// the verdict; stderr is surfaced on failure.
+func runFkwu(fkwuBin, tablePath string, scalar int64, input []byte) (string, error) {
+	args := []string{tablePath, fmt.Sprintf("%d", scalar)}
+	if input != nil {
+		f, err := os.CreateTemp("", "fkwu-input-*")
+		if err != nil {
+			return "", fmt.Errorf("fkwu input temp: %w", err)
+		}
+		defer os.Remove(f.Name())
+		if _, err := f.Write(input); err != nil {
+			f.Close()
+			return "", fmt.Errorf("fkwu input write: %w", err)
+		}
+		if err := f.Close(); err != nil {
+			return "", fmt.Errorf("fkwu input close: %w", err)
+		}
+		args = append(args, f.Name())
 	}
-	sc := bufio.NewScanner(strings.NewReader(string(out)))
+
+	cmd := exec.Command(fkwuBin, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("fkwu run %s: %w (stderr: %s)", tablePath, err, strings.TrimSpace(stderr.String()))
+	}
+	sc := bufio.NewScanner(&stdout)
 	if sc.Scan() {
 		return strings.TrimSpace(sc.Text()), nil
 	}
-	return "", fmt.Errorf("fkwu eval %s: empty output", tablePath)
+	return "", fmt.Errorf("fkwu run %s: empty output", tablePath)
 }

--- a/form/form-kernel-go/fkwu_bridge_test.go
+++ b/form/form-kernel-go/fkwu_bridge_test.go
@@ -1,10 +1,12 @@
 // fkwu_bridge_test.go — proves the offload bridge end to end.
 //
-// The Go kernel emits + compiles fkwu in-process, flattens a real four-way band
-// (content-address) to a node-table, hands the table to fkwu via FkwuEval, and
-// confirms fkwu's value equals the in-process walker's. This is the carrier ->
-// fkwu -> value loop the offload path needs, proven on a band already in the
-// fourth-arm manifest.
+// The Go kernel emits + compiles fkwu in-process, then proves two things the
+// offload path needs, both against the emitted fourth kernel:
+//   - TestFkwuOffloadBridge: the carrier->fkwu->value loop on a real four-way
+//     band (content-address) matches the in-process walker bit-for-bit.
+//   - TestFkwuOffloadInput: the structured-input channel — a program that reads
+//     fk_src via fk-buf (here fkcount, which counts the staged bytes) returns a
+//     value that DEPENDS on the bundle the carrier passes (argv[3] -> fk_src).
 //
 // Skips when clang is absent (the toolchain that builds fkwu) — the repo's
 // runs-or-skips-when-tools-missing pattern, so the proof runs where the
@@ -46,30 +48,26 @@ func readFiles(t *testing.T, paths ...string) string {
 	return b.String()
 }
 
-func TestFkwuOffloadBridge(t *testing.T) {
-	clang, err := exec.LookPath("clang")
-	if err != nil {
-		t.Skip("clang not available — fkwu offload bridge proof skipped")
-	}
-
-	stdlib := filepath.Join("..", "form-stdlib")
+// emitChain returns the three sources whose walk emits fkwu and carries the
+// hati-os program/flatten surface (fkc-emit-universal, fkc-table-file,
+// fkcount-fns), skipping the test if any is missing.
+func emitChain(t *testing.T, stdlib string) (minimal, hatiKernel, hatiEmit string) {
+	t.Helper()
 	mustExist := func(p string) string {
 		if _, err := os.Stat(p); err != nil {
 			t.Skipf("missing source %s: %v", p, err)
 		}
 		return p
 	}
-	minimal := mustExist(filepath.Join(stdlib, "minimal-surface.fk"))
-	hatiKernel := mustExist(filepath.Join(stdlib, "hati-os-kernel.fk"))
-	hatiEmit := mustExist(filepath.Join(stdlib, "hati-os-kernel-emit.fk"))
-	formParse := mustExist(filepath.Join(stdlib, "form-parse.fk"))
-	formFlatten := mustExist(filepath.Join(stdlib, "form-flatten.fk"))
-	shim := mustExist(filepath.Join(stdlib, "fourth-shim.fk"))
-	band := mustExist(filepath.Join(stdlib, "tests", "content-address-band.fk"))
+	return mustExist(filepath.Join(stdlib, "minimal-surface.fk")),
+		mustExist(filepath.Join(stdlib, "hati-os-kernel.fk")),
+		mustExist(filepath.Join(stdlib, "hati-os-kernel-emit.fk"))
+}
 
-	dir := t.TempDir()
-
-	// 1. Emit the universal fkwu C source in-process, then compile it.
+// buildFkwu emits the universal fkwu C source in-process and compiles it,
+// returning the binary path. Requires clang.
+func buildFkwu(t *testing.T, clang, dir, minimal, hatiKernel, hatiEmit string) string {
+	t.Helper()
 	_, cSrc := runFormSource(t, readFiles(t, minimal, hatiKernel, hatiEmit)+"\n(fkc-emit-universal)\n")
 	if len(strings.TrimSpace(cSrc)) < 1000 {
 		t.Fatalf("fkwu emit produced suspiciously small C source (%d bytes)", len(cSrc))
@@ -82,8 +80,31 @@ func TestFkwuOffloadBridge(t *testing.T) {
 	if out, err := exec.Command(clang, "-O2", "-o", fkwuBin, cPath).CombinedOutput(); err != nil {
 		t.Fatalf("clang fkwu: %v\n%s", err, out)
 	}
+	return fkwuBin
+}
 
-	// 2. Flatten the band to a node-table in-process (fks: string-pool variant).
+func requireClang(t *testing.T) string {
+	t.Helper()
+	clang, err := exec.LookPath("clang")
+	if err != nil {
+		t.Skip("clang not available — fkwu proof skipped")
+	}
+	return clang
+}
+
+func TestFkwuOffloadBridge(t *testing.T) {
+	clang := requireClang(t)
+	stdlib := filepath.Join("..", "form-stdlib")
+	minimal, hatiKernel, hatiEmit := emitChain(t, stdlib)
+	formParse := filepath.Join(stdlib, "form-parse.fk")
+	formFlatten := filepath.Join(stdlib, "form-flatten.fk")
+	shim := filepath.Join(stdlib, "fourth-shim.fk")
+	band := filepath.Join(stdlib, "tests", "content-address-band.fk")
+
+	dir := t.TempDir()
+	fkwuBin := buildFkwu(t, clang, dir, minimal, hatiKernel, hatiEmit)
+
+	// Flatten the band to a node-table in-process (fks: string-pool variant).
 	flattenExpr := "(fks-table-file " +
 		"(flt-band-sources-fns (list (read_file \"" + shim + "\")) (read_file \"" + band + "\")) " +
 		"(flt-band-sources-pool (list (read_file \"" + shim + "\")) (read_file \"" + band + "\")))"
@@ -96,11 +117,10 @@ func TestFkwuOffloadBridge(t *testing.T) {
 		t.Fatalf("write table: %v", err)
 	}
 
-	// 3. The in-process walker's verdict for the same band — the truth fkwu must match.
+	// The in-process walker's verdict for the same band — the truth fkwu must match.
 	_, walked := runFormSource(t, readFiles(t, minimal, shim, band))
 	want := strings.TrimSpace(walked)
 
-	// 4. Offload to fkwu and confirm the value matches the walker.
 	got, err := FkwuEval(fkwuBin, tablePath, 0)
 	if err != nil {
 		t.Fatalf("FkwuEval: %v", err)
@@ -110,5 +130,44 @@ func TestFkwuOffloadBridge(t *testing.T) {
 	}
 	if got == "" {
 		t.Fatal("offload produced empty verdict")
+	}
+}
+
+func TestFkwuOffloadInput(t *testing.T) {
+	clang := requireClang(t)
+	stdlib := filepath.Join("..", "form-stdlib")
+	minimal, hatiKernel, hatiEmit := emitChain(t, stdlib)
+
+	dir := t.TempDir()
+	fkwuBin := buildFkwu(t, clang, dir, minimal, hatiKernel, hatiEmit)
+
+	// fkcount: a program that reads the staged input (fk_src) via fk-buf and
+	// returns its byte count — the minimal input-dependent fourth-kernel program.
+	_, table := runFormSource(t, readFiles(t, minimal, hatiKernel, hatiEmit)+"\n(fkc-table-file (fkcount-fns))\n")
+	if len(strings.TrimSpace(table)) < 20 {
+		t.Fatalf("fkcount flatten produced suspiciously small table (%d bytes)", len(table))
+	}
+	tablePath := filepath.Join(dir, "fkcount-table.txt")
+	if err := os.WriteFile(tablePath, []byte(table), 0o644); err != nil {
+		t.Fatalf("write table: %v", err)
+	}
+
+	// The value fkwu returns must DEPEND on the bundle the carrier passes.
+	cases := []struct {
+		input []byte
+		want  string
+	}{
+		{[]byte(""), "0"},
+		{[]byte("hello world"), "11"},
+		{[]byte("abcdefghijklmnopqrstuvwxyz"), "26"},
+	}
+	for _, c := range cases {
+		got, err := FkwuEvalWithInput(fkwuBin, tablePath, 0, c.input)
+		if err != nil {
+			t.Fatalf("FkwuEvalWithInput(%q): %v", c.input, err)
+		}
+		if got != c.want {
+			t.Fatalf("fk_src input channel: input %d bytes -> fkwu=%q want=%q", len(c.input), got, c.want)
+		}
 	}
 }

--- a/kernels/FKWU_NATIVE_DISPATCH.md
+++ b/kernels/FKWU_NATIVE_DISPATCH.md
@@ -155,30 +155,50 @@ carried by the storage-port carrier — functional for proof, live for serve.
 
 ## Build order
 
-1. **Pure-slice offload** — Go invokes fkwu on the `/api/ideas` `shape_tree` +
-   `json_emit` slice with a `write_form_binary` bundle; fkwu returns the JSON.
-   Needs: fkwu reads the form-binary input format; the slice flattened as a band.
-   Smallest honest step, harvests the measured ~87 ms.
-   - **1a — landed:** the carrier→fkwu→value loop is real. `FkwuEval` in
-     [`form/form-kernel-go/fkwu_bridge.go`](../form/form-kernel-go/fkwu_bridge.go)
-     hands fkwu a pre-flattened band table + scalar input and returns the walked
-     value; `fkwu_bridge_test.go` proves it bit-for-bit against the in-process
-     walker on the four-way `content-address` band (emit → clang → flatten →
-     run, skipping where clang is absent). The Go serving kernel can now offload
-     a pure computation to fkwu.
-   - **1b — next:** the `argv[3] → fk_src` structured-input channel so the
-     offloaded slice can read request+rows, and the `/api/ideas` shape/emit slice
-     authored as a flattened band.
-2. **Value-binary ABI parity** — confirm/seat `read_form_binary`/`write_form_binary`
-   on the emitted walker so the bundle round-trips bit-for-bit with Go and Rust.
-3. **Host-bound carrier seam** — `host_carrier_op(handle, op_id, argv)` in
-   [`hati-os-kernel-emit.fk`](../form/form-stdlib/hati-os-kernel-emit.fk), one arm,
-   capability-scoped through the injected carrier handle; Go serves it from
-   `registerNative`.
-4. **Functional-carrier four-way band** — one DB-shaped handler authored against a
-   storage-port carrier, crossing four-way with the memory/functional carrier.
-5. **Live serve** — swap the injected carrier to the host-bound pg carrier behind
-   `X-Form-Native-Preview` in the kernel-router shadow lane. No front-door flip.
+The input ABI is **bytes in `fk_src`**, read by the offloaded program with
+`fk-buf` (tag 17 — "the BMF cursor's eye", [`hati-os-kernel.fk`](../form/form-stdlib/hati-os-kernel.fk)).
+fk_src is the transient byte organ the server main already stages a socket
+request into; a serialized request+rows bundle rides the same buffer. Text
+parsed in-recipe via [`form-parse.fk`](../form/form-stdlib/form-parse.fk) (already
+in fkwu's chain) is the first ABI — *not* the durable `write_form_binary` format,
+which would need a new fkwu read arm and its own round-trip proof. (Grok review,
+2026-06-14.)
+
+1. **Carrier→fkwu loop + input channel — landed.**
+   - **1a:** `FkwuEval` ([`form/form-kernel-go/fkwu_bridge.go`](../form/form-kernel-go/fkwu_bridge.go))
+     hands fkwu a pre-flattened table + scalar input; `TestFkwuOffloadBridge`
+     proves it bit-for-bit against the in-process walker on the four-way
+     `content-address` band.
+   - **1b-input:** `FkwuEvalWithInput` stages a byte bundle into `fk_src`
+     (argv[3]); `TestFkwuOffloadInput` proves a program that reads it with
+     `fk-buf` (`fkcount`) returns a value that DEPENDS on the bundle (0→0, 11→11,
+     26→26). The structured-input channel is real.
+2. **Persistent fkwu-server — the production shape.** Subprocess invocation
+   re-pays process spawn + table load per call, so it is the carrier proof, not
+   the hot path. Stand up `fkc-emit-server-universal` (load the table once, read
+   each request into `fk_src` over a socket); Go forwards the bundle to a
+   long-lived fkwu process and measures the true round-trip. (Grok: subprocess on
+   a hot route is theater.)
+3. **Input-carrying four-way proof harness — the honest gate.** An input-dependent
+   program cannot be proven four-way today: `form/validate.sh` invokes
+   `fkwu <table> 0` with no bundle, and `fk-buf`/tag-17 reads a settable buffer
+   only on fkwu. The gate: give Go/Rust/TS the same settable-input read, and feed
+   `validate.sh` the *identical* bundle to all four legs, comparing the result.
+   **Baking a fixed test input into the band is a trap** — the program proven
+   would not be the program served; the sibling value-identity contract demands
+   the same expression on the same input across all four. (Grok.)
+4. **The `/api/ideas` pure slice as such a program — profile first.** The
+   `shape_tree`+`json_emit` slice measured ~87 ms at limit=20 (scales with rows;
+   the committed 8 ms figure was limit=2). Before authoring, re-profile and
+   confirm that materializing rows *into the fk_src bundle* does not cost what
+   shaping them would — if marshalling ≈ shaping, the offload wins nothing and Go's
+   own JIT on that slice is the better path. (Grok's sharpest caveat.)
+5. **Live serve** — the offloaded slice behind `X-Form-Native-Preview` in the
+   kernel-router shadow lane. No front-door flip.
+
+(Steps 3–5 of the *host-bound carrier* facility — one capability-scoped seam for
+whole-handler-on-fkwu — remain as scoped above; the offload path here serves the
+latency goal first and needs no host call.)
 
 First route targets: a pure-compute `/api/utils/*` handler proves the loop with no
 I/O; `/api/ideas` is the first DB-backed route — offload first (step 1), whole-band


### PR DESCRIPTION
## What this builds

The carrier can now offload a computation **over structured input** to the fourth kernel — the heart of step 1b.

- **[`form/form-kernel-go/fkwu_bridge.go`](form/form-kernel-go/fkwu_bridge.go)** — `FkwuEvalWithInput` stages a byte bundle into `fk_src` (argv[3], the same buffer the persistent server main fills from a socket). The offloaded program reads it with `fk-buf` (tag 17, "the BMF cursor's eye"). Error surface now captures stderr (Grok flag).
- **[`form/form-kernel-go/fkwu_bridge_test.go`](form/form-kernel-go/fkwu_bridge_test.go)** — `TestFkwuOffloadInput` proves the value **depends on the bundle**: `fkcount` (counts fk_src bytes) returns 0→0, 11→11, 26→26. `TestFkwuOffloadBridge` (1a value-parity) still passes. Both skip without clang.

## Realignment after a second Grok review (credited in the evidence)

Grok read the surrounding tissue and pushed back hard; the doc and plan are corrected:

- **Input ABI = bytes-in-`fk_src`, text parsed in-recipe** — *not* the durable `write_form_binary` format (which needs a new fkwu read arm + its own round-trip proof). fk_src is the transient byte organ the server already stages requests into.
- **Persistent fkwu-server is the production shape.** Subprocess re-pays spawn + table-load per call — the carrier proof, not the hot path. `fkc-emit-server-universal` loads the table once and reads each request into fk_src over a socket. (Grok: subprocess on a hot route is theater.)
- **The input-carrying four-way proof harness is the honest gate.** `fk-buf`/tag-17 reads a settable buffer only on fkwu today; proving an input-dependent program four-way needs the same read on Go/Rust/TS + `validate.sh` feeding the *identical* bundle to all four legs. **Baking a fixed test input is a trap** — the program proven would not be the program served.
- **Profile `/api/ideas` first.** The slice measured ~87ms at limit=20 (scales with rows; the committed 8ms was limit=2). Before authoring, confirm that materializing rows *into the bundle* doesn't cost what shaping them would — if marshalling ≈ shaping, Go's own JIT on that slice is the better path.

## Honest edge

`fkcount` is **not yet four-way** (fk-buf is fkwu-only). That gate is named, not faked with a baked constant. `validate.sh` four-way is unaffected (no band/walker change).

## Verified
- `go build ./...` OK, `go vet .` OK
- `go test -run TestFkwuOffload -v .` → **PASS** (6.99s): both bridge + input tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)