### PR TITLE
feat(form): native codegen learns to MULTIPLY — fa-mul + lo-mul, four-way

### DIFF
--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -50,6 +50,8 @@
     (defn fa-b    (off)       (fa-le (add 335544320 off)))
     ; add w<rd>, w<rn>, w<rm>  (register form) : base 0x0B000000 | rm<<16 | rn<<5 | rd
     (defn fa-add-r (rd rn rm) (fa-le (add 184549376 (add (mul rm 65536) (add (mul rn 32) rd)))))
+    ; mul w<rd>, w<rn>, w<rm>  (= MADD wd,wn,wm,wzr ; Ra=31) : base 0x1B007C00 | rm<<16 | rn<<5 | rd
+    (defn fa-mul  (rd rn rm) (fa-le (add 453016576 (add (mul rm 65536) (add (mul rn 32) rd)))))
 
     ; ── the call + frame instructions (recursion) ────────────────────────
     ; bl #off — branch-with-link, SIGNED 26-bit offset in instructions. The base

--- a/form/form-stdlib/form-lower.fk
+++ b/form/form-stdlib/form-lower.fk
@@ -42,8 +42,9 @@
         (if (eq (lo-tag prog i) 2) (fa-mov 0 argr)
         (if (eq (lo-tag prog i) 3) (lo-add prog i argr)
         (if (eq (lo-tag prog i) 4) (lo-sub prog i argr)
+        (if (eq (lo-tag prog i) 5) (lo-mul prog i argr)
         (if (eq (lo-tag prog i) 6) (lo-cond prog i argr)
-            (list)))))))
+            (list))))))))
     ; ADD: (x, LIT i) -> lower(x); add w0,w0,#i · (ARG, x) -> lower(x); add w0,w<argr>,w0
     (defn lo-add (prog i argr)
         (if (lo-lit? prog (lo-c2 prog i))
@@ -54,6 +55,21 @@
         (if (lo-arg? prog (lo-c1 prog i))
             (fa-sub 0 argr (lo-imm prog i))
             (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-sub 0 0 (lo-imm prog i)))))
+    ; MUL: arm64 has no mul-immediate, so it's operand-aware like ADD/SUB. (ARG, x) /
+    ; (x, ARG) -> lower the non-ARG operand into w0, mul w0,w0,w<argr> (the banked n is
+    ; never clobbered). (x, LIT i) -> lower x; movz w2,#i; mul w0,w0,w2 (the LIT lands in
+    ; scratch w2 AFTER x is fully in w0). Two non-trivial subtrees is the multi-register
+    ; frontier (would need allocation) — left as the empty tail, never a wrong answer.
+    (defn lo-mul (prog i argr)
+        (if (lo-arg? prog (lo-c1 prog i))
+            (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-mul 0 0 argr))
+        (if (lo-arg? prog (lo-c2 prog i))
+            (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-mul 0 0 argr))
+        (if (lo-lit? prog (lo-c2 prog i))
+            (lo-app (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-movz 2 (lo-imm prog i))) (fa-mul 0 0 2))
+        (if (lo-lit? prog (lo-c1 prog i))
+            (lo-app (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-movz 2 (lo-val prog (lo-c1 prog i)))) (fa-mul 0 0 2))
+            (list))))))
     ; COND(LE(ARG, LIT i), then, else) — the control-flow scheme with computed
     ; branch offsets (in instructions = bytes/4):
     ;   cmp w<argr>,#i ; b.gt +(len(then)+2) ; then ; b +(len(else)+1) ; else
@@ -84,8 +100,9 @@
         (if (eq (lo-tag prog i) 2) (list i)
         (if (eq (lo-tag prog i) 3) (lo-map-add prog i)
         (if (eq (lo-tag prog i) 4) (lo-map-sub prog i)
+        (if (eq (lo-tag prog i) 5) (lo-map-mul prog i)
         (if (eq (lo-tag prog i) 6) (lo-map-cond prog i)
-            (list)))))))
+            (list))))))))
     (defn lo-map-add (prog i)
         (if (lo-lit? prog (lo-c2 prog i))
             (lo-app (lo-map prog (lo-c1 prog i)) (list i))
@@ -94,6 +111,18 @@
         (if (lo-arg? prog (lo-c1 prog i))
             (list i)
             (lo-app (lo-map prog (lo-c1 prog i)) (list i))))
+    ; MUL mirror: ARG-operand forms emit one mul (one i); LIT-operand forms emit movz+mul
+    ; (two i's), both owned by the MUL node — exactly lo-mul's instruction order.
+    (defn lo-map-mul (prog i)
+        (if (lo-arg? prog (lo-c1 prog i))
+            (lo-app (lo-map prog (lo-c2 prog i)) (list i))
+        (if (lo-arg? prog (lo-c2 prog i))
+            (lo-app (lo-map prog (lo-c1 prog i)) (list i))
+        (if (lo-lit? prog (lo-c2 prog i))
+            (lo-app (lo-map prog (lo-c1 prog i)) (list i i))
+        (if (lo-lit? prog (lo-c1 prog i))
+            (lo-app (lo-map prog (lo-c2 prog i)) (list i i))
+            (list))))))
     ; cmp belongs to the LE node; both branches' jumps belong to the COND itself
     (defn lo-map-cond (prog i)
         (lo-cat (list

--- a/form/form-stdlib/tests/capability-form-mul-band.fk
+++ b/form/form-stdlib/tests/capability-form-mul-band.fk
@@ -1,0 +1,35 @@
+; capability-form-mul-band.fk — the body's native codegen can lower a MULTIPLY.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-lower.fk
+;
+; Until now form-lower had LIT/ARG/ADD/SUB/COND but no multiply — the body could
+; not emit a `mul` at all. lo-mul (tag 5) closes that: operand-aware like ADD/SUB,
+; the ARG operand multiplies through the banked register, a LIT operand lands in
+; scratch w2. fa-mul is byte-convicted against the assembler (mul w0,w0,w1 =
+; 0x1b017c00). This band lowers two functions OF n and asserts each lowered image
+; is byte-for-byte the hand-assembled sequence, THEN returns the images' byte-sum
+; (a content checksum the four kernels must agree on; a wrong lowering on any arm
+; diverges). Execution-verified separately: n*3 and n*n exact over n=2..15.
+;
+;   f(n)=n*3 -> mov w1,w0 ; movz w0,#3 ; mul w0,w0,w1 ; ret
+;   f(n)=n*n -> mov w1,w0 ; mov  w0,w1 ; mul w0,w0,w1 ; ret
+
+(do
+  (defn ap (xs ys) (if (eq (len xs) 0) ys (cons (head xs) (ap (tail xs) ys))))
+  (defn beq (a b)
+    (if (eq (len a) (len b))
+        (if (eq (len a) 0) 1
+            (if (eq (head a) (head b)) (beq (tail a) (tail b)) 0))
+        0))
+  (defn byte-sum (bs) (if (eq (len bs) 0) 0 (add (head bs) (byte-sum (tail bs)))))
+
+  (let img3  (lo-compile-fn (list (list 2 0 0 0) (list 1 3 0 0) (list 5 0 1 0)) 2))
+  (let exp3  (ap (fa-mov 1 0) (ap (fa-movz 0 3) (ap (fa-mul 0 0 1) (fa-ret)))))
+  (let imgnn (lo-compile-fn (list (list 2 0 0 0) (list 5 0 0 0)) 1))
+  (let expnn (ap (fa-mov 1 0) (ap (fa-mov 0 1) (ap (fa-mul 0 0 1) (fa-ret)))))
+
+  (if (eq (beq img3 exp3) 1)
+      (if (eq (beq imgnn expnn) 1)
+          (add (byte-sum img3) (byte-sum imgnn))
+          0)
+      0))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -499,3 +499,4 @@ model-roster-report fks 1388
 lowering-search fks 57
 rewrite-propose fks 7
 rewrite-rules fkc 13
+capability-form-mul fkc 2428


### PR DESCRIPTION
form-lower had LIT/ARG/ADD/SUB/COND but **no multiply** — the body could not emit a `mul` at all, while the optimizer and real `f(n)` recipes produce MUL constantly.

- **fa-mul** (form-asm): `mul wd,wn,wm` = MADD, base `0x1B007C00`. **Byte-convicted vs the assembler** (`mul w0,w0,w1 = 0x1b017c00`, bit-for-bit).
- **lo-mul** (form-lower, tag 5): operand-aware. arm64 has no mul-immediate, so an ARG operand multiplies through the banked register, a LIT operand lands in scratch `w2`. Two non-trivial subtrees = the multi-register frontier, left as the empty tail (never a wrong answer).
- **lo-map-mul** mirrors emission so the source map can't drift.

**Proof:** `capability-form-mul` band **four-way (→ 2428)**, byte-convicted against the hand-assembled sequence. **Execution-verified** on real binaries (zero clang): `n*3` and `n*n` exact over n=2..15. Existing form-asm/lower/macho bands still pass (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)