### PR TITLE
form-native SGD training-step atom — the seed of the training loop (four-way → 31)

### DIFF
--- a/form/form-stdlib/form-train-step.fk
+++ b/form/form-stdlib/form-train-step.fk
@@ -1,0 +1,58 @@
+; form-train-step.fk — the SGD ATOM of form-native training.
+;
+; preludes: form-stdlib/core.fk
+;
+; This is the smallest real piece of learning that runs four-way in pure Form: a
+; single gradient-descent update of a one-feature linear model. It is the SEED,
+; not the tree. The genuine large build is the form-native transformer training
+; loop — the freq-check detector / the transmuter, ~100M+ parameters — which
+; learns by composing MANY of these atoms through the CHAIN RULE: backprop walks
+; the gradient of the loss back through every attention + FFN layer, and at each
+; weight it lands on exactly this shape — w := w - lr * (dLoss/dw). That backprop
+; loop over the whole network is the heavy thing; this cell is the one weight's
+; worth of it, proven in isolation so the loop can be trusted to be built from it.
+; North stars: docs/coherence-substrate/form-native-agent-shape.form (the two
+; tiers — prototype atom vs the transformer it composes into) and
+; docs/coherence-substrate/freq-check-model.form (the real ~100M+ model this
+; training loop exists to fit).
+;
+; Kernel arithmetic is INTEGER, so every real number is fixed-point at scale
+; 1000: w = 1500 means 1.5, lr = 100 means 0.1. A product of two scaled values
+; carries scale^2, so each multiply is followed by /1000 to return to scale 1000.
+; Watch the truncation: a/1000 floors toward zero, so the fixture in the band is
+; chosen so the learning terms divide cleanly and never collapse to a degenerate
+; step. (sub) goes negative for under-prediction; that is fine — form-freq-check.fk
+; uses (sub) with negatives and validates four-way, so signed arithmetic is sound.
+;
+; Proven by: form-stdlib/tests/form-train-step-band.fk
+
+; prediction: w * x, brought back to scale 1000.
+(defn fts-pred (w x)
+    (div (mul w x) 1000))
+
+; error: prediction minus target (signed — negative when under-predicting).
+(defn fts-err (w x y)
+    (sub (fts-pred w x) y))
+
+; squared-error loss, kept at scale 1000 (err is scale 1000, so err*err is
+; scale^2 -> /1000). Always >= 0; squaring restores the sign of the error.
+(defn fts-loss (w x y)
+    (div (mul (fts-err w x y) (fts-err w x y)) 1000))
+
+; gradient dLoss/dw = 2 * err * x, back to scale 1000. This is the local slope
+; backprop would deliver to this one weight inside the larger network.
+(defn fts-grad (w x y)
+    (div (mul (mul 2 (fts-err w x y)) x) 1000))
+
+; one SGD update: w := w - lr * grad. lr is scale 1000 (lr=100 -> 0.1), grad is
+; scale 1000, so lr*grad is scale^2 -> /1000 returns the scale-1000 nudge.
+(defn fts-step (w x y lr)
+    (sub w (div (mul lr (fts-grad w x y)) 1000)))
+
+; apply fts-step n times — monomorphic recursion (fourth-arm safe; no higher-order
+; map). This is one training run over a single example repeated n epochs; the real
+; loop folds this over a corpus, but the descent shape is identical.
+(defn fts-steps (w x y lr n)
+    (if (eq n 0)
+        w
+        (fts-steps (fts-step w x y lr) x y lr (sub n 1))))

--- a/form/form-stdlib/tests/form-train-step-band.fk
+++ b/form/form-stdlib/tests/form-train-step-band.fk
@@ -1,0 +1,42 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-train-step.fk
+;
+; form-train-step-band — the SGD atom actually LEARNS, four-way in pure Form.
+; Fixture: the true relationship is y = 2*x (so the true weight is w = 2000 at
+; scale 1000), probed with one example x = 1000 (1.0), y = 2000 (2.0), starting
+; from w = 0 with learning rate lr = 100 (0.1). All values are fixed-point /1000.
+;
+; Hand-traced fixed-point arithmetic (a/1000 floors toward zero):
+;   start  w=0     loss = 4000
+;   step1  w=400   (grad = -4000, lr*grad/1000 = -400, w = 0 - (-400) = 400)
+;          loss(400) = 2560
+;   step8  w=1665  loss = 112   |2000 - w| = 335
+;   at true value w=2000: grad = 0 exactly, step keeps w = 2000, loss = 0
+;
+; Verdict 31 when every claim lands:
+;   1   an under-predicting start has positive loss            (loss(0)   > 0)
+;   2   ONE step moves w UP toward 2000                        (step(0)   > 0)
+;   4   loss is LESS after one step — learning happened        (2560 < 4000)
+;   8   after several steps w is closer to 2000 than after one (|2000-w8| < |2000-w1|)
+;   16  a w already AT the true value has ~zero gradient       (grad(2000) = 0, step barely moves)
+(do
+    (let x  1000)
+    (let y  2000)
+    (let lr 100)
+
+    ; the weights along the run
+    (let w0 0)
+    (let w1 (fts-step w0 x y lr))            ; after one step  -> 400
+    (let w8 (fts-steps w0 x y lr 8))         ; after eight steps -> 1665
+
+    ; 1 — under-predicting start carries positive loss
+    (let b0 (if (gt (fts-loss w0 x y) 0) 1 0))
+    ; 2 — one step pushes w up off zero toward the true 2000
+    (let b1 (if (gt w1 0) 2 0))
+    ; 4 — loss strictly decreases after that step (the learning)
+    (let b2 (if (lt (fts-loss w1 x y) (fts-loss w0 x y)) 4 0))
+    ; 8 — convergence: |true - w| shrinks from step1 to step8
+    (let b3 (if (lt (abs (sub 2000 w8)) (abs (sub 2000 w1))) 8 0))
+    ; 16 — at the true value the gradient vanishes and the step is a fixed point
+    (let b4 (if (and (eq (fts-grad 2000 x y) 0) (eq (fts-step 2000 x y lr) 2000)) 16 0))
+
+    (add b0 (add b1 (add b2 (add b3 b4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -159,6 +159,7 @@ code-tool-learning fks 131071
 tool-embodiment fks 127
 io-match fks 127
 training-catalog fks 31
+form-train-step fks 31
 form-cli-loop fks 31
 form-cli-router fks 31
 form-freq-check fks 31


### PR DESCRIPTION
The first real, four-way-proven stone of the form-native transformer training loop: a single gradient-descent step as a Form recipe, in integer fixed-point (scale 1000).

`form-train-step.fk`: `fts-pred / fts-err / fts-loss / fts-grad / fts-step / fts-steps` (monomorphic recursion). Fixture y=2x (true w=2000), x=1.0, w₀=0, lr=0.1:
- positive loss at start (4000); one step moves w up (→400); **loss drops 4000→2560** (learning); n steps converge toward 2000; **exact-zero gradient at the optimum**.
- **`form-train-step-band → 31`, four-way** (Go/Rust/TS/fkwu, 0 divergent). Truncation boundary traced by hand: the update divides cleanly, never floors to a degenerate zero.

Honest scale: this is the SGD **atom**. The transformer training loop (freq-check / transmuter, ~100M+) composes many of these through the chain rule across attention+FFN — that backprop loop is the genuine large build this atom seeds (`form-native-agent-shape.form`, `freq-check-model.form`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)