### PR TITLE
tend: capacity-based architecture search at d=4 — the architect discovers the width a task needs

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -400,9 +400,15 @@
 ;   champion-challenger.fk flips authority to it ("challenger"); a same-architecture challenger only TIES, so
 ;   the served champion is protected ("champion", not promoted). This is M7's infer-best-while-searching-better
 ;   in full: generate challenger architectures, train them, promote only the earned winner — improving the
-;   model without ever degrading what is served now. Next ring: richer architecture spaces (mixed layer types,
-;   widths, attention vs ffn per task), multi-example capacity selection at higher dim (LN collapses 2-D inputs
-;   to two directions), and the GPU as the trainer underneath the search.
+;   model without ever degrading what is served now. And CAPACITY-based search is now proven at d=4
+;   [arch-capacity-band.fk → 31 three-way]: the architect generates layers of configurable WIDTH, trains each
+;   over a 4-example DATASET (multi-example, not one target), and discovers the smallest width that fits — a
+;   width-1 FFN-residual UNDERFITS the dataset (total loss 5.65, one gelu unit is not enough), width-2 fits
+;   (loss → 0), and ac-min-width crowns 2. This is the proof 2-D could not give (in 2-D layernorm collapses
+;   any input to one of two directions, so width does not discriminate; at d=4 it does). So the body now
+;   discovers BOTH the depth and the width a task needs, trains them, and promotes only the earned architecture.
+;   Next ring: richer architecture spaces (mixed layer types, attention vs ffn per task), and the GPU as the
+;   trainer underneath the search.
 ;
 ; KIN: numeric-formats.canonical.json (the 19 formats + conformance) · cell-numerics.form / cosine.form
 ;   (the layer math) · attention.fk + embedding-as-recipe.fk (content-addressed attention) ·

--- a/docs/system_audit/commit_evidence_2026-06-16_arch_capacity.json
+++ b/docs/system_audit/commit_evidence_2026-06-16_arch_capacity.json
@@ -1,0 +1,110 @@
+{
+  "date": "2026-06-16",
+  "thread_branch": "claude/arch-capacity",
+  "commit_scope": "Capacity-based architecture search at d=4: the architect generates layers of configurable WIDTH, trains each over a multi-example DATASET, and discovers the smallest width that fits. arch-capacity.fk adds deterministic pseudo-random weight generators (fractional part of seed*12.9898, no RNG needed), width-H FFN-residual layers at any dim, multi-example training (one epoch = a stack-step per (x,t)), and ac-min-width which crowns the minimal fitting width. This closes the limitation named in the prior PR: in 2-D layernorm collapses any input to one of two normalized directions, so width cannot discriminate over a dataset; at d=4 it does. The body now discovers BOTH depth (arch-gen) and width (this) a task needs.",
+  "files_owned": [
+    "form/form-stdlib/arch-capacity.fk",
+    "form/form-stdlib/tests/arch-capacity-band.fk",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-backprop.fk form-stdlib/arch-capacity.fk form-stdlib/tests/arch-capacity-band.fk"
+    ],
+    "summary": "arch-capacity-band -> 31 three-way (Go=Rust=TS), 0 divergent. On a d=4 dataset of 4 examples (targets are the input reversed, lr 0.05, 150 epochs): a width-1 FFN-residual UNDERFITS (total loss 5.65 -- one gelu unit cannot represent four distinct input->target maps), width-2 FITS (total loss -> 0), width-4 also fits, and ac-min-width crowns the minimal fitting width 2. A d=4 width-2 layer's forward is deterministic (y[0]=2.026539). 3-KERNEL ONLY (Go=Rust=TS): composes the fp64 transformer-backward op family (with floor for the deterministic weight gen), not in the fourth-arm manifest -- same floor as transformer-block.fk / arch-gen.fk. Unsupported-op-family gap, not a divergence.",
+    "observed_delta": {
+      "band_verdict": 31,
+      "band_divergent": 0,
+      "width1_dataset_loss": "5.65 (underfits)",
+      "width2_dataset_loss": "~0 (fits)",
+      "width4_dataset_loss": "~0 (fits)",
+      "architect_crowned_min_width": 2,
+      "dim": 4,
+      "dataset_size": 4
+    },
+    "known_limitations": [
+      {
+        "limitation": "Capacity search here varies WIDTH of a single FFN-residual layer; arch-gen varies DEPTH. The full architecture space (width x depth x layer type x attention-vs-ffn per slot) is the richer search, the same generate-then-search shape over a wider config vocabulary.",
+        "follow_up": "Generate over the joint (depth, width, type) space; mixed attention/ffn stacks per task."
+      },
+      {
+        "limitation": "Weights are deterministic (no RNG): a pseudo-random float per seed via the fractional part of seed*12.9898. This makes the band bit-stable three-way but the capacity comparison is on one fixed init.",
+        "follow_up": "Sample inits when a host RNG carrier is wired; until then deterministic seeds keep the proof bit-stable."
+      },
+      {
+        "limitation": "3-kernel only: the fp64 transformer-backward op family (plus floor) is not in the fourth-arm manifest. Same floor as transformer-block.fk, arch-gen.fk. 0 divergent across Go/Rust/TS.",
+        "follow_up": "The fourth arm gains this family when the transformer bands are flattened for fkwu."
+      }
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "summary": "validate.sh runs arch-capacity-band in the default suite via its preludes header; CI three-way gate applies."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "Stdlib recipe + band + milestone-map doc; no route or service change. Rides normal merge."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "New capability: the body discovers the WIDTH (capacity) a task needs -- it generates width-configurable layers, trains each over a dataset, and crowns the smallest that fits, rejecting widths that underfit.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "validate.sh arch-capacity-band (three kernels agree, verdict 31): width-1 underfits a d=4 dataset, width-2 fits, the architect crowns minimal width 2"
+    ],
+    "summary": "Proven three-way: capacity-based architecture search -- the body finds the width a dataset needs."
+  },
+  "phase_gate": {
+    "phase": "m7-architect-capacity",
+    "gate": "the architect discovers WIDTH as well as depth: at d=4, width-1 underfits a multi-example dataset, width-2 fits, and ac-min-width crowns the minimal fitting width -- capacity-based NAS, three-way",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "joint (depth, width, type) architecture space; mixed attention/ffn stacks; the GPU as the trainer underneath the search"
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "arch-capacity-20260616"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "form-os-arc"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "measurement"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/arch-capacity.fk",
+    "form/form-stdlib/tests/arch-capacity-band.fk",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "change_files": [
+    "form/form-stdlib/arch-capacity.fk",
+    "form/form-stdlib/tests/arch-capacity-band.fk",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-16_arch_capacity.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/arch-capacity.fk
+++ b/form/form-stdlib/arch-capacity.fk
@@ -1,0 +1,53 @@
+; arch-capacity.fk — capacity-based architecture search: at d ≥ 4 (where layernorm keeps enough structure),
+; a dataset of several examples needs ENOUGH hidden width to fit. A narrow FFN-residual layer underfits the
+; dataset; a wider one fits it. The architect generates layers of configurable WIDTH, trains each over the
+; whole dataset (multi-example), and discovers the smallest width that fits — capacity discovered, not assumed.
+;
+; This is the deeper proof the 2-D fixtures could not give: in 2-D, layernorm collapses any input to one of
+; two normalized directions, so width does not discriminate over a dataset. At d=4 it does.
+;
+; Weights are deterministic (the kernel has no RNG): a pseudo-random float per (seed) via the fractional part
+; of seed·12.9898, in [-0.15, 0.15) — distinct so hidden units are not redundant, reproducible so the band is
+; bit-stable three-way. A width-H FFN-residual layer at dim d: W1 is H×d, b1 is H, W2 is d×H, b2 is d.
+;
+; Preludes: transformer-numerics.fk transformer-block.fk transformer-backprop.fk
+; Proven by: form-stdlib/tests/arch-capacity-band.fk
+
+(do
+    ; --- deterministic pseudo-random float weights ---
+    (defn ac-frac (x) (sub x (floor x)))
+    (defn ac-w (seed) (mul (sub (ac-frac (mul seed 12.9898)) 0.5) 0.3))      ; in [-0.15, 0.15)
+    (defn ac-row (n seed) (if (eq n 0) (empty) (cons (ac-w seed) (ac-row (sub n 1) (add seed 1.7)))))
+    (defn ac-mat (rows cols seed)
+        (if (eq rows 0) (empty) (cons (ac-row cols seed) (ac-mat (sub rows 1) cols (add seed 7.3)))))
+
+    ; --- a width-H FFN-residual layer at dim d (an "ffn" layer-cell the stack engine trains). ---
+    (defn ac-ffn-layer (d h seed)
+        (list "ffn" (ac-mat h d seed) (tb-zeros h) (ac-mat d h (add seed 100.0)) (tb-zeros d)))
+    (defn ac-arch (d h seed) (list (ac-ffn-layer d h seed)))                  ; a one-layer arch of width H
+
+    ; --- MULTI-EXAMPLE training: one epoch = one stack-step per (x,t) in the dataset; train E epochs. ---
+    (defn ac-epoch (layers data lr eps)
+        (if (eq (len data) 0) layers
+            (ac-epoch (tbp-stk-step layers (nth (head data) 0) (nth (head data) 1) lr eps)
+                      (tail data) lr eps)))
+    (defn ac-train (layers data lr eps epochs)
+        (if (eq epochs 0) layers (ac-train (ac-epoch layers data lr eps) data lr eps (sub epochs 1))))
+    (defn ac-set-loss (layers data eps)
+        (if (eq (len data) 0) 0.0
+            (add (tbp-stk-loss layers (nth (head data) 0) (nth (head data) 1) eps)
+                 (ac-set-loss layers (tail data) eps))))
+
+    ; --- the architect's capacity fitness: total dataset loss after training a width-H arch. ---
+    (defn ac-fit (d h seed data lr eps epochs)
+        (ac-set-loss (ac-train (ac-arch d h seed) data lr eps epochs) data eps))
+
+    ; --- crown the smallest width (1..maxh) whose trained dataset loss clears a fit threshold. ---
+    (defn ac-min-width-acc (h maxh d seed data lr eps epochs efit)
+        (if (gt h maxh) 0
+            (if (lt (ac-fit d h seed data lr eps epochs) efit) h
+                (ac-min-width-acc (add h 1) maxh d seed data lr eps epochs efit))))
+    (defn ac-min-width (maxh d seed data lr eps epochs efit)
+        (ac-min-width-acc 1 maxh d seed data lr eps epochs efit))
+
+    0)

--- a/form/form-stdlib/tests/arch-capacity-band.fk
+++ b/form/form-stdlib/tests/arch-capacity-band.fk
@@ -1,0 +1,40 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-backprop.fk form-stdlib/arch-capacity.fk
+;
+; arch-capacity-band — capacity-based architecture search, three-way: at d=4 (where layernorm keeps enough
+; structure), a 4-example dataset needs ENOUGH hidden width. A width-1 FFN-residual layer UNDERFITS the
+; dataset (it cannot represent four distinct input→target maps with one gelu unit); a width-2+ layer FITS.
+; The architect trains each width over the whole dataset (multi-example) and discovers the smallest width
+; that fits — capacity discovered, not assumed. This is the proof 2-D could not give: in 2-D layernorm
+; collapses any input to one of two directions, so width does not discriminate; at d=4 it does.
+; Dataset: four d=4 inputs, each target the input reversed (a demanding per-example map). lr 0.05, 150 epochs.
+;
+; Verdict 31 when every claim lands:
+;   1    a d=4 width-2 layer's forward is deterministic: y[0] → 2026539 (×1e6)
+;   2    capacity MATTERS: width 1 UNDERFITS the dataset (total loss > 0.5 — one gelu unit is not enough)
+;   4    width 2 FITS the dataset (total loss < 0.001)
+;   8    the architect discovers the MINIMAL fitting width: ac-min-width(maxh=4) = 2 (not 1, which underfits)
+;   16   a wider width (4) also fits (total loss < 0.001) — capacity sufficient, the search confirms it
+(do
+    (let data (list (list (list 2.0 1.0 0.0 0.0) (list 0.0 0.0 1.0 2.0))
+                    (list (list 0.0 2.0 1.0 0.0) (list 0.0 1.0 2.0 0.0))
+                    (list (list 0.0 0.0 2.0 1.0) (list 1.0 2.0 0.0 0.0))
+                    (list (list 1.0 0.0 0.0 2.0) (list 2.0 0.0 0.0 1.0))))
+    (let seed 0.3)
+    (let lr 0.05)
+    (let eps 0.00001)
+    (let epochs 150)
+    (let efit 0.001)
+
+    (let y0   (tbp-stk-fwd (ac-arch 4 2 seed) (list 2.0 1.0 0.0 0.0) eps))
+    (let l1   (ac-fit 4 1 seed data lr eps epochs))
+    (let l2   (ac-fit 4 2 seed data lr eps epochs))
+    (let l4   (ac-fit 4 4 seed data lr eps epochs))
+    (let minw (ac-min-width 4 4 seed data lr eps epochs efit))
+
+    (let c0 (if (eq (round (mul (nth y0 0) 1000000.0)) 2026539) 1 0))
+    (let c1 (if (gt l1 0.5) 2 0))
+    (let c2 (if (lt l2 0.001) 4 0))
+    (let c3 (if (eq minw 2) 8 0))
+    (let c4 (if (lt l4 0.001) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))


### PR DESCRIPTION
## What

The deeper proof 2-D could not give. `arch-capacity.fk` generates layers of configurable **width**, trains each over a multi-example **dataset**, and discovers the smallest width that fits.

On a d=4 dataset of 4 examples (targets = input reversed): width-1 FFN-residual **underfits** (total loss 5.65 — one gelu unit can't represent four distinct maps), width-2 **fits** (loss → 0), and `ac-min-width` crowns the minimal fitting width **2**.

Closes the limitation named in [#3204](https://github.com/seeker71/Coherence-Network/pull/3204): in 2-D, layernorm collapses any input to one of two directions, so width can't discriminate; at d=4 it does. The body now discovers **both depth and width** a task needs.

## Proof

`tests/arch-capacity-band.fk` → **31 three-way** (Go=Rust=TS), 0 divergent. `3-kernel only` (same fp64 transformer-backward floor).

## Next ring

Joint (depth, width, type) architecture space, mixed attention/ffn stacks, the GPU as the trainer underneath the search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)