### PR TITLE
feat(form-cli): score the reasoning lane — the hard frontier, measured

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 262 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 263 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -227,6 +227,30 @@ learnable prior + a keyword discriminator. The harder lanes — tool *order*, an
 the reasoning lane (`task → answer`, which needs semantic judging) — are still
 open. One lane retired; the rest is the road.
 
+## The reasoning lane — measured, and wide open
+
+Tool selection is a set problem; reasoning needs a *semantic* judge. So a local
+model gives a one-shot answer and a local **oracle judges** how well it covers
+the agent's captured answer (0–100); the Form judge recipe tallies — pass-rate +
+grade distribution (`form-cli-judge.fk` → grade/pass/tally, four-way
+`form-cli-judge-band` → 127).
+
+```bash
+scripts/form_cli_judge.sh 5 "ollama run coder" "ollama run coder" 60
+```
+
+Snapshot (local coder, threshold 60): native **~25% pass, avg ~25/100**, mostly
+*poor* grades — the opposite of tool selection. So the two lanes read:
+
+| lane | native vs agent |
+|---|---|
+| **tool selection** (set) | **100% / 95%** — won, oracle retired |
+| **reasoning** (`task → answer`) | **~25%** — the open frontier |
+
+That contrast *is* the finding: the easy lane is done; reasoning is the real
+road. (The judge here is a local oracle — a membrane crossing — so this score
+itself isn't yet offline-pure; a Form-native semantic judge is the next cell.)
+
 ## What is proven, and the honest frontier
 
 - **Proven, four-way**: the surface membrane + crossing ledger; the agent loop

--- a/form/form-stdlib/form-cli-judge.fk
+++ b/form/form-stdlib/form-cli-judge.fk
@@ -1,0 +1,50 @@
+; form-cli-judge.fk — score the REASONING lane: how well a native answer covers
+; the agent's, graded 0..100 by a judge.
+;
+; preludes: form-stdlib/core.fk
+;
+; Tool selection (form-cli-score / form-cli-predict) is a SET problem — exact,
+; cheap, and the native model already wins it. Reasoning is the hard lane: the
+; native answer must cover the SUBSTANCE of the agent's, which set-overlap can't
+; measure. So a judge (a local oracle, the membrane crossing) rates each native
+; answer 0..100 for how well it covers the agent's reference; this recipe is the
+; rubric and the tally over those scores — the proven (four-way) logic, the judge
+; is the carrier.
+;
+; A judged sample is one native score in 0..100. The recipe grades it, counts
+; passes at a threshold, sums for the average, and reports whether the native
+; reaches a majority — the same champion-challenger shape, on a graded lane.
+;
+; Proven by: form-stdlib/tests/form-cli-judge-band.fk
+
+; grade a score: 0 poor (<=25) / 1 weak (<=50) / 2 partial (<=75) / 3 strong
+(defn fcj-grade (score)
+    (if (le score 25) 0
+        (if (le score 50) 1
+            (if (le score 75) 2 3))))
+(defn fcj-grade-poor () 0)
+(defn fcj-grade-weak () 1)
+(defn fcj-grade-partial () 2)
+(defn fcj-grade-strong () 3)
+
+; does a score clear the bar?
+(defn fcj-pass? (score threshold) (if (ge score threshold) 1 0))
+
+; tallies over a list of scores
+(defn fcj-passed (scores threshold)
+    (if (eq (len scores) 0) 0
+        (add (fcj-pass? (head scores) threshold) (fcj-passed (tail scores) threshold))))
+(defn fcj-count-grade (scores g)
+    (if (eq (len scores) 0) 0
+        (add (if (eq (fcj-grade (head scores)) g) 1 0) (fcj-count-grade (tail scores) g))))
+(defn fcj-total (scores) (len scores))
+(defn fcj-sum (scores)
+    (if (eq (len scores) 0) 0 (add (head scores) (fcj-sum (tail scores)))))
+; (the average is sum/total — computed by the carrier; div is kept off the
+;  four-way path so the tally stays integer-identical on every arm.)
+
+; native reaches the lane when a majority of samples pass the threshold
+(defn fcj-native-reaches? (scores threshold)
+    (if (ge (add (fcj-passed scores threshold) (fcj-passed scores threshold)) (len scores)) 1 0))
+
+0

--- a/form/form-stdlib/tests/form-cli-judge-band.fk
+++ b/form/form-stdlib/tests/form-cli-judge-band.fk
@@ -1,0 +1,50 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-cli-judge.fk
+;
+; form-cli-judge-band - the reasoning-lane scoring proof.
+;
+; Verdict 127 when: grading and its boundaries hold; pass? clears the threshold;
+; and the passed / per-grade / sum tallies and the native-reaches-majority readout
+; are correct over a mixed score set.
+
+(do
+    (let scores (list 90 60 40 10 80))   ; grades 3 2 1 0 3
+    (let fail (list 40 10 20))           ; all below 60
+
+    ; ── grading ──
+    (let c0 (if (eq (fcj-grade 10) 0)
+                (if (eq (fcj-grade 40) 1)
+                    (if (eq (fcj-grade 60) 2)
+                        (if (eq (fcj-grade 90) 3) 1 0)
+                        0)
+                    0)
+                0))
+
+    ; ── grade boundaries ──
+    (let c1 (if (eq (fcj-grade 25) 0)
+                (if (eq (fcj-grade 26) 1)
+                    (if (eq (fcj-grade 75) 2)
+                        (if (eq (fcj-grade 76) 3) 2 0)
+                        0)
+                    0)
+                0))
+
+    ; ── pass at threshold ──
+    (let c2 (if (eq (fcj-pass? 80 60) 1) (if (eq (fcj-pass? 40 60) 0) 4 0) 0))
+
+    ; ── passed count ──
+    (let c3 (if (eq (fcj-passed scores 60) 3) 8 0))
+
+    ; ── per-grade counts ──
+    (let c4 (if (eq (fcj-count-grade scores (fcj-grade-strong)) 2)
+                (if (eq (fcj-count-grade scores (fcj-grade-poor)) 1) 16 0)
+                0))
+
+    ; ── sum (for the carrier's average) ──
+    (let c5 (if (eq (fcj-sum scores) 280) 32 0))
+
+    ; ── native reaches a majority on the good set, not on the failing one ──
+    (let c6 (if (eq (fcj-native-reaches? scores 60) 1)
+                (if (eq (fcj-native-reaches? fail 60) 0) 64 0)
+                0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -172,6 +172,7 @@ form-cli-gaps fks 4095
 form-cli-sample fks 1023
 form-cli-score fks 255
 form-cli-predict fks 127
+form-cli-judge fks 127
 obs-verify fks 31
 world-module-model fks 1023
 world-model-growth fks 4095

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 262
+**Total files**: 263
 
 | File | Purpose |
 |---|---|
@@ -83,6 +83,7 @@
 | [form_cli_close_gap.sh](form_cli_close_gap.sh) | form_cli_close_gap.sh — close a Form recipe gap OFFLINE with a local oracle. |
 | [form_cli_demo.sh](form_cli_demo.sh) | form_cli_demo.sh — exercise every form_cli subcommand end-to-end. |
 | [form_cli_gaps.sh](form_cli_gaps.sh) | form_cli_gaps.sh — the catalog of what is OPEN, walked from the live body. |
+| [form_cli_judge.sh](form_cli_judge.sh) | form_cli_judge.sh — measure the REASONING lane: how well a native model's answer |
 | [form_cli_preflight.sh](form_cli_preflight.sh) | form_cli_preflight.sh — air-gap readiness check for the form-cli. |
 | [form_cli_replay.sh](form_cli_replay.sh) | form_cli_replay.sh — measure how the native models do against the agent. |
 | [form_cli_slice.sh](form_cli_slice.sh) | form_cli_slice.sh — compile a Form recipe slice to a RUNNABLE native binary, |

--- a/scripts/form_cli_judge.sh
+++ b/scripts/form_cli_judge.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# form_cli_judge.sh — measure the REASONING lane: how well a native model's answer
+# covers the agent's, as graded by a local oracle judge.
+#
+# Tool selection is a set problem the native model already wins. Reasoning is the
+# hard lane: the native answer must cover the SUBSTANCE of the agent's, which
+# set-overlap can't measure. So for each task a LOCAL model gives a one-shot
+# answer, a LOCAL oracle judges how well it covers the agent's captured answer
+# (0..100), and the Form judge recipe (form-cli-judge.fk) tallies — pass-rate at a
+# threshold + grade distribution. The judge is the carrier; the tally is Form.
+#
+# Usage: form_cli_judge.sh [N] [native-model] [judge-model] [threshold] [corpus]
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STD="$ROOT/form/form-stdlib"; GO="$ROOT/form/form-kernel-go/bin-go"
+N="${1:-5}"; NATIVE="${2:-ollama run coder}"; JUDGE="${3:-ollama run coder}"; THR="${4:-60}"
+CORPUS="${5:-${FORM_CLI_CORPUS:-$HOME/.coherence-network/form-cli-corpus/corpus.jsonl}}"
+[[ -x "$GO" ]] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
+[[ -f "$CORPUS" ]] || { echo "no corpus at $CORPUS"; exit 1; }
+
+echo "── reasoning lane: native ($NATIVE) judged ($JUDGE) vs the agent, $N tasks ──"
+
+# pick N substantive tasks: emit task<TAB>agent_answer
+PICKS="$(python3 - "$CORPUS" "$N" <<'PY'
+import json,sys
+path,n=sys.argv[1],int(sys.argv[2])
+out=[]
+for l in open(path):
+    try: r=json.loads(l)
+    except: continue
+    t=r.get("task","").strip(); a=r.get("answer","").strip()
+    if len(t)<40 or len(a)<120: continue       # substantive task AND a real answer
+    out.append(t.replace("\n"," ")[:300]+"\t"+a.replace("\n"," ")[:1400])
+    if len(out)>=n: break
+print("\n".join(out))
+PY
+)"
+[[ -n "$PICKS" ]] || { echo "no substantive (task,answer) pairs found"; exit 1; }
+
+scores=""; i=0
+while IFS=$'\t' read -r task agent; do
+    [[ -z "$task" ]] && continue
+    i=$((i+1))
+    # 1. native one-shot answer
+    pf="$(mktemp)"; printf 'Task: %s\nGive a concise, concrete answer or approach (a few sentences).' "$task" > "$pf"
+    native_ans="$($NATIVE < "$pf" 2>/dev/null | tr '\n' ' ' | head -c 1200)"; rm -f "$pf"
+    # 2. local oracle judges coverage of the agent's reference, 0..100
+    jf="$(mktemp)"
+    printf 'You are grading. REFERENCE answer:\n%s\n\nCANDIDATE answer:\n%s\n\nHow well does the CANDIDATE cover the substance of the REFERENCE? Reply with ONLY an integer 0-100.' "$agent" "$native_ans" > "$jf"
+    raw="$($JUDGE < "$jf" 2>/dev/null)"; rm -f "$jf"
+    score="$(printf '%s' "$raw" | grep -oE '[0-9]+' | head -1)"; score="${score:-0}"
+    [[ "$score" -gt 100 ]] && score=100
+    scores="$scores $score"
+    printf "  %2d  judge=%3s  task: %s\n" "$i" "$score" "$(printf '%s' "$task" | head -c 56)"
+done <<< "$PICKS"
+
+# tally on the kernel (Form is the judge of the scores)
+sform="$(printf '%s' "$scores" | sed 's/^ *//; s/  */ /g')"
+prog="$(mktemp)"
+{ cat "$STD/form-cli-judge.fk"
+  echo "(let scores (list $sform))"
+  echo "(print (fcj-passed scores $THR))"
+  echo "(print (fcj-total scores))"
+  echo "(print (fcj-sum scores))"
+  echo "(print (fcj-count-grade scores (fcj-grade-poor)))"
+  echo "(print (fcj-count-grade scores (fcj-grade-weak)))"
+  echo "(print (fcj-count-grade scores (fcj-grade-partial)))"
+  echo "(print (fcj-count-grade scores (fcj-grade-strong)))"
+  echo "(print (fcj-native-reaches? scores $THR))"
+} > "$prog"
+o="$("$GO" "$prog" 2>/dev/null)"; rm -f "$prog"
+P=$(sed -n '1p' <<<"$o"); T=$(sed -n '2p' <<<"$o"); S=$(sed -n '3p' <<<"$o")
+G0=$(sed -n '4p' <<<"$o"); G1=$(sed -n '5p' <<<"$o"); G2=$(sed -n '6p' <<<"$o"); G3=$(sed -n '7p' <<<"$o"); R=$(sed -n '8p' <<<"$o")
+pct(){ [[ "${2:-0}" -gt 0 ]] && echo $(( $1 * 100 / $2 )) || echo 0; }
+avg(){ [[ "${2:-0}" -gt 0 ]] && echo $(( $1 / $2 )) || echo 0; }
+
+echo
+echo "── reasoning-lane score (Form-tallied) ──"
+printf "  native pass (>=%s)    %s/%s  (%s%%)\n" "$THR" "$P" "$T" "$(pct "${P:-0}" "${T:-0}")"
+printf "  average judge score  %s/100\n" "$(avg "${S:-0}" "${T:-0}")"
+printf "  grades   poor %s · weak %s · partial %s · strong %s\n" "${G0:-0}" "${G1:-0}" "${G2:-0}" "${G3:-0}"
+echo "  native reaches the lane (majority pass): $([[ "${R:-0}" == "1" ]] && echo yes || echo 'NOT YET — the open frontier')"
+echo "  (tool-selection lane is already won natively; reasoning is the hard road.)"


### PR DESCRIPTION
Tool selection (#3238) is the easy lane — a set problem the native model already wins. This measures the **hard lane: reasoning**, which needs a *semantic* judge.

## What it is

**`form-cli-judge.fk`** (four-way, `form-cli-judge-band` → **127**): the reasoning-lane scoring spine — grade a 0–100 judge score (poor/weak/partial/strong), count passes at a threshold, sum for the average, native-reaches-majority. Integer-only.

**`scripts/form_cli_judge.sh`**: a local model gives a one-shot answer; a local **oracle judges** how well it covers the agent's captured answer (0–100); the Form recipe tallies. The judge is the carrier; the tally is Form.

## The two lanes, now both measured

| lane | native vs agent |
|---|---|
| **tool selection** (set) | **100% / 95%** — won, oracle retired |
| **reasoning** (`task → answer`) | **~25%** — the open frontier |

Snapshot (local coder, threshold 60): native ~25% pass, avg ~25/100, mostly *poor* grades — the opposite of tool selection. **That contrast is the finding**: the easy lane is done; reasoning is the real road.

## Honest caveats

- The judge here is a *local oracle* (a membrane crossing), so this score isn't yet offline-pure — a Form-native semantic judge is the next cell.
- The corpus tasks sampled are conversational follow-ups needing context, so one-shot native is disadvantaged; the lane being hard is real regardless.

No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)