### PR TITLE
kernel host-io builtins (host-exec/read/write) — the runner is Form, not C

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -27,6 +27,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime/debug"
 	"sort"
@@ -1970,6 +1971,29 @@ func (k *Kernel) registerNatives() {
 	})
 	k.registerNative("str_concat", catMethod(), func(_ *Kernel, args []Value) Value {
 		return Value{Kind: VStr, Str: args[0].Str + args[1].Str}
+	})
+	// host-io builtins: the kernel's host-driver layer (host-kernel.form). These give a
+	// Form recipe the host effects the agent runner needs — run a process, read/write a
+	// file — so the runner is a Form recipe the kernel runs, NOT hand-written emitted C.
+	// Output is non-deterministic (host-io standing wall), so these are receipt-validated,
+	// not part of the four-way output-identity floor. The kernel already shells out (JIT
+	// go-build, plugin load), so this exposes an existing capability, not a new class.
+	k.registerNative("host-exec", catMethod(), func(_ *Kernel, args []Value) Value {
+		out, _ := exec.Command("sh", "-c", args[0].Str).CombinedOutput()
+		return Value{Kind: VStr, Str: string(out)}
+	})
+	k.registerNative("host-read", catMethod(), func(_ *Kernel, args []Value) Value {
+		b, err := os.ReadFile(args[0].Str)
+		if err != nil {
+			return Value{Kind: VStr, Str: ""}
+		}
+		return Value{Kind: VStr, Str: string(b)}
+	})
+	k.registerNative("host-write", catMethod(), func(_ *Kernel, args []Value) Value {
+		if err := os.WriteFile(args[0].Str, []byte(args[1].Str), 0o644); err != nil {
+			return Value{Kind: VStr, Str: "error"}
+		}
+		return Value{Kind: VStr, Str: "ok"}
 	})
 	k.registerNative("form_error", catWitness(), func(_ *Kernel, args []Value) Value {
 		panic(args[0].Str)


### PR DESCRIPTION
**Why are we focusing on C? We shouldn't be.** C was a workaround for the kernel not exposing host effects to recipes. The kernel *already* shells out (JIT `go build` + plugin load, file I/O) — it just never offered that to a Form recipe, so I reached for emitted C. Parallel machinery.

This exposes the existing capability per `host-kernel.form`: three Go-kernel host-io builtins —
- `host-exec(cmd)` → run a process, combined output
- `host-read(path)` → file contents
- `host-write(path, body)` → "ok"|"error"

**Proven:** a pure Form recipe runs `echo`, writes a file, reads it back (`alive-via-form`), the kernel performing the host effect. With existing string builtins (`str_find`/`substring`/`str_len`/`char_at`/`str_to_int`) a recipe can also **parse** the oracle's tool-call — so the whole runner can be Form.

Host-io output is non-deterministic (the host-io standing wall) → receipt-validated, **not** in the four-way output-identity floor; existing bands still pass four-way (`form-cli-router → 31` confirmed with the rebuilt kernel). Go-only now; Rust/TS host-io parity is the named follow-up. This makes the C runner (`fcrun-emit`) the composting path; the **Form runner** that replaces it is the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)