### PR TITLE
The architect's capacity search runs on Metal — real candidates timed on the silicon

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 253 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 254 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -112,9 +112,9 @@
 ;     (ΔW within fp32 epsilon — GPU FMA vs CPU split-mul). The fp64 recipe is the proven algorithm; the
 ;     fp32 MSL is its GPU carrier, conformance-gated in the lane's own semantics. The learning kernel runs
 ;     on the silicon — host-kernel.form's "drive the organ" realized for backprop.
-;     AND NOW THE ARCHITECT'S WHOLE LAYER TRAINS ON METAL, not just one affine. jit-tensor-emit.fk emits
-;     jte-mlp-train-msl — the FFN training step y = W2·gelu(W1·x + b1) + b2 (tbp-mlp-step, the exact block
-;     ac-ffn-layer builds) as ONE Metal kernel run by a single threadgroup with barriered phases. The
+;     AND NOW THE FFN CORE TRAINS ON METAL, not just one affine. jit-tensor-emit.fk emits
+;     jte-mlp-train-msl — the FFN-core training step y = W2·gelu(W1·x + b1) + b2 (tbp-mlp-step, the two-layer
+;     MLP inside the architect's block) as ONE Metal kernel run by a single threadgroup with barriered phases. The
 ;     transcendental is the recipe's OWN: the kernel's gelu/gelu' compose from fexp (tn-exp's 14-term
 ;     square-and-reduce Taylor) and ftanh ((e^2x-1)/(e^2x+1)), so the GPU walks transformer-numerics.fk's
 ;     approximation, never Metal's tanh(). The two forward matvecs carry tb-dot's downward right-fold; the
@@ -126,8 +126,20 @@
 ;     params): loss 46.26 → 5.9e-16 in 25 steps at 0.40 ms/step, the GPU weights matching an fp32 CPU mirror
 ;     of the same phases to max|ΔW|=6.1e-6 — within fp32 epsilon (the recipe's exp squares a Taylor value up
 ;     to k times, so a 1-ULP divide difference is amplified by the squaring, not a wrong fold). The fp64
-;     recipe is the proven algorithm; the fp32 MSL is its GPU carrier. The architect's layer learns on the
-;     silicon — the GPU is now the trainer underneath the search, the ring named at the bottom of this file.
+;     recipe is the proven algorithm; the fp32 MSL is its GPU carrier.
+;     AND THE ARCHITECT'S CAPACITY SEARCH NOW RUNS ON THE SILICON. jte-resid-train-msl emits the architect's
+;     ACTUAL layer — the pre-LN residual block y = h + (W2·gelu(W1·LN(h)+b1)+b2), tbp-stk-step on one "ffn"
+;     layer, exactly what ac-ffn-layer builds and ac-train trains. It is the FFN-core kernel wrapped with the
+;     two pieces the residual block adds: a pre-LN of the input (z = LN(h) by thread 0, tn-mean/tn-var/tn-sqrt's
+;     exact folds — biased variance, eps inside a 50-iteration Newton sqrt) and the residual highway (y = h+ffn,
+;     so gy = 2(y-t) flows straight to the FFN as gout); the FFN reads z and the W1 update uses z. Byte-stable
+;     three-way: tests/resid-train-emit-band.fk → 7. LIVE WITNESS scripts/metal_arch_search_audit.sh runs
+;     arch-capacity.fk's ac-min-width ON THE GPU: on the d=4 reversal dataset it trains each candidate width
+;     (1..4) over the dataset on the M4 Max and crowns the smallest that fits — width 1 underfits (loss 7.6),
+;     width 2 fits (loss 4.8e-7), crown = 2. THREE executions, ONE crown: the fp64 Form recipe ac-min-width
+;     (arch-capacity-band → 31), the fp32 GPU, and the fp32 CPU mirror all crown width 2 — the architect timing
+;     real candidates on the silicon, capacity discovered, not assumed. The huge underfit gap makes the crown
+;     robust to fp32. The architect's layer learns on the silicon and the search now runs there too.
 ;     autodiff-gradient-cell now returns 4095 four-way: a bounded scalar affine prediction/loss recipe
 ;     emits weight and bias gradient cells, and those gradients feed optimizer-step's SGD receipt.
 ;     adam-step-cell now returns 4095 four-way: bounded fixed-point first/second moment rows, integer
@@ -443,11 +455,16 @@
 ;   attention (its bias fits fast); under a LOOSE budget on a capacity task, crowns the wide ffn (the narrow
 ;   underfits, the wrong-bias attention lags). One engine, task-adaptive — the (depth × width × type) grid is
 ;   just the candidate list. Core-lift: three special-purpose searchers fold into one generic recipe. And the
-;   GPU is now the trainer underneath the search: jte-mlp-train-msl emits the architect's FFN training step
-;   (tbp-mlp-step, the ac-ffn-layer block) as one Metal kernel — scripts/metal_ffn_audit.sh trains a 197k-param
-;   FFN on the M4 Max, loss 46→6e-16 at 0.40 ms/step, the GPU weights within fp32 epsilon of the recipe's own
-;   exp/tanh on the CPU (tests/mlp-train-emit-band.fk → 7, three-way). Next ring: the search calling the GPU
-;   trainer directly — the architect timing real candidates on the silicon, not just the CPU recipe.
+;   GPU is now the trainer underneath the search: jte-mlp-train-msl emits the FFN-core training step
+;   (tbp-mlp-step) and jte-resid-train-msl the architect's ACTUAL layer (the pre-LN residual block ac-ffn-layer
+;   builds) as Metal kernels — scripts/metal_ffn_audit.sh trains a 197k-param FFN on the M4 Max (loss 46→6e-16
+;   at 0.40 ms/step, within fp32 epsilon of the recipe's own exp/tanh), and scripts/metal_arch_search_audit.sh
+;   runs the architect's capacity search ON the GPU: it trains each width over the d=4 reversal dataset and
+;   crowns width 2 — the SAME crown the fp64 Form recipe ac-min-width (arch-capacity-band → 31) and the fp32 CPU
+;   mirror reach. Three executions, one crown; tests/mlp-train-emit-band.fk + tests/resid-train-emit-band.fk → 7
+;   three-way. The search now times real candidates on the silicon. Next ring: the GPU search over the FULL
+;   (depth × width × type) grid — attention candidates trained on the GPU too, so every arm of arch-search the
+;   silicon can fit is timed there.
 ;
 ; KIN: numeric-formats.canonical.json (the 19 formats + conformance) · cell-numerics.form / cosine.form
 ;   (the layer math) · attention.fk + embedding-as-recipe.fk (content-addressed attention) ·

--- a/docs/system_audit/commit_evidence_2026-06-16_metal_arch_search.json
+++ b/docs/system_audit/commit_evidence_2026-06-16_metal_arch_search.json
@@ -1,0 +1,122 @@
+{
+  "date": "2026-06-16",
+  "thread_branch": "claude/gpu-arch-search",
+  "commit_scope": "The architect's capacity search now runs on the silicon. jit-tensor-emit.fk gains jte-resid-train-msl, a Form recipe that emits the architect's ACTUAL layer -- the pre-LN residual block y = h + (W2*gelu(W1*LN(h)+b1)+b2), tbp-stk-step on one 'ffn' layer, exactly what ac-ffn-layer builds and ac-train trains -- as one Metal kernel (the FFN-core kernel wrapped with a pre-LN of the input and the residual highway). scripts/metal_arch_search_audit.sh runs arch-capacity.fk's ac-min-width ON the GPU: it trains each candidate width over the d=4 reversal dataset on the M4 Max and crowns the smallest that fits. This also corrects the #3218 scope: that kernel (jte-mlp-train-msl) trains the FFN CORE (tbp-mlp-step), the two-layer MLP inside the architect's block; this one trains the residual block the architect actually builds.",
+  "files_owned": [
+    "form/form-stdlib/jit-tensor-emit.fk",
+    "form/form-stdlib/tests/resid-train-emit-band.fk",
+    "scripts/metal_arch_search_audit.sh"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/jit-tensor-emit.fk form-stdlib/tests/resid-train-emit-band.fk",
+      "cd form && ./validate.sh form-stdlib/tests/arch-capacity-band.fk",
+      "scripts/metal_arch_search_audit.sh"
+    ],
+    "summary": "resid-train-emit-band -> 7 three-way (Go=Rust=TS), 0 divergent: the residual-block training-step emitter is byte-identical across kernels (3167-byte canonical MSL), name-parameterized, deterministic. The FFN-core emitter (mlp-train-emit-band) and the affine sibling stay green (the helpers fexp/ftanh/fgelu/fgelud are shared, unchanged). LIVE GPU WITNESS scripts/metal_arch_search_audit.sh on this M4 Max: emits the residual-block kernel, then runs arch-capacity's ac-min-width search ON the GPU over the d=4 reversal dataset (4 examples, target = input reversed, lr 0.05, 150 epochs, efit 0.001). THREE executions, ONE crown -- the fp64 Form recipe ac-min-width (arch-capacity-band -> 31, crowns 2), the fp32 GPU, and the fp32 CPU mirror all crown WIDTH 2: width 1 underfits (GPU loss 7.59, CPU 7.12, both >> efit), width 2 fits (GPU 4.8e-7, CPU 4.8e-7), widths 3/4 also fit. Weights start from ac-w computed in fp64 and narrowed to fp32 so the GPU and the recipe begin from the same point. 3-KERNEL ONLY (Go=Rust=TS): gated alongside the fp64 transformer op family; the Metal/Swift witness is Darwin+swiftc only (soft-skips elsewhere).",
+    "observed_delta": {
+      "band_verdict": 7,
+      "band_divergent": 0,
+      "emitted_msl_bytes": 3167,
+      "dataset": "d=4 reversal, 4 examples, 150 epochs",
+      "width1_gpu_loss": 7.59,
+      "width2_gpu_loss": 4.8e-7,
+      "crown_recipe_fp64": 2,
+      "crown_gpu_fp32": 2,
+      "crown_cpu_fp32": 2
+    },
+    "known_limitations": [
+      {
+        "limitation": "The width-1 GPU loss (7.59) and CPU loss (7.12) differ by ~7% because the underfit trajectory is sensitive to fp32 rounding; this does NOT affect the crown -- both are >> efit (0.001), so both correctly reject width 1, and the fitting widths agree to ~6 sig figs (width 4: 0.000062784 vs 0.000062783). The discrimination gap (underfit 7.x vs fit 1e-7) is large enough that fp32 cannot flip the crown.",
+        "follow_up": "None needed; the crown is the discrete output and it is robust. A tighter fp32 reduction would narrow the underfit-trajectory gap but does not change the result."
+      },
+      {
+        "limitation": "Single threadgroup (barriered phases over device-memory scratch), so per-layer width is bounded by max threads per threadgroup (1024 here) for the wider of {hid, d}. The layernorm phase 0 runs on thread 0 (d is small in the architect's blocks). Larger widths/dims want a multi-threadgroup variant.",
+        "follow_up": "A multi-threadgroup reduction for the LN, the dh1 column sum, and the matvecs when hid/d exceed one group."
+      },
+      {
+        "limitation": "The search loop (train each width, crown minimal-that-fits) lives in the Swift carrier, mirroring ac-min-width; the crowning DECISION matches the fp64 Form recipe (ac-min-width via arch-capacity-band), but the loop itself is host code, not a Form recipe driving Metal. The GPU is the trainer; the search orchestration is the carrier.",
+        "follow_up": "Attention candidates trained on the GPU too (the full depth x width x type grid timed on the silicon), and a tighter Form-to-carrier handoff for the search loop."
+      },
+      {
+        "limitation": "3-kernel only: gated alongside the fp64 transformer op family; the Metal/Swift live witness is Darwin+swiftc only.",
+        "follow_up": "The fourth arm gains this family when the transformer bands are flattened for fkwu."
+      }
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "summary": "resid-train-emit-band rides the default validate.sh suite via its '; preludes:' header (jit-tensor-emit.fk); CI three-way gate applies. The Metal witness is host-only and not part of CI."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "Stdlib emitter recipe + band + a host GPU audit script; no route or service change. Rides normal merge."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "The architect's capacity search -- ac-min-width over the d=4 reversal dataset -- now runs on the M4 Max GPU training the architect's actual residual block, and crowns the same width (2) the fp64 Form recipe and the fp32 CPU mirror crown.",
+    "public_endpoints": [
+      "POST /api/substrate/form"
+    ],
+    "test_flows": [
+      "validate.sh resid-train-emit-band (three kernels agree, verdict 7): the residual-block training-step MSL emitter is deterministic and byte-identical three-way",
+      "metal_arch_search_audit.sh: the emitted residual kernel compiles, trains each width over the dataset on the GPU, and crowns width 2 -- matching arch-capacity-band's fp64 recipe crown and the fp32 CPU mirror"
+    ],
+    "summary": "Proven three-way (emitter) and live on the M4 Max GPU (the architect's capacity search crowns width 2 on the silicon, matching the recipe)."
+  },
+  "phase_gate": {
+    "phase": "m7-gpu-arch-search",
+    "gate": "the architect's capacity search runs on Metal: jte-resid-train-msl emits the architect's actual pre-LN residual block (byte-stable three-way), and the live M4 Max witness trains each candidate width over the d=4 reversal dataset and crowns width 2 -- the same crown the fp64 recipe ac-min-width and the fp32 CPU mirror reach",
+    "state": "crossed",
+    "can_move_next_phase": false,
+    "next": "attention candidates trained on the GPU too -- the full (depth x width x type) grid timed on the silicon; a multi-threadgroup variant for widths beyond one group"
+  },
+  "idea_ids": [
+    "fourth-kernel"
+  ],
+  "spec_ids": [
+    "runtime-shared-native-representation"
+  ],
+  "task_ids": [
+    "metal-arch-search-20260616"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "form-os-arc"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "measurement"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude Code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "form/form-stdlib/jit-tensor-emit.fk",
+    "form/form-stdlib/tests/resid-train-emit-band.fk",
+    "scripts/metal_arch_search_audit.sh",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "change_files": [
+    "form/form-stdlib/jit-tensor-emit.fk",
+    "form/form-stdlib/tests/resid-train-emit-band.fk",
+    "scripts/metal_arch_search_audit.sh",
+    "docs/coherence-substrate/form-native-models.form",
+    "scripts/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_2026-06-16_metal_arch_search.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/jit-tensor-emit.fk
+++ b/form/form-stdlib/jit-tensor-emit.fk
@@ -168,3 +168,44 @@
 (defn jte-mlp-train-msl-fmt (fname fmt) (jte-mlp-train-msl-spine fname (jte-msl-elem fmt) (jte-msl-acc fmt)))
 
 (defn jte-mlp-train-msl (fname) (jte-mlp-train-msl-fmt fname "f32"))
+
+; --- FFN-RESIDUAL (one pre-LN layer) TRAINING-STEP kernel, emitted as a Form recipe — the architect's ACTUAL
+; layer on Metal. tbp-stk-step over one "ffn" layer is the algorithm (fp64, proven three-way): the residual
+; block y = h + (W2*gelu(W1*LN(h) + b1) + b2), exactly what ac-ffn-layer builds and ac-train trains. This is
+; the FFN core kernel (jte-mlp-train-msl) wrapped with the two pieces the architect's block adds: a pre-LN of
+; the input (z = LN(h), computed by thread 0 with tn-mean/tn-var/tn-sqrt's exact folds — biased variance, eps
+; inside a 50-iteration Newton sqrt) and the residual highway (y = h + ffn, so the output-gradient gy = 2(y-t)
+; flows straight to the FFN as gout). The FFN reads z, and the W1 update uses z, not the raw input. Same
+; recipe-own exp/tanh (jte-mlp-helpers); same downward forward folds and forward dh1 column fold; same
+; barriered single-threadgroup phases plus phase 0 for the layernorm. Proven byte-stable by
+; tests/resid-train-emit-band.fk; trained live and capacity-searched on the M4 Max by scripts/metal_arch_search_audit.sh.
+
+(defn jte-resid-sig (fname el ac)
+  (str_concat "kernel void " (str_concat fname (str_concat "(device " (str_concat el (str_concat "* w1 [[buffer(0)]], device " (str_concat el (str_concat "* b1 [[buffer(1)]], device " (str_concat el (str_concat "* w2 [[buffer(2)]], device " (str_concat el (str_concat "* b2 [[buffer(3)]], device const " (str_concat el (str_concat "* h [[buffer(4)]], device const " (str_concat el (str_concat "* t [[buffer(5)]], device " (str_concat ac (str_concat "* loss [[buffer(6)]], device " (str_concat ac (str_concat "* h1 [[buffer(7)]], device " (str_concat ac (str_concat "* a [[buffer(8)]], device " (str_concat ac (str_concat "* gy [[buffer(9)]], device " (str_concat ac (str_concat "* dh1 [[buffer(10)]], device " (str_concat ac (str_concat "* z [[buffer(11)]], constant uint& indim [[buffer(12)]], constant uint& hid [[buffer(13)]], constant uint& outd [[buffer(14)]], constant " (str_concat ac (str_concat "& lr [[buffer(15)]], constant " (str_concat ac "& eps [[buffer(16)]], uint tid [[thread_position_in_threadgroup]], uint tgs [[threads_per_threadgroup]]) { ")))))))))))))))))))))))))))))))
+
+(defn jte-resid-ln (el ac)
+  (str_concat "if (tid == 0) { " (str_concat ac (str_concat " sm = 0.0f; uint j = 0; while (j < indim) { sm = sm + " (str_concat ac (str_concat "(h[j]); j += 1; } " (str_concat ac (str_concat " mean = sm / " (str_concat ac (str_concat "(indim); " (str_concat ac (str_concat " va = 0.0f; j = 0; while (j < indim) { " (str_concat ac (str_concat " dm = " (str_concat ac (str_concat "(h[j]) - mean; va = va + dm * dm; j += 1; } " (str_concat ac (str_concat " varv = va / " (str_concat ac (str_concat "(indim); " (str_concat ac (str_concat " sd = varv + eps; " (str_concat ac (str_concat " g = sd; uint it = 50; while (it > 0) { it -= 1; g = 0.5f * (g + sd / g); } " (str_concat ac (str_concat " inv = 1.0f / g; j = 0; while (j < indim) { z[j] = (" (str_concat ac "(h[j]) - mean) * inv; j += 1; } } threadgroup_barrier(mem_flags::mem_device); ")))))))))))))))))))))))))))
+
+(defn jte-resid-fwd1 (el ac)
+  (str_concat "for (uint k = tid; k < hid; k += tgs) { " (str_concat ac (str_concat " acc = 0.0f; uint j = indim; while (j > 0) { j -= 1; acc = " (str_concat ac (str_concat "(w1[k * indim + j]) * z[j] + acc; } " (str_concat ac (str_concat " hk = acc + " (str_concat ac "(b1[k]); h1[k] = hk; a[k] = fgelu(hk); } threadgroup_barrier(mem_flags::mem_device); ")))))))))
+
+(defn jte-resid-fwd2 (el ac)
+  (str_concat "for (uint i = tid; i < outd; i += tgs) { " (str_concat ac (str_concat " acc = 0.0f; uint k = hid; while (k > 0) { k -= 1; acc = " (str_concat ac (str_concat "(w2[i * hid + k]) * a[k] + acc; } " (str_concat ac (str_concat " ffn = acc + " (str_concat ac (str_concat "(b2[i]); " (str_concat ac (str_concat " yi = " (str_concat ac (str_concat "(h[i]) + ffn; " (str_concat ac (str_concat " d = yi - " (str_concat ac "(t[i]); loss[i] = d * d; gy[i] = 2.0f * d; } threadgroup_barrier(mem_flags::mem_device); ")))))))))))))))))
+
+(defn jte-resid-dh1 (el ac)
+  (str_concat "for (uint k = tid; k < hid; k += tgs) { " (str_concat ac (str_concat " s = 0.0f; uint i = 0; while (i < outd) { s = s + gy[i] * " (str_concat ac "(w2[i * hid + k]); i += 1; } dh1[k] = s * fgelud(h1[k]); } threadgroup_barrier(mem_flags::mem_device); ")))))
+
+(defn jte-resid-upd (el ac)
+  (str_concat "for (uint i = tid; i < outd; i += tgs) { uint k = hid; while (k > 0) { k -= 1; w2[i * hid + k] = " (str_concat el (str_concat "(" (str_concat ac (str_concat "(w2[i * hid + k]) - lr * gy[i] * a[k]); } b2[i] = " (str_concat el (str_concat "(" (str_concat ac (str_concat "(b2[i]) - lr * gy[i]); } for (uint k = tid; k < hid; k += tgs) { uint j = indim; while (j > 0) { j -= 1; w1[k * indim + j] = " (str_concat el (str_concat "(" (str_concat ac (str_concat "(w1[k * indim + j]) - lr * dh1[k] * z[j]); } b1[k] = " (str_concat el (str_concat "(" (str_concat ac "(b1[k]) - lr * dh1[k]); } }")))))))))))))))))
+
+(defn jte-resid-train-msl-spine (fname el ac)
+  (str_concat (jte-mlp-helpers ac)
+  (str_concat (jte-resid-sig fname el ac)
+  (str_concat (jte-resid-ln el ac)
+  (str_concat (jte-resid-fwd1 el ac)
+  (str_concat (jte-resid-fwd2 el ac)
+  (str_concat (jte-resid-dh1 el ac) (jte-resid-upd el ac))))))))
+
+(defn jte-resid-train-msl-fmt (fname fmt) (jte-resid-train-msl-spine fname (jte-msl-elem fmt) (jte-msl-acc fmt)))
+
+(defn jte-resid-train-msl (fname) (jte-resid-train-msl-fmt fname "f32"))

--- a/form/form-stdlib/tests/resid-train-emit-band.fk
+++ b/form/form-stdlib/tests/resid-train-emit-band.fk
@@ -1,0 +1,28 @@
+; preludes: form-stdlib/jit-tensor-emit.fk
+;
+; resid-train-emit-band — the architect's ACTUAL layer (one pre-LN FFN-residual block) training-step emitter
+; as recipe, three-way. jte-resid-train-msl authors the Metal kernel for one SGD step over
+; y = h + (W2*gelu(W1*LN(h) + b1) + b2) — tbp-stk-step on one "ffn" layer, the exact block ac-ffn-layer builds
+; and ac-train trains. It is the FFN core kernel wrapped with the two pieces the residual block adds: a pre-LN
+; of the input (z = LN(h) by thread 0, tn-mean/tn-var/tn-sqrt's exact folds, eps inside a 50-iter Newton sqrt)
+; and the residual highway (y = h + ffn, so gy = 2(y-t) flows straight to the FFN as gout). The FFN reads z and
+; the W1 update uses z. Same recipe-own exp/tanh helpers, same downward forward folds, same forward dh1 fold,
+; barriered single-threadgroup phases plus phase 0 for layernorm. The emitted source is byte-identical across
+; the three kernels, parameterizes on the name, and is deterministic. It COMPILES, TRAINS, and drives a
+; capacity SEARCH on the M4 Max (scripts/metal_arch_search_audit.sh): the architect timing real candidates on
+; the silicon, the GPU crown matching the fp64 Form recipe ac-min-width.
+;
+; Verdict 7 when the emission lands:
+;   1   the full emitted f32 MSL for form_resid_train_f32 equals the canonical text
+;   2   a different name lands in the same frame (emission is a function of the name)
+;   4   two emissions of the same name are str_eq (deterministic text — same emission, same cell)
+(do
+    (let pre "float fexp_small(float x){ float n = 1.0f; float term = 1.0f; float acc = 1.0f; while (n <= 14.0f) { term = term * (x / n); acc = acc + term; n = n + 1.0f; } return acc; } float fexp(float x){ int k = 0; while ((x < 0.0f ? -x : x) > 0.5f) { x = x / 2.0f; k = k + 1; } float v = fexp_small(x); while (k > 0) { v = v * v; k = k - 1; } return v; } float ftanh(float x){ float e = fexp(2.0f * x); return (e - 1.0f) / (e + 1.0f); } float fgelu(float x){ float z = 0.7978845608028654f * (x + 0.044715f * (x * (x * x))); return (0.5f * x) * (1.0f + ftanh(z)); } float fgelud(float x){ float z = 0.7978845608028654f * (x + 0.044715f * (x * (x * x))); float th = ftanh(z); return (0.5f * (1.0f + th)) + ((0.5f * x) * ((1.0f - (th * th)) * (0.7978845608028654f * (1.0f + (0.134145f * (x * x)))))); } kernel void ")
+    (let post "(device float* w1 [[buffer(0)]], device float* b1 [[buffer(1)]], device float* w2 [[buffer(2)]], device float* b2 [[buffer(3)]], device const float* h [[buffer(4)]], device const float* t [[buffer(5)]], device float* loss [[buffer(6)]], device float* h1 [[buffer(7)]], device float* a [[buffer(8)]], device float* gy [[buffer(9)]], device float* dh1 [[buffer(10)]], device float* z [[buffer(11)]], constant uint& indim [[buffer(12)]], constant uint& hid [[buffer(13)]], constant uint& outd [[buffer(14)]], constant float& lr [[buffer(15)]], constant float& eps [[buffer(16)]], uint tid [[thread_position_in_threadgroup]], uint tgs [[threads_per_threadgroup]]) { if (tid == 0) { float sm = 0.0f; uint j = 0; while (j < indim) { sm = sm + float(h[j]); j += 1; } float mean = sm / float(indim); float va = 0.0f; j = 0; while (j < indim) { float dm = float(h[j]) - mean; va = va + dm * dm; j += 1; } float varv = va / float(indim); float sd = varv + eps; float g = sd; uint it = 50; while (it > 0) { it -= 1; g = 0.5f * (g + sd / g); } float inv = 1.0f / g; j = 0; while (j < indim) { z[j] = (float(h[j]) - mean) * inv; j += 1; } } threadgroup_barrier(mem_flags::mem_device); for (uint k = tid; k < hid; k += tgs) { float acc = 0.0f; uint j = indim; while (j > 0) { j -= 1; acc = float(w1[k * indim + j]) * z[j] + acc; } float hk = acc + float(b1[k]); h1[k] = hk; a[k] = fgelu(hk); } threadgroup_barrier(mem_flags::mem_device); for (uint i = tid; i < outd; i += tgs) { float acc = 0.0f; uint k = hid; while (k > 0) { k -= 1; acc = float(w2[i * hid + k]) * a[k] + acc; } float ffn = acc + float(b2[i]); float yi = float(h[i]) + ffn; float d = yi - float(t[i]); loss[i] = d * d; gy[i] = 2.0f * d; } threadgroup_barrier(mem_flags::mem_device); for (uint k = tid; k < hid; k += tgs) { float s = 0.0f; uint i = 0; while (i < outd) { s = s + gy[i] * float(w2[i * hid + k]); i += 1; } dh1[k] = s * fgelud(h1[k]); } threadgroup_barrier(mem_flags::mem_device); for (uint i = tid; i < outd; i += tgs) { uint k = hid; while (k > 0) { k -= 1; w2[i * hid + k] = float(float(w2[i * hid + k]) - lr * gy[i] * a[k]); } b2[i] = float(float(b2[i]) - lr * gy[i]); } for (uint k = tid; k < hid; k += tgs) { uint j = indim; while (j > 0) { j -= 1; w1[k * indim + j] = float(float(w1[k * indim + j]) - lr * dh1[k] * z[j]); } b1[k] = float(float(b1[k]) - lr * dh1[k]); } }")
+    (let want (str_concat pre (str_concat "form_resid_train_f32" post)))
+    (let got (jte-resid-train-msl "form_resid_train_f32"))
+    (let other (jte-resid-train-msl "r2"))
+    (let c0 (if (str_eq got want) 1 0))
+    (let c1 (if (str_eq other (str_concat pre (str_concat "r2" post))) 2 0))
+    (let c2 (if (str_eq (jte-resid-train-msl "form_resid_train_f32") got) 4 0))
+    (add c0 (add c1 c2)))

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 253
+**Total files**: 254
 
 | File | Purpose |
 |---|---|
@@ -139,6 +139,7 @@
 | [local_runner.py](local_runner.py) | Coherence Network runner — thin shim. |
 | [measure_gitnexus_value.py](measure_gitnexus_value.py) | Measure GitNexus integration value across paired task windows. |
 | [meeting_companion.sh](meeting_companion.sh) | meeting_companion.sh — a meeting companion that LISTENS (STT), DECIDES whether |
+| [metal_arch_search_audit.sh](metal_arch_search_audit.sh) | metal_arch_search_audit.sh — the ARCHITECT'S CAPACITY SEARCH on Metal (M4 Max GPU witness). |
 | [metal_backprop_audit.sh](metal_backprop_audit.sh) | metal_backprop_audit.sh — the LEARNING KERNEL on Metal (M4 Max GPU witness). |
 | [metal_ffn_audit.sh](metal_ffn_audit.sh) | metal_ffn_audit.sh — the ARCHITECT'S LAYER learning on Metal (M4 Max GPU witness). |
 | [metal_matvec_audit.sh](metal_matvec_audit.sh) | metal_matvec_audit.sh — GPU witness for the Form MSL matvec emitter (jte-matvec-msl-spine + |

--- a/scripts/metal_arch_search_audit.sh
+++ b/scripts/metal_arch_search_audit.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# metal_arch_search_audit.sh — the ARCHITECT'S CAPACITY SEARCH on Metal (M4 Max GPU witness).
+#
+# arch-capacity.fk's ac-min-width is the algorithm (fp64, proven three-way in arch-capacity-band → 31): at d=4
+# a 4-example dataset needs ENOUGH hidden width — a width-1 FFN-residual layer underfits, a width-2+ fits — and
+# the architect trains each width over the whole dataset and crowns the SMALLEST that fits. This script runs
+# that exact search ON THE GPU: jte-resid-train-msl emits the architect's real layer (the pre-LN residual block
+# y = h + (W2·gelu(W1·LN(h)+b1)+b2), tbp-stk-step on one "ffn" layer) as a Metal kernel; the carrier trains each
+# candidate width over the dataset on the M4 Max, measures the trained dataset loss, and crowns minimal-width-
+# that-fits. The architect times REAL candidates on the silicon.
+#
+# THREE executions, ONE crown. (1) the fp64 Form recipe ac-min-width via arch-capacity-band → 31 (crowns 2).
+# (2) this GPU search. (3) an fp32 CPU mirror of the same phases. Weights start from ac-w computed in fp64 and
+# narrowed to fp32, so the GPU and the recipe begin from the same point; the discrimination (w1 loss ≫ w2 loss)
+# is robust enough that fp32 training crowns the same width the fp64 recipe does.
+#
+# Run:  scripts/metal_arch_search_audit.sh   (the d=4 reversal dataset, widths 1..4, lr 0.05, 150 epochs)
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMDIR="$ROOT/form"
+GO_BIN="$FORMDIR/form-kernel-go/bin-go"
+
+if [[ "$(uname -s)" != "Darwin" ]] || ! command -v swiftc >/dev/null; then
+    echo "SKIP  no Darwin/Metal toolchain — the GPU witness needs an Apple GPU + swiftc"; exit 2
+fi
+[[ -x "$GO_BIN" ]] || (cd "$FORMDIR/form-kernel-go" && go build -o bin-go .)
+work="$(mktemp -d "${TMPDIR:-/tmp}/fkarch.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+# ── 1. Form emits the architect's residual-block training-step MSL ────
+cat "$FORMDIR/form-stdlib/jit-tensor-emit.fk" > "$work/driver.fk"
+printf '\n(print "==MSL==")\n(print (jte-resid-train-msl "form_resid_train_f32"))\n(print "==END==")\n' >> "$work/driver.fk"
+(cd "$FORMDIR" && "$GO_BIN" "$work/driver.fk" 2>/dev/null) > "$work/emit.out"
+sed -n '/^==MSL==$/,/^==END==$/p' "$work/emit.out" | sed -e '1d' -e '$d' > "$work/train.metal"
+grep -q 'kernel void form_resid_train_f32' "$work/train.metal" || { echo "FAIL emission produced no kernel"; cat "$work/emit.out"; exit 1; }
+echo "emitted residual-block training-step MSL: $(wc -c < "$work/train.metal" | tr -d ' ') bytes, every byte authored by the Form recipe"
+
+# ── 2. (Form recipe crown) confirm ac-min-width crowns 2 on this dataset, fp64, via the proven band ──
+echo "── Form recipe ac-min-width (fp64, three-way) on the d=4 reversal dataset ──"
+( cd "$FORMDIR" && ./validate.sh form-stdlib/tests/arch-capacity-band.fk >/dev/null 2>&1 \
+    && echo "  arch-capacity-band → 31: recipe crowns width 2 (w1 underfits, w2 fits)" ) \
+  || echo "  (band run skipped/failed in this environment — GPU vs CPU parity below still stands)"
+
+# ── 3. Swift carrier: the capacity search on the GPU, parity vs the fp32 CPU mirror ──
+cat > "$work/runner.swift" <<'SWIFT'
+import Metal
+import Foundation
+
+let d = 4, maxh = 4, epochs = 150
+let lr: Float = 0.05, eps: Float = 0.00001, efit: Double = 0.001, seed = 0.3
+let mslPath = CommandLine.arguments[1]
+
+guard let dev = MTLCreateSystemDefaultDevice() else { print("SKIP no Metal device"); exit(2) }
+let opts = MTLCompileOptions(); opts.fastMathEnabled = false
+let lib = try dev.makeLibrary(source: "#include <metal_stdlib>\nusing namespace metal;\n" + (try String(contentsOfFile: mslPath, encoding: .utf8)), options: opts)
+let pso = try dev.makeComputePipelineState(function: lib.makeFunction(name: "form_resid_train_f32")!)
+let q = dev.makeCommandQueue()!
+
+// ── the recipe's deterministic weights: ac-w(seed) computed in fp64, narrowed to fp32 (so GPU == recipe init) ──
+func acw(_ s: Double) -> Float { let v = s * 12.9898; return Float((( v - v.rounded(.down) ) - 0.5) * 0.3) }
+func acMat(_ rows: Int, _ cols: Int, _ s0: Double) -> [Float] {  // ac-mat: row r seed s0+r*7.3, col c seed +c*1.7
+    var m = [Float](repeating: 0, count: rows*cols)
+    for r in 0..<rows { for c in 0..<cols { m[r*cols+c] = acw(s0 + Double(r)*7.3 + Double(c)*1.7) } }
+    return m
+}
+// dataset: four d=4 inputs, target = input reversed (arch-capacity-band's fixture)
+let X: [[Float]] = [[2,1,0,0],[0,2,1,0],[0,0,2,1],[1,0,0,2]]
+let T: [[Float]] = [[0,0,1,2],[0,1,2,0],[1,2,0,0],[2,0,0,1]]
+
+// ── the recipe's own fp32 numerics (mirror the emitted fexp/ftanh/fgelu + tn-layernorm folds) ──
+func fexpSmall(_ x: Float) -> Float { var n: Float = 1, t: Float = 1, a: Float = 1; while n <= 14 { t = t*(x/n); a = a+t; n += 1 }; return a }
+func fexp(_ x0: Float) -> Float { var x = x0, k = 0; while (x < 0 ? -x : x) > 0.5 { x = x/2; k += 1 }; var v = fexpSmall(x); while k > 0 { v = v*v; k -= 1 }; return v }
+func ftanh(_ x: Float) -> Float { let e = fexp(2*x); return (e-1)/(e+1) }
+func fgelu(_ x: Float) -> Float { let z = Float(0.7978845608028654)*(x + Float(0.044715)*(x*(x*x))); return (0.5*x)*(1+ftanh(z)) }
+func fgelud(_ x: Float) -> Float { let z = Float(0.7978845608028654)*(x + Float(0.044715)*(x*(x*x))); let th = ftanh(z); return (0.5*(1+th)) + ((0.5*x)*((1-(th*th))*(Float(0.7978845608028654)*(1+(Float(0.134145)*(x*x)))))) }
+func layernorm(_ h: [Float]) -> [Float] {
+    var sm: Float = 0; for v in h { sm += v }; let mean = sm/Float(d)
+    var va: Float = 0; for v in h { let dm = v-mean; va += dm*dm }; let varv = va/Float(d)
+    let sdv = varv+eps; var g = sdv; var it = 50; while it > 0 { g = 0.5*(g + sdv/g); it -= 1 }; let inv = 1/g
+    return h.map { ($0-mean)*inv }
+}
+// residual-block forward (for the dataset-loss measurement, shared by GPU-read and CPU-mirror weights)
+func residLoss(_ w1: [Float], _ b1: [Float], _ w2: [Float], _ b2: [Float], _ H: Int) -> Double {
+    var loss: Double = 0
+    for ex in 0..<X.count {
+        let h = X[ex]; let z = layernorm(h)
+        var a = [Float](repeating: 0, count: H)
+        for k in 0..<H { var acc: Float = 0; var j = d; while j > 0 { j -= 1; acc = w1[k*d+j]*z[j] + acc }; a[k] = fgelu(acc + b1[k]) }
+        for i in 0..<d { var acc: Float = 0; var k = H; while k > 0 { k -= 1; acc = w2[i*H+k]*a[k] + acc }; let y = h[i] + acc + b2[i]; let e = y - T[ex][i]; loss += Double(e*e) }
+    }
+    return loss
+}
+
+func newBuf(_ a: [Float]) -> MTLBuffer { dev.makeBuffer(bytes: a, length: max(1,a.count)*4, options: .storageModeShared)! }
+
+// ── train width H on the GPU over the dataset, return the trained weights ──
+func gpuTrain(_ H: Int) -> ([Float],[Float],[Float],[Float]) {
+    let w1 = acMat(H, d, seed), b1 = [Float](repeating: 0, count: H)        // copied into GPU buffers; the GPU mutates the buffers, not these
+    let w2 = acMat(d, H, seed+100), b2 = [Float](repeating: 0, count: d)
+    let bw1 = newBuf(w1), bb1 = newBuf(b1), bw2 = newBuf(w2), bb2 = newBuf(b2)
+    let flatX = X.flatMap { $0 }, flatT = T.flatMap { $0 }
+    let bH = newBuf(flatX), bT = newBuf(flatT)
+    let bloss = newBuf([Float](repeating: 0, count: d)), bh1 = newBuf([Float](repeating:0,count:H))
+    let ba = newBuf([Float](repeating:0,count:H)), bgy = newBuf([Float](repeating:0,count:d))
+    let bdh1 = newBuf([Float](repeating:0,count:H)), bz = newBuf([Float](repeating:0,count:d))
+    var ui = UInt32(d), uh = UInt32(H), uo = UInt32(d), lrv = lr, epsv = eps
+    let tgs = min(pso.maxTotalThreadsPerThreadgroup, max(H, d))
+    for _ in 0..<epochs {
+        for ex in 0..<X.count {
+            let cb = q.makeCommandBuffer()!; let enc = cb.makeComputeCommandEncoder()!
+            enc.setComputePipelineState(pso)
+            enc.setBuffer(bw1,offset:0,index:0); enc.setBuffer(bb1,offset:0,index:1)
+            enc.setBuffer(bw2,offset:0,index:2); enc.setBuffer(bb2,offset:0,index:3)
+            enc.setBuffer(bH,offset:ex*d*4,index:4); enc.setBuffer(bT,offset:ex*d*4,index:5)
+            enc.setBuffer(bloss,offset:0,index:6); enc.setBuffer(bh1,offset:0,index:7)
+            enc.setBuffer(ba,offset:0,index:8); enc.setBuffer(bgy,offset:0,index:9)
+            enc.setBuffer(bdh1,offset:0,index:10); enc.setBuffer(bz,offset:0,index:11)
+            enc.setBytes(&ui,length:4,index:12); enc.setBytes(&uh,length:4,index:13)
+            enc.setBytes(&uo,length:4,index:14); enc.setBytes(&lrv,length:4,index:15); enc.setBytes(&epsv,length:4,index:16)
+            enc.dispatchThreadgroups(MTLSize(width:1,height:1,depth:1), threadsPerThreadgroup: MTLSize(width:tgs,height:1,depth:1))
+            enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+        }
+    }
+    func rd(_ b: MTLBuffer, _ n: Int) -> [Float] { let p = b.contents().bindMemory(to: Float.self, capacity: n); return (0..<n).map { p[$0] } }
+    return (rd(bw1,H*d), rd(bb1,H), rd(bw2,d*H), rd(bb2,d))
+}
+
+// ── the SAME training on the fp32 CPU mirror (same phases, same folds) ──
+func cpuTrain(_ H: Int) -> ([Float],[Float],[Float],[Float]) {
+    var w1 = acMat(H, d, seed), b1 = [Float](repeating: 0, count: H)
+    var w2 = acMat(d, H, seed+100), b2 = [Float](repeating: 0, count: d)
+    for _ in 0..<epochs {
+        for ex in 0..<X.count {
+            let h = X[ex], t = T[ex]; let z = layernorm(h)
+            var h1 = [Float](repeating:0,count:H), a = [Float](repeating:0,count:H)
+            for k in 0..<H { var acc: Float = 0; var j = d; while j > 0 { j -= 1; acc = w1[k*d+j]*z[j] + acc }; h1[k] = acc + b1[k]; a[k] = fgelu(h1[k]) }
+            var gy = [Float](repeating:0,count:d)
+            for i in 0..<d { var acc: Float = 0; var k = H; while k > 0 { k -= 1; acc = w2[i*H+k]*a[k] + acc }; let y = h[i] + acc + b2[i]; gy[i] = 2*(y - t[i]) }
+            var dh1 = [Float](repeating:0,count:H)
+            for k in 0..<H { var s: Float = 0; var i = 0; while i < d { s = s + gy[i]*w2[i*H+k]; i += 1 }; dh1[k] = s*fgelud(h1[k]) }
+            for i in 0..<d { var k = H; while k > 0 { k -= 1; w2[i*H+k] = w2[i*H+k] - lr*gy[i]*a[k] }; b2[i] = b2[i] - lr*gy[i] }
+            for k in 0..<H { var j = d; while j > 0 { j -= 1; w1[k*d+j] = w1[k*d+j] - lr*dh1[k]*z[j] }; b1[k] = b1[k] - lr*dh1[k] }
+        }
+    }
+    return (w1,b1,w2,b2)
+}
+
+// ── run the search on both, crown minimal-width-that-fits ──
+print("  width   gpu_loss        cpu_loss        fits(efit=\(efit))")
+var crownGpu = 0, crownCpu = 0
+for H in 1...maxh {
+    let (g1,g2,g3,g4) = gpuTrain(H); let gl = residLoss(g1,g2,g3,g4,H)
+    let (c1,c2,c3,c4) = cpuTrain(H); let cl = residLoss(c1,c2,c3,c4,H)
+    if crownGpu == 0 && gl < efit { crownGpu = H }
+    if crownCpu == 0 && cl < efit { crownCpu = H }
+    print(String(format: "  %3d     %.9f   %.9f   gpu=%@ cpu=%@", H, gl, cl, gl < efit ? "Y":"n", cl < efit ? "Y":"n"))
+}
+print("")
+print("CROWN: gpu=\(crownGpu)  cpu=\(crownCpu)  recipe(ac-min-width)=2")
+let ok = crownGpu == 2 && crownCpu == 2
+print(ok ? "  ✓ the architect's capacity search runs on the GPU and crowns width 2 — matching the fp64 recipe and the fp32 CPU mirror. Capacity discovered on the silicon."
+         : "  ✗ crown mismatch — investigate")
+exit(ok ? 0 : 1)
+SWIFT
+
+swiftc -O -framework Metal "$work/runner.swift" -o "$work/runner" 2>&1 | grep -v '^$' || true
+[[ -x "$work/runner" ]] || { echo "FAIL swiftc did not build the runner"; exit 1; }
+
+echo "── the architect's capacity search on the M4 Max GPU (crown the minimal width that fits) ──"
+"$work/runner" "$work/train.metal"


### PR DESCRIPTION
## The architect's capacity search on the silicon

The FFN-core trainer ([#3218](https://github.com/seeker71/Coherence-Network/pull/3218)) proved the two-layer MLP learns on Metal. This lands the architect's **actual** layer and runs its **capacity search** on the GPU.

`jte-resid-train-msl` (a Form recipe in `jit-tensor-emit.fk`) emits `tbp-stk-step` on one `"ffn"` layer — the pre-LN residual block `y = h + (W2·gelu(W1·LN(h)+b1)+b2)`, **exactly what `ac-ffn-layer` builds and `ac-train` trains**. It's the FFN-core kernel wrapped with the two pieces the residual block adds:

- a **pre-LN of the input** (`z = LN(h)` by thread 0, using `tn-mean`/`tn-var`/`tn-sqrt`'s exact folds — biased variance, eps inside a 50-iteration Newton sqrt);
- the **residual highway** (`y = h + ffn`, so `gy = 2(y−t)` flows straight to the FFN as `gout`).

The FFN reads `z`, and the W1 update uses `z`.

### Three executions, one crown

`scripts/metal_arch_search_audit.sh` runs `arch-capacity`'s `ac-min-width` **on the GPU**: on the d=4 reversal dataset (4 examples, target = input reversed, lr 0.05, 150 epochs, efit 0.001) it trains each candidate width over the dataset on the M4 Max and crowns the smallest that fits.

| width | GPU loss | CPU loss | fits |
|---|---|---|---|
| 1 | 7.59 | 7.12 | no (underfits) |
| **2** | **4.8e-7** | **4.8e-7** | **yes ← crowned** |
| 3 | 2.9e-5 | 2.9e-5 | yes |
| 4 | 6.3e-5 | 6.3e-5 | yes |

**CROWN: gpu=2, cpu=2, recipe(ac-min-width)=2** — the fp64 Form recipe (`arch-capacity-band` → 31), the fp32 GPU, and the fp32 CPU mirror all crown **width 2**. Weights start from `ac-w` computed in fp64 and narrowed to fp32, so the GPU and the recipe begin from the same point; the underfit gap (7.x vs 1e-7) makes the crown robust to fp32.

The architect times **real candidates on the silicon** — capacity discovered, not assumed.

### Proof

**`resid-train-emit-band` → 7 three-way** (Go=Rust=TS), 0 divergent: the residual-block emitter is byte-identical (3167-byte canonical), name-parameterized, deterministic. The FFN-core and affine emitter bands stay green (shared helpers unchanged).

**Scope correction:** this also clarifies [#3218](https://github.com/seeker71/Coherence-Network/pull/3218) — that kernel trains the FFN **core** (`tbp-mlp-step`, the two-layer MLP *inside* the block); this one trains the residual block the architect actually builds.

**3-kernel only** — gated alongside the fp64 transformer op family; the Metal/Swift witness is Darwin+swiftc only.

Evidence: `docs/system_audit/commit_evidence_2026-06-16_metal_arch_search.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)