### PR TITLE
tend(form): heal blueprint name-drift — `bp` named two NodeIDs across bands

### DIFF
--- a/form/form-stdlib/tests/record-fold-band.fk
+++ b/form/form-stdlib/tests/record-fold-band.fk
@@ -25,12 +25,12 @@
 ;   - empty-list fold returns the identity accumulator (0)             → 16
 
 (do
-    (let bp (make_nodeid 1 5 4 1))
+    (let row-bp (make_nodeid 1 5 4 1))
 
     (let items (list
-        (record_new bp "n" 3 "tag" 1)
-        (record_new bp "n" 7 "tag" 1)
-        (record_new bp "n" 5 "tag" 0)))
+        (record_new row-bp "n" 3 "tag" 1)
+        (record_new row-bp "n" 7 "tag" 1)
+        (record_new row-bp "n" 5 "tag" 0)))
 
     ;; sum a named integer field across the list (head/tail accumulator fold)
     (defn sum_n (xs acc)
@@ -46,7 +46,7 @@
                 (count_tag (tail xs) (add acc 1))
                 (count_tag (tail xs) acc))))
 
-    (let one (record_new bp "n" 42 "tag" 9))
+    (let one (record_new row-bp "n" 42 "tag" 9))
     (let s1 (if (eq (record_get one "n") 42) 1 0))
     (let s2 (if (eq (record_get one "tag") 9) 1 0))
     (let s3 (if (eq (sum_n items 0) 15) 1 0))


### PR DESCRIPTION
## What

The Form blueprint scanner (`scripts/scan_form_blueprints.py --check`, also surfaced by `make wellness`) flagged a name-drift warning: one name bound to two distinct NodeIDs.

```
⚠  name drift — 1 name(s) bound to >1 NodeID:
   bp: ['1.2.99.9001', '1.5.4.1']
```

The local binding `bp` resolved to `1.5.4.1` in `record-fold-band.fk` and `1.2.99.9001` in `record-blueprint-band.fk`. Neither NodeID is a registered shape — both are test-local sentinels — so the honest fix is naming hygiene, not unifying the sentinels.

## How

Renamed the fold band's binding to `row-bp` (it's the shared blueprint of the rows being folded). Left `record-blueprint-band.fk`'s clean `bp`/`other-bp` A/B pair intact. Same NodeID literal, same record ops — a local-symbol rename only, so four-way kernel behavior is unchanged. Hyphenated let-names like `other-bp` already pass four-way in the sibling band.

## Proof

- `scan_form_blueprints.py --check` now exits 0 — the `⚠ name drift` line is gone.
- CI's `validate.sh` carries the real four-way proof (Go · Rust · TypeScript · fkwu) for the renamed band. (Local validate was unreliable — known-broken local source-compiler in this checkout.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)