### PR TITLE
feat(form): low-rank diff (LoRA adapter) — a tiny adapter adds capability, four-way

### DIFF
--- a/form/form-stdlib/lora-adapter.fk
+++ b/form/form-stdlib/lora-adapter.fk
@@ -1,0 +1,62 @@
+; lora-adapter.fk — a low-rank diff: the adapter is B·A (rank r), tiny vs the base.
+;
+; preludes: form-stdlib/core.fk
+;
+; model-compose.fk proved a diff STACKS over a base. This proves the diff can be
+; LOW-RANK — the reason "only diffs needed" is cheap: a base weight matrix W
+; (d×d) gets a new capability from an adapter B·A where B is d×r and A is r×d,
+; r ≪ d. The whole capability is 2·d·r numbers, not d·d. The load-bearing
+; identity (LoRA / adapter_forward, named in cell-numerics.form + slice-merge.fk
+; as τ = θ_local − θ_base):
+;
+;     (W + B·A)·x  ==  W·x + B·(A·x)
+;
+; computed the RIGHT way: never form the d×d diff; do A·x (an r-vector) then
+; B·that (a d-vector) — O(d·r), not O(d·d). Adapters stack: W·x + Σ Bk·(Ak·x).
+;
+; Smallest honest size: rank-1 (B, A are d-vectors), d = 3, fixed-size so the
+; ops use only nth/list/add/sub/mul/div (all four-way proven). Integer
+; fixed-point scale 1000. The chunked/general-d form is the next stone over this.
+;
+; Proven by: form-stdlib/tests/lora-adapter-band.fk
+
+; a·b dot (scale 1000)
+(defn la-dot3 (a b)
+    (add (div (mul (nth a 0) (nth b 0)) 1000)
+    (add (div (mul (nth a 1) (nth b 1)) 1000)
+         (div (mul (nth a 2) (nth b 2)) 1000))))
+
+; v·s scale (scale 1000)
+(defn la-scale3 (v s)
+    (list (div (mul (nth v 0) s) 1000)
+          (div (mul (nth v 1) s) 1000)
+          (div (mul (nth v 2) s) 1000)))
+
+; a + b (vectors)
+(defn la-add3 (a b)
+    (list (add (nth a 0) (nth b 0))
+          (add (nth a 1) (nth b 1))
+          (add (nth a 2) (nth b 2))))
+
+; W·x — W = (list row0 row1 row2)
+(defn la-matvec3 (W x)
+    (list (la-dot3 (nth W 0) x)
+          (la-dot3 (nth W 1) x)
+          (la-dot3 (nth W 2) x)))
+
+; the rank-1 diff matrix B⊗A — row_i = A * B[i]  (never needed for the forward,
+; only to show the low-rank form reconstructs the full diff)
+(defn la-outer3 (B A)
+    (list (la-scale3 A (nth B 0))
+          (la-scale3 A (nth B 1))
+          (la-scale3 A (nth B 2))))
+
+; matrix add (base + diff matrix)
+(defn la-madd3 (W M)
+    (list (la-add3 (nth W 0) (nth M 0))
+          (la-add3 (nth W 1) (nth M 1))
+          (la-add3 (nth W 2) (nth M 2))))
+
+; adapter_forward: (W + B·A)·x computed the LOW-RANK way — W·x + B·(A·x)
+(defn la-forward (W B A x)
+    (la-add3 (la-matvec3 W x) (la-scale3 B (la-dot3 A x))))

--- a/form/form-stdlib/tests/lora-adapter-band.fk
+++ b/form/form-stdlib/tests/lora-adapter-band.fk
@@ -1,0 +1,55 @@
+; preludes: form-stdlib/core.fk form-stdlib/lora-adapter.fk
+;
+; lora-adapter-band — a low-rank diff adds a capability to a base, four-way in
+; pure Form. The altitude above model-compose-band: the diff is rank-1 (B·A),
+; so the adapter is 2·d numbers, not d·d — the reason "one model on top of
+; another, only diffs" is CHEAP. Proves the LoRA identity, capability, stacking,
+; size, and that the low-rank form reconstructs the explicit diff.
+;
+; Fixture (scale 1000): base W = identity (3×3), input x = (1, 2, 1). Rank-1
+; adapter A=(1,0,0), B=(0,0,2) — reads x0 and adds 2·x0 to component 2. Second
+; adapter A2=(0,1,0), B2=(1,0,0) — reads x1, adds x1 to component 0. Reference
+; (integer, truncate-toward-zero), verified before authoring:
+;   base W·x        = (1000, 2000, 1000)
+;   low-rank fwd    = (1000, 2000, 3000) == explicit (W+B⊗A)·x
+;   stacked fwd2    = (3000, 2000, 3000) == explicit (W+B⊗A+B2⊗A2)·x
+;   B⊗A row 2       = (2000, 0, 0)
+;
+; Verdict 31 when every claim lands:
+;   1   the low-rank forward equals the explicit (W + B·A)·x   (the LoRA identity)
+;   2   the adapter ADDS capability — output changes vs base W·x
+;   4   two adapters STACK to the explicit (W + B·A + B2·A2)·x
+;   8   the rank-1 adapter is SMALLER than the full matrix     (|B|+|A| < d·d)
+;   16  the diff is exactly the outer product B⊗A             (row 2 = (2000,0,0))
+(do
+    (let x (list 1000 2000 1000))
+    (let W (list (list 1000 0 0) (list 0 1000 0) (list 0 0 1000)))
+    (let A (list 1000 0 0))
+    (let B (list 0 0 2000))
+    (let base (la-matvec3 W x))
+    (let fwd  (la-forward W B A x))
+    (let full (la-matvec3 (la-madd3 W (la-outer3 B A)) x))
+    (let A2 (list 0 1000 0))
+    (let B2 (list 1000 0 0))
+    (let fwd2  (la-add3 fwd (la-scale3 B2 (la-dot3 A2 x))))
+    (let full2 (la-matvec3 (la-madd3 (la-madd3 W (la-outer3 B A)) (la-outer3 B2 A2)) x))
+    (let row2 (nth (la-outer3 B A) 2))
+
+    ; 1 — low-rank forward == explicit (W+B·A)·x
+    (let c0 (if (and (eq (nth full 0) (nth fwd 0))
+                (and (eq (nth full 1) (nth fwd 1))
+                     (eq (nth full 2) (nth fwd 2)))) 1 0))
+    ; 2 — the adapter changed the output (capability added)
+    (let c1 (if (not (eq (nth fwd 2) (nth base 2))) 2 0))
+    ; 4 — two adapters stack to the explicit sum
+    (let c2 (if (and (eq (nth fwd2 0) (nth full2 0))
+                (and (eq (nth fwd2 1) (nth full2 1))
+                     (eq (nth fwd2 2) (nth full2 2)))) 4 0))
+    ; 8 — the rank-1 adapter is smaller than the full matrix: |B|+|A| < d·d
+    (let c3 (if (lt (add (len B) (len A)) (mul (len W) (len (nth W 0)))) 8 0))
+    ; 16 — the diff is exactly the outer product B⊗A
+    (let c4 (if (and (eq (nth row2 0) 2000)
+                (and (eq (nth row2 1) 0)
+                     (eq (nth row2 2) 0))) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -163,6 +163,7 @@ form-train-step fks 31
 affine-train fks 31
 affine-corpus-fit fks 31
 model-compose fks 31
+lora-adapter fks 31
 form-cli-loop fks 31
 form-cli-router fks 31
 obs-verify fks 31


### PR DESCRIPTION
The altitude above `model-compose`: the diff can be **low-rank**. A base matrix `W` (d×d) gains a capability from an adapter `B·A` (B is d×r, A is r×d, r≪d) — the whole capability is `2·d·r` numbers, not `d²`. That's *why* "one model on top of another, only diffs" is cheap.

The body named `adapter_forward` (`cell-numerics.form`) and the LoRA task-vector `τ = θ_local − θ_base` (`slice-merge.fk`) but had **no four-way proof**. `lora-adapter.fk` is the smallest honest floor — the identity `(W+B·A)·x == W·x + B·(A·x)`, computed the right way (`A·x` is an r-vector, then `B·that` — O(d·r), never the d×d diff).

`lora-adapter-band.fk` → **31 four-way, 0 divergent**:
- the low-rank forward equals the explicit `(W+B⊗A)·x` (the LoRA identity)
- the adapter **changes the output** (capability added)
- two adapters **stack** to the explicit sum
- `|B|+|A| < d·d` (the adapter is smaller than the full matrix)
- the diff is exactly the outer product `B⊗A`

Verified vs an integer reference before authoring. The chunked/general-`d` form is the next stone over this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)