### PR TITLE
feat(form-cli): the runner self-guides — predictor-guidance wired permanently into the runner

### DIFF
--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -250,6 +250,14 @@ coder unguided answered `[Grep, Edit]` (no Bash) becomes `[Bash, Read, Write,
 Edit]` once guided. The corpus-trained native model makes the live local model
 better: the flywheel turning, not just measured.
 
+**This is now permanent in the runner**, not a demo. `form_native_run.sh`
+self-guides every call: it consults the predictor (`form-cli-predict.fk`) for the
+task's likely tools, maps them to the runner's tool vocabulary, and feeds them to
+the loop via `fnr-run-guided` (`form-native-run.fk`). So the local model's tool
+selection is corrected on every real run — e.g. a read/validate/write task
+auto-guides to `bash, read_file, write_file`. `FNR_NO_GUIDE=1` gives the bare
+unguided runner. The runner uses its own trained model to guide itself.
+
 ## The reasoning lane — measured, and wide open
 
 Tool selection is a set problem; reasoning needs a *semantic* judge. So a local

--- a/form/form-stdlib/form-native-run.fk
+++ b/form/form-stdlib/form-native-run.fk
@@ -55,19 +55,23 @@
 (defn fnr-toolcall? (reply)
     (if (and (ge (str_find reply "\"name\"" 0) 0) (ge (str_find reply "\"arguments\"" 0) 0)) 1 0))
 
-; ── the loop: recurse over (transcript, step) until a final answer or max ──
-(defn fnr-step (oracle transcript step max)
+; ── the loop: recurse over (transcript, step) until a final answer or max. The
+;    `guide` is the runner's self-guidance — the corpus-trained tool predictor's
+;    likely-tools hint for this task (form-cli-predict.fk, computed by the
+;    carrier), prepended to the system prompt so the local model stops omitting
+;    tools it learned to need (e.g. Bash). Empty guide = the unguided runner. ──
+(defn fnr-step (oracle guide transcript step max)
     (if (ge step max)
         (str_concat "(reached max-steps)\n" transcript)
         (do
-            (let prompt (str_concat (fnr-sys) (str_concat transcript "\nYour reply:")))
+            (let prompt (str_concat (fnr-sys) (str_concat guide (str_concat transcript "\nYour reply:"))))
             (let reply (fnr-oracle oracle prompt))
             (if (eq (fnr-toolcall? reply) 0)
                 reply
                 (do
                     (let nm (fnr-jf reply "name"))
                     (let obs (fnr-exec nm reply))
-                    (fnr-step oracle
+                    (fnr-step oracle guide
                         (str_concat transcript
                             (str_concat "\nACTION " (str_concat (int_to_str step)
                                 (str_concat ": " (str_concat reply (str_concat "\nOBSERVATION: " obs))))))
@@ -75,4 +79,7 @@
 
 ; ── the entry: run a task. returns the final answer (or the capped transcript). ──
 (defn fnr-run (task oracle max)
-    (fnr-step oracle (str_concat "TASK: " task) 1 max))
+    (fnr-step oracle "" (str_concat "TASK: " task) 1 max))
+; ── self-guided entry: the runner runs with the predictor's likely-tools hint. ──
+(defn fnr-run-guided (task oracle max guide)
+    (fnr-step oracle guide (str_concat "TASK: " task) 1 max))

--- a/scripts/form_native_run.sh
+++ b/scripts/form_native_run.sh
@@ -1,15 +1,56 @@
 #!/usr/bin/env bash
 # form_native_run.sh — run the PURE FORM agent runner (form-stdlib/form-native-run.fk)
-# via the kernel. No C, no Python; host effects via the kernel's host-io builtins.
+# via the kernel. No C, no Python in the body; host effects via the kernel's host-io.
+#
+# The runner SELF-GUIDES: before the loop it consults the corpus-trained tool
+# predictor (form-cli-predict.fk) for the tools this task will likely need, maps
+# them to the runner's tool vocabulary, and feeds them to the loop via
+# fnr-run-guided — so the local model stops omitting tools it learned to need
+# (e.g. bash). The guidance is computed in Form; this shell wires it. Set
+# FNR_NO_GUIDE=1 for the bare unguided runner.
+#
 # Usage: form_native_run.sh "<task>" "<oracle-cmd>" [max-steps]
 set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-GO="$ROOT/form/form-kernel-go/bin-go"
+GO="$ROOT/form/form-kernel-go/bin-go"; STD="$ROOT/form/form-stdlib"
 [[ -x "$GO" ]] || (cd "$ROOT/form/form-kernel-go" && go build -o bin-go .)
 TASK="${1:?task}"; ORACLE="${2:-ollama run qwen2.5:72b}"; MAX="${3:-8}"
 esc(){ printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
 work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
-{ cat "$ROOT/form/form-stdlib/form-native-run.fk"
-  echo "(print (fnr-run \"$(esc "$TASK")\" \"$(esc "$ORACLE")\" $MAX))"
+
+# ── self-guidance: ask the trained predictor which tools this task needs ──
+GUIDE=""
+if [[ "${FNR_NO_GUIDE:-0}" != "1" && -f "$STD/form-cli-predict.fk" ]]; then
+    # task keywords (lowercase 4+ letter words, deduped)
+    kw="$(printf '%s' "$TASK" | tr 'A-Z' 'a-z' | grep -oE '[a-z]{4,}' | awk '!s[$0]++' | head -12 | sed 's/.*/"&"/' | tr '\n' ' ')"
+    { cat "$STD/form-cli-predict.fk"
+      echo '(let base (list (fcp-base-pair "Bash" 93) (fcp-base-pair "Edit" 56) (fcp-base-pair "Read" 54) (fcp-base-pair "Write" 47) (fcp-base-pair "Agent" 9)))'
+      echo '(let boosts (list (fcp-boost-pair "parallel" "Agent") (fcp-boost-pair "explore" "Agent") (fcp-boost-pair "spawn" "Agent") (fcp-boost-pair "audit" "Agent") (fcp-boost-pair "sweep" "Agent")))'
+      echo "(let kw (list ${kw:-\"\"}))"
+      for t in Bash Read Write Edit Grep Glob Agent; do echo "(print (fcp-predicted? base boosts kw \"$t\" 40 50))"; done
+    } > "$work/predict.fk"
+    # map predictor tools -> the runner's tool vocabulary (bash/read_file/write_file/search)
+    j=0; runner_tools=""
+    while IFS= read -r v; do
+        j=$((j+1)); pt=$(echo "Bash Read Write Edit Grep Glob Agent" | cut -d' ' -f$j)
+        [[ "$(printf '%s' "$v" | tr -d '[:space:]')" == "1" ]] || continue
+        case "$pt" in
+            Bash) runner_tools="$runner_tools bash";;
+            Read) runner_tools="$runner_tools read_file";;
+            Write|Edit) runner_tools="$runner_tools write_file";;
+            Grep|Glob) runner_tools="$runner_tools search";;
+        esac
+    done < <("$GO" "$work/predict.fk" 2>/dev/null | head -7)
+    runner_tools="$(printf '%s\n' $runner_tools | awk '!s[$0]++' | tr '\n' ' ' | sed 's/ *$//')"
+    [[ -n "$runner_tools" ]] && GUIDE="GUIDANCE: similar past tasks needed these tools — reach for them when relevant: ${runner_tools// /, }.\n\n"
+fi
+
+{ cat "$STD/form-native-run.fk"
+  if [[ -n "$GUIDE" ]]; then
+      echo "(print (fnr-run-guided \"$(esc "$TASK")\" \"$(esc "$ORACLE")\" $MAX \"$(esc "$GUIDE")\"))"
+  else
+      echo "(print (fnr-run \"$(esc "$TASK")\" \"$(esc "$ORACLE")\" $MAX))"
+  fi
 } > "$work/run.fk"
+[[ -n "$GUIDE" ]] && printf '  [self-guided: %s]\n' "${GUIDE%%.*}" >&2
 "$GO" "$work/run.fk"


### PR DESCRIPTION
The guided demo (#3242) proved the predictor improves the live model. This makes it **permanent in the runner** — every real run self-guides.

## What changed

- **`form-native-run.fk`**: `fnr-step` gains a `guide` prepended to the system prompt; `fnr-run-guided` runs with it; `fnr-run` stays 3-arg (empty guide) — **backward compatible**. The runner is not band-tested and only `form_native_run.sh` calls it, so the blast radius is one carrier.
- **`form_native_run.sh`**: every call consults the corpus-trained predictor (`form-cli-predict.fk`) for the task's likely tools, maps them to the runner's vocabulary (`bash`/`read_file`/`write_file`/`search`), and feeds them via `fnr-run-guided`. `FNR_NO_GUIDE=1` = bare unguided runner.

## Proof

Smoke-tested both paths. A read/validate/write task auto-guides to `bash, read_file, write_file` — including the `bash` the model would otherwise omit. The unguided path (`FNR_NO_GUIDE=1`) still fires tools correctly (`OBSERVATION: RUNNER-OK`), so the recipe change is non-breaking.

**The runner uses its own trained model to guide itself** — the flywheel is now load-bearing, not a demo. Guidance is computed in Form; the shell wires it. Fresh-from-main + rebased. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)