### PR TITLE
feat(form): native codegen lowers arbitrary trees — lo-tree register stack, four-way

### DIFF
--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -54,6 +54,8 @@
     (defn fa-mul  (rd rn rm) (fa-le (add 453016576 (add (mul rm 65536) (add (mul rn 32) rd)))))
     ; udiv w<rd>, w<rn>, w<rm>  (unsigned divide, rd = rn / rm) : base 0x1AC00800 | rm<<16 | rn<<5 | rd
     (defn fa-udiv (rd rn rm) (fa-le (add 448792576 (add (mul rm 65536) (add (mul rn 32) rd)))))
+    ; sub w<rd>, w<rn>, w<rm>  (register form, rd = rn - rm) : base 0x4B000000 | rm<<16 | rn<<5 | rd
+    (defn fa-sub-r (rd rn rm) (fa-le (add 1258291200 (add (mul rm 65536) (add (mul rn 32) rd)))))
 
     ; ── the call + frame instructions (recursion) ────────────────────────
     ; bl #off — branch-with-link, SIGNED 26-bit offset in instructions. The base

--- a/form/form-stdlib/form-lower.fk
+++ b/form/form-stdlib/form-lower.fk
@@ -70,7 +70,7 @@
             (lo-app (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-movz 2 (lo-imm prog i))) (fa-mul 0 0 2))
         (if (lo-lit? prog (lo-c1 prog i))
             (lo-app (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-movz 2 (lo-val prog (lo-c1 prog i)))) (fa-mul 0 0 2))
-            (list))))))
+            (lo-tree prog i argr 0))))))
     ; DIV: like MUL but NON-commutative — numerator is Rn, denominator Rm, order kept.
     ; (ARG, x) -> n/x: lower x->w0; udiv w0,w<argr>,w0 · (x, ARG) -> x/n: lower x->w0; udiv w0,w0,w<argr>
     ; (x, LIT i) -> x/i: lower x->w0; movz w2,#i; udiv w0,w0,w2 · (LIT a, x) -> a/x: lower x->w0; movz w2,#a; udiv w0,w2,w0
@@ -83,7 +83,30 @@
             (lo-app (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-movz 2 (lo-imm prog i))) (fa-udiv 0 0 2))
         (if (lo-lit? prog (lo-c1 prog i))
             (lo-app (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-movz 2 (lo-val prog (lo-c1 prog i)))) (fa-udiv 0 2 0))
+            (lo-tree prog i argr 0))))))
+    ; lo-tree — the GENERAL register-stack lowering for arbitrary expression trees, the
+    ; fallback when neither operand of an op is ARG/LIT (the case the single-accumulator
+    ; scheme can't reach). It spills each level's LEFT result to w(9+depth) and lowers the
+    ; RIGHT subtree one depth deeper, so a right-child's registers are always strictly
+    ; above the parent's save slot — nesting never clobbers. Order is preserved (left=Rn,
+    ; right=Rm), so non-commutative SUB/DIV stay correct. w9..w15 are caller-saved temps
+    ; (7 levels of right-depth); deeper would need a frame — the named next.
+    (defn lo-tree-op (tag sr)
+        (if (eq tag 3) (fa-add-r 0 sr 0)
+        (if (eq tag 4) (fa-sub-r 0 sr 0)
+        (if (eq tag 5) (fa-mul 0 sr 0)
+        (if (eq tag 8) (fa-udiv 0 sr 0)
             (list))))))
+    (defn lo-tree-bin (prog i argr depth sr)
+        (lo-app
+            (lo-app
+                (lo-app (lo-tree prog (lo-c1 prog i) argr depth) (fa-mov sr 0))
+                (lo-tree prog (lo-c2 prog i) argr (add depth 1)))
+            (lo-tree-op (lo-tag prog i) sr)))
+    (defn lo-tree (prog i argr depth)
+        (if (lo-lit? prog i) (fa-movz 0 (lo-val prog i))
+        (if (lo-arg? prog i) (fa-mov 0 argr)
+            (lo-tree-bin prog i argr depth (add 9 depth)))))
     ; COND(LE(ARG, LIT i), then, else) — the control-flow scheme with computed
     ; branch offsets (in instructions = bytes/4):
     ;   cmp w<argr>,#i ; b.gt +(len(then)+2) ; then ; b +(len(else)+1) ; else
@@ -137,7 +160,7 @@
             (lo-app (lo-map prog (lo-c1 prog i)) (list i i))
         (if (lo-lit? prog (lo-c1 prog i))
             (lo-app (lo-map prog (lo-c2 prog i)) (list i i))
-            (list))))))
+            (lo-map-tree prog i))))))
     ; DIV mirror: same operand-shape as MUL (one udiv, or movz+udiv for a LIT operand).
     (defn lo-map-div (prog i)
         (if (lo-arg? prog (lo-c1 prog i))
@@ -148,7 +171,17 @@
             (lo-app (lo-map prog (lo-c1 prog i)) (list i i))
         (if (lo-lit? prog (lo-c1 prog i))
             (lo-app (lo-map prog (lo-c2 prog i)) (list i i))
-            (list))))))
+            (lo-map-tree prog i))))))
+    ; lo-tree mirror: each binary node owns its left-save (mov) and its combine op; the
+    ; subtrees own their own instructions. Depth doesn't change ownership, only registers.
+    (defn lo-map-tree (prog i)
+        (if (lo-lit? prog i) (list i)
+        (if (lo-arg? prog i) (list i)
+            (lo-app
+                (lo-app
+                    (lo-app (lo-map-tree prog (lo-c1 prog i)) (list i))
+                    (lo-map-tree prog (lo-c2 prog i)))
+                (list i)))))
     ; cmp belongs to the LE node; both branches' jumps belong to the COND itself
     (defn lo-map-cond (prog i)
         (lo-cat (list

--- a/form/form-stdlib/tests/capability-form-tree-band.fk
+++ b/form/form-stdlib/tests/capability-form-tree-band.fk
@@ -1,0 +1,45 @@
+; capability-form-tree-band.fk — the body lowers ARBITRARY expression trees.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-lower.fk
+;
+; The single-accumulator scheme (one result in w0, ARG banked in w1, scratch w2)
+; could not lower an op whose BOTH operands are non-trivial subtrees — e.g.
+; (n+1)*(n+2). That was the empty tail in lo-mul/lo-div. lo-tree closes it with a
+; register stack: each level spills its LEFT result to w(9+depth) and lowers the
+; RIGHT subtree one depth deeper, so a right-child's registers are strictly above
+; the parent's save slot — nesting never clobbers. fa-sub-r (register sub) is byte-
+; convicted against the assembler (0x4b000000); fa-add-r/mul/udiv already were.
+;
+; This band byte-convicts the lowered (n+1)*(n+2) against the hand-assembled 12-
+; instruction register-stack sequence, then returns the byte-sum of that AND the
+; ((n+4)-(n+1))*(n+1) image (a content checksum the four kernels must agree on).
+; Execution-verified separately: (n+1)*(n+2) = 12,20,42,72 and the sub-in-tree case
+; = 9,12,18,24 exact over n=2..7.
+;
+;   (n+1)*(n+2) -> mov w1,w0 ; [ADD: w0=n,w9=n,w0=1,w0=w9+w0] ; w9=n+1 ;
+;                  [ADD@d1: w0=n,w10=n,w0=2,w0=w10+w0] ; mul w0,w9,w0 ; ret
+
+(do
+  (defn ap (xs ys) (if (eq (len xs) 0) ys (cons (head xs) (ap (tail xs) ys))))
+  (defn beq (a b)
+    (if (eq (len a) (len b))
+        (if (eq (len a) 0) 1
+            (if (eq (head a) (head b)) (beq (tail a) (tail b)) 0))
+        0))
+  (defn byte-sum (bs) (if (eq (len bs) 0) 0 (add (head bs) (byte-sum (tail bs)))))
+
+  (let img1 (lo-compile-fn
+              (list (list 2 0 0 0) (list 1 1 0 0) (list 3 0 1 0)
+                    (list 1 2 0 0) (list 3 0 3 0) (list 5 2 4 0)) 5))
+  (let exp1 (ap (fa-mov 1 0)
+            (ap (fa-mov 0 1) (ap (fa-mov 9 0) (ap (fa-movz 0 1) (ap (fa-add-r 0 9 0)
+            (ap (fa-mov 9 0)
+            (ap (fa-mov 0 1) (ap (fa-mov 10 0) (ap (fa-movz 0 2) (ap (fa-add-r 0 10 0)
+            (ap (fa-mul 0 9 0) (fa-ret)))))))))))))
+  (let img2 (lo-compile-fn
+              (list (list 2 0 0 0) (list 1 4 0 0) (list 3 0 1 0) (list 1 1 0 0)
+                    (list 3 0 3 0) (list 4 2 4 0) (list 5 5 4 0)) 6))
+
+  (if (eq (beq img1 exp1) 1)
+      (add (byte-sum img1) (byte-sum img2))
+      0))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -501,3 +501,4 @@ rewrite-propose fks 7
 rewrite-rules fkc 13
 capability-form-mul fkc 2428
 capability-form-div fkc 3027
+capability-form-tree fkc 7255


### PR DESCRIPTION
The single-accumulator scheme couldn't lower an op whose **both** operands are non-trivial subtrees — `(n+1)*(n+2)`. That was the empty tail in `lo-mul`/`lo-div`. `lo-tree` closes it with a **register stack**: each level spills its LEFT result to `w(9+depth)` and lowers the RIGHT subtree one depth deeper, so a right-child's registers are strictly above the parent's save slot — **nesting never clobbers**. Order preserved (left=Rn, right=Rm) so SUB/DIV stay correct. w9..w15 = 7 levels of right-depth; deeper needs a frame (named next).

- **fa-sub-r** byte-convicted vs assembler (`0x4B000000`).
- empty tails route to `lo-tree`; `lo-map-tree` mirrors emission.

**Proof:** `capability-form-tree` band **four-way (→ 7255)**, byte-convicted against the hand-assembled 12-instruction sequence. **Execution-verified** (zero clang): `(n+1)*(n+2)` = 12,20,42,72 and `((n+4)-(n+1))*(n+1)` = 9,12,18,24 over n=2..7. Existing bands unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)