### PR TITLE
Recursion-safe let binding via reserved frame slots (fixes a hidden divergence)

### DIFF
--- a/docs/coherence-substrate/fourth-arm-substrate-carriers.form
+++ b/docs/coherence-substrate/fourth-arm-substrate-carriers.form
@@ -36,7 +36,8 @@
       graph-node-file-carrier-reopen            # file carrier reopen proof (band graph-node-mutation-file-carrier)
       graph-node-full-mutation-verdict          # memory/file agreement and full file mutation verdict (bands graph-node-mutation-carrier, graph-node-mutation-file-verdict)
       ideas-graph-file-projection               # idea response projection over reopened file stores (band ideas-graph-projection)
-      postgres-carrier-boundary-receipt)        # storage-port-all-carriers over throwaway Postgres, verdict 111111
+      postgres-carrier-boundary-receipt         # storage-port-all-carriers over throwaway Postgres, verdict 111111
+      recursion-safe-let-frame-tags-109-111)    # a stored let binds on a reserved per-call frame block (RESERVE tag 111 reserves K=source-let-count slots at entry; LETF tag 109 writes fk_vs[fp+offset]; FARG tag 110 reads it). Recursion-safe (each call its own fp) and immune to argument-position scratch (block reserved before arg packing). Replaces the global-RAM-slot binding that clobbered across recursive frames (band recursive-let-clobber: outermost frame reads 1, not the deepest 3)
     (current-unsupported
       broader-source-scan-recipes))             # remaining host-io lift after scan_run/file_mtime
 

--- a/form/form-stdlib/form-flatten.fk
+++ b/form/form-stdlib/form-flatten.fk
@@ -99,6 +99,30 @@
 (defn flt-current-fidx (env) (flt-env-row-value (flt-assoc (flt-fidxq) env) 0))
 (defn flt-slot (env) (fk-lit (add 128 (add (mul (flt-current-fidx env) 32) (len env)))))
 
+; ── recursion-safe let binding on a RESERVED per-call frame block ──
+; A stored let lives at fk_vs[fp+offset] in a block the function reserves at
+; entry (RESERVE), so argument-packing scratch lands ABOVE the block and can
+; never shift a frame let's slot. Each call gets its own fp, so a recursive
+; re-entry reserves its own block — the deepest frame cannot clobber an outer
+; binding. ARG is offset 0; the k-th frame let is offset k = letdepth+1.
+(defn flt-letdepth-q () "(defn-letdepth)")
+(defn flt-current-letdepth (env) (flt-env-row-value (flt-assoc (flt-letdepth-q) env) 0))
+(defn fk-farg (off) (fk-node 110 (fk-lit off)))
+(defn fk-letf (off value body) (fk-node 109 (ms-intern (fk-lit off) (ms-intern value body))))
+(defn fk-reserve (k body) (fk-node 111 (ms-intern (fk-lit k) body)))
+; K = how many frame slots a function reserves. We count "(let " occurrences in
+; the function's SOURCE span — a linear, robust upper bound on the max frame-let
+; offset (sequential do-lets take incrementing offsets, so the deepest chain's
+; let count bounds it; inline/branch lets only over-reserve, never under). This
+; replaces a recipe-tree walk that crashed (as_nid: null) on source-compiled
+; module recipes. Over-reserving is safe: the slots cost value-stack space only.
+(defn flt-count-lets (s pos end) (flt-count-lets-go s (str_find s "(let " pos) end 0))
+(defn flt-count-lets-go (s found end acc)
+    (if (lt found 0) acc
+        (if (ge found end) acc
+            (flt-count-lets-go s (str_find s "(let " (add found 5)) end (add acc 1)))))
+(defn flt-reserve-wrap-k (k body) (if (eq k 0) body (fk-reserve k body)))
+
 (defn flt-mkop (row a b)
     (if (eq (nth row 1) 1) (fk-node (nth row 2) a)
         (fk-node (nth row 2) (ms-intern a b))))
@@ -279,20 +303,25 @@
     (if (str_eq op "http_get") 1 0)))))))))))))))
 (defn flt-do-let-done (name op s ve fns env val)
     (if (eq (flt-do-let-store-op op fns env) 1)
-        (flt-do-let-store name s ve fns env val (flt-slot env))
+        (flt-do-let-frame name s ve fns env val (add (flt-current-letdepth env) 1))
         (flt-do2 s (fp-skip s (fp-close s (nth ve 1))) fns
                  (cons (list name (nth ve 0)) env) val)))
 (defn flt-do-let-store-op (op fns env)
     (if (eq (flt-do-let-effect-op op) 1) 1
         (if (eq (flt-current-recursive env) 1) 0
             (if (eq (len (flt-assoc op fns)) 0) 0 1))))
-(defn flt-do-let-store (name s ve fns env val slot)
-    (flt-do-let-store-rest
-        (fk-store slot (nth ve 0))
+; A stored let lowers to LETF: walk the value once, write it to the reserved
+; frame slot fp+offset, walk the rest of the do with a frame-relative FARG
+; binding. No fk_vsp push — the slot is pre-reserved, so it survives sub-calls
+; and a recursive re-entry that reserves its own block higher up the stack.
+(defn flt-do-let-frame (name s ve fns env val offset)
+    (flt-do-let-frame-rest offset (nth ve 0)
         (flt-do2 s (fp-skip s (fp-close s (nth ve 1))) fns
-                 (cons (list name (fk-load slot)) env) val)))
-(defn flt-do-let-store-rest (store rest)
-    (list (flt-sequence store (nth rest 0)) (nth rest 1)))
+                 (cons (list name (fk-farg offset))
+                       (cons (list (flt-letdepth-q) offset) env))
+                 val)))
+(defn flt-do-let-frame-rest (offset value rest)
+    (list (fk-letf offset value (nth rest 0)) (nth rest 1)))
 
 ; two operands, then the lowering picked by selector k (lowerings are rules,
 ; not tag rows — they BUILD shapes instead of naming one)
@@ -551,9 +580,11 @@
                           (cons (list (flt-fidxq) (nth row 1)) env)))
                 rbodies env main))
 (defn flt-defn-b (s pos fns benv rbodies env main)
-    (flt-defn-done s (flt-expr s pos fns benv) fns rbodies env main))
-(defn flt-defn-done (s be fns rbodies env main)
-    (flt-items s (fp-close s (nth be 1)) fns (cons (nth be 0) rbodies) env main))
+    (flt-defn-b2 s pos (flt-expr s pos fns benv) fns rbodies env main))
+(defn flt-defn-b2 (s pos be fns rbodies env main)
+    (flt-defn-done s (flt-count-lets s pos (fp-close s (nth be 1))) be fns rbodies env main))
+(defn flt-defn-done (s k be fns rbodies env main)
+    (flt-items s (fp-close s (nth be 1)) fns (cons (flt-reserve-wrap-k k (nth be 0)) rbodies) env main))
 
 ; (let name value) — the value cell binds into env and inlines at each use
 (defn flt-let (s pos fns rbodies env main)
@@ -602,9 +633,11 @@
                             (cons (list (flt-fidxq) (nth row 1)) env)))
                   rbodies env main))
 (defn flt-defn-b-s (s pos fns benv rbodies env main)
-    (flt-defn-done-s s (flt-expr s pos fns benv) fns rbodies env main))
-(defn flt-defn-done-s (s be fns rbodies env main)
-    (flt-items-s s (fp-close s (nth be 1)) fns (cons (nth be 0) rbodies) env main))
+    (flt-defn-b2-s s pos (flt-expr s pos fns benv) fns rbodies env main))
+(defn flt-defn-b2-s (s pos be fns rbodies env main)
+    (flt-defn-done-s s (flt-count-lets s pos (fp-close s (nth be 1))) be fns rbodies env main))
+(defn flt-defn-done-s (s k be fns rbodies env main)
+    (flt-items-s s (fp-close s (nth be 1)) fns (cons (flt-reserve-wrap-k k (nth be 0)) rbodies) env main))
 (defn flt-let-s (s pos fns rbodies env main)
     (flt-let-n-s s (fp-skip s (fp-sym-end s (fp-skip s (add pos 1)))) fns rbodies env main))
 (defn flt-let-n-s (s pos fns rbodies env main)
@@ -715,9 +748,10 @@
 (defn flt-band-fns2 (modsrc bandsrc pool)
     (flt-band2 (flt-top modsrc (list) (list) pool) bandsrc pool))
 (defn flt-band2 (mr bandsrc pool)
-    (flt-band3 (flt-top-env-snap bandsrc (nth mr 0) (nth mr 1) pool (nth mr 4))))
-(defn flt-band3 (br)
-    (cons (nth br 2) (flt-rev (nth br 1) (list))))
+    (flt-band3 bandsrc (flt-top-env-snap bandsrc (nth mr 0) (nth mr 1) pool (nth mr 4))))
+(defn flt-band3 (bandsrc br)
+    (cons (flt-reserve-wrap-k (flt-count-lets bandsrc 0 (str_len bandsrc)) (nth br 2))
+          (flt-rev (nth br 1) (list))))
 (defn flt-modsrcs-top (modsrcs fns rbodies pool)
     (flt-modsrcs-top-env modsrcs fns rbodies pool (list)))
 (defn flt-modsrcs-top-env (modsrcs fns rbodies pool env)
@@ -744,4 +778,4 @@
         (flt-band-sources-fns (flt-srcs-mods srcs (list)) (flt-srcs-last srcs))))
 
 ; single-source door (prelude-free bands, mini programs)
-(defn flt-src-fns (src) (flt-band3 (flt-top src (list) (list) (flt-src-pool src))))
+(defn flt-src-fns (src) (flt-band3 src (flt-top src (list) (list) (flt-src-pool src))))

--- a/form/form-stdlib/hati-os-kernel-emit.fk
+++ b/form/form-stdlib/hati-os-kernel-emit.fk
@@ -44,6 +44,13 @@
     ; 101 temp_dir — nullary host-io leaf: the walker arm reads no operands, so
     ; the row carries the tag alone (fk_tempdir resolves $TMPDIR at walk time).
     (if (eq (fk-tag n) 101) (cons (list 101 0 0 0) acc)
+    ; 110 FARG — frame-relative read: unary, single child is the offset LIT the
+    ; walker adds to fp. 109 LETF (offset, value, body) is tri: writes the value
+    ; to reserved slot fp+offset, then walks the body. 111 RESERVE (k, body) is
+    ; binary and rides the fallback. Together: recursion-safe let on a reserved
+    ; per-call frame block, immune to argument-position scratch.
+    (if (eq (fk-tag n) 110) (fkc-un2 110 (fkc-flat (fk-body n) acc))
+    (if (eq (fk-tag n) 109) (fkc-tri2 109 (fkc-flat (ms-child (fk-body n) 0) acc) n)
     (if (eq (fk-tag n) 20) (fkc-un2 20 (fkc-flat (fk-body n) acc))
     (if (eq (fk-tag n) 21) (fkc-un2 21 (fkc-flat (fk-body n) acc))
     (if (eq (fk-tag n) 22) (fkc-un2 22 (fkc-flat (fk-body n) acc))
@@ -110,7 +117,7 @@
     (if (eq (fk-tag n) 98) (fkc-tri2 98 (fkc-flat (ms-child (fk-body n) 0) acc) n)
     (if (or (eq (fk-tag n) 81) (or (eq (fk-tag n) 82) (or (eq (fk-tag n) 83) (or (eq (fk-tag n) 85) (or (eq (fk-tag n) 87) (or (eq (fk-tag n) 88) (or (eq (fk-tag n) 89) (eq (fk-tag n) 90))))))))
         (fkc-un2 (fk-tag n) (fkc-flat (fk-body n) acc))
-        (fkc-bin2 (fk-tag n) (fkc-flat (ms-child (fk-body n) 0) acc) n))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+        (fkc-bin2 (fk-tag n) (fkc-flat (ms-child (fk-body n) 0) acc) n))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 
 (defn fkc-call2 (fidx acc1) (cons (list 12 fidx (sub (len acc1) 1) 0) acc1))
 
@@ -466,7 +473,7 @@ extern int open(const char *, int, ...); extern long long read(int, void *, unsi
                 (str_concat (fkc-record-field-arms-text)
                 (str_concat (fkc-record-blueprint-arms-text)
                 (str_concat (fkc-jit-lower-arms-text)
-                            "if (t == 69) { fk_walk(fk_node[i][1], fp); return fk_walk(fk_node[i][2], fp); } if (t == 102) { long long ae = fk_walk(fk_node[i][1], fp); long long be = fk_walk(fk_node[i][2], fp); if (fk_num(ae) == fk_num(be)) { return 2; } return 0; } if (t == 103) { long long al = fk_walk(fk_node[i][1], fp); long long bl = fk_walk(fk_node[i][2], fp); if (fk_num(al) < fk_num(bl)) { return 2; } return 0; } return 0; } ")))))))))))))
+                            "if (t == 69) { fk_walk(fk_node[i][1], fp); return fk_walk(fk_node[i][2], fp); } if (t == 102) { long long ae = fk_walk(fk_node[i][1], fp); long long be = fk_walk(fk_node[i][2], fp); if (fk_num(ae) == fk_num(be)) { return 2; } return 0; } if (t == 103) { long long al = fk_walk(fk_node[i][1], fp); long long bl = fk_walk(fk_node[i][2], fp); if (fk_num(al) < fk_num(bl)) { return 2; } return 0; } if (t == 109) { fk_vs[fp + (fk_walk(fk_node[i][1], fp) >> 1)] = fk_walk(fk_node[i][2], fp); return fk_walk(fk_node[i][3], fp); } if (t == 110) { return fk_vs[fp + (fk_walk(fk_node[i][1], fp) >> 1)]; } if (t == 111) { long long k111 = fk_walk(fk_node[i][1], fp) >> 1; long long sv111 = fk_vsp; long long need111 = fp + 1 + k111; while (fk_vsp < need111) { fk_vs[fk_vsp] = 0; fk_vsp = fk_vsp + 1; } long long r111 = fk_walk(fk_node[i][2], fp); fk_vsp = sv111; return r111; } return 0; } ")))))))))))))
 
 ; figure-ops arms (tags 34..42), emitted: each mirrors the walking kernels'
 ; native bit-for-bit — band/bor/bxor/mul are int64 ops; the *_u32 family

--- a/form/form-stdlib/tests/recursive-let-clobber.fk
+++ b/form/form-stdlib/tests/recursive-let-clobber.fk
@@ -1,0 +1,28 @@
+; recursive-let-clobber.fk — an effecting let bound PER FRAME of a recursive
+; function, read AFTER the recursive descent. The strange-minimal witness for
+; recursion-safe let binding on the fourth arm.
+;
+; preludes: form-stdlib/core.fk
+;
+; descend appends one byte per frame; file_append_bytes returns the new total
+; length, so len_here is THIS frame's length (1 at the outermost call, deeper
+; frames see 2 then 3). It then recurses for effect and finally returns
+; len_here. Lexical scope (Go/Rust/TS interpret the source) keeps each frame's
+; own len_here, so the OUTERMOST frame returns 1 — it saw length 1 before any
+; deeper append. A flattener that binds effecting lets to a GLOBAL per-function
+; slot clobbers len_here across frames: every frame's read returns the DEEPEST
+; frame's length (3), because all frames share one constant slot. len_here is
+; the FIRST statement, so there is no prior-statement ordering confound — the
+; only thing under test is whether the binding survives the recursive descent.
+; Correct four-way verdict: 1. A clobbering fourth arm answers 3.
+(defn descend (path n)
+    (do
+        (let len_here (file_append_bytes path (list 65)))
+        (do
+            (if (le n 1) 0 (descend path (sub n 1)))
+            len_here)))
+(do
+    (let dir (temp_dir))
+    (let path (str_concat dir "/fk-recursive-let-clobber.txt"))
+    (fs_remove path)
+    (descend path 3))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -55,8 +55,8 @@
 # record-blueprint rows among its focused four-way rows, and
 # android-mesh-learning now carries
 # active mic/camera/GPU sample rows at focused verdict 32767. The latest
-# completed full `cd form && ./validate.sh` on this branch reads 234
-# four-way bands and 615 total passing workloads with 0 residual divergent
+# completed full `cd form && ./validate.sh` on this branch reads 238
+# four-way bands and 620 total passing workloads with 0 residual divergent
 # bands; refresh the full aggregate on a quiet host after focused release
 # rather than spending repeated validation cycles under shared-runner
 # contention. Literal bp registry aliases now fold through make_nodeid for the
@@ -386,11 +386,18 @@ substrate-core fks 11111
 # (eq-effect-once appends one byte inside an eq and reads len 1). The Form
 # meta-circular walkers (fk-walk-lowered, fkm-walk-lowered) carry the same arms,
 # keeping the spec consistent with the emitted fkwu. Third piece crossed:
-# nested do-lets now snapshot effecting values through fk-store/fk-load, not only
-# record_new, so a side-effecting binding is walked once and read many times
-# (let-effect-once appends one byte, checks the bound size twice, and reads len
-# 1). segmented-FILE/Postgres carriers can now build on
-# effect-once let discipline instead of working around re-walked bindings.
+# nested do-lets bind effecting values once on a RESERVED per-call frame block.
+# Each function reserves K local slots at entry (RESERVE tag 111, K = its source
+# let count); a stored let writes fk_vs[fp+offset] (LETF tag 109) and reads it
+# back frame-relative (FARG tag 110). Because the block is reserved before any
+# argument-packing scratch and each call gets its own fp, a side-effecting
+# binding is walked once, survives a recursive descent, and is immune to
+# argument-position scratch (let-effect-once reads len 1; recursive-let-clobber
+# descends three frames, each binding the file length it saw before recursing,
+# and the outermost correctly reads 1 — the global-RAM-slot binding it replaced
+# clobbered all frames to the deepest length 3). segmented-FILE/Postgres carriers
+# now build on recursion-safe effect-once let discipline instead of working
+# around re-walked or clobbered bindings.
 # The next host-io carrier rows are now admitted too: write_file_text rides fkwu
 # tag 104 with overwrite/truncate semantics, and file-append rides the native
 # append carrier. Text emitters no longer need to materialize byte lists for the
@@ -432,6 +439,7 @@ chart-cast fks 1111111
 native-training-receipt fks 16383
 eq-effect-once fks 1
 let-effect-once fks 111
+recursive-let-clobber fks 1
 write-file-text fks 1111
 file-append fks 11111
 storage-port fks 11111


### PR DESCRIPTION
## What

A nested `do`-let binding an **effecting** value lowered to a **global per-function RAM slot** (a compile-time-constant index). In a **recursive** function every frame stored to the same slot, so a binding read *after* the recursive descent returned the **deepest frame's** value, not its own. The three reference kernels interpret the source with proper lexical scope — so this was a real **four-way divergence**, hidden only because no band exercised an effecting let in a recursive function read after the recursive call.

`recursive-let-clobber` descends three frames, each binding the file length it saw *before* recursing; the outermost must read **1**. The global-slot binding answered **3**.

## Fix — reserved per-call frame block

A stored let now binds on the **value stack**, in a block the function reserves at entry:

- **RESERVE (tag 111)** — each function reserves `K` local slots at entry (`fk_vs` bumped to `fp+1+K`, zero-initialized). `K` = the function's source `(let ` count (a linear upper bound on the max frame offset).
- **LETF (tag 109)** — walks the value once, writes it to `fk_vs[fp+offset]`, walks the rest of the do with a frame-relative binding.
- **FARG (tag 110)** — reads `fk_vs[fp+offset]`; `ARG` is offset 0, the k-th frame let is offset k.

Reserving **at entry, before any argument-packing scratch**, makes the binding immune to a do-with-lets running in argument position (the failure an earlier `fp`-relative attempt hit — it read sibling-arg scratch). Each call gets its own `fp`, so a recursive re-entry reserves its own block and cannot clobber an outer binding. One binding mechanism for params and lets; the global-slot special case retires.

`K` is a **linear source let-count**, not a recipe-tree walk — the walk crashed (`as_nid: null`) on source-compiled module recipes and silently dropped 51 multi-prelude bands to three-kernel. Over-reserving costs only value-stack space.

### Touchpoints
- Shared C arm tail `fkc-arms-many-text` — covers the base, JIT, and crystallize walkers in one place.
- Table serializer `fkc-flat` — FARG unary, LETF tri, RESERVE binary.
- `form-flatten` do-let path + per-function RESERVE wrap (defn bodies and main).
- **No** meta-circular walker change (the binding is fkwu-only; `form-flatten-band` never triggers the store path).

## Verification

`cd form && ./validate.sh` on the rebased tree:
- **fourth arm: 238 band(s) four-way** (no band lost — all multi-prelude bands still build)
- **620 ok, 0 divergent**
- `recursive-let-clobber → 1` four-way; every existing effecting/record/substrate/carrier band unchanged.

North-star cell `fourth-arm-substrate-carriers.form` and the manifest narrative name the recursion-safe reserved-frame binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)