### PR TITLE
Recursion-safe let binding on the fourth arm (frame let — fixes a hidden divergence)

### DIFF
--- a/docs/coherence-substrate/fourth-arm-substrate-carriers.form
+++ b/docs/coherence-substrate/fourth-arm-substrate-carriers.form
@@ -10,7 +10,7 @@
   (north-star
     (sentence "The content-addressed substrate is durable across REAL carriers on all four kernels: the same substrate-core module crosses four-way over the in-memory, segmented-FILE, and Postgres carriers, so content-addressing survives a process and persistence boundary, not only memory — one engine, no parallel paths.")
     (connected-tissue "Harmonizes with form/fourth-arm-bands.txt (the floor source for four-way coverage), hati-os.form (the kernel surface), the native executor proof ledger, and commit evidence so the sister nodes name one current floor and one next gap.")
-    (must-carry content-addressed-intern durable-named-cells memory-carrier file-carrier postgres-carrier effect-once-let single-walk-comparison sequenced-effects native-host-io native-text-write native-file-append)
+    (must-carry content-addressed-intern durable-named-cells memory-carrier file-carrier postgres-carrier effect-once-let recursion-safe-let single-walk-comparison sequenced-effects native-host-io native-text-write native-file-append)
     (proof-shape same-shape-same-nodeid durable-content-key-roundtrip four-way-0-divergent))
 
   (floor
@@ -27,13 +27,14 @@
       host-io-fs-carriers-tags-55-63            # open/read/write/close/lseek/mkdir/rmdir/unlink/rename/size/append/slice
       host-io-real-roundtrip                    # real filesystem write -> read crosses four-way deterministically (band hostio-roundtrip)
       native-write-file-text-tag-104            # overwrite/truncate text write floor (band write-file-text)
-      native-file-append)                       # append log write floor (band file-append)
+      native-file-append                        # append log write floor (band file-append)
+      recursion-safe-let-frame-tags-106-107)    # a stored let binds on the call's value stack (LETF push + FARG read), so a recursive re-entry stores to its own frame and the deepest frame cannot clobber an outer binding read after the descent (band recursive-let-clobber)
     (current-unsupported
       file_mtime scan_run                       # broader host-io read/scan recipes
-      segmented-file-carrier-four-way           # gated on threaded carrier-store receipts beyond the minimum write floor
+      segmented-file-carrier-four-way           # gated on the threaded carrier-store band itself; the binding that threads effectful values through a recursive carrier loop is now recursion-safe (frame let)
       postgres-carrier-four-way))               # gated on the broader host-io recipes
 
   (next-step
     (sentence "Land the remaining host-io read/scan recipes, then substrate-core threaded over the segmented-FILE carrier crosses four-way, then Postgres.")
     (gate file_mtime scan_run segmented-file-carrier-four-way)
-    (why "Statement-level effects already fire once (sequenced bare-do, tag 69), operand-level effects already fire once (single-walk eq/lt, tags 102/103), nested do-lets snapshot effecting values, and the minimum write floor now includes write_file_text plus append. The next carrier proof is no longer basic writing; it is threaded durable file-store receipts, mtime/scan observation, and then the Postgres carrier over the same content-key discipline the memory carrier already proves four-way.")))
+    (why "Statement-level effects already fire once (sequenced bare-do, tag 69), operand-level effects already fire once (single-walk eq/lt, tags 102/103), nested do-lets bind effecting values once on the call's value stack so they survive a recursive descent (frame let, tags 106/107), and the minimum write floor now includes write_file_text plus append. The next carrier proof is no longer basic writing or recursion-safe binding; it is threaded durable file-store receipts, mtime/scan observation, and then the Postgres carrier over the same content-key discipline the memory carrier already proves four-way.")))

--- a/form/form-stdlib/form-flatten.fk
+++ b/form/form-stdlib/form-flatten.fk
@@ -94,6 +94,19 @@
 (defn flt-current-fidx (env) (flt-env-row-value (flt-assoc (flt-fidxq) env) 0))
 (defn flt-slot (env) (fk-lit (add 128 (add (mul (flt-current-fidx env) 32) (len env)))))
 
+; Frame-relative let binding — the recursion-safe successor to the global RAM
+; slot. A stored let pushes its value ONCE onto the call's value stack (the same
+; fk_vs frame the packed ARG already rides) and binds a frame-relative read
+; (FARG offset) for the rest of the do. Because every call gets its own frame
+; pointer, a recursive re-entry stores to its OWN slot — the deepest frame can no
+; longer clobber an outer frame's binding. ARG is FARG offset 0; the k-th frame
+; let lives at offset k. flt-current-letdepth counts the frame lets already
+; active in this frame, so the next one binds at depth+1.
+(defn flt-letdepth-q () "(defn-letdepth)")
+(defn flt-current-letdepth (env) (flt-env-row-value (flt-assoc (flt-letdepth-q) env) 0))
+(defn fk-farg (off) (fk-node 106 (fk-lit off)))
+(defn fk-letf (value body) (fk-node 107 (ms-intern value body)))
+
 (defn flt-mkop (row a b)
     (if (eq (nth row 1) 1) (fk-node (nth row 2) a)
         (fk-node (nth row 2) (ms-intern a b))))
@@ -274,20 +287,26 @@
     (if (str_eq op "http_get") 1 0)))))))))))))))
 (defn flt-do-let-done (name op s ve fns env val)
     (if (eq (flt-do-let-store-op op fns env) 1)
-        (flt-do-let-store name s ve fns env val (flt-slot env))
+        (flt-do-let-frame name s ve fns env val (add (flt-current-letdepth env) 1))
         (flt-do2 s (fp-skip s (fp-close s (nth ve 1))) fns
                  (cons (list name (nth ve 0)) env) val)))
 (defn flt-do-let-store-op (op fns env)
     (if (eq (flt-do-let-effect-op op) 1) 1
         (if (eq (flt-current-recursive env) 1) 0
             (if (eq (len (flt-assoc op fns)) 0) 0 1))))
-(defn flt-do-let-store (name s ve fns env val slot)
-    (flt-do-let-store-rest
-        (fk-store slot (nth ve 0))
+; The stored let lowers to a scoped frame push: LETF walks the value once, holds
+; it on the call's value stack, walks the rest of the do with a frame-relative
+; binding, then pops. Recursion-safe by construction — the outer frame's slot is
+; below the callee's frame pointer, so a deeper re-entry cannot overwrite it.
+(defn flt-do-let-frame (name s ve fns env val offset)
+    (flt-do-let-frame-rest
+        (nth ve 0)
         (flt-do2 s (fp-skip s (fp-close s (nth ve 1))) fns
-                 (cons (list name (fk-load slot)) env) val)))
-(defn flt-do-let-store-rest (store rest)
-    (list (flt-sequence store (nth rest 0)) (nth rest 1)))
+                 (cons (list name (fk-farg offset))
+                       (cons (list (flt-letdepth-q) offset) env))
+                 val)))
+(defn flt-do-let-frame-rest (value rest)
+    (list (fk-letf value (nth rest 0)) (nth rest 1)))
 
 ; two operands, then the lowering picked by selector k (lowerings are rules,
 ; not tag rows — they BUILD shapes instead of naming one)

--- a/form/form-stdlib/hati-os-kernel-emit.fk
+++ b/form/form-stdlib/hati-os-kernel-emit.fk
@@ -37,6 +37,10 @@
     ; 101 temp_dir — nullary host-io leaf: the walker arm reads no operands, so
     ; the row carries the tag alone (fk_tempdir resolves $TMPDIR at walk time).
     (if (eq (fk-tag n) 101) (cons (list 101 0 0 0) acc)
+    ; 106 FARG — frame-relative read: unary, its single child is the offset LIT
+    ; the walker adds to fp. 107 LETF (value, body) is binary and rides the
+    ; fallback. Together they carry recursion-safe let binding on the value stack.
+    (if (eq (fk-tag n) 106) (fkc-un2 106 (fkc-flat (fk-body n) acc))
     (if (eq (fk-tag n) 20) (fkc-un2 20 (fkc-flat (fk-body n) acc))
     (if (eq (fk-tag n) 21) (fkc-un2 21 (fkc-flat (fk-body n) acc))
     (if (eq (fk-tag n) 22) (fkc-un2 22 (fkc-flat (fk-body n) acc))
@@ -100,7 +104,7 @@
     (if (eq (fk-tag n) 98) (fkc-tri2 98 (fkc-flat (ms-child (fk-body n) 0) acc) n)
     (if (or (eq (fk-tag n) 81) (or (eq (fk-tag n) 82) (or (eq (fk-tag n) 83) (or (eq (fk-tag n) 85) (or (eq (fk-tag n) 87) (or (eq (fk-tag n) 88) (or (eq (fk-tag n) 89) (eq (fk-tag n) 90))))))))
         (fkc-un2 (fk-tag n) (fkc-flat (fk-body n) acc))
-        (fkc-bin2 (fk-tag n) (fkc-flat (ms-child (fk-body n) 0) acc) n))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+        (fkc-bin2 (fk-tag n) (fkc-flat (ms-child (fk-body n) 0) acc) n)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 
 (defn fkc-call2 (fidx acc1) (cons (list 12 fidx (sub (len acc1) 1) 0) acc1))
 
@@ -432,7 +436,7 @@
                 (str_concat (fkc-record-field-arms-text)
                 (str_concat (fkc-record-blueprint-arms-text)
                 (str_concat (fkc-jit-lower-arms-text)
-                            "if (t == 69) { fk_walk(fk_node[i][1], fp); return fk_walk(fk_node[i][2], fp); } if (t == 102) { long long ae = fk_walk(fk_node[i][1], fp); long long be = fk_walk(fk_node[i][2], fp); if (fk_num(ae) == fk_num(be)) { return 2; } return 0; } if (t == 103) { long long al = fk_walk(fk_node[i][1], fp); long long bl = fk_walk(fk_node[i][2], fp); if (fk_num(al) < fk_num(bl)) { return 2; } return 0; } return 0; } ")))))))))))))
+                            "if (t == 69) { fk_walk(fk_node[i][1], fp); return fk_walk(fk_node[i][2], fp); } if (t == 102) { long long ae = fk_walk(fk_node[i][1], fp); long long be = fk_walk(fk_node[i][2], fp); if (fk_num(ae) == fk_num(be)) { return 2; } return 0; } if (t == 103) { long long al = fk_walk(fk_node[i][1], fp); long long bl = fk_walk(fk_node[i][2], fp); if (fk_num(al) < fk_num(bl)) { return 2; } return 0; } if (t == 106) { return fk_vs[fp + (fk_walk(fk_node[i][1], fp) >> 1)]; } if (t == 107) { fk_vp(fk_walk(fk_node[i][1], fp)); long long r107 = fk_walk(fk_node[i][2], fp); fk_vsp = fk_vsp - 1; return r107; } return 0; } ")))))))))))))
 
 ; figure-ops arms (tags 34..42), emitted: each mirrors the walking kernels'
 ; native bit-for-bit — band/bor/bxor/mul are int64 ops; the *_u32 family

--- a/form/form-stdlib/tests/recursive-let-clobber.fk
+++ b/form/form-stdlib/tests/recursive-let-clobber.fk
@@ -1,0 +1,28 @@
+; recursive-let-clobber.fk — an effecting let bound PER FRAME of a recursive
+; function, read AFTER the recursive descent. The strange-minimal witness for
+; recursion-safe let binding on the fourth arm.
+;
+; preludes: form-stdlib/core.fk
+;
+; descend appends one byte per frame; file_append_bytes returns the new total
+; length, so len_here is THIS frame's length (1 at the outermost call, deeper
+; frames see 2 then 3). It then recurses for effect and finally returns
+; len_here. Lexical scope (Go/Rust/TS interpret the source) keeps each frame's
+; own len_here, so the OUTERMOST frame returns 1 — it saw length 1 before any
+; deeper append. A flattener that binds effecting lets to a GLOBAL per-function
+; slot clobbers len_here across frames: every frame's read returns the DEEPEST
+; frame's length (3), because all frames share one constant slot. len_here is
+; the FIRST statement, so there is no prior-statement ordering confound — the
+; only thing under test is whether the binding survives the recursive descent.
+; Correct four-way verdict: 1. A clobbering fourth arm answers 3.
+(defn descend (path n)
+    (do
+        (let len_here (file_append_bytes path (list 65)))
+        (do
+            (if (le n 1) 0 (descend path (sub n 1)))
+            len_here)))
+(do
+    (let dir (temp_dir))
+    (let path (str_concat dir "/fk-recursive-let-clobber.txt"))
+    (fs_remove path)
+    (descend path 3))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -55,7 +55,7 @@
 # record-blueprint rows among its focused four-way rows, and
 # android-mesh-learning now carries
 # active mic/camera/GPU sample rows at focused verdict 32767. The latest
-# completed full `cd form && ./validate.sh` on this branch reads 223
+# completed full `cd form && ./validate.sh` on this branch reads 224
 # four-way bands and 612 total passing workloads with 0 residual divergent
 # bands; refresh the full aggregate on a quiet host after focused release
 # rather than spending repeated validation cycles under shared-runner
@@ -376,11 +376,17 @@ substrate-core fks 11111
 # (eq-effect-once appends one byte inside an eq and reads len 1). The Form
 # meta-circular walkers (fk-walk-lowered, fkm-walk-lowered) carry the same arms,
 # keeping the spec consistent with the emitted fkwu. Third piece crossed:
-# nested do-lets now snapshot effecting values through fk-store/fk-load, not only
-# record_new, so a side-effecting binding is walked once and read many times
-# (let-effect-once appends one byte, checks the bound size twice, and reads len
-# 1). file_mtime/scan_run and segmented-FILE/Postgres carriers can now build on
-# effect-once let discipline instead of working around re-walked bindings.
+# nested do-lets bind effecting values once on the call's value stack (LETF push
+# tag 107 + frame-relative FARG read tag 106), so a side-effecting binding is
+# walked once and read many times (let-effect-once appends one byte, checks the
+# bound size twice, and reads len 1). The frame binding is recursion-safe: each
+# call gets its own frame pointer, so a deeper recursive re-entry stores to its
+# own slot and cannot clobber an outer frame's binding read after the descent
+# (recursive-let-clobber descends three frames, each binding the file length it
+# saw before recursing, and the outermost correctly reads 1, not the deepest 3 —
+# the global-RAM-slot binding it replaces answered 3). file_mtime/scan_run and
+# segmented-FILE/Postgres carriers can now build on recursion-safe effect-once
+# let discipline instead of working around re-walked or clobbered bindings.
 # The next host-io carrier rows are now admitted too: write_file_text rides fkwu
 # tag 104 with overwrite/truncate semantics, and file-append rides the native
 # append carrier. Text emitters no longer need to materialize byte lists for the
@@ -412,5 +418,6 @@ translation-quality fks 1111111
 chart-cast fks 1111111
 eq-effect-once fks 1
 let-effect-once fks 111
+recursive-let-clobber fks 1
 write-file-text fks 1111
 file-append fks 11111


### PR DESCRIPTION
## What

A nested `do`-let that binds an **effecting** value lowered to a **global per-function RAM slot** (`fk_mem`, a compile-time-constant index). In a **recursive** function every frame stored to the *same* slot, so a binding read *after* the recursive descent returned the **deepest frame's** value, not its own. The three reference kernels (Go/Rust/TS) interpret the source with proper lexical scope — so this was a real **four-way divergence**, hidden only because no band exercised an effecting let in a recursive function read after the recursive call.

## Proof of the bug

`recursive-let-clobber` descends three frames, each binding the file length it saw *before* recursing. Lexical scope → the outermost frame reads **1**. On `main`, fkwu answered **3** (the deepest frame's length). A divergence, not a gap.

## Fix

A stored let now binds on the **call's value stack** (`fk_vs`) — the same frame the packed `ARG` already rides — instead of a global slot:

- **LETF (tag 107)** walks the value once, pushes it, walks the rest of the `do` with a frame-relative binding, then pops.
- **FARG (tag 106)** reads `fk_vs[fp + offset]`; `ARG` is FARG offset 0, the k-th frame let is offset k.

Every call has its own frame pointer, so a recursive re-entry stores **below the callee's frame** and can no longer clobber an outer binding. One binding mechanism for params and lets, no global slot, GC-rooted on the stack — a step toward the elegant core (retiring the global-slot special case).

### Touchpoints
- Shared C arm tail `fkc-arms-many-text` — covers the base, JIT, and crystallize walkers in one place.
- Table serializer `fkc-flat` — FARG unary; LETF binary via the fallback.
- `form-flatten` do-let store path — routes the store decision through frame binding with offset tracking.
- **No** meta-circular walker change (the store path is fkwu-only; `form-flatten-band` never triggers it). **No** `fkc-nat-expr` change (stored lets never reach JIT codegen).

## Verification

`cd form && ./validate.sh`:
- **fourth arm: 224 band(s) four-way** (was 223)
- **614 ok, 0 divergent**
- `recursive-let-clobber → 1` four-way; every existing effecting/record/substrate band unchanged.

North-star cell `fourth-arm-substrate-carriers.form` and the manifest narrative updated to name the recursion-safe binding and the gate it unblocks (threaded carrier-store receipts — the clobber was *why* threading effectful values through a recursive carrier loop was hard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)