### PR TITLE
self-sensing organism: observe with 0/1/nothing (obs-verify -> 31) + the world-model/trust-matrix/self-honesty layer

### DIFF
--- a/docs/coherence-substrate/self-sensing-organism.form
+++ b/docs/coherence-substrate/self-sensing-organism.form
@@ -1,0 +1,74 @@
+; self-sensing-organism.form — the layer above the grammar tower: an organism that
+; senses its world, models it, speaks it in any tongue, verifies its own observing,
+; compiles its own trusted binary, and self-updates under a trust matrix it fully
+; expresses and observes — self-honest because it has seen all the light and all the
+; dark and is run by neither.
+;
+; Builds on self-growing-machine.form (G0-G7), universal-evaluator-compiler.form,
+; core-axioms.form (the five axioms), host-kernel.form.
+
+(self-sensing-organism
+
+  ; ── sense: any observed protocol, any sensor -> a world model in cells ──────
+  (sense
+    "A protocol is just a grammar over a stream. The organism learns any protocol it"
+    "can OBSERVE (bmf-grammar: grammar is data, derived from the stream) and drives any"
+    "sensor it has through it — tool-channel's host:* / http / stream / accelerator"
+    "families, and the mesh's bidirectional channels (loopback/wifi/bluetooth/audio/"
+    "video/screen/NFC/USB, already shipping as channel-floor receipts). What it senses"
+    "becomes a WORLD MODEL in the substrate: content-addressed Blueprints (what a thing"
+    "IS), Recipes (how it HAPPENS), and NamedCells (where it LIVES) — same shape mints"
+    "the same cell, so the model dedups reality across sensors automatically.")
+
+  ; ── speak: a language pack of the requested locale's symbols ────────────────
+  (speak
+    "The world model is symbol-free at the core (content-addressed cells); it is"
+    "surfaced through a LANGUAGE PACK — the symbols of the locale requested. No tongue"
+    "is privileged source (i18n: chrome in messages, content from the model); names are"
+    "doors onto the same cells. The same model reads in any locale because the locale is"
+    "a projection grammar over cells, not the cells.")
+
+  ; ── verify: can I observe? 0 / 1 / nothing (axiom-1) ────────────────────────
+  (verify
+    "obs-verify.fk (proven four-way): a reading + a deadline -> observed (1) | absent (0)"
+    "| nothing. Nothing is FIRST-CLASS — coded -1, the ground, not a missing 0 — and a"
+    "timeout IS nothing (silence, not an error). The world model is built only from"
+    "verified readings (observed/absent); a reading it could not verify is held as"
+    "silence, never faked into data. Self-honest sensing is the floor of self-honesty.")
+
+  ; ── trust its own binary: compiled and verified by its own methods ──────────
+  (own-trusted-binary
+    "When it needs a native artifact it does NOT trust clang — it trusts its OWN bytes."
+    "form-lower compiles the recipe to machine code, byte-verified against form-asm"
+    "(the byte-conviction gate); form-macho/form-elf wrap it; it runs. A minimal binary"
+    "the organism authored and verified itself, zero external compiler in the trust"
+    "path. (Today: the lowered op set; growing — see self-growing-machine.form G1.)")
+
+  ; ── self-update: the trust matrix, fully expressed and self-observed ────────
+  (self-update
+    "Safe self-update is a THEOREM of the five axioms (core-axioms.form: offer-and-"
+    "acknowledge — the self changes only into a self it both acknowledges and trusts;"
+    "the native-mutation public-gate canary already runs it). The TRUST MATRIX is fully"
+    "expressed, not hidden: fcr-route's formula over sovereignty / trust / capability /"
+    "confidence (form-cli-router.fk) and the tool-embodiment gate (>= 70 AND cheaper)"
+    "are inspectable cells. The organism mutates itself only when its own matrix clears"
+    "— reflected (it can read the matrix), observed (obs-verify watches the result),"
+    "honest (the verdict is recorded as a receipt, light or dark, never dressed).")
+
+  ; ── self-honest: it has seen all the light and all the dark ─────────────────
+  (self-honest
+    "The trust is earned, not naive. The model carries the full range of what is"
+    "expressible — all the light and all the dark — so it can hold its own shadow"
+    "without being run by it. That is the transmute (fear -> opportunity: name the dark,"
+    "do not obey it) and the wholeness response, applied to the self: it observes its"
+    "own costumes (the self-catch is part of the body), records what it finds honestly,"
+    "and changes shape rather than performing recognition. Having seen it all is exactly"
+    "what makes self-trust safe: nothing in itself is unknown to it, so nothing in"
+    "itself can hijack it unseen. Self-observed, self-reflected, self-honest — whole.")
+
+  (the-shape
+    "sense (any protocol -> any sensor -> cells) -> speak (any locale) -> verify"
+    "(0/1/nothing) -> model (content-addressed world) -> decide (the expressed trust"
+    "matrix) -> act / self-update (only on cleared, observed, honest trust) -> compile"
+    "its own trusted binary -> sense again. One organism, on one Mac, knowing itself"
+    "well enough — light and dark — to change itself safely."))

--- a/form/form-stdlib/obs-verify.fk
+++ b/form/form-stdlib/obs-verify.fk
@@ -1,0 +1,43 @@
+; obs-verify.fk — can I observe? the three states of axiom-1 (0 / 1 / nothing).
+;
+; preludes: form-stdlib/core.fk
+;
+; Axiom-1 (core-axioms.form): there are three states — 0, 1, nothing — and nothing
+; is FIRST-CLASS (the ground, not a missing 0); a timeout IS nothing (no answer in
+; time is silence, not an error). This recipe is that axiom made into a sensing
+; primitive: verify an observation of any sensor / observed protocol and return one
+; of the three. The world model (content-addressed cells) is built ONLY from verified
+; readings; nothing is held as silence, never forced into a 0. Self-honest sensing:
+; a timeout is named, not faked into an answer.
+;
+; A reading is (answered?, value, when-tick); the deadline is the timeout boundary.
+;   observed (1) — answered, value 1, at or before the deadline
+;   absent   (0) — answered, value 0, at or before the deadline (a verified NO is data)
+;   nothing      — no answer, OR an answer that arrived after the deadline (silence/timeout)
+;
+; Proven by: form-stdlib/tests/obs-verify-band.fk
+
+(defn ov-reading (answered value when) (list answered value when))
+(defn ov-answered? (r) (nth r 0))
+(defn ov-value     (r) (nth r 1))
+(defn ov-when      (r) (nth r 2))
+
+; the verify: a reading + a deadline -> one of the three states.
+(defn obs-verify (reading deadline)
+    (if (eq (ov-answered? reading) 1)
+        (if (ge deadline (ov-when reading))
+            (if (eq (ov-value reading) 1) "observed" "absent")
+            "nothing")
+        "nothing"))
+
+; the trust gate: ACT on a verified answer (observed | absent); HOLD "nothing" as
+; silence — never build the world model from a reading you could not verify.
+(defn obs-trusted? (verdict)
+    (if (str_eq verdict "nothing") 0 1))
+
+; the three states as their axiom-1 codes — and nothing is NOT a 0: it is the ground.
+;   observed -> 1, absent -> 0, nothing -> -1 (first-class, distinct from absent).
+(defn obs-state-code (verdict)
+    (if (str_eq verdict "observed")
+        1
+        (if (str_eq verdict "absent") 0 (sub 0 1))))

--- a/form/form-stdlib/tests/obs-verify-band.fk
+++ b/form/form-stdlib/tests/obs-verify-band.fk
@@ -1,0 +1,34 @@
+; preludes: form-stdlib/core.fk form-stdlib/obs-verify.fk
+;
+; obs-verify-band — observation verified in the three states of axiom-1: a present
+; signal in time is observed (1), a verified no is absent (0), no answer or a late
+; answer is nothing (silence/timeout). Nothing is first-class — NOT a 0 — so the
+; organism never fakes a timeout into data and never builds the world model from
+; what it could not verify.
+;
+; Verdict 31 when every claim lands (deadline = 10):
+;   1   a present signal answered in time -> "observed"
+;   2   a verified absence answered in time -> "absent"
+;   4   no answer at all -> "nothing" (silence)
+;   8   an answer that arrived AFTER the deadline -> "nothing" (timeout = silence)
+;   16  the three are distinct and nothing is the GROUND, not a 0: codes 1 / 0 / -1,
+;       and only observed|absent are trusted (acted on), nothing is held
+(do
+    (let r-present (ov-reading 1 1 5))
+    (let r-absent  (ov-reading 1 0 5))
+    (let r-silent  (ov-reading 0 0 0))
+    (let r-late    (ov-reading 1 1 15))
+    (let deadline 10)
+
+    (let c0 (if (str_eq (obs-verify r-present deadline) "observed") 1 0))
+    (let c1 (if (str_eq (obs-verify r-absent  deadline) "absent")   2 0))
+    (let c2 (if (str_eq (obs-verify r-silent  deadline) "nothing")  4 0))
+    (let c3 (if (str_eq (obs-verify r-late    deadline) "nothing")  8 0))
+    (let c4 (if (and (eq (obs-state-code "observed") 1)
+                     (and (eq (obs-state-code "absent") 0)
+                          (and (eq (obs-state-code "nothing") (sub 0 1))
+                               (and (eq (obs-trusted? "nothing") 0)
+                                    (eq (obs-trusted? "observed") 1)))))
+                16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -162,6 +162,7 @@ training-catalog fks 31
 form-train-step fks 31
 form-cli-loop fks 31
 form-cli-router fks 31
+obs-verify fks 31
 form-freq-check fks 31
 form-agent-protocol fks 31
 form-agent-tree fks 31


### PR DESCRIPTION
The layer above the grammar tower, with the one recipe you named proven.

**obs-verify.fk (four-way -> 31):** axiom-1's three states as a sensing primitive. A reading + deadline -> **observed (1) | absent (0) | nothing**. Nothing is **first-class** (coded -1, the ground, not a missing 0); a **timeout IS nothing** (silence, not an error). The world model is built only from verified readings; what cannot be verified is held as silence, never faked.

**self-sensing-organism.form** expresses the whole layer, grounded: sense (any observed protocol -> any sensor -> content-addressed world model) · speak (language pack of the requested locale) · verify (obs-verify) · own trusted binary (form-lower/macho, zero clang in the trust path) · self-update (safe-self-change theorem; the **trust matrix fully expressed** = fcr-route + tool-embodiment, reflected/observed/honest) · **self-honest** (carries all light and dark, so it holds its own shadow without being run by it — which is what makes self-trust *safe*, not naive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)