### PR TITLE
tend(catalog): git (message→diff) pairs feed the training catalog on every merge

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 250 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 251 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 250
+**Total files**: 251
 
 | File | Purpose |
 |---|---|
@@ -108,6 +108,7 @@
 | [ghx.sh](ghx.sh) | _no top-of-file purpose_ |
 | [git_artifact_perceptron.py](git_artifact_perceptron.py) | git_artifact_perceptron.py — the smallest real version of the form perceptron. |
 | [git_artifact_perceptron_substrate.py](git_artifact_perceptron_substrate.py) | git_artifact_perceptron_substrate.py — the substrate-native perceptron. |
+| [git_training_corpus.py](git_training_corpus.py) | Feed git (commit message -> diff) pairs into the form-cli training catalog. |
 | [grammar_coverage.py](grammar_coverage.py) | grammar_coverage.py — surface which file formats have Form grammars. |
 | [grounded_cost_endpoint_probe.py](grounded_cost_endpoint_probe.py) | Focused end-to-end probe for /api/utils/grounded_cost. |
 | [guided_somatic_exit.py](guided_somatic_exit.py) | Guided Somatic Exit — daily practice for walking out of the fear-pattern loop. |

--- a/scripts/git_training_corpus.py
+++ b/scripts/git_training_corpus.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Feed git (commit message -> diff) pairs into the form-cli training catalog.
+
+Each merged commit is a labeled (intent -> code) training pair: the message is the
+intent, the diff is the realization, the label is `merged` (passed review + CI; for
+.fk/.form commits, four-way at merge time). The pair-shape, the three separable
+lanes (raw / transmute / reasoning), and content-addressing live in
+form-stdlib/training-catalog.fk; this is the host-IO bootstrap carrier that sources
+git into the existing catalog_capture on the `git-commit-to-diff` lane. North star:
+the kernel reads git itself via a host-io source-scan recipe (a named frontier wall
+in form/fourth-arm-bands.txt) — this carrier composts when that lands.
+
+Usage:
+  git_training_corpus.py --range ORIG_HEAD..HEAD   # post-merge: just-landed commits
+  git_training_corpus.py --backfill 200            # manual: last N .fk/.form commits
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "mcp-server"))
+from coherence_mcp_server.form_cli_tools import catalog_capture  # noqa: E402
+
+LANE = "git-commit-to-diff"
+MAX_DIFF = 8000  # bound each record; the full diff always lives in git
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(["git", *args], capture_output=True, text=True).stdout
+
+
+def _commits(range_spec: str | None, backfill: int | None) -> list[str]:
+    if backfill:
+        return _git("log", "--format=%H", "-n", str(backfill), "--", "*.fk", "*.form").split()
+    if range_spec:
+        return _git("log", "--format=%H", range_spec, "--", "*.fk", "*.form").split()
+    return []
+
+
+def feed(commits: list[str]) -> int:
+    fed = 0
+    for sha in commits:
+        msg = _git("show", "-s", "--format=%s%n%n%b", sha).strip()
+        diff = _git("show", sha, "--format=", "--unified=3")[:MAX_DIFF]
+        if not msg or not diff.strip():
+            continue
+        # request = intent, raw = transmuted = diff (merged code is the trusted
+        # realization — no fear to transmute), lane + outcome carry the label.
+        catalog_capture(msg, diff, diff, LANE, "merged")
+        fed += 1
+    return fed
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--range", dest="range_spec", default=None,
+                    help="git range of just-merged commits, e.g. ORIG_HEAD..HEAD")
+    ap.add_argument("--backfill", type=int, default=None,
+                    help="manual backfill: last N .fk/.form commits")
+    args = ap.parse_args()
+    fed = feed(_commits(args.range_spec, args.backfill))
+    print(f"[catalog] {LANE}: fed {fed} (intent->code) pairs")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/substrate_post_merge_hook.sh
+++ b/scripts/substrate_post_merge_hook.sh
@@ -73,6 +73,16 @@ if [ -n "$CHANGED_VOCAB" ]; then
     python3 scripts/sync_substrate_vocabulary.py
 fi
 
+# Git (message -> diff -> merged) pairs -> the form-cli training catalog's
+# commit-to-diff lane. Every merge teaches the english->code memory, labeled by
+# the merge itself (review + CI; four-way for .fk/.form). Pair-shape lives in
+# form-stdlib/training-catalog.fk; git_training_corpus.py is the host-IO bootstrap
+# carrier until the kernel reads git natively. Never fail the merge over it.
+if git diff --name-only "$RANGE" -- '*.fk' '*.form' 2>/dev/null | grep -q .; then
+    echo "[catalog] feeding git (message->diff) pairs from $RANGE:"
+    python3 scripts/git_training_corpus.py --range "$RANGE" || true
+fi
+
 CHANGED=$(printf "%s\n%s" "$CHANGED_MD" "$CHANGED_CODE" | sed '/^$/d')
 
 if [ -z "$CHANGED" ]; then


### PR DESCRIPTION
Makes the git→catalog wire **stand** — durable, event-driven, at the merge moment.

Two turns ago I fed 120 git `(intent → code)` pairs into the training catalog by hand. This wires that into `scripts/substrate_post_merge_hook.sh` so it keeps happening: every merge to main, the hook walks the just-landed `.fk`/`.form` commits and feeds `(message → diff → merged)` pairs to the catalog's `git-commit-to-diff` lane. The english→code memory grows itself, labeled by the merge (review + CI; four-way for `.fk`/`.form`).

- **`scripts/git_training_corpus.py`** — thin host-IO carrier; `--range ORIG_HEAD..HEAD` (post-merge) or `--backfill N` (manual history). Pair-shape + the three separable lanes + content-addressing live in `form-stdlib/training-catalog.fk`; this sources git into the existing `catalog_capture`. Composts when the kernel reads git natively (host-io source-scan frontier).
- **`substrate_post_merge_hook.sh`** — one guarded block (`|| true` — never fails the merge over corpus growth).

**Verified:** hook `bash -n` clean; carrier fed 3 pairs from a real range; INDEX + MANIFEST edges in the same commit.

Scoped deliberately to the **data wire** — the predictor that trains on this lane is a sibling's (codex) active work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)