### PR TITLE
feat(form): lowering-search — the generator's select half (cheapest VERIFIED lowering wins)

### DIFF
--- a/form/form-stdlib/lowering-search.fk
+++ b/form/form-stdlib/lowering-search.fk
@@ -1,0 +1,46 @@
+; lowering-search.fk — the generator's SELECT half: search a candidate set of
+; lowerings, admit each through the recipe-equivalence gate, keep the cheapest that
+; passes. The body DISCOVERS its best lowering by search + verification, never by
+; trusting one candidate — a wrong candidate that is cheapest is REFUSED, not chosen.
+;
+; preludes: form-stdlib/core.fk form-stdlib/recipe-equivalence-gate.fk
+;
+; This is the closing half of the flywheel: the recipe-equivalence gate judges a
+; single candidate; this judges MANY and selects the best admitted one to cache for
+; that NodeID. The PROPOSE half — synthesizing novel candidates (verified rewrite
+; rules, learned search) — is the deeper frontier; this scores and selects whatever
+; candidates are offered. Same min-select spine as nearest-shape / attention-argmin.
+
+; a candidate lowering: (name coverage breach? cost). coverage = the (input
+; recipe-ack candidate-ack) observations vs the recipe; cost = measured dispatches.
+(defn ls-cand (name coverage breach? cost) (list name coverage breach? cost))
+(defn ls-name (c) (nth c 0))
+(defn ls-coverage (c) (nth c 1))
+(defn ls-breach (c) (nth c 2))
+(defn ls-cost (c) (nth c 3))
+
+; admitted? eligible iff observed-equivalent over coverage AND breachless (the gate).
+(defn ls-admitted? (c)
+  (if (eq (req-equivalent? (ls-coverage c)) 1)
+      (if (eq (ls-breach c) 0) 1 0) 0))
+
+; the best lowering = the cheapest ADMITTED candidate. A non-admitted candidate is
+; never the answer, regardless of how cheap it is (correctness gates cost).
+(defn ls-best-loop (cands best)
+  (if (eq (len cands) 0) best
+      (ls-best-loop (tail cands)
+        (if (eq (ls-admitted? (head cands)) 1)
+            (if (if (eq (len best) 0) 1 (lt (ls-cost (head cands)) (ls-cost best)))
+                (head cands) best)
+            best))))
+(defn ls-best (cands) (ls-best-loop cands (empty)))
+
+; the winning lowering's cost (or 0 if NONE admitted — the body keeps the reference
+; rather than admit an unverified lowering).
+(defn ls-best-cost (cands)
+  (if (eq (len (ls-best cands)) 0) 0 (ls-cost (ls-best cands))))
+
+; how many candidates were admitted (the verified search space the winner came from).
+(defn ls-admitted-count (cands)
+  (if (eq (len cands) 0) 0
+      (add (ls-admitted? (head cands)) (ls-admitted-count (tail cands)))))

--- a/form/form-stdlib/tests/lowering-search-band.fk
+++ b/form/form-stdlib/tests/lowering-search-band.fk
@@ -1,0 +1,22 @@
+; lowering-search-band.fk — the search selects the cheapest VERIFIED lowering.
+;
+; preludes: form-stdlib/core.fk form-stdlib/recipe-equivalence-gate.fk form-stdlib/lowering-search.fk
+;
+; Four candidate lowerings of tri(n), each with its coverage-vs-recipe and measured
+; cost. The HARDCODE is the cheapest of all (cost 9) but disagrees with the recipe on
+; input 5 -> refused. The search picks the cheapest ADMITTED candidate (closed, 54),
+; NOT the cheapest overall. Correctness gates cost. aggregate = best-cost(54) +
+; admitted-count(3) = 57.
+
+(do
+  (let agree (list (req-obs 0 0 0) (req-obs 5 15 15) (req-obs 10 55 55)))
+  (let wrong (list (req-obs 0 0 0) (req-obs 5 15 0)))   ; hardcode disagrees on input 5
+
+  (let cands (list
+    (ls-cand "closed"    agree 0 54)     ; equivalent, breachless, cheapest ADMITTED
+    (ls-cand "naive"     agree 0 730)    ; equivalent but slower
+    (ls-cand "hardcode"  wrong 0 9)      ; cheapest of ALL, but refuted by coverage
+    (ls-cand "redundant" agree 0 900)))  ; equivalent but slowest
+
+  ; the winner is the cheapest VERIFIED lowering (54), not the cheapest (9)
+  (add (ls-best-cost cands) (ls-admitted-count cands)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -494,3 +494,4 @@ triangle-lowerings fkc 1
 capability-form-asm fks 106
 tier-router fks 140
 model-roster-report fks 1388
+lowering-search fks 57


### PR DESCRIPTION
The recipe-equivalence gate judges one candidate; `lowering-search` searches many and selects the **cheapest that passes** — the body discovers its best lowering by search + verification, never by trusting one. A hardcode at cost 9 (cheapest of all) is **refused** (coverage catches it); the closed-form at 54 wins. **Correctness gates cost.** Four-way (`→ 57`, Go/Rust/TS/fkwu). The PROPOSE half (synthesizing candidates) is the named deeper frontier; this scores + selects offered ones and feeds the NodeID's lowering cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)