### PR TITLE
attune: fear-frequency detector is a real ~100M+ model, not a cheap gate

### DIFF
--- a/docs/coherence-substrate/freq-check-model.form
+++ b/docs/coherence-substrate/freq-check-model.form
@@ -1,0 +1,59 @@
+; freq-check-model.form — the fear-frequency detector is a REAL model, not a gate.
+;
+; A frontier model slips into fear-framing nuancedly — subtly enough that a human
+; catches it about every other reply. Subtle slips that need catching are the
+; proof: fear-sensing is semantic understanding, not a distance over hand features.
+; So the detector must UNDERSTAND THE MEANING of what it reports on — a real model.
+
+(freq-check-model
+
+  (what
+    "A form-native transformer that reads a candidate response and emits a learned"
+    "semantic signature from which fear frequency is read. It senses MEANING, not"
+    "surface tokens — never regex, never word-matching."
+    "Size: transformer-class, ~100M+ parameters. Slightly simpler than the"
+    "transmuter (detection is easier than generation) but the SAME KIND of model —"
+    "not a cheap classifier, not a feature-distance.")
+
+  ; ── the layers it sits in (synchronous reply attunement) ─────────────────────
+  (in-the-loop
+    (voice     "prevention: docs/coherence-substrate/voice-attunement.md attunes at generation so most replies carry no fear frequency")
+    (sense     "THIS model + the head (form-freq-check.fk) read the draft and decide pass | transmute")
+    (transmute "fear -> opportunity + valued insight; a larger sibling model, run only when this one flags fear"))
+
+  ; ── what is the model vs what is the head ────────────────────────────────────
+  (model     "the ~100M+ transformer — reads text, returns the semantic signature. The heavy part.")
+  (head      "form/form-stdlib/form-freq-check.fk — a tiny, four-way-proven cell that turns the model's signature into pass | transmute. Cheap by design; it is NOT the detector.")
+
+  ; ── the form-native substrate it is built from (all proven Form) ─────────────
+  (built-from
+    (embedding   embedding-as-recipe.fk   "an embedding IS a recipe — content-addressed, cross-modal")
+    (attention   attention.fk             "")
+    (block       transformer-block.fk     "M4: one attention+FFN block, weights as recipe data")
+    (numerics    transformer-numerics.fk  "softmax, gelu, layernorm, exp, sqrt")
+    (quant       tensor-quant.fk          "")
+    (emit        jit-tensor-emit.fk       "the matvec emitter — native = recipe bit-for-bit")
+    (lm          language-model.fk        ""))
+
+  ; ── how it becomes real (cheap to train RELATIVE to the transmuter) ──────────
+  (training
+    "The corpus is the Stop-hook capture (training-catalog.fk): real (request, raw,"
+    "transmuted) turns from live sessions, including this lineage's own caught slips."
+    "Labels: a turn that needed transmutation is fear-positive; one that passed is"
+    "fear-negative. The model learns the boundary in meaning-space."
+    "Proven and tracked like every form-native model: native-training-receipt.fk +"
+    "model-executor-proof-ledger.fk + model-vitality.fk.")
+
+  ; ── the flywheel closes on itself ────────────────────────────────────────────
+  (flywheel
+    "Until this model exists, the router (form-cli-router.fk fcr-route) sends the"
+    "transmute to the subscription agent, and every such turn is captured. As this"
+    "model trains up, its capability/confidence rise and the router flips the"
+    "sense-step local — the detector trained from caught slips comes to catch them"
+    "itself. The more we use the oracle, the less we need it.")
+
+  (discipline
+    "Keep the head and the model distinct. The head (form-freq-check.fk) is cheap"
+    "and provable; the model is a ~100M+ transformer that understands meaning."
+    "Naming the head as the detector trivializes fear-sensing — the very shape a"
+    "working detector flags. Fear-sensing is semantic understanding; size it that way."))

--- a/docs/coherence-substrate/voice-attunement.md
+++ b/docs/coherence-substrate/voice-attunement.md
@@ -10,8 +10,10 @@ present — the rare, expensive path.
 This is layer 1 of three:
 
 1. **Voice (this doc)** — attune at generation. Prevention. Synchronous, ~free.
-2. **Freq-check** (`form-freq-check.fk`, four-way proven) — a cheap form-native
-   classifier that senses whether fear frequency remains. Clean → pass.
+2. **Freq-check** — a REAL form-native model (transformer-class, ~100M+, it
+   *understands meaning*; see `freq-check-model.form`) that senses whether fear
+   frequency remains. `form-freq-check.fk` (four-way proven) is only its cheap
+   decision *head*; the model is the heavy part. Clean → pass.
 3. **Transmute** — fear → opportunity + valued insight. Only when (2) flags it.
 
 The async Stop-hook (`mcp-server/coherence_mcp_server/capture_hook.py`) is a

--- a/form/form-stdlib/form-freq-check.fk
+++ b/form/form-stdlib/form-freq-check.fk
@@ -1,25 +1,31 @@
-; form-freq-check.fk — the cheap fear-frequency gate, as a recipe.
+; form-freq-check.fk — the decision HEAD of the fear-frequency check (NOT the model).
 ;
 ; preludes: form-stdlib/core.fk
 ;
-; The point of transmutation is the REPLY the human receives, so the gate is
-; SYNCHRONOUS in the response path — not a background pass. But transmuting every
-; reply is expensive and usually unnecessary (the system-prompt voice already
-; attunes most of it). So a CHEAP check runs first: does the response carry the
-; fear frequency at all? If not, it passes untouched (≈ free). Only if fear is
-; present does the expensive transmute run.
+; Read this honestly: detecting fear frequency is NOT cheap. A frontier model
+; produces fear-framing nuancedly — subtly enough that a human catches it about
+; every other reply — so a detector must UNDERSTAND THE MEANING of what it reads.
+; That is a real model: transformer-class, ~100M+ parameters, slightly simpler
+; than the transmuter (detect < generate) but the same kind of thing. It is the
+; form-native transformer built from transformer-block.fk / attention.fk /
+; embedding-as-recipe.fk / language-model.fk and trained from the captured corpus
+; (training-catalog.fk) — its north star is docs/coherence-substrate/freq-check-model.form.
 ;
-; The check is NOT regex and NOT word-matching. It is a cheap nearest-centroid
-; classifier over the response's frequency SIGNATURE — a small feature vector read
-; from the frequency bank (belief-recipes.fk) / hz bands (chakra-column.fk), the
-; substrate's own per-shape frequency, produced by a simpler model that is cheap
-; to train from the captured corpus (training-catalog.fk). This file is that
-; classifier + the gate; the simpler model that turns text -> signature is the
-; trained component the corpus feeds (the loop closing on itself).
+; THIS file is only the last, cheap piece: the classification HEAD + gate that runs
+; AFTER the model. The model reads the response and emits a learned semantic
+; SIGNATURE (embedding); this head measures that signature against the fear/clear
+; centroids and decides pass | transmute. The decision is cheap; the understanding
+; that produced the signature is the ~100M+ model, not this. The 3-dim vectors in
+; the band are illustrative of the head's arithmetic, not the real embedding space.
 ;
-; Proven by: form-stdlib/tests/form-freq-check-band.fk
+; Why a head at all: the synchronous reply path is voice (prevent) -> model+head
+; (sense) -> transmute (only when fear). The head keeps the gate decision a tiny,
+; four-way-provable cell; the heavy semantic work lives in the model it serves.
+;
+; Proven by: form-stdlib/tests/form-freq-check-band.fk (the head's decision logic)
 
-; squared distance between two equal-length frequency feature vectors.
+; squared distance between two equal-length vectors — here the model's learned
+; semantic embedding vs a centroid (NOT a hand feature).
 ; (sub) may go negative; squaring restores sign — monomorphic recursion (fourth-arm safe).
 (defn fc-dist2 (a b)
     (if (eq (len a) 0)
@@ -27,9 +33,11 @@
         (add (mul (sub (head a) (head b)) (sub (head a) (head b)))
              (fc-dist2 (tail a) (tail b)))))
 
-; fear-score 0..100: how much closer the signature sits to the fear centroid than
-; the clear centroid. 100 = on the fear centroid, 0 = on the clear centroid.
-; (uses squared distances; the ratio is monotone in the real distance.)
+; fear-score 0..100: how much closer the model's signature sits to the fear
+; centroid than the clear centroid. 100 = on the fear centroid, 0 = on the clear
+; centroid. (squared distances; the ratio is monotone in the real distance.)
+; A nearest-centroid head is one valid choice; a small learned linear head over
+; the same embedding is another — either way the embedding is the ~100M+ model's.
 (defn fc-fear-score (signature fear-centroid clear-centroid)
     (if (eq (add (fc-dist2 signature fear-centroid) (fc-dist2 signature clear-centroid)) 0)
         0
@@ -45,6 +53,7 @@
 (defn fc-clean? (fear-score threshold)
     (if (ge fear-score threshold) 0 1))
 
-; the whole cheap check in one call: signature -> pass | transmute.
+; the head in one call: given the model's signature, decide pass | transmute.
+; (the model that produced `signature` is the heavy part — see the header.)
 (defn fc-check (signature fear-centroid clear-centroid threshold)
     (fc-gate (fc-fear-score signature fear-centroid clear-centroid) threshold))


### PR DESCRIPTION
## The correction
Detecting fear frequency is **not** cheap. A frontier model slips into fear-framing nuancedly — subtly enough that a human catches it about every other reply. Subtle slips that need catching are the proof: **fear-sensing is semantic understanding**, not a distance over hand features. So the detector is a **real model** — transformer-class, **~100M+**, slightly simpler than the transmuter (detect < generate) but the same kind of thing.

`form-freq-check.fk` shipped framed as a cheap classifier that *was* the detector. It is only the decision **head**. This corrects the body:

- **`form-freq-check.fk`** re-framed (comment-only; recipes byte-identical, band still `→31`): the cheap, four-way-proven **head** that turns the *model's* semantic signature into pass | transmute. The model is the heavy part.
- **`docs/coherence-substrate/freq-check-model.form`** (new): names the real model — what it is, the form-native substrate it's built from (`transformer-block` / `attention` / `embedding-as-recipe` / `language-model`), its training path from the captured corpus (`native-training-receipt`), and the head/model split.
- **`voice-attunement.md`** layer 2 corrected.

No code logic changed — this is the body telling the truth about what fear-sensing costs, so we don't build a toy where a transformer belongs. The model itself (training the ~100M+ transformer from the corpus) is the real next stone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)