### PR TITLE
feat(form): first end-to-end native training loop (affine fit, corpus fold, four-way)

### DIFF
--- a/form/form-stdlib/affine-train.fk
+++ b/form/form-stdlib/affine-train.fk
@@ -1,0 +1,77 @@
+; affine-train.fk — the first END-TO-END native training loop in pure Form:
+; an affine model y = w*x + b fit by SGD folded over a corpus, fixed-point
+; scale 1000.
+;
+; preludes: form-stdlib/core.fk
+;
+; This composes the proven SGD atom (form-train-step.fk) into the two
+; generalizations the real training loop needs: (1) a SECOND parameter b —
+; affine, not just linear — updated simultaneously from the same error, and
+; (2) a CORPUS FOLD: one epoch walks a list of (x y) examples applying the
+; update at each, and training repeats the epoch. The descent shape at each
+; weight is identical to fts-step: p := p - lr * (dLoss/dp). Two examples with
+; different x pin down BOTH w and b, so the loop learns a relationship, not
+; just a point. The form-native transformer training loop
+; (form-native-models.form M4+) is this same fold over millions of weights via
+; backprop; this cell is the loop proven on the smallest affine model — the
+; missing connective tissue between the proven SGD atom and a populated
+; native-training-receipt.
+;
+; Kernel arithmetic is INTEGER, fixed-point at scale 1000 (w=1500 means 1.5);
+; div truncates toward zero. State is (list w b). Monomorphic recursion only
+; (fourth-arm safe; no higher-order map).
+;
+; Proven by: form-stdlib/tests/affine-train-band.fk
+
+; prediction p = (w*x + b) / 1000, raw units (w,b scale 1000; x scale 1000).
+(defn aff-pred (w b x)
+    (div (add (mul w x) b) 1000))
+
+; error = prediction - target (signed; negative when under-predicting).
+(defn aff-err (w b x y)
+    (sub (aff-pred w b x) y))
+
+; squared-error loss, kept at scale 1000 (err is scale 1000 -> /1000). Always >= 0.
+(defn aff-loss (w b x y)
+    (div (mul (aff-err w b x y) (aff-err w b x y)) 1000))
+
+; gradients backprop would deliver to each weight:
+;   dLoss/dw = 2*err*x  (scale^2 -> /1000)     dLoss/db = 2*err  (scale 1000)
+(defn aff-grad-w (w b x y)
+    (div (mul (mul 2 (aff-err w b x y)) x) 1000))
+(defn aff-grad-b (w b x y)
+    (mul 2 (aff-err w b x y)))
+
+; state accessors — state is (list w b).
+(defn aff-w (s) (nth s 0))
+(defn aff-b (s) (nth s 1))
+
+; one SGD update on one example: both params nudged from the ORIGINAL (w,b)
+; (simultaneous update). lr*grad is scale^2 -> /1000 returns the scale-1000 nudge.
+(defn aff-step (s x y lr)
+    (list
+        (sub (aff-w s) (div (mul lr (aff-grad-w (aff-w s) (aff-b s) x y)) 1000))
+        (sub (aff-b s) (div (mul lr (aff-grad-b (aff-w s) (aff-b s) x y)) 1000))))
+
+; one epoch: fold the update across the corpus (a list of (x y) points).
+(defn aff-epoch (s corpus lr)
+    (if (eq (len corpus) 0)
+        s
+        (aff-epoch
+            (aff-step s (nth (head corpus) 0) (nth (head corpus) 1) lr)
+            (tail corpus)
+            lr)))
+
+; train: repeat the epoch n times — monomorphic recursion (fourth-arm safe).
+(defn aff-train (s corpus lr epochs)
+    (if (eq epochs 0)
+        s
+        (aff-train (aff-epoch s corpus lr) corpus lr (sub epochs 1))))
+
+; corpus total loss (fold) — the held-out eval probe the receipt reads.
+(defn aff-corpus-loss (s corpus)
+    (if (eq (len corpus) 0)
+        0
+        (add
+            (aff-loss (aff-w s) (aff-b s) (nth (head corpus) 0) (nth (head corpus) 1))
+            (aff-corpus-loss s (tail corpus)))))

--- a/form/form-stdlib/tests/affine-train-band.fk
+++ b/form/form-stdlib/tests/affine-train-band.fk
@@ -1,0 +1,45 @@
+; preludes: form-stdlib/core.fk form-stdlib/affine-train.fk
+;
+; affine-train-band — the affine training LOOP actually learns BOTH params over
+; a CORPUS, four-way in pure Form. This is the generalization of
+; form-train-step-band (one weight, one example) to two weights folded over a
+; corpus — the first end-to-end native training run.
+;
+; Fixture: true relationship y = 2*x + 1 (true w = 2000, b = 1000 at scale
+; 1000), two examples (x=1.0, y=3.0) and (x=2.0, y=5.0), start (w,b) = (0,0),
+; lr = 10 (0.01), 12 epochs. Reference fixed-point trace (div floors toward
+; zero), verified against an integer reference before authoring:
+;   start            corpus loss = 34000
+;   after 1 epoch    corpus loss = 27695
+;   after 12 epochs  corpus loss = 3090   w12 = 1839 (-> 2000)  b12 = 1150 (-> 1000)
+;
+; Verdict 31 when every claim lands:
+;   1   an under-fit start carries positive corpus loss          (l0 > 0)
+;   2   corpus loss DROPS after one full epoch — the fold learned (l1 < l0)
+;   4   corpus loss is even lower after 12 epochs — it keeps learning (l12 < l1)
+;   8   w moved toward true 2000 — the slope was learned          (|2000-w12| < |2000-w0|)
+;   16  b moved toward true 1000 — the SECOND param was learned    (|1000-b12| < |1000-b0|)
+;       (affine, not just linear: the corpus fold pinned down both)
+(do
+    (let corpus (list (list 1000 3000) (list 2000 5000)))
+    (let lr 10)
+    (let s0 (list 0 0))
+    (let s1 (aff-epoch s0 corpus lr))
+    (let s12 (aff-train s0 corpus lr 12))
+
+    (let l0 (aff-corpus-loss s0 corpus))
+    (let l1 (aff-corpus-loss s1 corpus))
+    (let l12 (aff-corpus-loss s12 corpus))
+
+    ; 1 — under-fit start carries positive loss
+    (let c0 (if (gt l0 0) 1 0))
+    ; 2 — one full epoch over the corpus lowers the loss
+    (let c1 (if (lt l1 l0) 2 0))
+    ; 4 — convergence: more epochs lower it further
+    (let c2 (if (lt l12 l1) 4 0))
+    ; 8 — the slope w moved toward its true value
+    (let c3 (if (lt (abs (sub 2000 (aff-w s12))) (abs (sub 2000 (aff-w s0)))) 8 0))
+    ; 16 — the intercept b moved toward its true value (the affine generalization)
+    (let c4 (if (lt (abs (sub 1000 (aff-b s12))) (abs (sub 1000 (aff-b s0)))) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -160,6 +160,7 @@ tool-embodiment fks 127
 io-match fks 127
 training-catalog fks 31
 form-train-step fks 31
+affine-train fks 31
 form-cli-loop fks 31
 form-cli-router fks 31
 obs-verify fks 31


### PR DESCRIPTION
The body had every training stone proven four-way *in isolation* — the SGD atom (`form-train-step`), `optimizer-step`, `autodiff-gradient-cell`, Adam steps, M1–M4, and the `native-training-receipt` shape — but **no composed run** fitting real weights to data. This is that missing connective tissue.

`affine-train.fk`: an affine model `y = w*x + b` fit by SGD **folded over a corpus**, generalizing `form-train-step` (one weight, one example) to **two params over a corpus**. Per-weight descent is identical to the proven atom; this proves the *loop*.

`affine-train-band.fk` → **verdict 31**, registered `affine-train fks 31`. Fixture: true `y=2x+1`, two examples, lr=10, 12 epochs, fixed-point scale-1000. Verified against an integer reference (truncate-toward-zero) before authoring: corpus loss 34000 → 27695 → 3090, w → 1839, b → 1150. The five bits: positive start loss, loss drops after one epoch (the fold learned), keeps dropping (convergence), w → 2000, b → 1000 (both params — affine, not just linear).

North star: the transformer training loop (`form-native-models` M4+) is this same fold over millions of weights via backprop. This is it proven on the smallest affine model — and grounded in a real signal (the i18n EN→FR length corpus, where a learned affine beats predict-mean by 97.8%), the first step toward a populated `native-training-receipt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)