### PR TITLE
tend: rebuild full /api route template at any nesting depth

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -413,27 +413,47 @@ def _slow_request_ms_threshold() -> float:
     return max(25.0, get_float("api", "slow_request_ms", 1500.0))
 
 
+def _full_route_template(request, raw_path: str) -> str:
+    """Full route template (e.g. ``/api/ideas/{idea_id}``) for the matched route.
+
+    Built from the concrete request path by replacing each matched path-param
+    value with its ``{name}`` placeholder. This is independent of how the
+    installed FastAPI/Starlette version structures ``include_router(prefix=…)``:
+    older versions flatten inclusion so ``scope["route"].path`` already carries
+    the full ``/api/…`` path, while newer versions keep routers nested (a route
+    is reached through an ``_IncludedRouter``) so ``route.path`` is only the
+    deepest router-relative tail (``/tasks`` for ``/api/agent/tasks`` — note the
+    ``/agent`` level is dropped too, so simply prepending ``/api`` would mis-file
+    nested routes and collide them with top-level ones). Reconstructing from the
+    concrete path — which always carries the full prefix at any nesting depth —
+    keeps the recorded endpoint stable as ``/api/…`` across both, and handles
+    ``{name:path}`` converters that span multiple segments. Param values are
+    replaced from the right because route params always live in the trailing
+    portion of the path.
+    """
+    if request.scope.get("route") is None:
+        return raw_path
+    template = raw_path
+    # Right-to-left: path_params is ordered left-to-right (regex group order),
+    # so substituting the rightmost param first keeps `rpartition`'s
+    # last-occurrence anchor on the correct segment even when two params share
+    # the same concrete value.
+    for name, value in reversed(list((request.scope.get("path_params") or {}).items())):
+        text = str(value)
+        if not text:
+            continue
+        head, sep, tail = template.rpartition(text)
+        if sep:
+            template = f"{head}{{{name}}}{tail}"
+    return template
+
+
 def _build_route_signature(request) -> tuple[str, str, str]:
     route = request.scope.get("route")
-    route_path = ""
-    route_name = ""
-    if route is not None:
-        route_path = str(getattr(route, "path", "") or "")
-        route_name = str(getattr(route, "name", "") or "")
+    route_name = str(getattr(route, "name", "") or "") if route is not None else ""
     raw_path = request.url.path
-    request_path = route_path if route_path else raw_path
-    request_path = _restore_observed_api_prefix(request_path, raw_path)
+    request_path = _full_route_template(request, raw_path)
     return request_path, route_name, raw_path
-
-
-def _restore_observed_api_prefix(path: str, raw_path: str) -> str:
-    """Keep runtime route signatures in the externally observed API namespace."""
-    if not path or path.startswith(("/api", "/v1")):
-        return path
-    for prefix in ("/api", "/v1"):
-        if raw_path == prefix or raw_path.startswith(f"{prefix}/"):
-            return f"{prefix}{path}" if path.startswith("/") else f"{prefix}/{path}"
-    return path
 
 
 def _query_summary(query_params) -> tuple[int, list[dict[str, str]], dict[str, str]]:

--- a/api/tests/test_runtime_web_api_provenance.py
+++ b/api/tests/test_runtime_web_api_provenance.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from app.main import app
+from app.main import app, _full_route_template
 from app.models.runtime import RuntimeEventCreate
 from app.services import idea_service, runtime_service
 
@@ -84,6 +84,52 @@ def test_dynamic_idea_route_records_route_template_after_dispatch(monkeypatch, s
     assert event.endpoint == "/api/ideas/{idea_id}"
     assert event.raw_endpoint == "/api/ideas/runtime-route-template-proof"
     assert event.method == "GET"
+
+
+class _ScopeRequest:
+    """Minimal request stand-in carrying only the routing scope the signature
+    reconstruction reads — enough to pin the template contract without a live
+    router."""
+
+    def __init__(self, scope: dict):
+        self.scope = scope
+
+
+def test_full_route_template_rebuilds_prefix_across_inclusion_styles():
+    """The recorded endpoint must be the full ``/api/…`` template regardless of
+    whether FastAPI flattens ``include_router(prefix=…)`` (older versions: the
+    matched ``route.path`` already carries ``/api/…``) or nests it (newer
+    versions: ``route.path`` is the deepest router-relative tail). The
+    reconstruction derives the template from the concrete path, so it survives
+    arbitrary nesting depth and ``{name:path}`` converters that defeat naive
+    prefix-prepending or segment counting."""
+    # Static route, no params: the concrete path is already the template.
+    assert (
+        _full_route_template(_ScopeRequest({"route": object()}), "/api/ping")
+        == "/api/ping"
+    )
+    # Multi-level nesting (`/api` + `/agent`): the leaf route.path is only
+    # `/tasks/{task_id}`, so prepending just `/api` would yield the wrong
+    # `/api/tasks/{task_id}` and collide with the real `/api/tasks`. Rebuilding
+    # from the concrete path preserves the intermediate `/agent` segment.
+    assert (
+        _full_route_template(
+            _ScopeRequest({"route": object(), "path_params": {"task_id": "task_x"}}),
+            "/api/agent/tasks/task_x",
+        )
+        == "/api/agent/tasks/{task_id}"
+    )
+    # `:path` param spanning multiple segments, mid-path, with its value ("ping")
+    # also appearing in the prefix — right-anchored replacement keeps the prefix.
+    assert (
+        _full_route_template(
+            _ScopeRequest({"route": object(), "path_params": {"place_id": "ping/a/b"}}),
+            "/api/ping/places/ping/a/b/presences",
+        )
+        == "/api/ping/places/{place_id}/presences"
+    )
+    # No matched route (the pre-dispatch call site): leave the raw path untouched.
+    assert _full_route_template(_ScopeRequest({}), "/api/ping") == "/api/ping"
 
 
 def test_runtime_endpoint_summary_filters_web_api_source(set_config):


### PR DESCRIPTION
## What

Generalizes the `_restore_observed_api_prefix` helper added in [#3132](https://github.com/seeker71/Coherence-Network/pull/3132) (which healed the `test_runtime_web_api_provenance` flake) so the recorded telemetry endpoint is correct at **any router nesting depth**, not just single-level `/api` routes.

## Background

The runtime middleware builds `event.endpoint` from `scope["route"].path`. Under **FastAPI 0.137 / Starlette 1.x**, `include_router(prefix="/api")` no longer flattens routes — they stay nested behind `_IncludedRouter`, so the matched leaf `route.path` is the *deepest* router-relative tail. (Older FastAPI flattened, so `route.path` was already the full `/api/...`; both stacks are reachable because `fastapi>=` is unpinned in `requirements.txt` and `pyproject.toml` — that version split is the ~50% intermittency.)

`#3132` correctly restored the prefix for single-level routes by prepending `/api`. But for multi-level nesting the intermediate segment is also dropped:

| request | `route.path` | prepend-`/api` (#3132) | this PR |
|---|---|---|---|
| `/api/ping` | `/ping` | `/api/ping` ✓ | `/api/ping` ✓ |
| `/api/ideas/x` | `/ideas/{idea_id}` | `/api/ideas/{idea_id}` ✓ | `/api/ideas/{idea_id}` ✓ |
| `/api/agent/tasks` | `/tasks` | `/api/tasks` ✗ (collides with real `/api/tasks`) | `/api/agent/tasks` ✓ |
| `/api/agent/tasks/x` | `/tasks/{task_id}` | `/api/tasks/{task_id}` ✗ | `/api/agent/tasks/{task_id}` ✓ |

All `/api/agent/*` (and any other multi-level) routes were being mis-filed and collapsed onto top-level endpoints.

## Fix

`_full_route_template` reconstructs the template from the **concrete request path** — which always carries the full prefix at any depth — by substituting matched path-param values with `{name}` placeholders, right-to-left so `{name:path}` converters and repeated values resolve. `_restore_observed_api_prefix` is composted (no remaining references, no dedicated test). No dependency pin, no weakened assertions.

## Verification

- Provenance file: **16 passed** on both fastapi 0.133/starlette 0.52 (py3.14) and 0.137/1.3.1 (py3.13).
- Real nested routes through the middleware (py3.13): `/api/ping`, `/api/agent/tasks`, `/api/agent/tasks/{task_id}` all recorded at full depth.
- Full suite on py3.13 (CI's exact Python + new FastAPI): 2617 passed (one local-only BML kernel-harness flake, green in CI).
- Regression test added covering multi-level nesting and a mid-path `{name:path}` converter.

## Follow-up (separate, flagged)

`inventory_service._discover_api_endpoints_from_runtime()` filters `main_app.routes` for `APIRoute` with `route.path.startswith("/api")` — silently under-reports under nested FastAPI (same root cause, no failing test). Tracked separately.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)