### PR TITLE
tend(form-cli): strengthen sovereignty filter + sweep the session history into a training corpus

### DIFF
--- a/form/form-samples/agent-turns/README.md
+++ b/form/form-samples/agent-turns/README.md
@@ -36,6 +36,22 @@ scripts/form_cli_capture.sh --from-transcript <session>.jsonl 10
 scripts/form_cli_capture.sh --gap "<task>" "<reasoning>" "<answer>" <outcome> <oracle>
 ```
 
+### Historical archive
+
+`FORM_CLI_CORPUS` points the corpus at a stable path that survives worktree
+cleanup — used to sweep the whole session history into one durable store:
+
+```bash
+PD=~/.claude/projects/-Users-ursmuff-source-Coherence-Network
+for f in "$PD"/*.jsonl; do
+  FORM_CLI_CORPUS=~/.coherence-network/form-cli-corpus/corpus.jsonl \
+    scripts/form_cli_capture.sh --from-transcript "$f" 100
+done
+```
+
+The sovereignty filter runs on every turn, so a month of sessions sweeps down to
+only the technical reasoning + tool use. Dedup by `(task_sig, answer_sig)`.
+
 ## Cell sovereignty — structural, not manual
 
 The capture carrier **refuses** any turn touching tender/personal markers — a

--- a/scripts/form_cli_capture.sh
+++ b/scripts/form_cli_capture.sh
@@ -17,8 +17,11 @@
 set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STD="$ROOT/form/form-stdlib"; GO="$ROOT/form/form-kernel-go/bin-go"
-CORPUS_DIR="$ROOT/form/form-samples/agent-turns"; mkdir -p "$CORPUS_DIR"
-CORPUS="$CORPUS_DIR/corpus.jsonl"
+# Corpus path: defaults to the gitignored in-repo store; FORM_CLI_CORPUS points it
+# at a stable location (e.g. ~/.coherence-network/form-cli-corpus) that survives
+# worktree cleanup — used for the historical archive.
+CORPUS="${FORM_CLI_CORPUS:-$ROOT/form/form-samples/agent-turns/corpus.jsonl}"
+mkdir -p "$(dirname "$CORPUS")"
 [[ -x "$GO" ]] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
 
 MODE="${1:-}"; shift || true
@@ -35,12 +38,20 @@ path, n = sys.argv[1], int(sys.argv[2])
 def sig(s): return hashlib.sha256((s or "").encode("utf-8","replace")).hexdigest()[:16]
 def clip(s, k=2000): return (s or "")[:k]
 # Cell sovereignty: a turn touching tender/personal context never enters the
-# corpus. Structural redaction, not manual — specific personal markers only, so
-# the technical "flight-ready" metaphor stays. A matched turn is dropped whole.
-GATED=re.compile(r"irina|\bpartner\b|psoriatic|dispenza|\bcancer\b|longmont|"
-                 r"switzerland|intimacy|\babuse\b|insomnia|maija|louisa|\bmerly\b|"
-                 r"chrysanthemum|\bbali\b|\bcolorado\b|household|infusion|"
-                 r"loneliness|\blonely\b|\bval\b(?!id)", re.I)
+# corpus. Structural redaction, not manual — a matched turn is dropped WHOLE,
+# never scrubbed-and-kept. Markers span named people, medical, personal places,
+# the relational arc, AND gated file paths (a turn that READ a tender memory file
+# carries its content in the step result, so the path match catches it). The
+# technical "flight-ready" metaphor survives — those words are not markers.
+GATED=re.compile(
+    r"irina|louisa|maija|\balex\b|dispenza|gottschlich|\bjustin\b|\brocco\b|\baly\b|"
+    r"zach\s*bush|\bzach\b|bagus|kesnawa|anne\s*tucker|amanda\s*walsh|pam\s*gregory|"
+    r"psoriatic|\bcancer\b|\bcpap\b|remicade|biologic|infusion|insomnia|chrysanthemum|"
+    r"longmont|switzerland|\bbali\b|\bcolorado\b|\bubud\b|hati[\s._-]*suci|\bboulder\b|"
+    r"\bpartner\b|intimacy|sexual|divorce|snor(?:e|ing)|household|loneliness|\blonely\b|"
+    r"pleiadian|sacred\s*union|soul\s*compass|\bval\b(?!id)|\bson\b|\babuse\b|\bmerly\b|"
+    r"partner_presence|project_may_june|urs_waking|documents/2026|sacred_union|soul_compass",
+    re.I)
 def gated(t):
     blob=" ".join([t["task"], t["reasoning"] if isinstance(t["reasoning"],str) else " ".join(t["reasoning"]),
                    t["answer"]] + [s.get("args","")+" "+s.get("result","") for s in t["steps"]])


### PR DESCRIPTION
> "Capture those session samples from as far back as you can — those are gold for our internal training." — Urs

Swept the **whole session history** (May 17 → Jun 16, 63 sessions, 94k lines) into one durable training corpus of the agent's own reasoning + tool use.

## Result

- **553 unique clean samples**, **~10,000 tool steps** captured
- All `oracle=claude` (the agent's own turns), all **offline-reproducible**, avg **18 steps/turn**
- Top tools: Bash 5829 · Edit 1640 · Read 1118 · Write 617 · Agent 135
- Lives at `~/.coherence-network/form-cli-corpus/corpus.jsonl` (stable, local — survives worktree cleanup)

## The sovereignty filter, hardened first

A month of sessions holds the full personal arc, not just code — so before writing a single line I strengthened the filter to span named people, medical terms, personal places, the relational arc, **and gated file paths** (a turn that *read* a tender memory file carries its content in its step result, so the path match catches it). A matched turn is dropped **whole**, never scrubbed.

Verified at scale: **0 tender markers** in 553 samples. The only scan hits were technical false-positives (`hati.mesh` the organ, `val` code-variable clip-artifacts) — and the `hati-suci` *worktree/route identifier*, which I dropped anyway (it echoes a place name) by matching punctuation variants `hati[\s._-]*suci`.

This PR ships the **filter + `FORM_CLI_CORPUS` stable-path override + README sweep recipe**. The corpus itself stays local/gitignored — only the hand-verified 8-sample seed is ever committed. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)