### PR TITLE
tend: the auto-ml serving loop — promote a challenger architecture only when it earns it

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -393,9 +393,16 @@
 ;   transformer-backprop.fk's stack engine, and crowns the one that fits — the no-op (depth 0, y=x) cannot
 ;   fit a target ≠ input (loss stays 0.34) and is rejected, while generated depth-1/2 architectures train to
 ;   loss → 0. So the system designs the architecture AND learns it: the same generate-then-search shape that
-;   composes experts (recipe-gen) now does NAS over layer-stacks, trained by the proven backward. Next ring:
-;   richer architecture spaces (mixed layer types, widths, attention vs ffn per task) and champion-challenger
-;   flipping serving authority to a synthesized-and-trained architecture once it earns it.
+;   composes experts (recipe-gen) now does NAS over layer-stacks, trained by the proven backward.
+;   And the SERVING loop is now closed [arch-champion-challenger-band.fk → 31 three-way]: the architect's
+;   challenger replaces the served champion ONLY when it EARNS it. A deeper challenger fits the task's targets
+;   faster (closer in 5 steps), strictly exceeds the champion across the window (score 3 > 1), and
+;   champion-challenger.fk flips authority to it ("challenger"); a same-architecture challenger only TIES, so
+;   the served champion is protected ("champion", not promoted). This is M7's infer-best-while-searching-better
+;   in full: generate challenger architectures, train them, promote only the earned winner — improving the
+;   model without ever degrading what is served now. Next ring: richer architecture spaces (mixed layer types,
+;   widths, attention vs ffn per task), multi-example capacity selection at higher dim (LN collapses 2-D inputs
+;   to two directions), and the GPU as the trainer underneath the search.
 ;
 ; KIN: numeric-formats.canonical.json (the 19 formats + conformance) · cell-numerics.form / cosine.form
 ;   (the layer math) · attention.fk + embedding-as-recipe.fk (content-addressed attention) ·

--- a/docs/system_audit/commit_evidence_2026-06-16_arch_champion_challenger.json
+++ b/docs/system_audit/commit_evidence_2026-06-16_arch_champion_challenger.json
@@ -1,0 +1,112 @@
+{
+  "date": "2026-06-16",
+  "thread_branch": "claude/arch-champion-challenger",
+  "commit_scope": "The auto-ml SERVING loop, closed: the architect (arch-gen.fk) generates a challenger architecture, trains it through the proven backward, and champion-challenger.fk flips serving authority to it ONLY when it EARNS it. A deeper challenger fits the task's targets faster (closer in fixed steps) and strictly exceeds the champion across the window; a same-architecture challenger only ties, so the served champion is protected. This is M7's infer-best-while-searching-better in full -- improve the model without ever degrading what is served now -- composing arch-gen with the existing champion-challenger cell (cc-exceeds? gates promotion strictly).",
+  "files_owned": [
+    "form/form-stdlib/arch-gen.fk",
+    "form/form-stdlib/tests/arch-champion-challenger-band.fk",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-backprop.fk form-stdlib/champion-challenger.fk form-stdlib/arch-gen.fk form-stdlib/tests/arch-champion-challenger-band.fk",
+      "cd form && ./validate.sh form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-backprop.fk form-stdlib/arch-gen.fk form-stdlib/tests/arch-gen-band.fk"
+    ],
+    "summary": "arch-champion-challenger-band -> 31 three-way (Go=Rust=TS), 0 divergent. Over three targets (5 training steps each, fit threshold 0.005), the depth-2 challenger fits all three while the depth-1 champion fits one -- trials [[0,1],[0,1],[1,1]], champ score 1, chall score 3. champion-challenger PROMOTES the earned challenger (cc-exceeds? strict + min-samples=3 -> authority 'challenger') and PROTECTS the served champion against a same-depth challenger (a tie, no strict gain -> authority 'champion', not promoted). Prior arch-gen-band unchanged -> 31. 3-KERNEL ONLY (Go=Rust=TS): composes the fp64 transformer-backward op family, not in the fourth-arm manifest -- same floor as transformer-block.fk / arch-gen.fk. Unsupported-op-family gap, not a divergence.",
+    "observed_delta": {
+      "band_verdict": 31,
+      "band_divergent": 0,
+      "trials_depth1_vs_depth2": "[[0,1],[0,1],[1,1]]",
+      "champ_score": 1,
+      "chall_score": 3,
+      "promote_deeper_challenger": 1,
+      "promote_same_depth_challenger": 0,
+      "authority_earned": "challenger",
+      "authority_tie": "champion"
+    },
+    "known_limitations": [
+      {
+        "limitation": "Promotion uses cc-exceeds? (strict) rather than the cell's default cc-promote? (match-or-exceed) because both arms are OUR architectures: a tie should not churn the served model. This is a deliberate composition choice; the cell's reaches/margin path stays available for the foreign-champion-retire case it was built for.",
+        "follow_up": "Expose a margin so near-ties within a tolerance can be configured per task."
+      },
+      {
+        "limitation": "Discrimination is by fit-speed (a deeper architecture is closer in fixed steps), proven on single-target-per-sample training. Multi-example capacity-based selection is the deeper proof but needs higher input dim: in 2-D the layernorm collapses any input to one of two normalized directions, so 2-D FFN-residual capacity does not discriminate over a dataset. At d>=4 LN preserves enough structure for a capacity gap.",
+        "follow_up": "Lift the architecture fixtures to d>=4 and train over a multi-example dataset for capacity-based champion-challenger; richer architecture spaces (mixed layer types, widths)."
+      },
+      {
+        "limitation": "3-kernel only: the fp64 transformer-backward op family is not in the fourth-arm manifest. Same floor as transformer-block.fk and arch-gen.fk. 0 divergent across Go/Rust/TS.",
+        "follow_up": "The fourth arm gains this family when the transformer bands are flattened for fkwu."
+      }
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "summary": "validate.sh runs arch-champion-challenger-band in the default suite via its preludes header; CI three-way gate applies."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "Stdlib recipe + band + milestone-map doc; no route or service change. Rides normal merge."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "New capability: the body improves its own served model by generating challenger architectures, training them, and promoting only an earned winner -- never degrading what is served now.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "validate.sh arch-champion-challenger-band (three kernels agree, verdict 31): deeper challenger fits faster, strictly exceeds, promoted; same-depth challenger ties, champion protected"
+    ],
+    "summary": "Proven three-way: the auto-ml serving loop -- generate, train, promote only the earned challenger."
+  },
+  "phase_gate": {
+    "phase": "m7-architect-serving-loop",
+    "gate": "infer-best-while-searching-better closed for architectures: the architect generates challengers, trains them, and champion-challenger promotes only an earned winner while protecting the served champion, three-way",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "richer architecture spaces (mixed types, widths); multi-example capacity selection at d>=4; the GPU as the trainer underneath the search"
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "arch-champion-challenger-20260616"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "form-os-arc"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "measurement"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/arch-gen.fk",
+    "form/form-stdlib/tests/arch-champion-challenger-band.fk",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "change_files": [
+    "form/form-stdlib/arch-gen.fk",
+    "form/form-stdlib/tests/arch-champion-challenger-band.fk",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-16_arch_champion_challenger.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/arch-gen.fk
+++ b/form/form-stdlib/arch-gen.fk
@@ -39,4 +39,25 @@
     (defn ag-best (maxd x t lr eps steps)
         (ag-best-acc 1 maxd x t lr eps steps 0 (ag-fit 0 x t lr eps steps)))
 
+    ; --- SERVE: champion-challenger over architectures. A synthesized-and-trained challenger replaces the
+    ;     served champion ONLY when it EARNS it — fitting the task's targets better (closer in fixed steps)
+    ;     across enough samples — never on a tie, so the served model is never degraded. This is M7's
+    ;     infer-best-while-searching-better: the architect generates challengers, champion-challenger.fk
+    ;     gates the promotion. (Needs champion-challenger.fk preluded: cc-exceeds?, cc-champ/chall-score.) ---
+    (defn ag-correct? (depth x t lr eps steps efit)          ; 1 if this architecture fits t within efit
+        (if (lt (ag-fit depth x t lr eps steps) efit) 1 0))
+    (defn ag-trials (cd dd x targets lr eps steps efit)      ; per-target (champ-correct chall-correct)
+        (if (eq (len targets) 0) (empty)
+            (cons (list (ag-correct? cd x (head targets) lr eps steps efit)
+                        (ag-correct? dd x (head targets) lr eps steps efit))
+                  (ag-trials cd dd x (tail targets) lr eps steps efit))))
+    ; promote the challenger architecture iff the window is long enough AND it STRICTLY exceeds the champion
+    ; (cc-exceeds? — strict, so a same-architecture challenger ties and the champion is protected).
+    (defn ag-promote? (cd dd x targets lr eps steps efit min-samples)
+        (if (and (ge (len (ag-trials cd dd x targets lr eps steps efit)) min-samples)
+                 (eq (cc-exceeds? (ag-trials cd dd x targets lr eps steps efit)) 1))
+            1 0))
+    (defn ag-authority (cd dd x targets lr eps steps efit min-samples)
+        (if (eq (ag-promote? cd dd x targets lr eps steps efit min-samples) 1) "challenger" "champion"))
+
     0)

--- a/form/form-stdlib/tests/arch-champion-challenger-band.fk
+++ b/form/form-stdlib/tests/arch-champion-challenger-band.fk
@@ -1,0 +1,34 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-backprop.fk form-stdlib/champion-challenger.fk form-stdlib/arch-gen.fk
+;
+; arch-champion-challenger-band — the auto-ml SERVING loop, three-way: the architect generates a challenger
+; architecture, trains it, and champion-challenger.fk flips serving authority to it ONLY when it EARNS it —
+; fitting the task's targets better (closer in fixed steps) across enough samples — never on a tie, so the
+; served model is never degraded. This is M7's infer-best-while-searching-better: improve the model without
+; ever degrading what is served now. Fixture: input (1.0,0.5); three targets; 5 training steps; a target
+; counts as "fit" when the architecture's loss drops below efit = 0.005; min-samples = 3.
+;
+; Verdict 31 when every claim lands:
+;   1    a DEEPER challenger fits a target the champion cannot yet (depth-2 correct, depth-1 not — capacity)
+;   2    over the window the challenger STRICTLY exceeds the champion (chall score 3 > champ score 1)
+;   4    champion-challenger PROMOTES the earned challenger (ag-promote? depth1→depth2 = 1)
+;   8    champion-challenger PROTECTS the served champion against a same-architecture challenger (no strict gain → 0)
+;   16   authority flips right: "challenger" when earned, "champion" when not
+(do
+    (let x (list 1.0 0.5))
+    (let targets (list (list 1.5 0.8) (list 0.2 1.4) (list 2.0 -0.3)))
+    (let lr 0.1)
+    (let eps 0.00001)
+    (let steps 5)
+    (let efit 0.005)
+    (let ms 3)
+    (let h (ag-trials 1 2 x targets lr eps steps efit))
+
+    (let c0 (if (eq (ag-correct? 2 x (list 1.5 0.8) lr eps steps efit) 1)
+                (if (eq (ag-correct? 1 x (list 1.5 0.8) lr eps steps efit) 0) 1 0) 0))
+    (let c1 (if (gt (cc-chall-score h) (cc-champ-score h)) 2 0))
+    (let c2 (if (eq (ag-promote? 1 2 x targets lr eps steps efit ms) 1) 4 0))
+    (let c3 (if (eq (ag-promote? 1 1 x targets lr eps steps efit ms) 0) 8 0))
+    (let c4 (if (str_eq (ag-authority 1 2 x targets lr eps steps efit ms) "challenger")
+                (if (str_eq (ag-authority 1 1 x targets lr eps steps efit ms) "champion") 16 0) 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))


### PR DESCRIPTION
## What

infer-best-while-searching-better, closed for architectures. The architect (`arch-gen.fk`) generates a challenger architecture, trains it through the proven backward, and `champion-challenger.fk` flips serving authority to it **only when it earns it**.

- a deeper challenger fits the task's targets faster (closer in 5 steps) and **strictly exceeds** the champion across the window (score 3 > 1) → authority `challenger`
- a same-architecture challenger only **ties**, so the served champion is **protected** → authority `champion`, not promoted

Composes `arch-gen` with the existing `champion-challenger` cell; `cc-exceeds?` gates promotion strictly (a tie should never churn the served model).

## Proof

`tests/arch-champion-challenger-band.fk` → **31 three-way** (Go=Rust=TS), 0 divergent. Prior `arch-gen-band` unchanged → 31. `3-kernel only` (same fp64 transformer-backward floor).

So the model improves itself **without ever degrading what it serves**.

## Next ring

Richer architecture spaces (mixed layer types, widths), multi-example capacity selection at d≥4 (in 2-D layernorm collapses inputs to two directions), the GPU as the trainer underneath the search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)