### PR TITLE
feat(form-cli): the open-gap catalog — what's open, with the offline-vs-stage split

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 258 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 259 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -43,6 +43,43 @@ ledger inherits proven four-way validation. Each is tagged:
 - **air-gap-clean?** — zero `remote-oracle` crossings. The offline-readiness
   number; on a plane it must be 0.
 
+## The open-gap catalog
+
+The membrane shows gaps *per crossing* — what one run hit. The catalog is the
+*standing inventory* of everything open in the body, so you can see every gap at
+rest and pick which to close:
+
+```bash
+scripts/form_cli_gaps.sh            # the full catalog
+scripts/form_cli_gaps.sh --stage    # only what must be staged before the flight
+```
+
+Three lanes of openness:
+
+- **open idea** — an idea no spec references → `author-form-spec`
+- **open spec** — a non-draft spec with no `test:`/`proof:` → `write-validation-band`
+- **open capability** — an oracle-catalog teacher lane, placed on the **closing
+  ladder** by its `(trust, state)`
+
+The capability ladder names, for each open capability, the cheapest next move and
+whether it's **offline-closable** or needs the network **first**:
+
+| rung | meaning | next move | offline |
+|---|---|---|---|
+| `samples` | samples on disk, no recipe | train a native recipe | yes |
+| `local-oracle` | a local oracle is installed | distill samples | yes |
+| `source-local` | local oracle source on disk, needs building | build the source | yes |
+| `remote-only` | only a remote oracle | **stage remote→local** | **no — ⚑ before flight** |
+| `none` | no oracle at all | find/stage an oracle | **no** |
+
+The catalog tallies `open / offline-closable / stage-before-flight` and reads
+**flight-ready** iff nothing needs the network first — the membrane's
+air-gap-clean notion at body scale. A membrane crossing tagged `gap=1`
+corresponds to a catalog item. Recipe:
+[`form-cli-gaps.fk`](../../form/form-stdlib/form-cli-gaps.fk) — proven four-way
+(`form-cli-gaps-band` → 4095). Measured on the body today: 27 open, 26
+offline-closable, 1 stage-before-flight (`remote-llm`).
+
 Recipe: [`form-cli-membrane.fk`](../../form/form-stdlib/form-cli-membrane.fk) —
 proven four-way (`form-cli-membrane-band`, verdict 1023, go/rust/ts/fkwu).
 

--- a/form/form-stdlib/form-cli-gaps.fk
+++ b/form/form-stdlib/form-cli-gaps.fk
@@ -1,0 +1,136 @@
+; form-cli-gaps.fk — the catalog of what is OPEN, with the closing ladder.
+;
+; preludes: form-stdlib/core.fk
+;
+; The membrane (form-cli-membrane.fk) shows gaps PER CROSSING — what one run hit.
+; This is the standing inventory: every open thing in the body at rest, so we see
+; the gaps and choose which to close, by which move, and — the flight lever —
+; which are closable OFFLINE versus which need the network first.
+;
+; Three lanes of openness:
+;   - open IDEA       — an idea with no form spec            → author a spec
+;   - open SPEC       — a spec with no validation/proof       → write a band
+;   - open CAPABILITY — a model/capability with no native     → climb the ladder
+;     recipe, no samples, no local oracle, no remote oracle
+;
+; The capability LADDER (Urs's framing made executable) — rungs from most-open to
+; closed, each naming the cheapest next move and whether it needs the network:
+;
+;   none         no recipe, no samples, no oracle at all   find/stage an oracle   NEEDS NETWORK
+;   remote-only  only a remote oracle reachable            stage remote->local    NEEDS NETWORK  ← flight flag
+;   local-oracle a local oracle is on the device           distill samples         offline
+;   samples      samples on disk, no recipe yet            train a native recipe   offline
+;   recipe       a native Form recipe carries it           (closed — not open)
+;
+; "stage-before-flight" = the rung needs the network to even begin (remote-only /
+; none). flight-ready = the catalog has zero such items: every open gap can be
+; worked air-gapped. This composes the membrane's air-gap-clean notion at body
+; scale; a membrane crossing tagged gap=1 corresponds to a catalog item here.
+;
+; Registered Blueprint coordinates (form/user-blueprint-registry.md):
+(let GAPS-TAG-ITEM 1893)
+(let GAPS-TAG-CATALOG 1894)
+
+(defn gaps-tagged? (v tag arity) (if (eq (len v) arity) (eq (nth v 0) tag) false))
+
+; ── the rungs of the closing ladder ──
+(defn gaps-rung-closed () "closed")
+(defn gaps-rung-samples () "samples")
+(defn gaps-rung-local () "local-oracle")
+(defn gaps-rung-remote () "remote-only")
+(defn gaps-rung-none () "none")
+(defn gaps-rung-no-spec () "no-spec")     ; an open idea
+(defn gaps-rung-no-proof () "no-proof")   ; an open spec
+
+; the kinds of open thing
+(defn gaps-kind-idea () "idea")
+(defn gaps-kind-spec () "spec")
+(defn gaps-kind-capability () "capability")
+
+; ── the capability rung from four facts (each 1/0) ──
+; climb down: a native recipe closes it; else samples; else a local oracle; else
+; a remote oracle; else nothing. The FIRST available rung is where it sits.
+(defn gaps-capability-rung (recipe? samples? local? remote?)
+    (if (eq recipe? 1) (gaps-rung-closed)
+        (if (eq samples? 1) (gaps-rung-samples)
+            (if (eq local? 1) (gaps-rung-local)
+                (if (eq remote? 1) (gaps-rung-remote)
+                    (gaps-rung-none))))))
+
+; ── the cheapest next move to climb one rung toward closed ──
+(defn gaps-next-move (rung)
+    (if (str_eq rung (gaps-rung-samples)) "train-native-recipe"
+        (if (str_eq rung (gaps-rung-local)) "distill-samples-from-local-oracle"
+            (if (str_eq rung (gaps-rung-remote)) "stage-remote-to-local-oracle"
+                (if (str_eq rung (gaps-rung-none)) "find-or-stage-an-oracle"
+                    (if (str_eq rung (gaps-rung-no-spec)) "author-form-spec"
+                        (if (str_eq rung (gaps-rung-no-proof)) "write-validation-band"
+                            "none")))))))
+
+; ── can the next move happen with NO network? (the offline lever) ──
+(defn gaps-offline-closable? (rung)
+    (if (or (str_eq rung (gaps-rung-samples))
+            (or (str_eq rung (gaps-rung-local))
+                (or (str_eq rung (gaps-rung-no-spec))
+                    (str_eq rung (gaps-rung-no-proof))))) 1 0))
+
+; ── does this rung NEED the network before it can even begin? (flight flag) ──
+(defn gaps-stage-before-flight? (rung)
+    (if (or (str_eq rung (gaps-rung-remote)) (str_eq rung (gaps-rung-none))) 1 0))
+
+; ── is this rung open at all? (closed is the only non-open rung) ──
+(defn gaps-open-rung? (rung) (if (str_eq rung (gaps-rung-closed)) 0 1))
+
+; ── an open item: a thing in the body and the rung it sits on ──
+(defn gaps-item (kind id rung)
+    (list GAPS-TAG-ITEM kind id rung
+        (gaps-next-move rung)
+        (gaps-offline-closable? rung)
+        (gaps-stage-before-flight? rung)))
+(defn gaps-item? (x) (gaps-tagged? x GAPS-TAG-ITEM 7))
+(defn gaps-i-kind (x) (nth x 1))
+(defn gaps-i-id (x) (nth x 2))
+(defn gaps-i-rung (x) (nth x 3))
+(defn gaps-i-next (x) (nth x 4))
+(defn gaps-i-offline? (x) (nth x 5))
+(defn gaps-i-stage? (x) (nth x 6))
+; an item is well-formed when its derived fields agree with its rung
+(defn gaps-item-valid? (x)
+    (and (gaps-item? x)
+         (and (gt (str_len (gaps-i-id x)) 0)
+              (and (str_eq (gaps-i-next x) (gaps-next-move (gaps-i-rung x)))
+                   (and (eq (gaps-i-offline? x) (gaps-offline-closable? (gaps-i-rung x)))
+                        (eq (gaps-i-stage? x) (gaps-stage-before-flight? (gaps-i-rung x))))))))
+
+; ── the catalog: the open items and what they tally to ──
+(defn gaps-catalog (items) (list GAPS-TAG-CATALOG items))
+(defn gaps-catalog? (c) (gaps-tagged? c GAPS-TAG-CATALOG 2))
+(defn gaps-cat-items (c) (nth c 1))
+
+(defn gaps-count (items) (len items))
+(defn gaps-count-kind (items kind)
+    (if (eq (len items) 0) 0
+        (add (if (str_eq (gaps-i-kind (head items)) kind) 1 0)
+             (gaps-count-kind (tail items) kind))))
+(defn gaps-count-offline (items)
+    (if (eq (len items) 0) 0
+        (add (gaps-i-offline? (head items)) (gaps-count-offline (tail items)))))
+(defn gaps-count-stage (items)
+    (if (eq (len items) 0) 0
+        (add (gaps-i-stage? (head items)) (gaps-count-stage (tail items)))))
+(defn gaps-count-rung (items rung)
+    (if (eq (len items) 0) 0
+        (add (if (str_eq (gaps-i-rung (head items)) rung) 1 0)
+             (gaps-count-rung (tail items) rung))))
+
+(defn gaps-cat-open-count (c) (gaps-count (gaps-cat-items c)))
+(defn gaps-cat-idea-count (c) (gaps-count-kind (gaps-cat-items c) (gaps-kind-idea)))
+(defn gaps-cat-spec-count (c) (gaps-count-kind (gaps-cat-items c) (gaps-kind-spec)))
+(defn gaps-cat-capability-count (c) (gaps-count-kind (gaps-cat-items c) (gaps-kind-capability)))
+(defn gaps-cat-offline-count (c) (gaps-count-offline (gaps-cat-items c)))
+(defn gaps-cat-stage-count (c) (gaps-count-stage (gaps-cat-items c)))
+; flight-ready: nothing in the catalog needs the network to begin closing —
+; every open gap can be worked air-gapped.
+(defn gaps-cat-flight-ready? (c) (if (eq (gaps-cat-stage-count c) 0) 1 0))
+
+0

--- a/form/form-stdlib/form-cli-gaps.fk
+++ b/form/form-stdlib/form-cli-gaps.fk
@@ -38,6 +38,7 @@
 (defn gaps-rung-samples () "samples")
 (defn gaps-rung-local () "local-oracle")
 (defn gaps-rung-remote () "remote-only")
+(defn gaps-rung-source () "source-local")  ; local oracle source on disk, needs building (offline)
 (defn gaps-rung-none () "none")
 (defn gaps-rung-no-spec () "no-spec")     ; an open idea
 (defn gaps-rung-no-proof () "no-proof")   ; an open spec
@@ -57,22 +58,35 @@
                 (if (eq remote? 1) (gaps-rung-remote)
                     (gaps-rung-none))))))
 
+; ── map an oracle-catalog teacher (trust, state) onto the ladder ──
+; oracle-catalog.fk names each teacher lane the body leans on. A lane the body
+; senses only through a teacher is an open capability: an installed LOCAL teacher
+; sits at local-oracle (distill offline); an installed REMOTE teacher sits at
+; remote-only (stage before flight); source-pending / absent sit at none.
+(defn gaps-rung-from-oracle (trust state)
+    (if (str_eq state "installed")
+        (if (str_eq trust "local") (gaps-rung-local) (gaps-rung-remote))
+        (if (str_eq state "source-pending") (gaps-rung-source)
+            (gaps-rung-none))))
+
 ; ── the cheapest next move to climb one rung toward closed ──
 (defn gaps-next-move (rung)
     (if (str_eq rung (gaps-rung-samples)) "train-native-recipe"
         (if (str_eq rung (gaps-rung-local)) "distill-samples-from-local-oracle"
-            (if (str_eq rung (gaps-rung-remote)) "stage-remote-to-local-oracle"
-                (if (str_eq rung (gaps-rung-none)) "find-or-stage-an-oracle"
-                    (if (str_eq rung (gaps-rung-no-spec)) "author-form-spec"
-                        (if (str_eq rung (gaps-rung-no-proof)) "write-validation-band"
-                            "none")))))))
+            (if (str_eq rung (gaps-rung-source)) "build-local-oracle-source"
+                (if (str_eq rung (gaps-rung-remote)) "stage-remote-to-local-oracle"
+                    (if (str_eq rung (gaps-rung-none)) "find-or-stage-an-oracle"
+                        (if (str_eq rung (gaps-rung-no-spec)) "author-form-spec"
+                            (if (str_eq rung (gaps-rung-no-proof)) "write-validation-band"
+                                "none"))))))))
 
 ; ── can the next move happen with NO network? (the offline lever) ──
 (defn gaps-offline-closable? (rung)
     (if (or (str_eq rung (gaps-rung-samples))
             (or (str_eq rung (gaps-rung-local))
-                (or (str_eq rung (gaps-rung-no-spec))
-                    (str_eq rung (gaps-rung-no-proof))))) 1 0))
+                (or (str_eq rung (gaps-rung-source))
+                    (or (str_eq rung (gaps-rung-no-spec))
+                        (str_eq rung (gaps-rung-no-proof)))))) 1 0))
 
 ; ── does this rung NEED the network before it can even begin? (flight flag) ──
 (defn gaps-stage-before-flight? (rung)

--- a/form/form-stdlib/tests/form-cli-gaps-band.fk
+++ b/form/form-stdlib/tests/form-cli-gaps-band.fk
@@ -1,0 +1,111 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-cli-gaps.fk
+;
+; form-cli-gaps-band - the open-gap catalog + closing-ladder proof.
+;
+; Verdict 1023 when: the capability ladder classifies all five rungs; each rung
+; names its next move; the offline-closable and stage-before-flight flags hold;
+; open-rung? excludes only closed; idea / spec / capability items construct and
+; validate with rung-consistent derived fields; and the catalog tallies open /
+; per-kind / offline / stage counts and reads flight-ready iff nothing needs the
+; network first.
+
+(do
+    ; ── the ladder classifies all five rungs (closest-to-closed wins) ──
+    (let c0 (if (str_eq (gaps-capability-rung 1 0 0 0) (gaps-rung-closed))
+                (if (str_eq (gaps-capability-rung 0 1 0 0) (gaps-rung-samples))
+                    (if (str_eq (gaps-capability-rung 0 0 1 0) (gaps-rung-local))
+                        (if (str_eq (gaps-capability-rung 0 0 0 1) (gaps-rung-remote))
+                            (if (str_eq (gaps-capability-rung 0 0 0 0) (gaps-rung-none)) 1 0)
+                            0)
+                        0)
+                    0)
+                0))
+
+    ; ── each rung names the cheapest next move ──
+    (let c1 (if (str_eq (gaps-next-move (gaps-rung-samples)) "train-native-recipe")
+                (if (str_eq (gaps-next-move (gaps-rung-local)) "distill-samples-from-local-oracle")
+                    (if (str_eq (gaps-next-move (gaps-rung-remote)) "stage-remote-to-local-oracle")
+                        (if (str_eq (gaps-next-move (gaps-rung-none)) "find-or-stage-an-oracle")
+                            (if (str_eq (gaps-next-move (gaps-rung-no-spec)) "author-form-spec")
+                                (if (str_eq (gaps-next-move (gaps-rung-no-proof)) "write-validation-band") 2 0)
+                                0)
+                            0)
+                        0)
+                    0)
+                0))
+
+    ; ── offline-closable: samples / local / no-spec / no-proof yes; remote / none no ──
+    (let c2 (if (eq (gaps-offline-closable? (gaps-rung-samples)) 1)
+                (if (eq (gaps-offline-closable? (gaps-rung-local)) 1)
+                    (if (eq (gaps-offline-closable? (gaps-rung-no-spec)) 1)
+                        (if (eq (gaps-offline-closable? (gaps-rung-no-proof)) 1)
+                            (if (eq (gaps-offline-closable? (gaps-rung-remote)) 0)
+                                (if (eq (gaps-offline-closable? (gaps-rung-none)) 0) 4 0)
+                                0)
+                            0)
+                        0)
+                    0)
+                0))
+
+    ; ── stage-before-flight: remote / none need the network; local / samples do not ──
+    (let c3 (if (eq (gaps-stage-before-flight? (gaps-rung-remote)) 1)
+                (if (eq (gaps-stage-before-flight? (gaps-rung-none)) 1)
+                    (if (eq (gaps-stage-before-flight? (gaps-rung-local)) 0)
+                        (if (eq (gaps-stage-before-flight? (gaps-rung-samples)) 0) 8 0)
+                        0)
+                    0)
+                0))
+
+    ; ── open-rung? excludes only closed ──
+    (let c4 (if (eq (gaps-open-rung? (gaps-rung-closed)) 0)
+                (if (eq (gaps-open-rung? (gaps-rung-remote)) 1)
+                    (if (eq (gaps-open-rung? (gaps-rung-no-spec)) 1) 16 0)
+                    0)
+                0))
+
+    ; ── the three kinds of open item construct and validate ──
+    (let cap-remote (gaps-item (gaps-kind-capability) "remote-thing" (gaps-capability-rung 0 0 0 1)))
+    (let cap-local (gaps-item (gaps-kind-capability) "stt" (gaps-capability-rung 0 0 1 1)))
+    (let cap-none (gaps-item (gaps-kind-capability) "void-thing" (gaps-capability-rung 0 0 0 0)))
+    (let idea-open (gaps-item (gaps-kind-idea) "agent-pipeline" (gaps-rung-no-spec)))
+    (let spec-open (gaps-item (gaps-kind-spec) "private-channels" (gaps-rung-no-proof)))
+
+    (let c5 (if (gaps-item-valid? cap-remote)
+                (if (eq (gaps-i-offline? cap-remote) 0)
+                    (if (eq (gaps-i-stage? cap-remote) 1)
+                        (if (str_eq (gaps-i-next cap-remote) "stage-remote-to-local-oracle") 32 0)
+                        0)
+                    0)
+                0))
+
+    (let c6 (if (gaps-item-valid? idea-open)
+                (if (eq (gaps-i-offline? idea-open) 1)
+                    (if (eq (gaps-i-stage? idea-open) 0) 64 0)
+                    0)
+                0))
+
+    (let c7 (if (gaps-item-valid? spec-open)
+                (if (eq (gaps-i-offline? spec-open) 1) 128 0)
+                0))
+
+    ; ── the catalog tallies (mixed: 1 idea, 1 spec, 3 capabilities) ──
+    (let catB (gaps-catalog (list idea-open spec-open cap-local cap-remote cap-none)))
+    (let c8 (if (eq (gaps-cat-open-count catB) 5)
+                (if (eq (gaps-cat-idea-count catB) 1)
+                    (if (eq (gaps-cat-spec-count catB) 1)
+                        (if (eq (gaps-cat-capability-count catB) 3)
+                            (if (eq (gaps-cat-offline-count catB) 3)
+                                (if (eq (gaps-cat-stage-count catB) 2) 256 0)
+                                0)
+                            0)
+                        0)
+                    0)
+                0))
+
+    ; ── flight-ready iff nothing needs the network first ──
+    (let catA (gaps-catalog (list idea-open spec-open cap-local)))
+    (let c9 (if (eq (gaps-cat-flight-ready? catA) 1)
+                (if (eq (gaps-cat-flight-ready? catB) 0) 512 0)
+                0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 c9))))))))))

--- a/form/form-stdlib/tests/form-cli-gaps-band.fk
+++ b/form/form-stdlib/tests/form-cli-gaps-band.fk
@@ -108,4 +108,20 @@
                 (if (eq (gaps-cat-flight-ready? catB) 0) 512 0)
                 0))
 
-    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 c9))))))))))
+    ; ── oracle-catalog (trust, state) maps onto the ladder ──
+    (let c10 (if (str_eq (gaps-rung-from-oracle "local" "installed") (gaps-rung-local))
+                 (if (str_eq (gaps-rung-from-oracle "remote-membrane" "installed") (gaps-rung-remote))
+                     (if (str_eq (gaps-rung-from-oracle "local" "source-pending") (gaps-rung-source))
+                         (if (str_eq (gaps-rung-from-oracle "local" "absent") (gaps-rung-none)) 1024 0)
+                         0)
+                     0)
+                 0))
+
+    ; ── source-local: a local oracle source on disk is offline-buildable, not a network stage ──
+    (let c11 (if (str_eq (gaps-next-move (gaps-rung-source)) "build-local-oracle-source")
+                 (if (eq (gaps-offline-closable? (gaps-rung-source)) 1)
+                     (if (eq (gaps-stage-before-flight? (gaps-rung-source)) 0) 2048 0)
+                     0)
+                 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 (add c9 (add c10 c11))))))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -168,6 +168,7 @@ oracle-flywheel fks 31
 form-cli-loop fks 31
 form-cli-router fks 31
 form-cli-membrane fks 1023
+form-cli-gaps fks 1023
 obs-verify fks 31
 world-module-model fks 1023
 world-model-growth fks 4095

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -168,7 +168,7 @@ oracle-flywheel fks 31
 form-cli-loop fks 31
 form-cli-router fks 31
 form-cli-membrane fks 1023
-form-cli-gaps fks 1023
+form-cli-gaps fks 4095
 obs-verify fks 31
 world-module-model fks 1023
 world-model-growth fks 4095

--- a/form/user-blueprint-registry.md
+++ b/form/user-blueprint-registry.md
@@ -266,3 +266,5 @@ The relationship protocol exposes skill verbs so agents and humans can present i
 
 - 1891 MEMBRANE-CROSSING — one crossing of the form-cli surface membrane: op, capability, surface (native-recipe/os-kernel/local-oracle/remote-oracle), native-recipe availability, gap-or-feedback note, outcome, certainty, and cost. Lowers to CHOICE-RECEIPT for proven validation.
 - 1892 MEMBRANE-REPORT — the form-cli surface report: the crossing ledger with native/gap/retirable/local-oracle/network tallies and the air-gap-clean readout.
+- 1893 GAPS-OPEN-ITEM — one open thing in the body: kind (idea/spec/capability), id, ladder rung, cheapest next move, offline-closable flag, stage-before-flight flag.
+- 1894 GAPS-CATALOG — the standing inventory of open items with open/per-kind/offline/stage tallies and the flight-ready readout (nothing needs the network first).

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 258
+**Total files**: 259
 
 | File | Purpose |
 |---|---|
@@ -81,6 +81,7 @@
 | [form_cli.py](form_cli.py) | form_cli.py — Form-native CLI: ask, generate, execute, convert. |
 | [form_cli_close_gap.sh](form_cli_close_gap.sh) | form_cli_close_gap.sh — close a Form recipe gap OFFLINE with a local oracle. |
 | [form_cli_demo.sh](form_cli_demo.sh) | form_cli_demo.sh — exercise every form_cli subcommand end-to-end. |
+| [form_cli_gaps.sh](form_cli_gaps.sh) | form_cli_gaps.sh — the catalog of what is OPEN, walked from the live body. |
 | [form_cli_preflight.sh](form_cli_preflight.sh) | form_cli_preflight.sh — air-gap readiness check for the form-cli. |
 | [form_cli_slice.sh](form_cli_slice.sh) | form_cli_slice.sh — compile a Form recipe slice to a RUNNABLE native binary, |
 | [form_debug_demo.sh](form_debug_demo.sh) | form_debug_demo.sh — LIVE DEBUGGING: the value trace joined with provenance. |

--- a/scripts/form_cli_gaps.sh
+++ b/scripts/form_cli_gaps.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# form_cli_gaps.sh — the catalog of what is OPEN, walked from the live body.
+#
+# Gathers the three lanes of openness and renders them through the Form gaps
+# recipe (form-cli-gaps.fk) — the ladder logic (rung, next move, offline-closable,
+# stage-before-flight) is Form; this shell is a thin carrier that gathers facts
+# and formats. The headline numbers (open / offline-closable / stage-before-flight
+# / flight-ready) are computed by the recipe, not here.
+#
+#   open IDEA       — an idea slug no spec references        → author a spec
+#   open SPEC       — a non-draft spec with no test/proof    → write a band
+#   open CAPABILITY — an oracle-catalog teacher lane, placed  → climb the ladder
+#                     on the ladder by its (trust, state)
+#
+# Usage: scripts/form_cli_gaps.sh            # full catalog
+#        scripts/form_cli_gaps.sh --stage    # only the stage-before-flight items
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STD="$ROOT/form/form-stdlib"; GO="$ROOT/form/form-kernel-go/bin-go"
+ONLY_STAGE=0; [[ "${1:-}" == "--stage" ]] && ONLY_STAGE=1
+[[ -x "$GO" ]] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
+
+# ── gather lane 1: open ideas (idea slugs no spec references) ────────────────
+ideas_tmp="$(mktemp)"; specideas_tmp="$(mktemp)"; trap 'rm -f "$ideas_tmp" "$specideas_tmp"' EXIT
+find "$ROOT/ideas" -maxdepth 1 -name '*.md' 2>/dev/null | while IFS= read -r f; do
+    b="$(basename "$f" .md)"; case "$b" in INDEX|TEMPLATE|MANIFEST|README) ;; *) echo "$b";; esac
+done | sort > "$ideas_tmp"
+grep -hE '^\s*idea_id\s*:' "$ROOT"/specs/*.md 2>/dev/null | sed -E 's/.*idea_id\s*:\s*//; s/["'"'"']//g; s/[[:space:]]*$//' | sort -u > "$specideas_tmp"
+OPEN_IDEAS="$(comm -23 "$ideas_tmp" "$specideas_tmp")"
+
+# ── gather lane 2: open specs (non-draft, no test: and no proof:) ────────────
+OPEN_SPECS=""
+for f in "$ROOT"/specs/*.md; do
+    b="$(basename "$f" .md)"; case "$b" in INDEX|TEMPLATE|MANIFEST) continue;; esac
+    fm="$(awk 'NR==1&&/^---/{f=1;next} /^---/{if(f)exit} f' "$f")"
+    printf '%s\n' "$fm" | grep -qiE '^\s*status\s*:\s*draft' && continue
+    printf '%s\n' "$fm" | grep -qE '^\s*(test|proof)\s*:' || OPEN_SPECS="$OPEN_SPECS $b"
+done
+
+# ── gather lane 3: open capabilities — ASK the recipe, not the source ────────
+# evaluate oracle-catalog's oc-catalog on the kernel and emit (lane|trust|state)
+# per real teacher row. The recipe maps (trust,state) onto the ladder rung.
+captmp="$(mktemp)"; trap 'rm -f "$ideas_tmp" "$specideas_tmp" "$captmp"' EXIT
+{ cat "$STD/oracle-catalog.fk"
+  echo '(defn gaps-cap-row (xs) (if (eq (len xs) 0) 0 (do (print (str_concat (oc-lane (head xs)) (str_concat "|" (str_concat (oc-trust (head xs)) (str_concat "|" (oc-state (head xs))))))) (gaps-cap-row (tail xs)))))'
+  echo '(gaps-cap-row (oc-catalog))'
+} > "$captmp"
+CAP_ROWS="$("$GO" "$captmp" 2>/dev/null | grep '|')"
+
+# ── build the Form program: the recipe classifies + tallies everything ──────
+prog="$(mktemp)"; out="$(mktemp)"; trap 'rm -f "$ideas_tmp" "$specideas_tmp" "$captmp" "$prog" "$out"' EXIT
+{
+    cat "$STD/form-cli-gaps.fk"
+    echo '(defn gaps-emit (x) (print (str_concat "ITEM|" (str_concat (gaps-i-kind x) (str_concat "|" (str_concat (gaps-i-id x) (str_concat "|" (str_concat (gaps-i-rung x) (str_concat "|" (str_concat (gaps-i-next x) (str_concat "|" (str_concat (int_to_str (gaps-i-offline? x)) (str_concat "|" (int_to_str (gaps-i-stage? x)))))))))))))))'
+    echo '(defn gaps-emit-all (xs) (if (eq (len xs) 0) 0 (do (gaps-emit (head xs)) (gaps-emit-all (tail xs)))))'
+    printf '(let items (list'
+    while IFS= read -r s; do [[ -n "$s" ]] && printf ' (gaps-item "idea" "%s" (gaps-rung-no-spec))' "$s"; done <<< "$OPEN_IDEAS"
+    for s in $OPEN_SPECS; do printf ' (gaps-item "spec" "%s" (gaps-rung-no-proof))' "$s"; done
+    while IFS='|' read -r lane trust state; do
+        [[ -z "$lane" ]] && continue
+        printf ' (gaps-item "capability" "%s" (gaps-rung-from-oracle "%s" "%s"))' "$lane" "$trust" "$state"
+    done <<< "$CAP_ROWS"
+    printf '))\n'
+    echo '(gaps-emit-all items)'
+    echo '(let cat (gaps-catalog items))'
+    echo '(print "TALLY")'
+    echo '(print (gaps-cat-open-count cat))'
+    echo '(print (gaps-cat-idea-count cat))'
+    echo '(print (gaps-cat-spec-count cat))'
+    echo '(print (gaps-cat-capability-count cat))'
+    echo '(print (gaps-cat-offline-count cat))'
+    echo '(print (gaps-cat-stage-count cat))'
+    echo '(print (gaps-cat-flight-ready? cat))'
+} > "$prog"
+"$GO" "$prog" 2>"${GAPS_DEBUG:-/dev/null}" > "$out"
+[[ -n "${GAPS_DEBUG:-}" ]] && cp "$prog" "$GAPS_DEBUG.prog"
+
+# ── render ──────────────────────────────────────────────────────────────────
+echo "── the open-gap catalog (walked from the body) ──"
+render_lane() {
+    local want="$1" title="$2" shown=0
+    while IFS='|' read -r tag kind id rung next offline stage; do
+        [[ "$tag" != "ITEM" || "$kind" != "$want" ]] && continue
+        [[ "$ONLY_STAGE" -eq 1 && "$stage" != "1" ]] && continue
+        if [[ "$shown" -eq 0 ]]; then printf "\n%s\n" "$title"; shown=1; fi
+        local flag="offline-ok"; [[ "$stage" == "1" ]] && flag="⚑ STAGE BEFORE FLIGHT"
+        printf "  %-26s [%-12s] → %-32s %s\n" "$id" "$rung" "$next" "$flag"
+    done < "$out"
+}
+render_lane idea       "open IDEAS (no form spec):"
+render_lane spec       "open SPECS (no validation):"
+render_lane capability "open CAPABILITIES (model leans on an oracle):"
+
+TVALS="$(awk '/^TALLY$/{f=1;next} f{v=$0;gsub(/[[:space:]]/,"",v);if(v!=""){print v;n++}} n>=7{exit}' "$out" | paste -sd' ' -)"
+read -r T_OPEN T_IDEA T_SPEC T_CAP T_OFF T_STAGE T_FLIGHT <<< "$TVALS"
+echo
+echo "── tally ──"
+printf "  open total         %s   (ideas %s · specs %s · capabilities %s)\n" "$T_OPEN" "$T_IDEA" "$T_SPEC" "$T_CAP"
+printf "  offline-closable   %s   (workable air-gapped, right now)\n" "$T_OFF"
+printf "  stage before flight %s   (need the network FIRST — stage these before you lose it)\n" "$T_STAGE"
+if [[ "${T_FLIGHT:-0}" == "1" ]]; then
+    echo "  flight-ready       yes — every open gap can be worked offline."
+else
+    echo "  flight-ready       NO  — stage the ⚑ items above before the network goes dark."
+fi


### PR DESCRIPTION
> "The key is to know what is open: open ideas (without form specs), open specs (without validation), and models without native recipes or samples or local or remote oracles; that catalog being available to us is essential so we see the gaps and focus on how to close those gaps." — Urs

The membrane (#3229) shows gaps **per crossing** — what one run hit. This is the **standing inventory** of everything open in the body, so we can see every gap at rest, pick which to close, and — the flight lever — see which are closable **offline** vs which need the network **first**.

## What it is

**`form-cli-gaps.fk`** (four-way proven, `form-cli-gaps-band` → **4095**) models three lanes of openness and the capability **closing ladder**:

```
none → remote-only → source-local → local-oracle → samples → recipe(closed)
```

Each rung names the cheapest next move and two flags: **offline-closable?** and **stage-before-flight?** (the rung needs the network to even begin). The catalog tallies open / offline / stage and reads **flight-ready** iff nothing needs the network first — the membrane's air-gap-clean notion at body scale.

**`scripts/form_cli_gaps.sh`** walks the live body and renders it. The ladder logic is Form; the shell gathers facts and formats. Capability lane asks the recipe (`oc-catalog`), not the source text.

## Measured on the body today

```
open total          27   (ideas 17 · specs 2 · capabilities 8)
offline-closable    26   (workable air-gapped, right now)
stage before flight  1   (remote-llm / ollama-cloud — needs network to localize)
flight-ready        NO   — stage the ⚑ item before the network goes dark
```

- **17 open ideas** (no spec) → `author-form-spec`, all offline
- **2 open specs** (no validation) → `write-validation-band`, offline
- **8 capabilities** from oracle-catalog: stt/tts/local-llm/ground-truth at `local-oracle` (offline distill); audio-body/camera/audio-music at `source-local` (offline build); **remote-llm at `remote-only` — ⚑ the one thing to stage before the flight**

## The source-local refinement

A local oracle whose Swift source is on disk needs *building*, which is offline — not a network stage. So `source-pending` local teachers read `offline-ok`, not `stage-before-flight`. Without this, the catalog would overstate the network need and mislead the flight prep.

Blueprint tags 1893 GAPS-OPEN-ITEM / 1894 GAPS-CATALOG registered; manifest carries the band. No `api`/`web` changes — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)