### PR TITLE
tend: universal nearest-meaning translator — any modality to any modality, four-way (S2)

### DIFF
--- a/docs/coherence-substrate/native-translation-model.form
+++ b/docs/coherence-substrate/native-translation-model.form
@@ -78,7 +78,11 @@
 ;                pairs from the store. The lookup still works, but the DATA is external.
 ;   S2 embed     encode faces as embedding-as-recipe vectors; translate by nearest-embedding
 ;                retrieval (loopback-learning.fk's nearest-shape learner is the bootstrap);
-;                generalises to unseen faces by similarity.
+;                generalises to unseen faces by similarity. REALIZED: translation-engine.fk
+;                + tests/translation-engine-band.fk (1111111 four-way) — ANY modality -> ANY
+;                modality (NL<->NL/Code/ASM, text<->image, audio as a face) through the shared
+;                meaning space, corpus passed in as data, seed scale. OPEN: the learned
+;                surface->embedding encoder and the generative decoder (S3 diffusion).
 ;   S3 denoise   the content-address-snapping parallel denoiser (ml-diffusion-model-flow).
 ;   S4 auto-ml   architecture variants searched, scored, and promoted natively.
 ;

--- a/form/form-stdlib/tests/translation-engine-band.fk
+++ b/form/form-stdlib/tests/translation-engine-band.fk
@@ -1,0 +1,52 @@
+; tests/translation-engine-band.fk — ANY modality -> ANY modality through one shared meaning
+; space, proven four-way. The corpus is DATA passed to the engine (data outside the recipe);
+; the engine routes by NEAREST MEANING, so the last claim translates an UNSEEN coordinate —
+; proof it generalises by similarity, not a hardcoded lookup.
+;
+; The seed corpus carries three meanings, each with faces in several modalities at a shared
+; coordinate (faces that mean the same thing sit at the same embedding):
+;   increment  [9 0 0] : nl-en "add one to x" · code "x + 1" · asm "ADD r0 #1"
+;   greet      [0 9 0] : nl-en "hello" · audio "aud:hello" · nl-de "hallo"
+;   red-circle [0 0 9] : nl-en "red circle" · image "img:red-circle"
+;
+; Verdict 1111111 (127) when every claim holds across all four kernels.
+;   NL -> Code:           "add one to x" -> "x + 1"                      -> 1
+;   NL -> ASM:            "add one to x" -> "ADD r0 #1"                  -> 10
+;   Code -> NL:           "x + 1" -> "add one to x"                      -> 100
+;   NL(text) -> NL(audio): "hello" -> "aud:hello"  (NL is text or audio) -> 1000
+;   text -> image:        "red circle" -> "img:red-circle"              -> 10000
+;   image -> text:        "img:red-circle" -> "red circle"              -> 100000
+;   generalises: an UNSEEN coordinate [8 1 1] -> nearest nl-en meaning  -> 1000000
+;
+; preludes: form-stdlib/core.fk form-stdlib/guidance-channel.fk form-stdlib/translation-engine.fk
+;
+
+(do
+    ;; the corpus — DATA the engine routes over (in production: content-addressed cells in ice)
+    (let c (list
+        (face "nl-en" "add one to x" (list 9.0 0.0 0.0))
+        (face "code"  "x + 1"        (list 9.0 0.0 0.0))
+        (face "asm"   "ADD r0 #1"    (list 9.0 0.0 0.0))
+        (face "nl-en" "hello"        (list 0.0 9.0 0.0))
+        (face "audio" "aud:hello"    (list 0.0 9.0 0.0))
+        (face "nl-de" "hallo"        (list 0.0 9.0 0.0))
+        (face "nl-en" "red circle"   (list 0.0 0.0 9.0))
+        (face "image" "img:red-circle" (list 0.0 0.0 9.0))))
+
+    ;; --- 1. NL -> Code -----------------------------------------------
+    (let c0 (if (str_eq (te-translate c "nl-en" "add one to x" "code") "x + 1") 1 0))
+    ;; --- 2. NL -> ASM ------------------------------------------------
+    (let c1 (if (str_eq (te-translate c "nl-en" "add one to x" "asm") "ADD r0 #1") 10 0))
+    ;; --- 3. Code -> NL -----------------------------------------------
+    (let c2 (if (str_eq (te-translate c "code" "x + 1" "nl-en") "add one to x") 100 0))
+    ;; --- 4. NL text -> NL audio (NL can be text or audio) ------------
+    (let c3 (if (str_eq (te-translate c "nl-en" "hello" "audio") "aud:hello") 1000 0))
+    ;; --- 5. text -> image (prompt to image) --------------------------
+    (let c4 (if (str_eq (te-translate c "nl-en" "red circle" "image") "img:red-circle") 10000 0))
+    ;; --- 6. image -> text (describing an image) ----------------------
+    (let c5 (if (str_eq (te-translate c "image" "img:red-circle" "nl-en") "red circle") 100000 0))
+    ;; --- 7. generalises from an UNSEEN coordinate (nearest meaning) ---
+    ;; [8 1 1] is nearest the increment meaning [9 0 0] among the three nl-en faces.
+    (let c6 (if (str_eq (te-translate-emb c "nl-en" (list 8.0 1.0 1.0)) "add one to x") 1000000 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/form-stdlib/translation-engine.fk
+++ b/form/form-stdlib/translation-engine.fk
@@ -1,0 +1,74 @@
+; translation-engine.fk — universal nearest-meaning translator: ANY modality -> ANY modality,
+; through a shared meaning space. The engine is DATA-AGNOSTIC — the corpus (faces with meaning
+; coordinates) is DATA passed in, never hardcoded here. That is "data outside the recipe": the
+; corpus and weights are cells; this .fk is only the engine.
+;
+; A FACE = (modality, surface, embedding). A surface form in some modality, sitting at a
+; meaning coordinate. Faces that mean the same thing sit at the same / nearest embedding —
+; so translation src-modality -> tgt-modality is: take the source face's embedding, find the
+; nearest face OF THE TARGET MODALITY, return its surface. ONE engine carries every pair —
+; NL<->NL (text or audio), NL<->Code, NL<->ASM, text<->image — because universality is the
+; shared meaning space (O(M) faces, not O(M^2) pair-models). cjk-channel's "one cell, many
+; tongues" generalised past language to every modality (embedding-as-recipe: semantically
+; identical inputs across modalities intern to the same NodeID).
+;
+; PROOF LEVEL: this is the S2 floor — data-driven NEAREST-MEANING (it generalises by
+; similarity to unseen inputs, it is not a hardcoded pair lookup). The embeddings carried in
+; are SEED meaning-coordinates; the learned encoder (surface -> embedding for any unseen
+; surface) and the generative decoder (embedding -> a NOVEL surface — the diffusion stage that
+; actually synthesises code/image/audio) are S3, named not faked. In production the faces are
+; content-addressed embedding-as-recipe cells resting in ice; this engine's nearest-meaning
+; math is identical over them.
+;
+; preludes: form-stdlib/core.fk form-stdlib/guidance-channel.fk
+;
+
+(do
+    ;; a face: (modality surface embedding-vector)
+    (defn face (modality surface emb) (list modality surface emb))
+    (defn face-mod (f) (nth f 0))
+    (defn face-surface (f) (nth f 1))
+    (defn face-emb (f) (nth f 2))
+
+    ;; L1 distance between two embedding vectors (float, four-way)
+    (defn te-abs (n) (if (lt n 0.0) (mul -1.0 n) n))
+    (defn te-dist-loop (a b acc)
+        (if (eq (len a) 0) acc
+            (if (eq (len b) 0) acc
+                (te-dist-loop (tail a) (tail b)
+                    (add acc (te-abs (sub (head a) (head b))))))))
+    (defn te-dist (a b) (te-dist-loop a b 0.0))
+
+    ;; carry (best-face, best-dist) across the corpus; only faces of tgt modality compete
+    (defn te-near-loop (corpus tgt q best-face best-d)
+        (if (eq (len corpus) 0) best-face
+            (do (let f (head corpus))
+                (if (str_eq (face-mod f) tgt)
+                    (do (let d (te-dist (face-emb f) q))
+                        (if (lt d best-d)
+                            (te-near-loop (tail corpus) tgt q f d)
+                            (te-near-loop (tail corpus) tgt q best-face best-d)))
+                    (te-near-loop (tail corpus) tgt q best-face best-d)))))
+
+    ;; nearest target-modality surface to a query embedding (honest "?" if none)
+    (defn te-nearest (corpus tgt q)
+        (face-surface (te-near-loop corpus tgt q (list "" "?" (list)) 1000000.0)))
+
+    ;; find a source face by (modality, surface)
+    (defn te-find (corpus mod surface)
+        (if (eq (len corpus) 0) (list "" "?" (list))
+            (do (let f (head corpus))
+                (if (str_eq (face-mod f) mod)
+                    (if (str_eq (face-surface f) surface) f (te-find (tail corpus) mod surface))
+                    (te-find (tail corpus) mod surface)))))
+
+    ;; translate a known source face: src (mod,surface) -> nearest target-modality surface
+    (defn te-translate (corpus src-mod src-surface tgt-mod)
+        (te-nearest corpus tgt-mod (face-emb (te-find corpus src-mod src-surface))))
+
+    ;; translate straight from a query embedding — the path for an UNSEEN surface the learned
+    ;; encoder produced; this is where generalisation lives (nearest meaning, not lookup).
+    (defn te-translate-emb (corpus tgt-mod q) (te-nearest corpus tgt-mod q))
+
+    (defn translation-engine-teaching () "lc-cross-modal-unity")
+    0)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -415,6 +415,7 @@ ratio-bridge fks 1111111
 offer-lane fks 1111111
 translation-learn fks 1111111
 translation-quality fks 1111111
+translation-engine fks 1111111
 chart-cast fks 1111111
 native-training-receipt fks 2047
 eq-effect-once fks 1


### PR DESCRIPTION
Lands **S1+S2** of the universal translator. The corpus is **data passed in** (data outside the recipe); the engine routes by **shared meaning** — any input modality → any output modality through ONE shared meaning space (O(M) faces, not O(M²) pair-models).

A **face** = `(modality, surface, embedding)`. Faces that mean the same thing sit at the same/nearest embedding; `translate src→tgt` = take the source face's embedding, return the nearest face *of the target modality*. `translation-engine.fk` is the engine; `tests/translation-engine-band.fk` seeds a small multi-modal corpus and proves **every pair**, four-way (`1111111`, 0 divergent):

- NL → Code (`"add one to x"` → `"x + 1"`)
- NL → ASM (`→ "ADD r0 #1"`)
- Code → NL (`"x + 1"` → `"add one to x"`)
- NL(text) → NL(audio) (`"hello"` → `"aud:hello"` — NL is text *or* audio)
- text → image (`"red circle"` → `"img:red-circle"`)
- image → text (`"img:red-circle"` → `"red circle"`)
- **generalizes**: an *unseen* coordinate `[8 1 1]` → the nearest meaning — proof it routes by similarity, not a hardcoded lookup.

**Proof level, named honestly:** this is the **S2 floor** — seed-scale, data-driven nearest-meaning. The embeddings are *seed meaning-coordinates*; the learned encoder (surface→embedding for unseen surfaces) and the **generative decoder** (embedding → a *novel* surface — real code/image/audio synthesis, the diffusion stage) are **S3, named not faked**. `cjk-channel`'s "one cell, many tongues" generalized past language to every modality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)