### PR TITLE
form-cli: qwen2.5:72b as the cross-training oracle (verified native Hermes tags)

### DIFF
--- a/docs/coherence-substrate/cross-train-oracle.form
+++ b/docs/coherence-substrate/cross-train-oracle.form
@@ -1,0 +1,48 @@
+; cross-train-oracle.form — the local teacher the form-native lanes learn from.
+;
+; The cross-training loop is form-native-agent-shape.form: a local oracle's decisions
+; become ground-truth labels (predictor-sampling.fk) that grow the form-native
+; challenger (predictor-train.fk) toward the champion, proven by native-vs-oracle score
+; (native-training-receipt.fk). This cell names the teacher and its status.
+
+(cross-train-oracle
+
+  (teacher
+    "qwen2.5:72b, run locally via ollama — the strongest local tool-calling model"
+    "available. Local, no key, no metered API. Set as _CROSS_TRAIN_ORACLE in"
+    "mcp-server/coherence_mcp_server/form_cli_tools.py (env FORM_CLI_ORACLE to override)."
+    "deepseek-r1:32b is the reasoning/transmute teacher when reasoning depth matters.")
+
+  (verified
+    "Probed live: given a tool and a request, qwen2.5:72b emitted exactly"
+    "<tool_call>{\"name\":\"bash\",\"arguments\":{\"cmd\":\"ls\"}}</tool_call> — it"
+    "speaks the Hermes tag encoding form-agent-protocol.fk standardized on, NATIVELY."
+    "So the teacher's raw output drops straight into the protocol's hermes lane with no"
+    "translation: the label and the wire format are already aligned.")
+
+  (loop
+    (decide   "the teacher makes a routing / tool-use decision on a real request")
+    (label    "predictor-sampling.fk fuses it (a circle of models) into ONE ground-truth label, gating contested ones")
+    (score    "io-match.fk scores by EFFICACY — did the candidate's output WORK — not by reproducing the teacher's exact tokens")
+    (grow     "predictor-train.fk pt-learn interns (label, feature-vector) into the form-native challenger")
+    (infer    "nearest-shape.fk routes the live query to the nearest interned shape")
+    (prove    "native-training-receipt.fk: native-vs-oracle score over a heldout window")
+    (graduate "fcr-route flips the shape local once the lane's pass-rate crosses threshold"))
+
+  (corpus
+    "The corpus fills from live sessions via the Stop-hook capture (capture_hook.py ->"
+    "training-catalog.fk), on main now. Honest status at this writing: empty — the hook"
+    "fires only for Claude Code sessions that load settings AFTER it merged, so"
+    "accumulation begins with fresh sessions, not retroactively. The days-clock starts"
+    "there: no labels yet, so no receipt is trustworthy yet.")
+
+  (timescale
+    "Days, measured not assumed. The mesh training-carrier floors quantify 'enough'"
+    "(order >=10k labels, >=100 MiB heldout) before a lane's native-training-receipt is"
+    "trusted. We read the native-vs-oracle score rising over the heldout window across"
+    "days; that number — not a claim — tells us how well the form-native version learned.")
+
+  (next
+    "Two tiers learn from this teacher: the router (prototype: predictor-train/"
+    "nearest-shape, can converge online as labels arrive) and the freq-check/transmuter"
+    "(transformer: real backprop epochs on transformer-block.fk — the genuine build)."))

--- a/mcp-server/coherence_mcp_server/form_cli_tools.py
+++ b/mcp-server/coherence_mcp_server/form_cli_tools.py
@@ -119,6 +119,20 @@ def catalog_capture(request: str, raw: str, transmuted: str, lane: str, outcome:
 # to use the subscription CLI). A rewrite is light enough for a small local model.
 _TRANSMUTE_ORACLE = os.environ.get("FORM_CLI_TRANSMUTE_ORACLE", "ollama run llama3.2:3b")
 
+# the CROSS-TRAINING oracle — the best LOCAL tool-calling model as the teacher whose
+# decisions become ground-truth labels (predictor-sampling -> predictor-train). Local,
+# no key, no metered API. qwen2.5:72b is the strongest local function-caller available
+# and emits the Hermes <tool_call>{...}</tool_call> tags natively, so its output drops
+# straight into form-agent-protocol's hermes encoding. Quality over speed here: this is
+# the teacher generating labels, not the hot transmute path. See
+# docs/coherence-substrate/cross-train-oracle.form.
+_CROSS_TRAIN_ORACLE = os.environ.get("FORM_CLI_ORACLE", "ollama run qwen2.5:72b")
+
+
+def cross_train_oracle() -> str:
+    """The local tool-calling teacher whose decisions label the cross-training corpus."""
+    return _CROSS_TRAIN_ORACLE
+
 
 def _reason(prompt: str, oracle_cmd: str, timeout: float = 120.0) -> str:
     """Run a reasoner — a host command reading the prompt on stdin (ollama run


### PR DESCRIPTION
Point the local teacher at the best local tool-caller, per `form-native-agent-shape.form`: its decisions become the ground-truth labels that grow the form-native challenger (predictor-sampling → predictor-train → nearest-shape → native-training-receipt).

- `form_cli_tools.py`: `_CROSS_TRAIN_ORACLE = "ollama run qwen2.5:72b"` (env `FORM_CLI_ORACLE`) + `cross_train_oracle()`. Local, no key, no metered API; quality over speed (it labels).
- **Verified live:** qwen2.5:72b emitted exactly `<tool_call>{"name":"bash","arguments":{"cmd":"ls"}}</tool_call>` — it speaks `form-agent-protocol`'s Hermes encoding **natively**, so its output drops straight into the protocol's hermes lane.
- `docs/coherence-substrate/cross-train-oracle.form`: the teacher, the loop, and the **honest corpus status** — empty now (the Stop-hook captures only sessions loading settings after it merged; accumulation starts with fresh sessions). Days-clock starts there; native-vs-oracle over the heldout window, measured not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)