### PR TITLE
feat(form): ADD/SUB of two subtrees route to lo-tree — arbitrary-tree lowering completed

### DIFF
--- a/form/form-stdlib/form-lower.fk
+++ b/form/form-stdlib/form-lower.fk
@@ -46,16 +46,24 @@
         (if (eq (lo-tag prog i) 8) (lo-div prog i argr)
         (if (eq (lo-tag prog i) 6) (lo-cond prog i argr)
             (list)))))))))
-    ; ADD: (x, LIT i) -> lower(x); add w0,w0,#i · (ARG, x) -> lower(x); add w0,w<argr>,w0
+    ; ADD: (x, LIT i) -> lower(x); add w0,w0,#i · (ARG, x) -> lower(x); add w0,w<argr>,w0 ·
+    ; else (two subtrees) -> lo-tree. The (ARG, x) fast path needs c1=ARG; without that
+    ; guard the general case would silently add w<argr> in place of the left subtree.
     (defn lo-add (prog i argr)
         (if (lo-lit? prog (lo-c2 prog i))
             (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-add 0 0 (lo-imm prog i)))
-            (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-add-r 0 argr 0))))
-    ; SUB: (ARG, LIT i) -> sub w0,w<argr>,#i (direct) · (x, LIT i) -> lower(x); sub w0,w0,#i
-    (defn lo-sub (prog i argr)
         (if (lo-arg? prog (lo-c1 prog i))
-            (fa-sub 0 argr (lo-imm prog i))
-            (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-sub 0 0 (lo-imm prog i)))))
+            (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-add-r 0 argr 0))
+            (lo-tree prog i argr 0))))
+    ; SUB: (ARG, LIT i) -> sub w0,w<argr>,#i (direct) · (x, LIT i) -> lower(x); sub w0,w0,#i ·
+    ; else (denominator not a LIT) -> lo-tree. Both fast paths require c2=LIT (they read its
+    ; immediate); a non-LIT second operand is the general case the register stack handles.
+    (defn lo-sub (prog i argr)
+        (if (lo-lit? prog (lo-c2 prog i))
+            (if (lo-arg? prog (lo-c1 prog i))
+                (fa-sub 0 argr (lo-imm prog i))
+                (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-sub 0 0 (lo-imm prog i))))
+            (lo-tree prog i argr 0)))
     ; MUL: arm64 has no mul-immediate, so it's operand-aware like ADD/SUB. (ARG, x) /
     ; (x, ARG) -> lower the non-ARG operand into w0, mul w0,w0,w<argr> (the banked n is
     ; never clobbered). (x, LIT i) -> lower x; movz w2,#i; mul w0,w0,w2 (the LIT lands in
@@ -144,11 +152,15 @@
     (defn lo-map-add (prog i)
         (if (lo-lit? prog (lo-c2 prog i))
             (lo-app (lo-map prog (lo-c1 prog i)) (list i))
-            (lo-app (lo-map prog (lo-c2 prog i)) (list i))))
-    (defn lo-map-sub (prog i)
         (if (lo-arg? prog (lo-c1 prog i))
-            (list i)
-            (lo-app (lo-map prog (lo-c1 prog i)) (list i))))
+            (lo-app (lo-map prog (lo-c2 prog i)) (list i))
+            (lo-map-tree prog i))))
+    (defn lo-map-sub (prog i)
+        (if (lo-lit? prog (lo-c2 prog i))
+            (if (lo-arg? prog (lo-c1 prog i))
+                (list i)
+                (lo-app (lo-map prog (lo-c1 prog i)) (list i)))
+            (lo-map-tree prog i)))
     ; MUL mirror: ARG-operand forms emit one mul (one i); LIT-operand forms emit movz+mul
     ; (two i's), both owned by the MUL node — exactly lo-mul's instruction order.
     (defn lo-map-mul (prog i)

--- a/form/form-stdlib/tests/capability-form-tree-band.fk
+++ b/form/form-stdlib/tests/capability-form-tree-band.fk
@@ -39,7 +39,15 @@
   (let img2 (lo-compile-fn
               (list (list 2 0 0 0) (list 1 4 0 0) (list 3 0 1 0) (list 1 1 0 0)
                     (list 3 0 3 0) (list 4 2 4 0) (list 5 5 4 0)) 6))
+  ; ADD and SUB of two subtrees route to lo-tree too (the fast paths assume an ARG/LIT
+  ; operand; the general case is the register stack). (n+1)+(n+2)=2n+3 and (n*n)-(n+1).
+  (let img3 (lo-compile-fn
+              (list (list 2 0 0 0) (list 1 1 0 0) (list 3 0 1 0)
+                    (list 1 2 0 0) (list 3 0 3 0) (list 3 2 4 0)) 5))
+  (let img4 (lo-compile-fn
+              (list (list 2 0 0 0) (list 5 0 0 0) (list 1 1 0 0)
+                    (list 3 0 2 0) (list 4 1 3 0)) 4))
 
   (if (eq (beq img1 exp1) 1)
-      (add (byte-sum img1) (byte-sum img2))
+      (add (add (byte-sum img1) (byte-sum img2)) (add (byte-sum img3) (byte-sum img4)))
       0))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -501,4 +501,4 @@ rewrite-propose fks 7
 rewrite-rules fkc 13
 capability-form-mul fkc 2428
 capability-form-div fkc 3027
-capability-form-tree fkc 7255
+capability-form-tree fkc 13113


### PR DESCRIPTION
The register-stack lift covered `lo-mul`/`lo-div`, but `lo-add`/`lo-sub` still assumed an operand was ARG/LIT — so ADD/SUB of two non-trivial subtrees silently used `w<argr>` (add) or a non-LIT immediate (sub) instead of a real operand. **Untriggered by current recipes, but the optimizer can produce such trees** (rewrite-rules), so it's a real latent hole. Closed:

- `lo-add`: `(x,LIT)`/`(ARG,x)` fast paths kept; else → `lo-tree`.
- `lo-sub`: both `(.,LIT)` fast paths kept; non-LIT second operand → `lo-tree`.
- `lo-map-add`/`lo-map-sub` mirror.

All four arith ops now lower the general two-subtree case through one register stack — **"lower arbitrary trees" is now true**, not MUL/DIV-only.

**Proof:** `capability-form-tree` extended to ADD/SUB two-subtree, **four-way (→ 13113)**, MUL byte-conviction still holds. **Execution-verified**: `(n+1)+(n+2)` and `(n*n)-(n+1)` exact over n=2..6. All existing bands unchanged (fast paths emit identical bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)