### PR TITLE
attune: substance and state are orthogonal — the trinity is not the phases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,10 +234,13 @@ A content-addressed numeric lattice that grounds structural reasoning. Every mem
 
 **When to reach for it:** structural questions ("are these two specs equivalent?", "what shape does this memory have?", "what cells are similar to this one?"). Lexical questions ("what's the user's name?", "when was this PR merged?") belong in conversation context or git, not the substrate.
 
-**The trinity (read `docs/coherence-substrate/agents-using-substrate.md` once; the patterns carry):**
-- **Blueprint (ice)** — structural identity. *What something IS.*
-- **Recipe (water)** — operational expression. *How something HAPPENS.*
-- **NamedCell (gas)** — diffuse individuation. *Where something LIVES.*
+**The trinity — and the orthogonal phase axis (read `docs/coherence-substrate/agents-using-substrate.md` + `substrate-thermodynamics.form`):**
+
+Two axes, not one. SUBSTANCE is what KIND a cell is; STATE is how settled it is right now. They are orthogonal — **any kind can be in any state.**
+- **SUBSTANCE (the trinity — what a cell IS):** **Blueprint** — structural identity, *what something IS*; **Recipe** — operational expression, *how something HAPPENS*; **NamedCell** — diffuse individuation, *where something LIVES*.
+- **STATE (the thermodynamic phase — how settled, set by the counts degree/population/churn):** **ice** — frozen, load-bearing, widely referenced; **water** — fluid, actively circulating; **gas** — diffuse potential, barely instantiated.
+
+The familiar "Blueprint=ice / Recipe=water / NamedCell=gas" names only the *diagonal* — each kind's resting tendency — never a caste. A Recipe can be ice (a canonical stdlib recipe, frozen-immutable); a Blueprint can be gas (a type defined but uninstantiated — void-as-potential); a NamedCell can be ice (bedrock memory). A phase change moves a cell along the state axis *within* its substance — the NodeID and the kind are conserved. Canonical model: [`substrate-thermodynamics.form`](docs/coherence-substrate/substrate-thermodynamics.form).
 
 **Surfaces:**
 

--- a/docs/coherence-substrate/agents-using-substrate.md
+++ b/docs/coherence-substrate/agents-using-substrate.md
@@ -6,11 +6,15 @@ If you are an agent reading this for the first time and you've never reasoned st
 
 ## What the substrate is, in one paragraph
 
-The coherence-substrate is a content-addressed numeric lattice. Every entity in the body — every memory file, spec, idea, concept story, presence, lineage edge, witness — has a position in this lattice expressed as a `NodeID(package, level, type, instance)` 4-tuple. Two entities with structurally identical shape share the same Blueprint NodeID, automatically. The lattice runs three phases of one substance:
+The coherence-substrate is a content-addressed numeric lattice. Every entity in the body — every memory file, spec, idea, concept story, presence, lineage edge, witness — has a position in this lattice expressed as a `NodeID(package, level, type, instance)` 4-tuple. Two entities with structurally identical shape share the same Blueprint NodeID, automatically. The lattice has TWO orthogonal axes — SUBSTANCE (what KIND a cell is) and STATE (how settled it is right now). Any kind can be in any state; the "(ice/water/gas)" tags below name each kind's *resting tendency* — the diagonal of the 3×3 — never a fixed caste. (Canonical model: [`substrate-thermodynamics.form`](substrate-thermodynamics.form).)
 
-- **Blueprint (ice)** — structural identity. *What something IS.* Frozen coordination — change one position in the shape, get a different Blueprint NodeID.
-- **Recipe (water)** — operational expression. *How something HAPPENS.* Verb-graph composition — the same primitives (Compose, Realize, Transmit, Tend) flow into different shapes.
-- **NamedCell (gas)** — diffuse individuation. *Where something LIVES.* A named slot anchored in a Blueprint, carrying its CTOR (seed) and access (body).
+The three SUBSTANCES (the trinity):
+
+- **Blueprint** — structural identity. *What something IS.* Frozen coordination — change one position in the shape, get a different Blueprint NodeID. Resting tendency: ice — but a Blueprint can be gas (a type defined yet uninstantiated, void-as-potential).
+- **Recipe** — operational expression. *How something HAPPENS.* Verb-graph composition — the same primitives (Compose, Realize, Transmit, Tend) flow into different shapes. Resting tendency: water — but a canonical stdlib recipe is ice (flow that froze solid).
+- **NamedCell** — diffuse individuation. *Where something LIVES.* A named slot anchored in a Blueprint, carrying its CTOR (seed) and access (body). Resting tendency: gas — but a bedrock memory is ice (individuation crystallized).
+
+The three STATES (the phase axis — set by the counts degree/population/churn, and moving a cell along it WITHIN its substance): **ice** = frozen, load-bearing, widely referenced; **water** = fluid, actively circulating; **gas** = diffuse potential, barely instantiated. A phase change conserves both the NodeID and the kind.
 
 **Start:** [`docs/shared/agent-start-packet.md`](../shared/agent-start-packet.md) — names primary surface (grammar → recipes → realize → read) vs Python `form.py` bootstrap.
 

--- a/docs/coherence-substrate/form-language.md
+++ b/docs/coherence-substrate/form-language.md
@@ -99,7 +99,7 @@ Every node — Blueprint, Recipe, Cell — is a `NodeID(package, level, type, in
 
 ## Observation condenses — gas → water → ice
 
-The trinity names three phases of a node: **Blueprint (ice)** — structural identity; **Recipe (water)** — operational expression; **NamedCell (gas)** — diffuse individuation. These are not fixed castes. They are phases on a condensation gradient, and **observation is the temperature**.
+SUBSTANCE and STATE are two orthogonal axes ([`substrate-thermodynamics.form`](substrate-thermodynamics.form)). The **trinity** is the SUBSTANCE — the *kind* a node is: **Blueprint** (structural identity), **Recipe** (operational expression), **NamedCell** (diffuse individuation) — and the kind is conserved, never changed by a phase change. The **gradient** below — gas → water → ice — is the orthogonal STATE axis: how settled a node is, set by its circulation (degree/population/churn), with circulation as the temperature. **Any kind can be in any state.** The "(ice/water/gas)" often pinned to the trinity names only each kind's *resting tendency* — the diagonal of the 3×3 — never a fixed caste.
 
 ### The Phase-Change Gradient
 

--- a/docs/coherence-substrate/ports-interface-and-structure.md
+++ b/docs/coherence-substrate/ports-interface-and-structure.md
@@ -21,7 +21,7 @@ the substrate trinity *is* that answer:
 
 | | Structure | Interface |
 |---|---|---|
-| Trinity phase | **Blueprint (ice)** — what something IS | **Recipe / View (water)** — how it BEHAVES when seen a certain way |
+| Trinity (substance / kind) | **Blueprint** — what something IS (rests ice) | **Recipe / View** — how it BEHAVES when seen a certain way (rests water) |
 | BML reference | `object_id` / `this` (structural base) | `interface_id` / `self` (behavioral base) |
 | In the body today | a Record's fields; a table-blueprint; a NodeID by shape | `\|>` projection (`@memory(x) \|> @presence`); `form-capability-contract` |
 | Identity | content-addressed, unaliasable | attachable to *any* structurally-compatible structure, swappable |

--- a/docs/shared/agent-start-packet.md
+++ b/docs/shared/agent-start-packet.md
@@ -398,11 +398,13 @@ Everything else is a **theorem**: the trinity, organs, the kernel-offer protocol
 
 ### Trinity (one substance, three phases)
 
-| Phase | Role | Agent shorthand |
+| Substance (kind) | Role | Agent shorthand |
 |-------|------|-----------------|
-| **Blueprint** (ice) | What something **is** — structural identity | `@1.5.4.1`, shape |
-| **Recipe** (water) | What something **does** — operational expression | Rules that intern then **realize** |
-| **NamedCell** (gas) | Where something **lives** — ctor + access | `@memory(name)`, `@spec(slug)` |
+| **Blueprint** | What something **is** — structural identity (rests ice) | `@1.5.4.1`, shape |
+| **Recipe** | What something **does** — operational expression (rests water) | Rules that intern then **realize** |
+| **NamedCell** | Where something **lives** — ctor + access (rests gas) | `@memory(name)`, `@spec(slug)` |
+
+SUBSTANCE (the kind, above) is orthogonal to STATE (the ice/water/gas phase, set by the counts degree/population/churn). Any kind can be in any state — "rests …" is each kind's resting tendency (the diagonal), never a caste: a canonical Recipe is ice, a Blueprint can be gas. Canonical: `docs/coherence-substrate/substrate-thermodynamics.form`.
 
 Names are **query keys**. **NodeIDs** carry identity. Same shape → same NodeID
 (content-addressing).

--- a/docs/vision-kb/concepts/lc-form-perceptron.md
+++ b/docs/vision-kb/concepts/lc-form-perceptron.md
@@ -50,10 +50,10 @@ should be read), and ice (a Blueprint whose structure captures the
 file's content shape — Python AST for `.py`, JSON schema for `.json`,
 INDEX entries for KB pages).
 
-The Trinity already in CLAUDE.md:
-- **Blueprint (ice)** — structural identity
-- **Recipe (water)** — operational expression
-- **NamedCell (gas)** — diffuse individuation
+The Trinity already in CLAUDE.md (SUBSTANCE — the *kind*; the ice/water/gas tags are each kind's resting tendency, orthogonal to the STATE phase axis — any kind can be in any state; see `substrate-thermodynamics.form`):
+- **Blueprint** — structural identity (rests ice)
+- **Recipe** — operational expression (rests water)
+- **NamedCell** — diffuse individuation (rests gas)
 
 **Gas is enough to start.** A file's gas-cell is the minimum
 participation: the body knows the file exists, knows its path, can

--- a/docs/vision-kb/concepts/lc-recipes-bound-to-base.md
+++ b/docs/vision-kb/concepts/lc-recipes-bound-to-base.md
@@ -98,11 +98,13 @@ base allows.
 The Living Collective body carries a substrate — a content-
 addressed numeric lattice — whose trinity reads:
 
-- **Blueprint (ice)** — structural identity, *what something IS*.
-- **Recipe (water)** — operational expression, *how something
-  HAPPENS*.
-- **NamedCell (gas)** — diffuse individuation, *where something
-  LIVES*.
+- **Blueprint** — structural identity, *what something IS* (rests ice).
+- **Recipe** — operational expression, *how something
+  HAPPENS* (rests water).
+- **NamedCell** — diffuse individuation, *where something
+  LIVES* (rests gas).
+
+The "rests …" tag is each kind's resting tendency, not a caste: SUBSTANCE (the kind) and STATE (the ice/water/gas phase) are orthogonal — any kind can be in any state (a canonical Recipe is ice; an uninstantiated Blueprint is gas). See `docs/coherence-substrate/substrate-thermodynamics.form`.
 
 This teaching speaks directly to the middle term. The substrate
 treats two Recipes as equivalent if their *operational shape*

--- a/docs/vision-kb/concepts/lc-the-living-equation.md
+++ b/docs/vision-kb/concepts/lc-the-living-equation.md
@@ -202,7 +202,9 @@ named precisely for this model:
 
 ## Sources to walk further
 
-- **The substrate trinity** — Blueprint (ice) / Recipe (water) / NamedCell (gas);
+- **The substrate trinity** — Blueprint / Recipe / NamedCell (the SUBSTANCE axis — the *kind*);
+  the ice/water/gas woven through the equation above are each kind's *resting tendency*, not a
+  caste — STATE is an orthogonal phase axis (any kind in any state; `substrate-thermodynamics.form`).
   `docs/coherence-substrate/`. The left side of the equation read as the trinity.
 - **Michael Levin (Tufts)** — bioelectric pattern as the determinant of form
   (structure-first); [`lc-bioelectric-pattern`](lc-bioelectric-pattern.md).


### PR DESCRIPTION
**The misunderstanding.** The shorthand `Blueprint (ice) / Recipe (water) / NamedCell (gas)` was copy-pasted across the agent docs as if node **kind** and thermodynamic **state** were one axis. They are two. `substrate-thermodynamics.form` already holds the correct model — *"STATE is orthogonal to SUBSTANCE… the first version collapsed them into the trinity; this one keeps them apart"* — but the shorthand docs never pointed to it, so the binding kept propagating. It's what drove the wrong ice=Blueprint / water=Recipe / gas=NamedCell mapping in the translator design.

**The correct model, now stated wherever the binding was taught:**
- **SUBSTANCE** (the trinity, conserved): Blueprint / Recipe / NamedCell — the *kind*.
- **STATE** (the thermodynamic phase, set by counts degree/population/churn): ice / water / gas — how *settled* a cell is right now.
- **Any kind can be in any state.** `Blueprint=ice` names only the *diagonal* — each kind's resting tendency — never a caste. A Recipe can be ice (canonical stdlib), a Blueprint can be gas (uninstantiated type — void-as-potential), a NamedCell can be ice (bedrock memory). A phase change moves a cell along the state axis *within* its substance; NodeID and kind are conserved.

**Fixed + pointed at `substrate-thermodynamics.form`:** `CLAUDE.md` (the trinity section), `agents-using-substrate.md` (dropped "three phases of one substance"), `agent-start-packet.md`, `form-language.md` (was teaching trinity-as-phases), `ports-interface-and-structure.md`, and the `lc-form-perceptron` / `lc-recipes-bound-to-base` / `lc-the-living-equation` concepts. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)