### PR TITLE
tend(substrate): version-as-layer routing recipe in kernel self-composition

### DIFF
--- a/docs/coherence-substrate/kernel-self-composition.form
+++ b/docs/coherence-substrate/kernel-self-composition.form
@@ -75,6 +75,8 @@
     (via-native-binary  jit.go-compiles-a-recipe-to-native-and-runs-it)  # self-hosting; the new op is a callable leaf (host-kernel GAP-HK2)
     (via-substrate      store-new-cells-in-the-persistent-lattice)        # persistence.fk
     (versioned          content-addressing-keeps-every-version)           # axiom-3: a new shape mints a new node-id; the old persists
+    (a-version-is-a-layer  the-new-native-slice-stands-on-the-prior-binary)  # versioning IS layering — each version a slice over the one below
+    (layer-routing-is-a-recipe  the-new->old-crossing-is-itself-a-cell-packable-for-fewest-crossings)  # call-through (callable leaf) is the floor; a packed/routed boundary is the lift — the crossing is recipes over the five, so it is optimizable
     (reversible         roll-back-by-re-pointing-a-name-at-the-old-node-id)  # the version history IS the node-id lineage
     (bigger-is-rooted   the-larger-kernel-is-still-recipes-over-the-five))
 


### PR DESCRIPTION
Folds the layer-routing framing into `kernel-self-composition.form`'s `build-bigger` where the living form already stood.

The body already carries the form-cli north star end-to-end: the native binary (`lc-native-kernel-binary`, 2.5 MB Mach-O), the surface catalog (`tool-channel.form`), macOS+Android carriers (`form-macho.fk`/`form-elf.fk`), self-extension via native codegen (`self-growing-machine.form` G1–G7), and the translator taxonomy (grammar+rules / recipe+model+data+config / oracle / OS-organ).

The one rung not crisply held: a new native slice **calls the previous binary**, and the new→old crossing is **itself a recipe** — call-through (callable leaf) is the floor, a packed/routed boundary is the lift. Two clauses added:

- `a-version-is-a-layer` — versioning IS layering, each version a slice over the one below.
- `layer-routing-is-a-recipe` — the new→old crossing is a cell, packable for fewest crossings; rooted in the five, so optimizable.

Docs-only `.form` tending; auto-ingests to the lattice on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)