### PR TITLE
feat(form-cli): score the native models against the agent — tool-selection replay

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 260 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 261 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -175,9 +175,28 @@ tender/personal markers — dropped whole, never scrubbed-and-kept — so the co
 can never hold gated content by construction. (A turn that *read* a gated file is
 dropped because its step-results carry that content.)
 
-The replay — take a sample's task, run form-cli's native loop, compare to the
-captured answer + tool sequence — is how we see how the native models are doing
-on real work.
+## Scoring — how the native models are doing
+
+Replay measures the native models against the agent over the corpus. The first
+scoreable lane is **tool selection** — the agentic core: given a task, which
+tools to reach for.
+
+```bash
+scripts/form_cli_replay.sh 12 "ollama run coder"
+```
+
+For each task the local model predicts its tool sequence; the kernel scores the
+prediction against the tools the agent actually used (`form-cli-score.fk` →
+overlap → majority-match → tally; champion = the agent reference, challenger =
+native). It reports native match rate vs an **always-Bash baseline**, so the
+signal is honest: real skill, or just guessing the most common tool? Proven
+four-way (`form-cli-score-band` → 255).
+
+Snapshot (local coder, 8 tasks): native majority-match ~87%, full-cover ~37%,
+above a 25% baseline — real skill, but it **systematically omits `Bash`** (the
+model doesn't think to run shell commands) and over-predicts `Grep`/`Glob`. That
+named gap is what the corpus then trains toward — the flywheel closing on real
+work. Numbers drift run to run; the readout is the measurement, not a fixed score.
 
 ## What is proven, and the honest frontier
 

--- a/form/form-stdlib/form-cli-score.fk
+++ b/form/form-stdlib/form-cli-score.fk
@@ -1,0 +1,58 @@
+; form-cli-score.fk — score the native models against the agent over the corpus.
+;
+; preludes: form-stdlib/core.fk
+;
+; The samples (form-cli-sample.fk) capture what the AGENT did; this scores how
+; close a NATIVE prediction comes. The first scoreable lane is tool selection —
+; the agentic core: given a task, which tools to reach for. A trial pairs the
+; agent's actual tool list (the reference / champion) with the native model's
+; predicted tool list (the challenger). The native "matches" on a sample when its
+; prediction covers at least HALF of the agent's tools (overlap*2 >= count) — a
+; majority, not exact order, so partial native skill is credited honestly.
+;
+; This is the champion-challenger spine (champion = the agent reference, always
+; correct; challenger = native, correct on a match) made concrete on the corpus.
+; Integer-only — no float, no mul/div — so the verdict is identical on all arms.
+;
+; Proven by: form-stdlib/tests/form-cli-score-band.fk
+
+; a trial: (agent-tools native-tools), each a list of tool-name strings
+(defn fcsc-trial (agent-tools native-tools) (list agent-tools native-tools))
+(defn fcsc-agent (t) (nth t 0))
+(defn fcsc-native (t) (nth t 1))
+
+; is a tool present in a list of tools?
+(defn fcsc-in? (tool lst)
+    (if (eq (len lst) 0) 0
+        (if (str_eq (head lst) tool) 1 (fcsc-in? tool (tail lst)))))
+; overlap: how many of the agent's tools the native prediction covers
+(defn fcsc-overlap (agent native)
+    (if (eq (len agent) 0) 0
+        (add (fcsc-in? (head agent) native) (fcsc-overlap (tail agent) native))))
+
+; native matches when its prediction covers a majority of the agent's tools:
+;   overlap * 2 >= count   (no mul — overlap+overlap)
+(defn fcsc-match? (agent native)
+    (if (eq (len agent) 0) 0
+        (if (ge (add (fcsc-overlap agent native) (fcsc-overlap agent native)) (len agent)) 1 0)))
+; native covers ALL of the agent's tools (the strict bar)
+(defn fcsc-full? (agent native)
+    (if (eq (len agent) 0) 0
+        (if (ge (fcsc-overlap agent native) (len agent)) 1 0)))
+
+; tally over trials
+(defn fcsc-matched (trials)
+    (if (eq (len trials) 0) 0
+        (add (fcsc-match? (fcsc-agent (head trials)) (fcsc-native (head trials)))
+             (fcsc-matched (tail trials)))))
+(defn fcsc-full-matched (trials)
+    (if (eq (len trials) 0) 0
+        (add (fcsc-full? (fcsc-agent (head trials)) (fcsc-native (head trials)))
+             (fcsc-full-matched (tail trials)))))
+(defn fcsc-total (trials) (len trials))
+; the challenger reaches the champion when it matches on at least as many
+; samples as a margin allows — here: did native match a MAJORITY of samples?
+(defn fcsc-native-reaches? (trials)
+    (if (ge (add (fcsc-matched trials) (fcsc-matched trials)) (len trials)) 1 0))
+
+0

--- a/form/form-stdlib/tests/form-cli-score-band.fk
+++ b/form/form-stdlib/tests/form-cli-score-band.fk
@@ -1,0 +1,42 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-cli-score.fk
+;
+; form-cli-score-band - the native-vs-agent tool-selection scoring proof.
+;
+; Verdict 255 when: tool membership and overlap count hold; the majority-match and
+; full-cover verdicts are right; and the matched / full-matched / total tallies
+; and the native-reaches-majority readout are correct over a mixed trial set.
+
+(do
+    ; ── membership ──
+    (let c0 (if (eq (fcsc-in? "Bash" (list "Bash" "Read")) 1)
+                (if (eq (fcsc-in? "Grep" (list "Bash" "Read")) 0) 1 0)
+                0))
+
+    ; ── overlap count ──
+    (let c1 (if (eq (fcsc-overlap (list "Bash" "Read") (list "Bash" "Edit" "Read")) 2)
+                (if (eq (fcsc-overlap (list "Bash" "Grep") (list "Read" "Edit")) 0) 2 0)
+                0))
+
+    ; ── majority match: covers >= half; a single tool out of four does not ──
+    (let c2 (if (eq (fcsc-match? (list "Bash" "Read" "Edit") (list "Bash" "Read")) 1)
+                (if (eq (fcsc-match? (list "Bash" "Read" "Edit") (list "Grep")) 0)
+                    (if (eq (fcsc-match? (list "Bash" "Read" "Edit" "Write") (list "Bash")) 0) 4 0)
+                    0)
+                0))
+
+    ; ── full cover ──
+    (let c3 (if (eq (fcsc-full? (list "Bash" "Read") (list "Bash" "Read" "Edit")) 1)
+                (if (eq (fcsc-full? (list "Bash" "Read") (list "Bash")) 0) 8 0)
+                0))
+
+    ; ── tallies over a mixed trial set ──
+    (let t1 (fcsc-trial (list "Bash" "Read" "Edit") (list "Bash" "Read")))     ; match, not full
+    (let t2 (fcsc-trial (list "Bash" "Read" "Edit") (list "Grep")))            ; no match
+    (let t3 (fcsc-trial (list "Bash" "Read") (list "Bash" "Read" "Edit")))     ; match and full
+    (let trials (list t1 t2 t3))
+    (let c4 (if (eq (fcsc-matched trials) 2) 16 0))
+    (let c5 (if (eq (fcsc-full-matched trials) 1) 32 0))
+    (let c6 (if (eq (fcsc-total trials) 3) 64 0))
+    (let c7 (if (eq (fcsc-native-reaches? trials) 1) 128 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -170,6 +170,7 @@ form-cli-router fks 31
 form-cli-membrane fks 1023
 form-cli-gaps fks 4095
 form-cli-sample fks 1023
+form-cli-score fks 255
 obs-verify fks 31
 world-module-model fks 1023
 world-model-growth fks 4095

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 260
+**Total files**: 261
 
 | File | Purpose |
 |---|---|
@@ -84,6 +84,7 @@
 | [form_cli_demo.sh](form_cli_demo.sh) | form_cli_demo.sh — exercise every form_cli subcommand end-to-end. |
 | [form_cli_gaps.sh](form_cli_gaps.sh) | form_cli_gaps.sh — the catalog of what is OPEN, walked from the live body. |
 | [form_cli_preflight.sh](form_cli_preflight.sh) | form_cli_preflight.sh — air-gap readiness check for the form-cli. |
+| [form_cli_replay.sh](form_cli_replay.sh) | form_cli_replay.sh — measure how the native models do against the agent. |
 | [form_cli_slice.sh](form_cli_slice.sh) | form_cli_slice.sh — compile a Form recipe slice to a RUNNABLE native binary, |
 | [form_debug_demo.sh](form_debug_demo.sh) | form_debug_demo.sh — LIVE DEBUGGING: the value trace joined with provenance. |
 | [form_diagnose_demo.sh](form_diagnose_demo.sh) | form_diagnose_demo.sh — the live-diagnosis organ on REAL channels. One fib |

--- a/scripts/form_cli_replay.sh
+++ b/scripts/form_cli_replay.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# form_cli_replay.sh — measure how the native models do against the agent.
+#
+# For each sample in the corpus, ask a LOCAL model to predict which tools it would
+# reach for on that task, then score the prediction against the tools the agent
+# actually used — through the Form score recipe (form-cli-score.fk, champion =
+# the agent reference, challenger = the native model). Reports native match rate
+# vs an always-Bash baseline, so the signal is honest: does the native model
+# carry real tool-selection skill, or just guess the most common tool?
+#
+# The scoring is Form (the kernel computes overlap + match + tally); this shell
+# runs the predictor and tallies the report. No remote calls — the model is local.
+#
+# Usage: form_cli_replay.sh [N] [oracle] [corpus]
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STD="$ROOT/form/form-stdlib"; GO="$ROOT/form/form-kernel-go/bin-go"
+N="${1:-12}"; ORACLE="${2:-ollama run coder}"
+CORPUS="${3:-${FORM_CLI_CORPUS:-$HOME/.coherence-network/form-cli-corpus/corpus.jsonl}}"
+[[ -x "$GO" ]] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
+[[ -f "$CORPUS" ]] || { echo "no corpus at $CORPUS"; exit 1; }
+
+echo "── replay: native ($ORACLE) vs the agent, on $N tasks ──"
+KNOWN="Bash Read Write Edit Grep Glob Agent"
+
+# pick N substantive tasks; emit "agent_tools<TAB>task" per line
+mapfile_compat() { while IFS= read -r l; do printf '%s\n' "$l"; done; }
+PICKS="$(python3 - "$CORPUS" "$N" <<'PY'
+import json,sys
+path,n=sys.argv[1],int(sys.argv[2])
+KNOWN={"Bash","Read","Write","Edit","Grep","Glob","Agent"}
+out=[]
+for l in open(path):
+    try: r=json.loads(l)
+    except: continue
+    t=r.get("task","").strip()
+    if len(t)<28: continue
+    tools=[]
+    for s in r.get("steps",[]):
+        tn=s.get("tool")
+        if tn in KNOWN and tn not in tools: tools.append(tn)
+    if not tools: continue
+    out.append((",".join(tools), t.replace("\n"," ")[:240]))
+    if len(out)>=n: break
+for a,t in out: print(a+"\t"+t)
+PY
+)"
+[[ -n "$PICKS" ]] || { echo "no substantive tasks found"; exit 1; }
+
+# for each task: ask the model to predict tools, build a Form trial
+trials=""; baseline=""; shown=""
+i=0
+while IFS=$'\t' read -r agent_tools task; do
+    [[ -z "$task" ]] && continue
+    i=$((i+1))
+    prompt="You are a coding agent with these tools: $KNOWN. For the task below, list ONLY the tool names you would use, one per line, most important first, nothing else.
+Task: $task"
+    pf="$(mktemp)"; printf '%s' "$prompt" > "$pf"
+    raw="$($ORACLE < "$pf" 2>/dev/null)"; rm -f "$pf"
+    # extract known tool names from the reply, preserving order, unique
+    native="$(printf '%s\n' "$raw" | grep -oiE 'Bash|Read|Write|Edit|Grep|Glob|Agent' \
+        | awk '{print toupper(substr($0,1,1)) tolower(substr($0,2))}' | awk '!seen[$0]++' | head -8)"
+    # to Form lists
+    a_form="$(printf '%s' "$agent_tools" | tr ',' '\n' | sed 's/.*/"&"/' | tr '\n' ' ')"
+    n_form="$(printf '%s\n' "$native" | sed '/^$/d; s/.*/"&"/' | tr '\n' ' ')"
+    [[ -z "${n_form// }" ]] && n_form='""'
+    trials="$trials (fcsc-trial (list $a_form) (list $n_form))"
+    baseline="$baseline (fcsc-trial (list $a_form) (list \"Bash\"))"
+    nt="$(printf '%s' "$native" | tr '\n' ',' | sed 's/,$//')"
+    printf "  %2d  agent[%s]  native[%s]\n" "$i" "$agent_tools" "$nt"
+done <<< "$PICKS"
+
+# score on the kernel (Form is the judge)
+prog="$(mktemp)"
+{ cat "$STD/form-cli-score.fk"
+  echo "(let trials (list $trials))"
+  echo "(let baseline (list $baseline))"
+  echo '(print (fcsc-matched trials))'
+  echo '(print (fcsc-full-matched trials))'
+  echo '(print (fcsc-total trials))'
+  echo '(print (fcsc-native-reaches? trials))'
+  echo '(print (fcsc-matched baseline))'
+} > "$prog"
+mapfile_lines="$("$GO" "$prog" 2>/dev/null)"; rm -f "$prog"
+M="$(printf '%s\n' "$mapfile_lines" | sed -n '1p')"
+F="$(printf '%s\n' "$mapfile_lines" | sed -n '2p')"
+T="$(printf '%s\n' "$mapfile_lines" | sed -n '3p')"
+R="$(printf '%s\n' "$mapfile_lines" | sed -n '4p')"
+B="$(printf '%s\n' "$mapfile_lines" | sed -n '5p')"
+
+echo
+echo "── score (Form-judged) ──"
+pct(){ [[ "${2:-0}" -gt 0 ]] && echo $(( $1 * 100 / $2 )) || echo 0; }
+printf "  native majority-match   %s/%s  (%s%%)\n" "$M" "$T" "$(pct "${M:-0}" "${T:-0}")"
+printf "  native full-cover       %s/%s  (%s%%)\n" "$F" "$T" "$(pct "${F:-0}" "${T:-0}")"
+printf "  always-Bash baseline    %s/%s  (%s%%)\n" "$B" "$T" "$(pct "${B:-0}" "${T:-0}")"
+if [[ "${M:-0}" -gt "${B:-0}" ]]; then
+    echo "  → native carries real tool-selection skill above the baseline."
+elif [[ "${M:-0}" -eq "${B:-0}" ]]; then
+    echo "  → native matches the dumb baseline — no skill above guessing Bash yet."
+else
+    echo "  → native is below the baseline — the lane is wide open to train."
+fi
+echo "  native reaches the agent on a majority of tasks: $([[ "${R:-0}" == "1" ]] && echo yes || echo not yet)"


### PR DESCRIPTION
The corpus (#3231, #3232) is fed; this **measures it** — how the native models are doing, on real work.

## What it is

**`form-cli-score.fk`** (four-way, `form-cli-score-band` → **255**): scores a native tool-set prediction against the agent's actual tools — overlap → majority-match → full-cover → tally. Champion = the agent reference, challenger = native. Integer-only (no mul/div), so the verdict is identical on every arm.

**`scripts/form_cli_replay.sh`**: for each task, a **local** model predicts its tool sequence; the kernel scores it against what the agent actually did, versus an **always-Bash baseline** — so the signal is honest (real skill, or just guessing the most common tool?).

## First measurement (local coder, 8 tasks)

| | |
|---|---|
| native majority-match | **7/8 (87%)** |
| native full-cover | 3/8 (37%) |
| always-Bash baseline | 2/8 (25%) |

→ native carries **real tool-selection skill above the baseline** — but a specific, honest gap: it **systematically omits `Bash`** (the model doesn't think to run shell commands) and over-predicts `Grep`/`Glob`. That named gap is exactly what the corpus trains toward — the flywheel closing on real work.

The scoring is Form (the kernel judges); the shell runs the predictor and tallies. Numbers drift run to run — the readout is the measurement, not a fixed score. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)