### PR TITLE
tend: auto-ml as the architect — the body designs and trains layer-stack architectures

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -387,6 +387,15 @@
 ;   is realized: diffusion, sparse attention, CNN, memorizer, compute (runs recipes), short/long-term memory,
 ;   and recipe-generation. champion-challenger.fk flips serving authority between kinds on earned competition,
 ;   and the gate (recognition-router + the learned gating network) routes per input.
+;   M7's ARCHITECT [SHIPPED: arch-gen.fk + tests/arch-gen-band.fk → 31 three-way]: generation rises from
+;   composing experts to composing LAYERS into a trained ARCHITECTURE. The body generates layer-stacks of
+;   configurable DEPTH (each a list of typed layer-cells as data), ASSEMBLES and TRAINS each through
+;   transformer-backprop.fk's stack engine, and crowns the one that fits — the no-op (depth 0, y=x) cannot
+;   fit a target ≠ input (loss stays 0.34) and is rejected, while generated depth-1/2 architectures train to
+;   loss → 0. So the system designs the architecture AND learns it: the same generate-then-search shape that
+;   composes experts (recipe-gen) now does NAS over layer-stacks, trained by the proven backward. Next ring:
+;   richer architecture spaces (mixed layer types, widths, attention vs ffn per task) and champion-challenger
+;   flipping serving authority to a synthesized-and-trained architecture once it earns it.
 ;
 ; KIN: numeric-formats.canonical.json (the 19 formats + conformance) · cell-numerics.form / cosine.form
 ;   (the layer math) · attention.fk + embedding-as-recipe.fk (content-addressed attention) ·

--- a/docs/system_audit/commit_evidence_2026-06-16_arch_gen.json
+++ b/docs/system_audit/commit_evidence_2026-06-16_arch_gen.json
@@ -1,0 +1,108 @@
+{
+  "date": "2026-06-16",
+  "thread_branch": "claude/moe-layer-architect",
+  "commit_scope": "auto-ml as the ARCHITECT: generation rises from composing experts to composing LAYERS into a trained architecture. arch-gen.fk generates layer-stack architectures of configurable depth (each a list of typed layer-cells, as data), assembles and trains each through transformer-backprop.fk's stack engine (tbp-stk-train), and crowns the one that fits. This closes the loop between the two threads built on PR #3168: the same generate-then-search shape recipe-gen.fk uses to compose experts now does neural-architecture-search over layer-stacks, trained by the proven transformer backward. The body designs the architecture AND learns it, rejecting the no-op architecture that structurally cannot fit.",
+  "files_owned": [
+    "form/form-stdlib/arch-gen.fk",
+    "form/form-stdlib/tests/arch-gen-band.fk",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-backprop.fk form-stdlib/arch-gen.fk form-stdlib/tests/arch-gen-band.fk"
+    ],
+    "summary": "arch-gen-band -> 31 three-way (Go=Rust=TS), 0 divergent. The body GENERATES + CONFIGURES an architecture (depth-2 is a 2-layer stack); architecture MATTERS (the no-op depth-0 y=x cannot fit a target != input, loss stays 0.34); generated depth-1 and depth-2 architectures TRAIN to fit (loss -> 0); and the ARCHITECT crowns a non-empty architecture (depth >= 1), rejecting the no-op. Fixture: input (1.0,0.5), target (1.5,0.8), lr 0.1, 80 steps. 3-KERNEL ONLY (Go=Rust=TS): composes the fp64 transformer backward (transformer-block / transformer-numerics op family), not in the fourth-arm manifest -- the same floor transformer-block.fk and transformer-backprop are proven on. Unsupported-op-family gap, not a divergence.",
+    "observed_delta": {
+      "band_verdict": 31,
+      "band_divergent": 0,
+      "depth0_noop_loss": "0.34 (cannot fit)",
+      "depth1_loss": "~0 (fits)",
+      "depth2_loss": "~0 (fits)",
+      "architect_crowned_depth": 2
+    },
+    "known_limitations": [
+      {
+        "limitation": "The generated architecture space here is depth (a stack of n FFN-residual layers). Richer spaces -- mixed layer types (attention vs ffn per slot), widths, per-task type selection -- are the next ring, the same generate-then-search shape over a wider config vocabulary. The discrimination proven is structural (no-op cannot fit vs a layer can); capacity/type discrimination over a multi-example dataset is the deeper proof.",
+        "follow_up": "Extend the generator to mixed layer types and widths; train over a multi-example dataset so capacity-based architecture selection is provable; wire champion-challenger to flip serving authority to a synthesized-and-trained architecture."
+      },
+      {
+        "limitation": "Init is deterministic (the kernel has no RNG; each layer seeds by depth index), which makes the band reproducible and content-addressed but means architecture comparison is on one fixed init, not an init distribution.",
+        "follow_up": "When a host RNG carrier is wired, sample inits; until then deterministic seeds keep the proof bit-stable three-way."
+      },
+      {
+        "limitation": "3-kernel only: the fp64 transformer backward op family is not in the fourth-arm manifest. Same floor as transformer-block.fk and transformer-backprop. 0 divergent across Go/Rust/TS.",
+        "follow_up": "The fourth arm gains this family when the transformer numerics/block bands are flattened for fkwu."
+      }
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "summary": "validate.sh runs arch-gen-band in the default suite via its preludes header; CI three-way gate applies."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "Stdlib recipe + band + milestone-map doc; no route or service change. Rides normal merge."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "New capability: the body designs neural architectures -- it generates layer-stacks of configurable depth, trains each through the proven backward, and crowns the one that fits, rejecting architectures that structurally cannot.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "validate.sh arch-gen-band (three kernels agree, verdict 31): generate depth-n architecture, train each, no-op rejected, working depth crowned"
+    ],
+    "summary": "Proven three-way: auto-ml designs and trains architectures, not just hand-built models."
+  },
+  "phase_gate": {
+    "phase": "m7-architect-nas",
+    "gate": "generation rises from experts to architectures: the body generates, configures, assembles, and trains layer-stacks, crowning the one that fits and rejecting the no-op -- NAS over layer-stacks trained by the proven backward, three-way",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "richer architecture spaces (mixed types, widths, per-task type selection); multi-example capacity-based selection; champion-challenger authority-flip to a synthesized-and-trained architecture"
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "arch-gen-20260616"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "form-os-arc"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "measurement"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/arch-gen.fk",
+    "form/form-stdlib/tests/arch-gen-band.fk",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "change_files": [
+    "form/form-stdlib/arch-gen.fk",
+    "form/form-stdlib/tests/arch-gen-band.fk",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-16_arch_gen.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/arch-gen.fk
+++ b/form/form-stdlib/arch-gen.fk
@@ -1,0 +1,42 @@
+; arch-gen.fk — auto-ml as the ARCHITECT: the body generates layer-stack architectures, configures their
+; depth, assembles them, and trains each — then crowns the one that fits the task. This is where the two
+; threads meet: the generation discipline recipe-gen.fk uses to compose EXPERTS now composes LAYERS into a
+; STACK (an architecture as data), and transformer-backprop.fk's assembly engine TRAINS that stack. So the
+; system does not just run a hand-built model — it designs the architecture (how many layers, of what kind,
+; configured how) and learns it, rejecting the architectures that cannot fit.
+;
+; A generated architecture is a list of typed layer-cells (tbp-stk-* trains it). Init is deterministic
+; (the kernel has no RNG; each layer's seed varies by depth index), so a generated stack is reproducible
+; and content-addressed like any recipe.
+;
+; Preludes: transformer-numerics.fk transformer-block.fk transformer-backprop.fk
+; Proven by: form-stdlib/tests/arch-gen-band.fk
+
+(do
+    ; a deterministic FFN-residual layer, seeded by its depth index (distinct, reproducible weights).
+    (defn ag-ffn-layer (seed)
+        (list "ffn"
+              (list (list (add 0.2 seed) -0.1) (list 0.1 (add 0.3 seed))) (list 0.0 0.0)
+              (list (list 0.4 0.1) (list -0.2 0.5)) (list 0.0 0.0)))
+
+    ; --- GENERATE + CONFIGURE: a depth-n architecture is a stack of n seeded FFN-residual layers. ---
+    (defn ag-gen-acc (n seed acc)
+        (if (eq n 0) acc (ag-gen-acc (sub n 1) (add seed 0.05) (cons (ag-ffn-layer seed) acc))))
+    (defn ag-gen (n) (ag-gen-acc n 0.1 (empty)))       ; the architecture, as DATA — len = depth
+    (defn ag-depth (arch) (len arch))
+
+    ; --- ASSEMBLE + TRAIN: a generated architecture's fitness is its final loss after training. ---
+    (defn ag-fit (n x t lr eps steps) (tbp-stk-train-loss (ag-gen n) x t lr eps steps))
+
+    ; --- THE ARCHITECT: search depths 0..maxd, crown the one with the lowest trained loss. Depth 0 is the
+    ;     no-op (no layers, y = x) — it can fit only a target equal to the input, so the search rejects it
+    ;     when the task needs a non-trivial architecture, discovering the minimal depth that fits. ---
+    (defn ag-best-acc (d maxd x t lr eps steps bd bl)
+        (if (gt d maxd) bd
+            (if (lt (ag-fit d x t lr eps steps) bl)
+                (ag-best-acc (add d 1) maxd x t lr eps steps d (ag-fit d x t lr eps steps))
+                (ag-best-acc (add d 1) maxd x t lr eps steps bd bl))))
+    (defn ag-best (maxd x t lr eps steps)
+        (ag-best-acc 1 maxd x t lr eps steps 0 (ag-fit 0 x t lr eps steps)))
+
+    0)

--- a/form/form-stdlib/tests/arch-gen-band.fk
+++ b/form/form-stdlib/tests/arch-gen-band.fk
@@ -1,0 +1,33 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-backprop.fk form-stdlib/arch-gen.fk
+;
+; arch-gen-band — auto-ml as the ARCHITECT, three-way. The body GENERATES layer-stack architectures of
+; configurable depth, ASSEMBLES and TRAINS each through transformer-backprop.fk's stack engine, and crowns
+; the one that fits — rejecting the no-op architecture that structurally cannot. This closes the loop: the
+; same generate-then-search shape recipe-gen.fk uses to compose experts now designs and trains ARCHITECTURES.
+; Fixture: input (1.0, 0.5), target (1.5, 0.8) ≠ input, so a no-op (depth 0, y = x) cannot fit; lr 0.1.
+;
+; Verdict 31 when every claim lands:
+;   1    the body GENERATES + CONFIGURES an architecture: depth-2 is a 2-layer stack (len 2)
+;   2    architecture MATTERS: the no-op (depth 0, no layers) cannot fit — its loss stays at 0.34
+;   4    a generated depth-1 architecture TRAINS to fit (loss → 0)
+;   8    a generated depth-2 architecture TRAINS to fit (loss → 0)
+;   16   the ARCHITECT crowns a non-empty architecture (depth ≥ 1), rejecting the no-op that cannot fit
+(do
+    (let x (list 1.0 0.5))
+    (let t (list 1.5 0.8))
+    (let lr 0.1)
+    (let eps 0.00001)
+    (let steps 80)
+
+    (let l0 (ag-fit 0 x t lr eps steps))
+    (let l1 (ag-fit 1 x t lr eps steps))
+    (let l2 (ag-fit 2 x t lr eps steps))
+    (let crowned (ag-best 2 x t lr eps steps))
+
+    (let c0 (if (eq (ag-depth (ag-gen 2)) 2) 1 0))
+    (let c1 (if (gt l0 0.0) 2 0))
+    (let c2 (if (eq (round (mul l1 1000000.0)) 0) 4 0))
+    (let c3 (if (eq (round (mul l2 1000000.0)) 0) 8 0))
+    (let c4 (if (gt crowned 0) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))


### PR DESCRIPTION
## What

Generation rises from composing *experts* to composing *layers* into a trained **architecture**. `arch-gen.fk` generates layer-stacks of configurable depth (each a list of typed layer-cells, as data), assembles and trains each through `transformer-backprop.fk`'s stack engine, and crowns the one that fits.

This closes the loop between the two threads landed in [#3168](https://github.com/seeker71/Coherence-Network/pull/3168): the same generate-then-search shape `recipe-gen.fk` uses to compose experts now does **NAS over layer-stacks**, trained by the proven transformer backward. The body designs the architecture *and* learns it.

## Proof

`tests/arch-gen-band.fk` → **31 three-way** (Go=Rust=TS), 0 divergent:
- the body **generates + configures** a depth-2 architecture (a 2-layer stack)
- architecture **matters**: the no-op (depth 0, `y=x`) cannot fit a target ≠ input — loss stays 0.34 — and is **rejected**
- generated depth-1 and depth-2 architectures **train to fit** (loss → 0)
- the **architect crowns** a non-empty architecture (depth ≥ 1)

`3-kernel only` — same fp64 transformer-backward floor as `transformer-block`.

## Next ring

Richer architecture spaces (mixed layer types, widths, per-task type selection), multi-example capacity-based selection, and `champion-challenger` flipping serving authority to a synthesized-and-trained architecture once it earns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)