### PR TITLE
tend: enumerate nested API routes in inventory across FastAPI inclusion styles

### DIFF
--- a/api/app/services/inventory_service.py
+++ b/api/app/services/inventory_service.py
@@ -8,6 +8,7 @@ import json
 import logging
 import re
 import time
+from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -4244,23 +4245,80 @@ def _source_path_aliases(file_path: str) -> set[str]:
     return {item for item in out if item}
 
 
+def _iter_api_route_leaves(
+    routes: Iterable[Any],
+    prefix: str = "",
+    _depth: int = 0,
+) -> Iterator[tuple[str, Any]]:
+    """Yield ``(full_path, api_route)`` for every leaf APIRoute reachable from ``routes``.
+
+    Works across FastAPI inclusion styles. Older FastAPI (< ~0.135 / Starlette
+    0.52) flattens ``include_router(prefix=…)`` so every APIRoute already sits at
+    the top level carrying its full ``/api/…`` path. Newer FastAPI (0.137+ /
+    Starlette 1.x) keeps routers nested behind ``_IncludedRouter`` (and sub-apps
+    behind ``Mount``), so a leaf ``APIRoute.path`` is only the router-relative
+    tail (``/ping``, ``/ideas/{idea_id}``). This walks the route tree and
+    accumulates each enclosing container's prefix down to the leaf,
+    reconstructing the externally observed full path in both regimes — detected
+    by structure, not by a pinned dependency version.
+
+    A router's *own* ``prefix=`` is already baked into its leaf paths, so only
+    the inclusion-time prefix (``_IncludedRouter.include_context.prefix``) and
+    the mount path are accumulated here.
+    """
+    from fastapi.routing import APIRoute
+    from starlette.routing import Mount
+
+    if _depth > 25:  # guard against pathological cycles; real trees are shallow
+        return
+    for route in routes or []:
+        if isinstance(route, APIRoute):
+            yield f"{prefix}{route.path}", route
+            continue
+        # New FastAPI nests included routers behind _IncludedRouter, whose
+        # include_context carries the inclusion prefix and the child router.
+        include_context = getattr(route, "include_context", None)
+        if include_context is not None:
+            child_prefix = str(getattr(include_context, "prefix", "") or "")
+            included_router = getattr(include_context, "included_router", None)
+            child_routes = getattr(included_router, "routes", None)
+            if child_routes:
+                yield from _iter_api_route_leaves(
+                    child_routes, f"{prefix}{child_prefix}", _depth + 1
+                )
+            continue
+        # Mounted sub-apps (Starlette Mount) carry their prefix in ``.path``.
+        if isinstance(route, Mount):
+            mount_path = str(getattr(route, "path", "") or "")
+            child_routes = getattr(route, "routes", None)
+            if child_routes:
+                yield from _iter_api_route_leaves(
+                    child_routes, f"{prefix}{mount_path}", _depth + 1
+                )
+            continue
+        # Fallback: any other container that exposes nested routes (a bare
+        # APIRouter without an include_context on some versions). Prefix is
+        # left unchanged since none is discoverable on the container itself.
+        nested = getattr(route, "routes", None)
+        if nested is None:
+            nested = getattr(getattr(route, "router", None), "routes", None)
+        if nested:
+            yield from _iter_api_route_leaves(nested, prefix, _depth + 1)
+
+
 def _discover_api_endpoints_from_runtime() -> list[dict[str, Any]]:
     try:
-        from fastapi.routing import APIRoute
         from app.main import app as main_app
     except Exception:
         return []
 
     grouped: dict[str, dict[str, Any]] = {}
-    for route in main_app.routes:
-        if not isinstance(route, APIRoute):
-            continue
-        path = str(route.path or "")
+    for path, route in _iter_api_route_leaves(main_app.routes):
         if not (path.startswith("/api") or path.startswith("/v1")):
             continue
         methods = sorted(
             method
-            for method in (route.methods or set())
+            for method in (getattr(route, "methods", None) or set())
             if method in {"GET", "POST", "PUT", "PATCH", "DELETE"}
         )
         if not methods:

--- a/api/tests/test_runtime_web_api_provenance.py
+++ b/api/tests/test_runtime_web_api_provenance.py
@@ -465,3 +465,76 @@ def test_bml_front_door_captures_query_errors_before_pg_close():
     assert "let query_failed = gt(str_len(query_error), 0);" in route_text
     assert 'if query_failed then api-service-unavailable("persistence", "' not in route_text
     assert 'if query_failed then api-service-unavailable("persistence", query_error)' in route_text
+
+
+# ---- inventory route discovery: full /api template survives FastAPI nesting ----
+#
+# Companion to the request-time middleware proof above. The endpoint
+# traceability inventory enumerates routes *statically* from the route tree
+# (no concrete request to substitute params back from), so it must reconstruct
+# each route's full `/api/...` path by accumulating prefixes down the tree.
+# Older FastAPI (< ~0.135) flattened `include_router(prefix=…)` so every leaf
+# already carried its full path; FastAPI 0.137+ / Starlette 1.x keeps routers
+# nested behind `_IncludedRouter`, so a leaf `APIRoute.path` is only the
+# router-relative tail. These two tests pin the reconstruction on whichever
+# FastAPI CI happens to install — detected by structure, not a pinned version.
+
+
+def test_iter_api_route_leaves_reconstructs_full_path_across_inclusion_styles():
+    """The static walker yields full `/api/...` paths regardless of how routers
+    were composed: include-time prefix, nested include with prefix, an
+    APIRouter's own constructor prefix, and a top-level decorated route. On old
+    FastAPI these flatten; on new FastAPI they nest behind `_IncludedRouter` —
+    the asserted set is identical either way."""
+    from fastapi import APIRouter, FastAPI
+
+    from app.services.inventory_service import _iter_api_route_leaves
+
+    leaf = APIRouter()
+    leaf.add_api_route("/ping", lambda: {}, methods=["GET"])
+    leaf.add_api_route("/ideas/{idea_id}", lambda idea_id: {}, methods=["GET"])
+
+    nested = APIRouter()  # included with its own prefix (mirrors agent.py)
+    nested.add_api_route("/tasks", lambda: {}, methods=["GET"])
+
+    own = APIRouter(prefix="/own")  # prefix baked into the router itself
+    own.add_api_route("/widget", lambda: {}, methods=["GET"])
+
+    parent = APIRouter()
+    parent.include_router(leaf)
+    parent.include_router(nested, prefix="/agent")
+    parent.include_router(own)
+
+    test_app = FastAPI()
+    test_app.include_router(parent, prefix="/api")
+    test_app.add_api_route("/api/toplevel", lambda: {}, methods=["GET"])
+
+    discovered = {full_path for full_path, _route in _iter_api_route_leaves(test_app.router.routes)}
+
+    assert {
+        "/api/ping",
+        "/api/ideas/{idea_id}",
+        "/api/agent/tasks",
+        "/api/own/widget",
+        "/api/toplevel",
+    } <= discovered
+
+
+def test_runtime_endpoint_discovery_enumerates_nested_api_routes():
+    """Against the real app, runtime discovery must surface known nested routes
+    with their full `/api/...` template, not the router-relative tail. The
+    pre-fix nested-only filter collapsed to ~1 endpoint on FastAPI 0.137; assert
+    a substantial count so that regression fails loudly."""
+    from app.services.inventory_service import _discover_api_endpoints_from_runtime
+
+    rows = _discover_api_endpoints_from_runtime()
+    paths = {row["path"] for row in rows}
+
+    assert "/api/ping" in paths
+    assert "/api/ideas/{idea_id}" in paths
+    # Multi-level nesting (app /api → agent.py /agent) must resolve too.
+    assert any(p.startswith("/api/agent/") for p in paths)
+    # Every discovered path carries the externally observed namespace.
+    assert all(p.startswith("/api") or p.startswith("/v1") for p in paths)
+    # Guard the nested-collapse regression: the real app serves hundreds.
+    assert len(rows) > 100


### PR DESCRIPTION
## What

`inventory_service._discover_api_endpoints_from_runtime()` silently under-reported API endpoints under FastAPI 0.137+ / Starlette 1.x.

It iterated `app.routes`, kept `isinstance(route, APIRoute)` whose `path.startswith("/api")`, and assumed `include_router(prefix="/api")` **flattens** routes so each leaf carries its full `/api/...` path. New FastAPI no longer flattens — routers stay nested behind `_IncludedRouter` (124 of 130 top-level entries in this app), and the leaf `APIRoute.path` is only the router-relative tail (`/ping`, `/ideas/{idea_id}`). The flat filter matched **~1** endpoint on new FastAPI instead of **~750**.

Worse: `build_endpoint_traceability_inventory` reads `runtime() or source()`, so that ~1 truthy result short-circuited the source-scan fallback too — collapsing the entire traceability inventory.

Both `requirements.txt` (`fastapi>=0.115.0`) and `pyproject.toml` (`fastapi>=0.128.8`) leave FastAPI unpinned, so a prod rebuild gets the nesting behavior.

## Fix

`_iter_api_route_leaves` walks the route tree and accumulates each enclosing container's prefix (`_IncludedRouter.include_context.prefix`, `Mount` path) down to the leaf, reconstructing the full external path. **Detected by structure, not a pinned version** — works on old (flat) and new (nested) FastAPI, and on arbitrary nesting depth (app `/api` → `agent.py` `/agent` → leaf). A router's own `prefix=` is already baked into its leaf paths, so only the inclusion-time prefix is accumulated (no double-counting).

This is the static-enumeration sibling of the request-time `_full_route_template` fix (on branch `claude/trusting-ishizaka-eff626`); inventory has no concrete request path to substitute params back from, so it tree-walks instead.

## Verification

| Regime | FastAPI | Old logic | Fixed logic |
|---|---|---|---|
| Flat | 0.133 / starlette 0.52 | 753 | 753 (byte-for-byte identical method sets) |
| Nested | 0.137 / starlette 1.3.1 | **1** | **753** |

- New regression tests pin both a synthetic multi-style-nesting walk and the real-app contract; they **pass on both FastAPI regimes** (verified in throwaway venvs).
- Full API suite on the flat env: **398 passed**, 2 failed — both pre-existing/environmental (`form-kernel-rust` binary not built in the worktree; confirmed identical failure with changes stashed), unrelated to route discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)