### PR TITLE
feat(form): the oracle-learning flywheel, closed — train on samples, retire the oracle, four-way

### DIFF
--- a/form/form-stdlib/oracle-flywheel.fk
+++ b/form/form-stdlib/oracle-flywheel.fk
@@ -1,0 +1,30 @@
+; oracle-flywheel.fk — the flywheel closed: ask native first, fall to the oracle
+; only when unsure, learn from samples until native handles the whole class.
+;
+; preludes: form-stdlib/core.fk form-stdlib/affine-train.fk form-stdlib/affine-corpus-fit.fk
+;
+; The body already has the two halves apart: the routing + the flip
+; (android-mesh-learning's aml-route-choice, form-cli-router "raised form-native's
+; confidence, flips agent-cli -> form-native") and the flywheel named
+; (form-cli-loop: "the more we use LLMs, the less we need them"); and the training
+; loop (affine-train / affine-corpus-fit) that raises native quality. This closes
+; the loop BETWEEN them.
+;
+; A question is routed to the ORACLE exactly when the native model is NOT confident
+; on it — its error on that query is above tolerance. So oracle-reliance over a
+; set of queries = the count the native model misses. Training the native model on
+; samples raises the confident count, dropping oracle calls. When it reaches zero,
+; native handles the whole class and the oracle retires for it.
+;
+; The honest lever is SAMPLES, not epochs: more epochs overfit a tiny set (the
+; reference showed native correct fall 3->1 at 80 epochs on 5 samples); more
+; SAMPLES generalize. This is the recipe/data split made measurable — the recipe
+; (the affine model + the descent) is fixed; the DATA (the ~100 samples for a
+; class) is what teaches it to retire the oracle.
+;
+; Proven by: form-stdlib/tests/oracle-flywheel-band.fk
+
+; oracle reliance over a query set: the queries the native model is NOT confident
+; on (|pred - y| > tol) route to the oracle. confident queries answer native.
+(defn of-oracle-calls (model test tol)
+    (sub (len test) (acf-native-correct model test tol)))

--- a/form/form-stdlib/tests/oracle-flywheel-band.fk
+++ b/form/form-stdlib/tests/oracle-flywheel-band.fk
@@ -1,0 +1,46 @@
+; preludes: form-stdlib/core.fk form-stdlib/affine-train.fk form-stdlib/affine-corpus-fit.fk form-stdlib/oracle-flywheel.fk
+;
+; oracle-flywheel-band — the closed flywheel, four-way in pure Form: ask native
+; first, fall to the oracle only when unsure, and training on SAMPLES drops oracle
+; reliance to zero. This connects the night's training loop to the body's routing
+; (android-mesh-learning / form-cli-router) — the two halves the body had apart.
+;
+; Fixture: the real i18n EN->FR length task (FX=50, from affine-corpus-fit).
+; test = 3 held-out real pairs, tol = 50 (= 1 char). A question routes to the
+; ORACLE when the native model misses it by > tol. Train from base (0,0), lr=3,
+; 40 epochs, on FEW samples (2) vs FULL samples (5). Reference (integer,
+; truncate-toward-zero), verified before authoring:
+;   untrained base      : oracle_calls = 3 (no native capability — all to oracle)
+;   trained on 2 samples: native 0/3, oracle_calls = 3 (too few to generalize)
+;   trained on 5 samples: native 3/3, oracle_calls = 0 (native handles the class)
+;
+; Verdict 31 when every claim lands:
+;   1   untrained routes EVERY query to the oracle (no native capability yet)
+;   2   training drops oracle reliance — the flip oracle -> native
+;   4   the samples taught it — native-correct rises off zero
+;   8   MORE SAMPLES -> reliance does not rise (the honest lever; epochs overfit)
+;   16  native now handles the WHOLE class — zero oracle calls
+(do
+    (let test (list (list 450 500) (list 1400 1550) (list 2200 2500)))
+    (let tol 50)
+    (let few  (list (list 400 450) (list 950 1150)))
+    (let full (list (list 400 450) (list 950 1150) (list 1350 1750) (list 1750 2150) (list 2200 2700)))
+    (let base (list 0 0))
+    (let t-few  (aff-train base few  3 40))
+    (let t-full (aff-train base full 3 40))
+    (let oc-base (of-oracle-calls base   test tol))
+    (let oc-few  (of-oracle-calls t-few  test tol))
+    (let oc-full (of-oracle-calls t-full test tol))
+
+    ; 1 — untrained routes every query to the oracle
+    (let c0 (if (eq oc-base (len test)) 1 0))
+    ; 2 — training drops oracle reliance (the flip)
+    (let c1 (if (lt oc-full oc-base) 2 0))
+    ; 4 — the samples taught it (native answers rise off zero)
+    (let c2 (if (gt (acf-native-correct t-full test tol) (acf-native-correct base test tol)) 4 0))
+    ; 8 — more samples never raise reliance (oc-full <= oc-few): the honest lever
+    (let c3 (if (ge oc-few oc-full) 8 0))
+    ; 16 — native handles the whole class: zero oracle calls
+    (let c4 (if (eq oc-full 0) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -164,6 +164,7 @@ affine-train fks 31
 affine-corpus-fit fks 31
 model-compose fks 31
 lora-adapter fks 31
+oracle-flywheel fks 31
 form-cli-loop fks 31
 form-cli-router fks 31
 obs-verify fks 31


### PR DESCRIPTION
Your operating model, proven at the smallest honest size: *ask native first, fall to the oracle only when unsure, and when a class hits the oracle too often, gather samples and train until native handles it.*

The body had the two halves apart — the routing + flip (`android-mesh-learning` / `form-cli-router`) and the training loop (`affine-train` / `affine-corpus-fit`). `oracle-flywheel.fk` closes the loop: a question routes to the **oracle** exactly when native is not confident (error > tol), so oracle-reliance = the count native misses; training on samples raises the confident count, dropping oracle calls to zero.

`oracle-flywheel-band.fk` → **31 four-way, 0 divergent** (real i18n EN→FR task):
- untrained routes **all 3** queries to the oracle
- trained on 5 real samples → **0 oracle calls** (native handles the class)
- the samples taught it (native-correct rises off zero)
- **the honest lever is SAMPLES, not epochs** — the reference caught that 80 epochs *overfit* the tiny set (native 3→1), so the monotone claim is `oc_full ≤ oc_few` (more samples), not more training

The recipe/data split made measurable: the **recipe** (model + descent) is fixed; the **data** (the ~100 samples for a class) is what retires the oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)