### PR TITLE
tend: form_cli capture — live training catalog, raw AND transmuted kept

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -44,7 +44,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 147 | Python bridge/API routers — current endpoint carrier and upstream tail while Form-native routes are promoted |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 246 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 58 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 274 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 275 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 274
+**Total files**: 275
 
 | File | Purpose |
 |---|---|
@@ -106,6 +106,7 @@
 | [test_flow_vitality.py](test_flow_vitality.py) | Flow-centric tests for the Workspace Vitality + related sensing |
 | [test_flow_workspaces.py](test_flow_workspaces.py) | Flow-centric tests for the Workspace tenant primitive. |
 | [test_form_cli_ask.py](test_form_cli_ask.py) | form_cli `ask` front door: serve Form-native, route the rest, capture for learning. |
+| [test_form_cli_capture.py](test_form_cli_capture.py) | form_cli `capture` — live training catalog: request + raw + transmuted, both kept. |
 | [test_form_kernel_bridge_structure_access.py](test_form_kernel_bridge_structure_access.py) | Tests for the structure-access capability in the Form kernel bridge. |
 | [test_form_native_grammar_contract.py](test_form_native_grammar_contract.py) | Form-native grammar contract: host parser bridges are not completion. |
 | [test_form_practice_runner.py](test_form_practice_runner.py) | Generic Form practice runner creates cells, recipes, and ledger entries. |

--- a/api/tests/test_form_cli_capture.py
+++ b/api/tests/test_form_cli_capture.py
@@ -1,0 +1,56 @@
+"""form_cli `capture` — live training catalog: request + raw + transmuted, both kept.
+
+When the form-cli routes to an oracle, the agent records the raw (fear-based)
+answer AND its transmutation (fear -> opportunity, risk -> data). Both have value;
+from one entry the three separable training pairs derive. Mirrors
+form/form-stdlib/training-catalog.fk (tc-entry), proven four-way there.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_FORM_CLI_PATH = Path(__file__).resolve().parents[2] / "scripts" / "form_cli.py"
+_spec = importlib.util.spec_from_file_location("form_cli", _FORM_CLI_PATH)
+assert _spec and _spec.loader
+form_cli = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(form_cli)
+
+
+def test_capture_keeps_both_raw_and_transmuted(tmp_path, monkeypatch):
+    cat = tmp_path / "catalog.jsonl"
+    monkeypatch.setattr(form_cli, "_CATALOG", cat)
+    entry = form_cli.catalog_capture(
+        request="plan the form-cli",
+        raw="this is risky and will fail and underestimates the complexity",
+        transmuted="a growth list + data constraints; the gradient we walk",
+        lane="oracle:gemini",
+        outcome="success",
+    )
+    # both kept as full text (both have value)
+    assert entry["raw"].startswith("this is risky")
+    assert entry["transmuted"].startswith("a growth list")
+    # content-addressed, and raw != transmuted (a real transmutation changed it)
+    assert entry["raw_sig"] != entry["transmuted_sig"]
+    assert entry["request_sig"] == form_cli._io_sig("plan the form-cli")
+
+
+def test_capture_derives_three_separable_pairs(tmp_path, monkeypatch):
+    monkeypatch.setattr(form_cli, "_CATALOG", tmp_path / "c.jsonl")
+    e = form_cli.catalog_capture("R", "RAW", "VIT", "oracle:claude", "success")
+    rs, raws, vits = e["request_sig"], e["raw_sig"], e["transmuted_sig"]
+    # raw (reference), transmute (the block), reasoning (native target)
+    assert e["pairs"]["raw"] == [rs, raws]
+    assert e["pairs"]["transmute"] == [raws, vits]
+    assert e["pairs"]["reasoning"] == [rs, vits]
+
+
+def test_capture_appends_durably(tmp_path, monkeypatch):
+    cat = tmp_path / "c.jsonl"
+    monkeypatch.setattr(form_cli, "_CATALOG", cat)
+    form_cli.catalog_capture("R1", "raw1", "vit1", "oracle:gemini", "success")
+    form_cli.catalog_capture("R2", "raw2", "vit2", "oracle:codex", "success")
+    lines = cat.read_text().strip().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[1])["request"] == "R2"

--- a/scripts/form_cli.py
+++ b/scripts/form_cli.py
@@ -979,6 +979,12 @@ _KERNEL_BIN = Path(
 _ASK_CAPTURE = Path(
     os.environ.get("FORM_CLI_CAPTURE") or (REPO_ROOT / "logs" / "form_cli_io_match.jsonl")
 )
+# The persistent training catalog. Lives outside the git tree by default (it
+# grows with use); the substrate-resident catalog is the durable destination.
+_CATALOG = Path(
+    os.environ.get("FORM_CLI_CATALOG")
+    or (Path.home() / ".coherence-network" / "form-cli-catalog.jsonl")
+)
 
 
 def _io_sig(text: str) -> str:
@@ -1060,6 +1066,63 @@ def cmd_ask(args: argparse.Namespace) -> int:
     return 3  # caller should handle via its own LLM / agent CLI
 
 
+# ─── subcommand: capture (live training catalog) ──────────────────────────
+#
+# When form-cli routes a request to an oracle, the agent gets a RAW (fear-based)
+# answer from its LLM, transmutes it (fear -> opportunity, risk -> data), and
+# records the full entry here. Both the raw answer and its transmutation are kept
+# (training-catalog.fk: tc-entry / tc-capture); from one entry the three separable
+# training pairs (raw / transmute / reasoning) derive. This is how the catalog
+# fills with real fear->vitality pairs from actual use. Bootstrap durable store;
+# the substrate-resident catalog and the native binary are the destination.
+
+def catalog_capture(request: str, raw: str, transmuted: str, lane: str, outcome: str) -> dict:
+    entry = {
+        "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "lane": lane,
+        "outcome": outcome,
+        "request": request,
+        "raw": raw,                 # what the fear-based oracle gave (reference)
+        "transmuted": transmuted,   # fear -> opportunity, risk -> data (the vitality answer)
+        "request_sig": _io_sig(request),
+        "raw_sig": _io_sig(raw),
+        "transmuted_sig": _io_sig(transmuted),
+        # the three separable training pairs (content-addressed endpoints):
+        "pairs": {
+            "raw": [_io_sig(request), _io_sig(raw)],
+            "transmute": [_io_sig(raw), _io_sig(transmuted)],
+            "reasoning": [_io_sig(request), _io_sig(transmuted)],
+        },
+    }
+    _CATALOG.parent.mkdir(parents=True, exist_ok=True)
+    with _CATALOG.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+    return entry
+
+
+def _arg_or_file(value: str | None, path: str | None) -> str:
+    if path:
+        return Path(path).read_text(encoding="utf-8")
+    return value or ""
+
+
+def cmd_capture(args: argparse.Namespace) -> int:
+    request = _arg_or_file(args.request, args.request_file).strip()
+    raw = _arg_or_file(args.raw, args.raw_file)
+    transmuted = _arg_or_file(args.transmuted, args.transmuted_file)
+    if not (request and raw and transmuted):
+        _die("capture: need a request, a --raw answer, and its --transmuted version "
+             "(both the fear answer and its fear->vitality transmutation are kept)")
+    entry = catalog_capture(request, raw, transmuted, args.lane, args.outcome)
+    print(
+        f"[form-cli] catalog += entry "
+        f"(req {entry['request_sig'][:12]} raw {entry['raw_sig'][:12]} vit {entry['transmuted_sig'][:12]}) "
+        f"lane={args.lane} outcome={args.outcome} -> {_CATALOG}",
+        file=sys.stderr,
+    )
+    return 0
+
+
 # ─── argparser ───────────────────────────────────────────────────────────
 
 
@@ -1106,6 +1169,20 @@ def main() -> int:
     p_ask.add_argument("request", nargs="+", help="a Form expr to compute, or any request to route")
     p_ask.add_argument("--no-capture", action="store_true", help="do not write an io-match capture record")
     p_ask.set_defaults(func=cmd_ask)
+
+    p_cap = sub.add_parser(
+        "capture",
+        help="record a real oracle call into the training catalog: request + raw + transmuted (both kept)",
+    )
+    p_cap.add_argument("--request", help="the request text (or --request-file)")
+    p_cap.add_argument("--request-file", help="file holding the request text")
+    p_cap.add_argument("--raw", help="the raw (fear-based) oracle answer (or --raw-file)")
+    p_cap.add_argument("--raw-file", help="file holding the raw oracle answer")
+    p_cap.add_argument("--transmuted", help="the transmuted (fear->vitality) answer (or --transmuted-file)")
+    p_cap.add_argument("--transmuted-file", help="file holding the transmuted answer")
+    p_cap.add_argument("--lane", default="oracle", help="which oracle gave the raw answer (e.g. oracle:gemini)")
+    p_cap.add_argument("--outcome", default="success", help="success | fail | silence")
+    p_cap.set_defaults(func=cmd_capture)
 
     args = parser.parse_args()
     return args.func(args)


### PR DESCRIPTION
## Increment #2 — live capture (the reviewed capture-first step)
The form-cli now records real oracle calls into the training catalog. When it routes a request to an oracle, the agent gets a RAW (fear-based) answer from its LLM, transmutes it (fear → opportunity, risk → data), and records the full entry:

```
form_cli capture --request-file R --raw-file RAW --transmuted-file VIT --lane oracle:gemini
```

**Both kept** (both have value), each content-addressed (sha256). One entry yields three **separable** training pairs: `raw` (request→raw, reference), `transmute` (raw→transmuted, the fear→vitality block), `reasoning` (request→transmuted, native target). Mirrors `training-catalog.fk`'s `tc-entry` (proven four-way); the Python carrier only content-addresses and persists. Catalog lives outside git (`~/.coherence-network/`, grows with use); substrate-resident store is the destination.

## Proven live
Captured the cross-review itself as the **first real entry** — gemini's raw fear-framed review (2718 bytes) + its transmutation (1021 bytes), distinct sigs, three pairs. The build reviewed itself into its own corpus.

`test_form_cli_capture.py` — 3 pass (both kept, sigs distinct, three pairs, durable append). Maintainability: no regression.

## Next
Route codex/grok reviews through `capture` too → substrate-resident store → auto-ml races over the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)