### PR TITLE
feat(form-cli): tiered local-first runner — the remote oracle retires on reasoning too

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 264 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 265 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -258,6 +258,26 @@ selection is corrected on every real run — e.g. a read/validate/write task
 auto-guides to `bash, read_file, write_file`. `FNR_NO_GUIDE=1` gives the bare
 unguided runner. The runner uses its own trained model to guide itself.
 
+## Tiered local-first — the remote oracle as last resort
+
+The reasoning lane can't be won by a frequency table — it needs a capable model.
+But "native" means *local silicon*, not "a Form recipe": so the runner escalates
+**within local tiers** before ever crossing the network:
+
+```bash
+scripts/form_cli_tiered.sh "<task>"   # small-local → big-local → remote (last)
+```
+
+The self-guided runner tries a small local model first; on failure (reached
+max-steps or no real answer) it escalates to a bigger local model; only if every
+*local* tier fails does it cross to a remote oracle. Each served tier is ledgered
+as a membrane crossing (`form-cli-membrane.fk`) — local tiers stay
+**air-gap-clean**, a remote escalation is the one network crossing. **Remote
+reliance = network crossings**, the flywheel's lever: as the bigger local tier
+improves, tier-3 goes to zero and the remote oracle retires on reasoning too.
+Proven both ways: the easy task is served by tier-1 offline; a failing tier-1
+(unavailable model) correctly escalates to tier-2, still offline.
+
 ## The reasoning lane — measured, and wide open
 
 Tool selection is a set problem; reasoning needs a *semantic* judge. So a local

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 264
+**Total files**: 265
 
 | File | Purpose |
 |---|---|
@@ -88,6 +88,7 @@
 | [form_cli_preflight.sh](form_cli_preflight.sh) | form_cli_preflight.sh — air-gap readiness check for the form-cli. |
 | [form_cli_replay.sh](form_cli_replay.sh) | form_cli_replay.sh — measure how the native models do against the agent. |
 | [form_cli_slice.sh](form_cli_slice.sh) | form_cli_slice.sh — compile a Form recipe slice to a RUNNABLE native binary, |
+| [form_cli_tiered.sh](form_cli_tiered.sh) | form_cli_tiered.sh — retire the REMOTE oracle on reasoning: local-first, tiered. |
 | [form_cli_train_predict.sh](form_cli_train_predict.sh) | form_cli_train_predict.sh — train a NATIVE tool predictor on the corpus, then |
 | [form_debug_demo.sh](form_debug_demo.sh) | form_debug_demo.sh — LIVE DEBUGGING: the value trace joined with provenance. |
 | [form_diagnose_demo.sh](form_diagnose_demo.sh) | form_diagnose_demo.sh — the live-diagnosis organ on REAL channels. One fib |

--- a/scripts/form_cli_tiered.sh
+++ b/scripts/form_cli_tiered.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# form_cli_tiered.sh — retire the REMOTE oracle on reasoning: local-first, tiered.
+#
+# The self-guided runner runs a SMALL local model first. If it fails (reaches
+# max-steps or returns nothing), escalate to a BIGGER local model. Only if every
+# LOCAL tier fails does the runner cross the network to a remote oracle — the
+# last resort. Each served tier is ledgered as a membrane crossing
+# (form-cli-membrane.fk): local tiers stay air-gap-clean; a remote escalation is
+# the one network crossing. The flywheel's measurable lever: remote reliance =
+# network crossings, which the bigger local tier drives toward zero.
+#
+# Composes the self-guiding runner (form_native_run.sh) + the membrane + existing
+# routing intent. No new recipe — operationalization of local-first routing.
+#
+# Usage: form_cli_tiered.sh "<task>" [max-steps] [tier1] [tier2] [remote]
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GO="$ROOT/form/form-kernel-go/bin-go"; STD="$ROOT/form/form-stdlib"
+TASK="${1:?task}"; MAX="${2:-4}"
+TIER1="${3:-ollama run llama3.2:3b}"     # fast, weak — handles the easy ones
+TIER2="${4:-ollama run coder}"           # bigger local — catches what tier1 drops
+REMOTE="${5:-claude -p}"                 # last resort: the only tier that needs network
+[[ -x "$GO" ]] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
+
+echo "── tiered local-first runner ──"
+echo "  task: $(printf '%s' "$TASK" | head -c 70)"
+
+# a run succeeds when it returns a real final answer (no max-steps cap, non-empty)
+served=""; surface=""; answer=""
+try_tier() {
+    local name="$1" model="$2" sfc="$3"
+    printf "  · tier %s (%s) …" "$name" "$model"
+    local out; out="$(bash "$ROOT/scripts/form_native_run.sh" "$TASK" "$model" "$MAX" 2>/dev/null)"
+    # a real success: non-trivial content, no max-steps cap, no model-availability
+    # or runtime error signature (an unavailable/erroring tier must escalate).
+    local clean; clean="$(printf '%s' "$out" | sed 's/null[[:space:]]*$//' | tr -d '[:space:]')"
+    if [[ ${#clean} -ge 10 ]] \
+       && ! printf '%s' "$out" | grep -q "reached max-steps" \
+       && ! printf '%s' "$out" | grep -qiE "error: |no such|not found|try pulling|manifest|connection refused|failed to"; then
+        echo " served ✓"; served="$name"; surface="$sfc"; answer="$out"; return 0
+    fi
+    echo " passed"; return 1
+}
+
+if   try_tier "1-local-small" "$TIER1" "local-oracle"; then :
+elif try_tier "2-local-big"   "$TIER2" "local-oracle"; then :
+else
+    # every LOCAL tier failed — the remote oracle is the only one left.
+    echo "  · tier 3 (remote: $REMOTE) — last resort"
+    served="3-remote"; surface="remote-oracle"
+    if command -v "${REMOTE%% *}" >/dev/null 2>&1; then
+        answer="$(bash "$ROOT/scripts/form_native_run.sh" "$TASK" "$REMOTE" "$MAX" 2>/dev/null)"
+    else
+        answer="(remote oracle unavailable offline — escalation point recorded)"
+    fi
+fi
+
+# ── ledger the served tier as a membrane crossing (Form judges the surface) ──
+led="$(mktemp)"; trap 'rm -f "$led"' EXIT
+{ echo '(defn nil? (xs) (eq (len xs) 0))'
+  cat "$STD/tool-channel.fk" "$STD/choice-receipt.fk" "$STD/form-cli-membrane.fk"
+  echo "(let cx (fcm-crossing \"tiered:$served\" \"cap.host.exec\" (fcm-surface-$( [[ "$surface" == remote-oracle ]] && echo remote-oracle || echo local-oracle )) 0 \"tier $served served the task\" \"success\" 80 0))"
+  echo '(let rep (fcm-report (list cx)))'
+  echo '(print (fcm-surface-needs-network? (fcm-x-surface cx)))'
+  echo '(print (fcm-report-airgap-clean? rep))'
+} > "$led"
+NETC=""; CLEAN=""; i=0
+while IFS= read -r v; do v="$(printf '%s' "$v"|tr -d '[:space:]')"; [[ -z "$v" || "$v" == null ]] && continue; case $i in 0) NETC="$v";; 1) CLEAN="$v";; esac; i=$((i+1)); done < <("$GO" "$led" 2>/dev/null)
+
+echo
+echo "── result ──"
+echo "  served by    tier $served ($surface)"
+echo "  network used $([[ "${NETC:-0}" == "1" ]] && echo "YES — remote oracle crossed" || echo "no — stayed offline")"
+echo "  air-gap-clean $([[ "${CLEAN:-0}" == "1" ]] && echo "yes" || echo "no")"
+printf "  answer: %s\n" "$(printf '%s' "$answer" | tr '\n' ' ' | head -c 160)"
+echo
+echo "  remote reliance is the flywheel's lever: as the local tiers improve, tier-3"
+echo "  crossings (network) go to zero — the remote oracle retires on reasoning too."


### PR DESCRIPTION
The reasoning lane can't be won by a frequency table — it needs a capable model. But "native" means *local silicon*, not "a Form recipe". So the runner escalates **within local tiers** before ever crossing the network.

`scripts/form_cli_tiered.sh`: the self-guided runner tries a small local model first; on failure (reached max-steps or no real answer) it escalates to a **bigger local** model; only if every *local* tier fails does it cross to a **remote** oracle (last resort). Each served tier is ledgered as a **membrane crossing** — local tiers stay air-gap-clean, a remote escalation is the one network crossing.

**No new recipe** — the routing intent already lives in `form-cli-router` / `tier-router` / `oracle-flywheel`; this *operationalizes* it in the runner, composing the membrane (from session-start) + the self-guiding runner.

## Proof

- Easy task → served by **tier-1 offline**, air-gap-clean.
- Failing tier-1 (unavailable model) → **correctly escalates to tier-2**, still offline.

**Remote reliance = network crossings** — the flywheel's lever toward zero: as the bigger local tier improves, tier-3 goes away and the remote oracle retires on reasoning too. Fresh-from-main + rebased. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)