### PR TITLE
form-cli: the recipe-realize tree step (forked-state + choice-receipt pair)

### DIFF
--- a/form/form-stdlib/form-agent-tree.fk
+++ b/form/form-stdlib/form-agent-tree.fk
@@ -1,0 +1,57 @@
+; form-agent-tree.fk — the step that turns the borrowed transcript into a TREE.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-agent-protocol.fk form-stdlib/choice-receipt.fk
+;
+; The highest-leverage first move named in form-native-agent-shape.form: instead of
+; APPENDING a tool_result message (the linear loop), an agent step REALIZES a recipe
+; and returns a (forked-state, choice-receipt) PAIR. That one change does two things
+; at once:
+;   - the state becomes a TREE, not a transcript: the step forks a NEW state from the
+;     parent and leaves the parent untouched, so an earlier state is always a
+;     checkpoint to backtrack to (search, not forward-only).
+;   - the receipt becomes a trainable SIGNAL: every step emits a cr-choice-receipt
+;     (outcome / certainty / the realized recipe) that choice-receipt-learning.fk and
+;     branch-choice-order.fk consume — the control flow is inspectable and learnable,
+;     not opaque token sampling.
+;
+; This extends form-agent-protocol.fk (the messages-of-parts shape on main) and reuses
+; choice-receipt.fk (the real receipt) — no parallel machinery. The node's state is the
+; conversation here; the deeper content-addressed search state (search-harness.fk
+; h1c-state) is the refinement named in form-native-agent-shape.form. The LLM-compat
+; projection drops the receipt and never forks: fat-transcript over a single path.
+;
+; Proven by: form-stdlib/tests/form-agent-tree-band.fk
+
+; append one message at the end of a state (a new list — the parent is untouched).
+(defn fat-snoc (xs x)
+    (if (eq (len xs) 0) (list x) (cons (head xs) (fat-snoc (tail xs) x))))
+
+; a compact tree-step receipt: the real cr-choice-receipt with agent-step defaults,
+; carrying the load-bearing trainable fields (selected recipe, outcome, certainty, tick).
+(defn fat-receipt (recipe outcome certainty tick)
+    (cr-choice-receipt "" "agent-step" "recipe-realize" (list) recipe
+                       outcome certainty 0 "" "agent" "tree" tick 0 (list)))
+
+; an agent node = (forked-state, receipt). state is a list of ap-msg; receipt is a
+; cr-choice-receipt. The pair IS the difference from the linear loop.
+(defn fat-node (state receipt) (list "agent-node" state receipt))
+(defn fat-node-state   (n) (nth n 1))
+(defn fat-node-receipt (n) (nth n 2))
+(defn fat-node? (n)
+    (if (and (str_eq (nth n 0) "agent-node") (cr-choice-receipt? (fat-node-receipt n))) 1 0))
+
+; THE step: realize a tool_call against a parent state, returning a forked node.
+;   parent  : the parent state (list of ap-msg) — NEVER mutated
+;   call    : an ap-tool-call part (id, name, args)
+;   result  : the tool's output content
+;   outcome : cr-outcome-success | fail | silence ; certainty 0..100 ; tick
+; the child state appends a tool-role message carrying the ap-tool-result; the receipt
+; records the realized recipe + outcome + certainty as the trainable signal.
+(defn fat-step (parent call result outcome certainty tick)
+    (fat-node
+        (fat-snoc parent (ap-msg "tool" (list (ap-tool-result (ap-tc-id call) (ap-tc-name call) result))))
+        (fat-receipt (ap-tc-name call) outcome certainty tick)))
+
+; the LLM-compat projection: the linear view of a node's state (drops the receipt,
+; never sees the fork) — this is all the borrowed loop ever keeps.
+(defn fat-transcript (n) (fat-node-state n))

--- a/form/form-stdlib/tests/form-agent-tree-band.fk
+++ b/form/form-stdlib/tests/form-agent-tree-band.fk
@@ -1,0 +1,36 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-agent-protocol.fk form-stdlib/choice-receipt.fk form-stdlib/form-agent-tree.fk
+;
+; form-agent-tree-band — the step that makes the agent a TREE, not a transcript:
+; it forks a new state from the parent (leaving the parent a checkpoint) AND emits a
+; trainable choice-receipt — the pair the borrowed linear loop discards.
+;
+; Verdict 31 when every claim lands:
+;   1   the step FORKS: the child state has the new tool message the parent lacked
+;   2   the step emits a real cr-choice-receipt (the trainable signal) -> fat-node? holds
+;   4   the receipt carries the OUTCOME (success) — learnable, not opaque
+;   8   the receipt carries the realized RECIPE (selected-path = the tool name) — recipe-realize provenance
+;   16  BACKTRACK: fat-step is pure — a second step from the SAME parent yields another
+;       child, and the parent is UNCHANGED (still a checkpoint). The tree forks.
+(do
+    (let S (cr-outcome-success))
+    (let parent (list (ap-msg "user" (list (ap-text "list the files")))))
+    (let callA  (ap-tool-call "c1" "bash" "ls"))
+    (let callB  (ap-tool-call "c2" "read_file" "README.md"))
+    (let nodeA  (fat-step parent callA "a.txt b.txt" S 80 1))
+    (let nodeB  (fat-step parent callB "# readme" S 70 1))
+
+    ; 1 — the child forked: it has one more message than the parent
+    (let c0 (if (eq (len (fat-node-state nodeA)) (add (len parent) 1)) 1 0))
+    ; 2 — a real receipt rode along (fat-node? checks the cr-choice-receipt)
+    (let c1 (if (eq (fat-node? nodeA) 1) 2 0))
+    ; 4 — the outcome is readable for training
+    (let c2 (if (str_eq (cr-receipt-outcome (fat-node-receipt nodeA)) "success") 4 0))
+    ; 8 — the realized recipe is recorded (selected-path = the tool name)
+    (let c3 (if (str_eq (cr-receipt-selected-path (fat-node-receipt nodeA)) "bash") 8 0))
+    ; 16 — backtrack: two children from one parent differ, and the parent is untouched
+    (let c4 (if (and (eq (len parent) 1)
+                     (and (str_eq (cr-receipt-selected-path (fat-node-receipt nodeB)) "read_file")
+                          (eq (len (fat-node-state nodeB)) 2)))
+                16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -163,6 +163,7 @@ form-cli-loop fks 31
 form-cli-router fks 31
 form-freq-check fks 31
 form-agent-protocol fks 31
+form-agent-tree fks 31
 text-summary-learning fks 262143
 llm-feature-channel-floor fks 131071
 android-mesh-learning fks 131071


### PR DESCRIPTION
The highest-leverage first move from `form-native-agent-shape.form`: an agent step returns a **(forked-state, choice-receipt) pair** instead of appending a message — turning the transcript into a **tree** and the receipt stream into a **trainable signal** in one move.

`form-agent-tree.fk` (four-way proven, `form-agent-tree-band → 31`):
- `fat-step` forks a new state (`fat-snoc`, parent untouched → always a backtrack checkpoint) and emits the real `cr-choice-receipt` (selected recipe + outcome + certainty).
- `fat-transcript` = the LLM-compat projection (the linear view the borrowed loop keeps).
- Extends `form-agent-protocol` (on main) + reuses `choice-receipt` — no parallel machinery. Backtrack proven: two steps from one parent → two children, parent unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)