### PR TITLE
feat(form): native codegen learns to DIVIDE — fa-udiv + lo-div, four-way

### DIFF
--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -52,6 +52,8 @@
     (defn fa-add-r (rd rn rm) (fa-le (add 184549376 (add (mul rm 65536) (add (mul rn 32) rd)))))
     ; mul w<rd>, w<rn>, w<rm>  (= MADD wd,wn,wm,wzr ; Ra=31) : base 0x1B007C00 | rm<<16 | rn<<5 | rd
     (defn fa-mul  (rd rn rm) (fa-le (add 453016576 (add (mul rm 65536) (add (mul rn 32) rd)))))
+    ; udiv w<rd>, w<rn>, w<rm>  (unsigned divide, rd = rn / rm) : base 0x1AC00800 | rm<<16 | rn<<5 | rd
+    (defn fa-udiv (rd rn rm) (fa-le (add 448792576 (add (mul rm 65536) (add (mul rn 32) rd)))))
 
     ; ── the call + frame instructions (recursion) ────────────────────────
     ; bl #off — branch-with-link, SIGNED 26-bit offset in instructions. The base

--- a/form/form-stdlib/form-lower.fk
+++ b/form/form-stdlib/form-lower.fk
@@ -43,8 +43,9 @@
         (if (eq (lo-tag prog i) 3) (lo-add prog i argr)
         (if (eq (lo-tag prog i) 4) (lo-sub prog i argr)
         (if (eq (lo-tag prog i) 5) (lo-mul prog i argr)
+        (if (eq (lo-tag prog i) 8) (lo-div prog i argr)
         (if (eq (lo-tag prog i) 6) (lo-cond prog i argr)
-            (list))))))))
+            (list)))))))))
     ; ADD: (x, LIT i) -> lower(x); add w0,w0,#i · (ARG, x) -> lower(x); add w0,w<argr>,w0
     (defn lo-add (prog i argr)
         (if (lo-lit? prog (lo-c2 prog i))
@@ -69,6 +70,19 @@
             (lo-app (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-movz 2 (lo-imm prog i))) (fa-mul 0 0 2))
         (if (lo-lit? prog (lo-c1 prog i))
             (lo-app (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-movz 2 (lo-val prog (lo-c1 prog i)))) (fa-mul 0 0 2))
+            (list))))))
+    ; DIV: like MUL but NON-commutative — numerator is Rn, denominator Rm, order kept.
+    ; (ARG, x) -> n/x: lower x->w0; udiv w0,w<argr>,w0 · (x, ARG) -> x/n: lower x->w0; udiv w0,w0,w<argr>
+    ; (x, LIT i) -> x/i: lower x->w0; movz w2,#i; udiv w0,w0,w2 · (LIT a, x) -> a/x: lower x->w0; movz w2,#a; udiv w0,w2,w0
+    (defn lo-div (prog i argr)
+        (if (lo-arg? prog (lo-c1 prog i))
+            (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-udiv 0 argr 0))
+        (if (lo-arg? prog (lo-c2 prog i))
+            (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-udiv 0 0 argr))
+        (if (lo-lit? prog (lo-c2 prog i))
+            (lo-app (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-movz 2 (lo-imm prog i))) (fa-udiv 0 0 2))
+        (if (lo-lit? prog (lo-c1 prog i))
+            (lo-app (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-movz 2 (lo-val prog (lo-c1 prog i)))) (fa-udiv 0 2 0))
             (list))))))
     ; COND(LE(ARG, LIT i), then, else) — the control-flow scheme with computed
     ; branch offsets (in instructions = bytes/4):
@@ -101,8 +115,9 @@
         (if (eq (lo-tag prog i) 3) (lo-map-add prog i)
         (if (eq (lo-tag prog i) 4) (lo-map-sub prog i)
         (if (eq (lo-tag prog i) 5) (lo-map-mul prog i)
+        (if (eq (lo-tag prog i) 8) (lo-map-div prog i)
         (if (eq (lo-tag prog i) 6) (lo-map-cond prog i)
-            (list))))))))
+            (list)))))))))
     (defn lo-map-add (prog i)
         (if (lo-lit? prog (lo-c2 prog i))
             (lo-app (lo-map prog (lo-c1 prog i)) (list i))
@@ -114,6 +129,17 @@
     ; MUL mirror: ARG-operand forms emit one mul (one i); LIT-operand forms emit movz+mul
     ; (two i's), both owned by the MUL node — exactly lo-mul's instruction order.
     (defn lo-map-mul (prog i)
+        (if (lo-arg? prog (lo-c1 prog i))
+            (lo-app (lo-map prog (lo-c2 prog i)) (list i))
+        (if (lo-arg? prog (lo-c2 prog i))
+            (lo-app (lo-map prog (lo-c1 prog i)) (list i))
+        (if (lo-lit? prog (lo-c2 prog i))
+            (lo-app (lo-map prog (lo-c1 prog i)) (list i i))
+        (if (lo-lit? prog (lo-c1 prog i))
+            (lo-app (lo-map prog (lo-c2 prog i)) (list i i))
+            (list))))))
+    ; DIV mirror: same operand-shape as MUL (one udiv, or movz+udiv for a LIT operand).
+    (defn lo-map-div (prog i)
         (if (lo-arg? prog (lo-c1 prog i))
             (lo-app (lo-map prog (lo-c2 prog i)) (list i))
         (if (lo-arg? prog (lo-c2 prog i))

--- a/form/form-stdlib/tests/capability-form-div-band.fk
+++ b/form/form-stdlib/tests/capability-form-div-band.fk
@@ -1,0 +1,37 @@
+; capability-form-div-band.fk — the body's native codegen can lower a DIVIDE.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-lower.fk
+;
+; With MUL landed, the symmetric gap was DIV — and it pays off the optimizer thread:
+; the triangle closed form T(n)=n*(n+1)/2 (the lowering the recipe-equivalence gate
+; admitted over the naive recursion) needs exactly MUL + ADD + DIV, so once lo-div
+; (tag 8) exists, T(n) compiles to a REAL native binary. DIV is non-commutative, so
+; lo-div keeps operand order (numerator Rn, denominator Rm) — unlike lo-mul it cannot
+; swap. fa-udiv is byte-convicted against the assembler (udiv w0,w0,w1 = 0x1ac10800).
+;
+; This band byte-convicts n/2's lowered image against the hand-assembled sequence,
+; then returns the byte-sum of n/2 AND the full T(n) image (a content checksum the
+; four kernels must agree on — a wrong DIV/MUL on any arm diverges). Execution-
+; verified separately: T(n) exact over n=2..15 (3,6,15,55,120), n/2 floor exact.
+;
+;   n/2          -> mov w1,w0 ; movz w0,#2 ; udiv w0,w1,w0 ; ret
+;   T(n)=n(n+1)/2 lowers ADD(n,1) -> MUL(n,·) -> DIV(·,2), single-accumulator throughout
+
+(do
+  (defn ap (xs ys) (if (eq (len xs) 0) ys (cons (head xs) (ap (tail xs) ys))))
+  (defn beq (a b)
+    (if (eq (len a) (len b))
+        (if (eq (len a) 0) 1
+            (if (eq (head a) (head b)) (beq (tail a) (tail b)) 0))
+        0))
+  (defn byte-sum (bs) (if (eq (len bs) 0) 0 (add (head bs) (byte-sum (tail bs)))))
+
+  (let imgd (lo-compile-fn (list (list 2 0 0 0) (list 1 2 0 0) (list 8 0 1 0)) 2))
+  (let expd (ap (fa-mov 1 0) (ap (fa-movz 0 2) (ap (fa-udiv 0 1 0) (fa-ret)))))
+  (let imgt (lo-compile-fn
+              (list (list 2 0 0 0) (list 1 1 0 0) (list 3 0 1 0)
+                    (list 5 0 2 0) (list 1 2 0 0) (list 8 3 4 0)) 5))
+
+  (if (eq (beq imgd expd) 1)
+      (add (byte-sum imgd) (byte-sum imgt))
+      0))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -500,3 +500,4 @@ lowering-search fks 57
 rewrite-propose fks 7
 rewrite-rules fkc 13
 capability-form-mul fkc 2428
+capability-form-div fkc 3027


### PR DESCRIPTION
The symmetric gap after MUL — and it pays off the optimizer thread. **T(n)=n*(n+1)/2** (the closed form the recipe-equivalence gate admitted over the naive recursion) needs MUL + ADD + DIV; with `lo-div` it now compiles to a **real native binary**.

- **fa-udiv** (form-asm): `udiv wd,wn,wm`, base `0x1AC00800`. **Byte-convicted vs the assembler** (`udiv w0,w0,w1 = 0x1ac10800`, bit-for-bit).
- **lo-div** (form-lower, tag 8): operand-aware like MUL but **non-commutative** — numerator Rn, denominator Rm, order preserved. Two non-trivial subtrees = multi-register frontier, left as the empty tail.
- **lo-map-div** mirrors emission.

**Proof:** `capability-form-div` band **four-way (→ 3027)**, byte-convicted. **Execution-verified** (zero clang): `T(n)` exact over n=2..15 (3,6,15,55,120), `n/2` floor exact. Existing form-asm/lower/macho/mul bands still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)