### PR TITLE
feat(form): rewrite-propose — the PROPOSE half closes the self-improving-compiler loop

### DIFF
--- a/form/form-stdlib/rewrite-propose.fk
+++ b/form/form-stdlib/rewrite-propose.fk
@@ -1,0 +1,43 @@
+; rewrite-propose.fk — the generator's PROPOSE half: a rewrite RULE synthesizes a
+; candidate lowering, and the recipe-equivalence gate VERIFIES it by evaluation over
+; coverage. A wrong rewrite is refused, never trusted — so the body can search the
+; lowering space safely. This closes the flywheel: propose -> verify -> select.
+;
+; preludes: form-stdlib/core.fk
+;
+; A recipe is a tiny op-tagged AST (the same shape form-lower lowers):
+;   (0 v)     LIT v        a constant
+;   (1)       VAR          the single input x
+;   (2 a b)   ADD a b      subtrees a + b
+;   (3 a b)   MUL a b      subtrees a * b
+; ast-eval IS the ground-truth evaluator (offer the AST an input, observe the ack).
+; rw-fold is one rewrite rule (constant folding); more rules (identity, strength
+; reduction, CSE) drop in the same way, each verified by the gate, never assumed.
+
+; evaluate the AST for input x — the recipe's ack (ground truth).
+(defn ast-eval (n x)
+  (do (let t (head n))
+      (if (eq t 0) (nth n 1)
+          (if (eq t 1) x
+              (if (eq t 2) (add (ast-eval (nth n 1) x) (ast-eval (nth n 2) x))
+                  (mul (ast-eval (nth n 1) x) (ast-eval (nth n 2) x)))))))
+
+; node count — the cost proxy (fewer nodes = cheaper lowering).
+(defn ast-size (n)
+  (do (let t (head n))
+      (if (if (eq t 0) 1 (eq t 1)) 1
+          (add 1 (add (ast-size (nth n 1)) (ast-size (nth n 2)))))))
+
+; rw-fold — constant folding: fold children first, then if both are LIT, collapse
+; ADD/MUL of two constants into a single LIT. A pure semantics-preserving rewrite
+; (still VERIFIED by the gate, not trusted).
+(defn rw-fold (n)
+  (do (let t (head n))
+      (if (if (eq t 0) 1 (eq t 1)) n
+          (do (let a (rw-fold (nth n 1)))
+              (let b (rw-fold (nth n 2)))
+              (if (if (eq (head a) 0) (eq (head b) 0) 0)
+                  (if (eq t 2)
+                      (list 0 (add (nth a 1) (nth b 1)))
+                      (list 0 (mul (nth a 1) (nth b 1))))
+                  (list t a b))))))

--- a/form/form-stdlib/tests/rewrite-propose-band.fk
+++ b/form/form-stdlib/tests/rewrite-propose-band.fk
@@ -1,0 +1,29 @@
+; rewrite-propose-band.fk — propose -> verify -> select, end to end.
+;
+; preludes: form-stdlib/core.fk form-stdlib/recipe-equivalence-gate.fk form-stdlib/lowering-search.fk form-stdlib/rewrite-propose.fk
+;
+; recipe: 2*3 + x  =  (ADD (MUL (LIT 2) (LIT 3)) VAR), 5 nodes.
+; PROPOSE: rw-fold collapses 2*3 -> 6  =>  (ADD (LIT 6) VAR), 3 nodes.
+; VERIFY: ast-eval both over input coverage {0,5,10} -> acks agree (a WRONG fold would
+;   diverge here and the gate would refuse it — the rewrite is verified, not trusted).
+; SELECT: lowering-search picks the cheaper VERIFIED candidate (variant, 3) over the
+;   original (5). aggregate = equivalent?(1) + best-cost(3) + variant-size(3) = 7.
+
+(do
+  (let recipe  (list 2 (list 3 (list 0 2) (list 0 3)) (list 1)))
+  (let variant (rw-fold recipe))
+
+  (let vcov (list
+    (req-obs 0  (ast-eval recipe 0)  (ast-eval variant 0))
+    (req-obs 5  (ast-eval recipe 5)  (ast-eval variant 5))
+    (req-obs 10 (ast-eval recipe 10) (ast-eval variant 10))))
+  (let rcov (list
+    (req-obs 0  (ast-eval recipe 0)  (ast-eval recipe 0))
+    (req-obs 5  (ast-eval recipe 5)  (ast-eval recipe 5))
+    (req-obs 10 (ast-eval recipe 10) (ast-eval recipe 10))))
+
+  (let cands (list
+    (ls-cand "recipe"  rcov 0 (ast-size recipe))
+    (ls-cand "variant" vcov 0 (ast-size variant))))
+
+  (add (req-equivalent? vcov) (add (ls-best-cost cands) (ast-size variant))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -495,3 +495,4 @@ capability-form-asm fks 106
 tier-router fks 140
 model-roster-report fks 1388
 lowering-search fks 57
+rewrite-propose fks 7


### PR DESCRIPTION
A rewrite rule **synthesizes** a candidate lowering; the recipe-equivalence gate **verifies** it by evaluation over coverage (a wrong rewrite is refused, not trusted); `lowering-search` **selects** the cheaper verified one. `rw-fold` collapses `2*3+x` (5 nodes) → `6+x` (3 nodes), verified equivalent over {0,5,10}. Full loop: **propose → verify → select**, four-way (`→ 7`). One rule today; identity/strength-reduction/CSE drop in the same way, each gate-verified. With this, the body discovers, verifies, and selects its own optimizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)