### PR TITLE
feat(form): native loop fit on real corpus beats the oracle, four-way

### DIFF
--- a/form/form-stdlib/affine-corpus-fit.fk
+++ b/form/form-stdlib/affine-corpus-fit.fk
@@ -1,0 +1,57 @@
+; affine-corpus-fit.fk — the native training loop fit on REAL corpus data,
+; evaluated against a baseline oracle. The eval layer on top of affine-train.fk.
+;
+; preludes: form-stdlib/core.fk form-stdlib/affine-train.fk
+;
+; affine-train.fk proved the LOOP learns on a clean fixture. This proves it
+; learns a REAL signal and beats a baseline: the EN->FR UI-string length
+; expansion in the body's own i18n corpus (web/messages/{en,fr}.json — the real
+; ~1.17x expansion). A handful of real (en_len, fr_len) pairs, feature-scaled by
+; 50 so the proven scale-1000 aff-step conditions cleanly (raw lengths 8..44
+; would either diverge or truncation-collapse — the classic fixed-point
+; conditioning the scale-1000 atom is tuned for), train an affine model; the
+; learned model is then scored against held-out real pairs and compared to a
+; predict-the-mean oracle. These counts are exactly the native-training-receipt
+; eval fields (sample / heldout / correct / wrong), computed natively, never
+; asserted by configuration.
+;
+; The oracle is the train-set mean predictor — the honest "no learning" baseline
+; (lc-sense-organ-ripening: a sense earns native authority only by beating the
+; teacher/baseline on held-out data, not by being declared). Scale 1000; div
+; truncates toward zero.
+;
+; Proven by: form-stdlib/tests/affine-corpus-fit-band.fk
+
+; a native prediction is a HIT when |pred - y| <= tol (tolerance in scaled units)
+(defn acf-native-hit (w b x y tol)
+    (if (ge tol (abs (sub (aff-pred w b x) y))) 1 0))
+
+; the oracle predicts a constant m (the train mean); same tolerance gate
+(defn acf-oracle-hit (m x y tol)
+    (if (ge tol (abs (sub m y))) 1 0))
+
+; count native hits over a held-out corpus (fold) — the receipt's correct-count
+(defn acf-native-correct (s held tol)
+    (if (eq (len held) 0)
+        0
+        (add
+            (acf-native-hit (aff-w s) (aff-b s) (nth (head held) 0) (nth (head held) 1) tol)
+            (acf-native-correct s (tail held) tol))))
+
+; count oracle hits over the same held-out corpus (fold)
+(defn acf-oracle-correct (m held tol)
+    (if (eq (len held) 0)
+        0
+        (add
+            (acf-oracle-hit m (nth (head held) 0) (nth (head held) 1) tol)
+            (acf-oracle-correct m (tail held) tol))))
+
+; sum of targets over a corpus (fold) — for the mean-predictor oracle
+(defn acf-sum-y (corpus)
+    (if (eq (len corpus) 0)
+        0
+        (add (nth (head corpus) 1) (acf-sum-y (tail corpus)))))
+
+; the oracle predictor = mean target over the training corpus
+(defn acf-mean-y (corpus)
+    (div (acf-sum-y corpus) (len corpus)))

--- a/form/form-stdlib/tests/affine-corpus-fit-band.fk
+++ b/form/form-stdlib/tests/affine-corpus-fit-band.fk
@@ -1,0 +1,47 @@
+; preludes: form-stdlib/core.fk form-stdlib/affine-train.fk form-stdlib/affine-corpus-fit.fk
+;
+; affine-corpus-fit-band — the native training loop, fit on REAL i18n corpus
+; data, beats a predict-the-mean oracle on REAL held-out pairs, four-way.
+;
+; Fixture: EN->FR UI-string length pairs from web/messages/{en,fr}.json, feature
+; -scaled by 50 (raw en_len -> *50) so the proven scale-1000 aff-step conditions
+; cleanly. Five real training pairs and three real held-out pairs (genuinely
+; translated, expansion 1.10..1.30 — the real signal):
+;   train (en,fr): (8,9) (19,23) (27,35) (35,43) (44,54)
+;   held  (en,fr): (9,10) (28,31) (44,50)
+; lr=3, 40 epochs, tolerance 50 (= 1.0 character). Verified against an integer
+; reference (truncate-toward-zero) before authoring:
+;   start corpus loss = 16500000   after training = 165992   w = 1116 (1.116x), b = 640
+;   native correct = 3/3 (all held-out within 1 char)   oracle (mean=1640) correct = 0/3
+;
+; Verdict 31 when every claim lands:
+;   1   training reduced corpus loss on REAL data        (loss_after < loss_start)
+;   2   the native model hits all 3 real held-out pairs  (native-correct = 3)
+;   4   the predict-mean oracle hits none                (oracle-correct = 0)
+;   8   the native sense BEATS the oracle on held-out    (native-correct > oracle-correct)
+;   16  the model learned the real ~1.17x slope          (1000 < w < 1300)
+(do
+    (let train (list (list 400 450) (list 950 1150) (list 1350 1750) (list 1750 2150) (list 2200 2700)))
+    (let held  (list (list 450 500) (list 1400 1550) (list 2200 2500)))
+    (let lr 3)
+    (let tol 50)
+
+    (let s0 (list 0 0))
+    (let sT (aff-train s0 train lr 40))
+
+    (let mean (acf-mean-y train))
+    (let nc (acf-native-correct sT held tol))
+    (let oc (acf-oracle-correct mean held tol))
+
+    ; 1 — training reduced the corpus loss on real data
+    (let c0 (if (lt (aff-corpus-loss sT train) (aff-corpus-loss s0 train)) 1 0))
+    ; 2 — the native model hits all three real held-out pairs within 1 char
+    (let c1 (if (eq nc 3) 2 0))
+    ; 4 — the predict-mean oracle hits none of them
+    (let c2 (if (eq oc 0) 4 0))
+    ; 8 — the native sense beats the oracle on real held-out data
+    (let c3 (if (gt nc oc) 8 0))
+    ; 16 — the learned slope is the real expansion (~1.1..1.3), not noise
+    (let c4 (if (if (gt (aff-w sT) 1000) (lt (aff-w sT) 1300) 0) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -161,6 +161,7 @@ io-match fks 127
 training-catalog fks 31
 form-train-step fks 31
 affine-train fks 31
+affine-corpus-fit fks 31
 form-cli-loop fks 31
 form-cli-router fks 31
 obs-verify fks 31


### PR DESCRIPTION
Follow-on to the first native training loop (#3202). That proved the loop *learns* on a clean fixture; this proves it learns a **real signal and beats a baseline** — on the body's own data.

The i18n corpus (`web/messages/en+fr.json`) carries a real EN→FR length expansion (~1.17×). Five real training pairs + three real held-out pairs, **feature-scaled by 50** so the proven scale-1000 `aff-step` conditions cleanly (one engine, no parallel path — just normalized data), train an affine model.

`affine-corpus-fit.fk` adds the eval layer (native/oracle tolerance gates + correct-count folds = the `native-training-receipt` eval fields, computed natively). **`affine-corpus-fit-band.fk` → 31 four-way, 0 divergent**:
- training cut corpus loss 16,500,000 → 165,992
- learned model (w = 1.116×) hits **all 3** real held-out within 1 char
- predict-mean oracle hits **none**
- native **beats** oracle; learned slope is the real ~1.17×

Verified against an integer reference before authoring. North star: `lc-sense-organ-ripening` — a sense earns native authority only by beating the baseline on held-out data. Smallest honest instance, on real body data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)