### PR TITLE
feat(form): self-improving compiler closes on real bytes — ast-to-prog bridge, four-way

### DIFF
--- a/form/form-stdlib/ast-to-prog.fk
+++ b/form/form-stdlib/ast-to-prog.fk
@@ -1,0 +1,38 @@
+; ast-to-prog.fk — the BRIDGE: the optimizer's rewrite-AST becomes a form-lower prog.
+;
+; preludes: form-stdlib/core.fk
+;
+; This is the seam that lets the optimizer's output be lowered to a real native binary.
+; rewrite-propose/rewrite-rules produce a nested AST; form-lower consumes a flat-indexed
+; prog. a2p flattens one into the other, so the whole flywheel composes on machine code:
+;   rw-all (propose) -> ast-to-prog (bridge) -> lo-compile-fn (lower) -> real bytes.
+;
+; rewrite-AST tags:  (0 v)=LIT  (1)=VAR  (2 a b)=ADD  (3 a b)=MUL.
+; form-lower prog:   (1 v 0 0)=LIT  (2 0 0 0)=ARG  (3 ia ib 0)=ADD  (5 ia ib 0)=MUL.
+; (VAR is the function's single input n, which form-lower banks as ARG.)
+;
+; a2p threads the accumulating row list; each node's index is its position when appended,
+; so a child emitted earlier keeps a stable index a later parent can reference.
+
+(defn a2p-app (xs ys) (if (eq (len xs) 0) ys (cons (head xs) (a2p-app (tail xs) ys))))
+
+; a2p: AST, acc-rows -> (list new-rows this-node-index)
+(defn a2p (ast acc)
+    (if (eq (head ast) 0)
+        (list (a2p-app acc (list (list 1 (nth ast 1) 0 0))) (len acc))
+    (if (eq (head ast) 1)
+        (list (a2p-app acc (list (list 2 0 0 0))) (len acc))
+        (a2p-bin ast acc))))
+(defn a2p-bin (ast acc)
+    (do (let la (a2p (nth ast 1) acc))
+        (let acc1 (nth la 0))
+        (let ia (nth la 1))
+        (let lb (a2p (nth ast 2) acc1))
+        (let acc2 (nth lb 0))
+        (let ib (nth lb 1))
+        (list (a2p-app acc2 (list (list (if (eq (head ast) 2) 3 5) ia ib 0))) (len acc2))))
+
+; the door: AST -> (list prog root-index), ready for lo-compile-fn.
+(defn ast-to-prog (ast) (a2p ast (list)))
+(defn a2p-prog (ast) (nth (ast-to-prog ast) 0))
+(defn a2p-root (ast) (nth (ast-to-prog ast) 1))

--- a/form/form-stdlib/tests/capability-form-pipeline-band.fk
+++ b/form/form-stdlib/tests/capability-form-pipeline-band.fk
@@ -1,0 +1,33 @@
+; capability-form-pipeline-band.fk — the self-improving compiler, end to end on bytes.
+;
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-lower.fk form-stdlib/recipe-equivalence-gate.fk form-stdlib/rewrite-propose.fk form-stdlib/rewrite-rules.fk form-stdlib/ast-to-prog.fk
+;
+; The whole flywheel composed on one artifact, no proxy:
+;   PROPOSE  rw-all folds 2*3+n -> 6+n         (rewrite-rules)
+;   VERIFY   ast-eval equal over coverage      (recipe-equivalence gate — a wrong fold refused)
+;   LOWER    ast-to-prog -> lo-compile-fn       (the bridge: optimizer AST -> real arm64 bytes)
+;   SELECT   admit iff equivalent AND cheaper   (the optimized image is FEWER real instructions)
+;
+; The aggregate is the byte-sum of both lowered images, returned ONLY when the gate says
+; equivalent and the optimized image is strictly smaller — so the four kernels agree on
+; the whole pipeline's output, not just one stage. Execution-verified separately (zero
+; clang): both binaries compute 6+n over n=2..10; the optimized one is 12 B smaller.
+
+(do
+  (defn byte-sum (bs) (if (eq (len bs) 0) 0 (add (head bs) (byte-sum (tail bs)))))
+
+  (let ast (list 2 (list 3 (list 0 2) (list 0 3)) (list 1)))   ; 2*3 + n
+  (let opt (rw-all ast))                                        ; -> 6 + n
+
+  (let cov (list (req-obs 2 (ast-eval ast 2) (ast-eval opt 2))
+                 (req-obs 5 (ast-eval ast 5) (ast-eval opt 5))
+                 (req-obs 9 (ast-eval ast 9) (ast-eval opt 9))))
+
+  (let img-orig (lo-compile-fn (a2p-prog ast) (a2p-root ast)))
+  (let img-opt  (lo-compile-fn (a2p-prog opt) (a2p-root opt)))
+
+  (if (eq (req-equivalent? cov) 1)
+      (if (ge (len img-orig) (add (len img-opt) 1))
+          (add (byte-sum img-orig) (byte-sum img-opt))
+          0)
+      0))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -502,3 +502,4 @@ rewrite-rules fkc 13
 capability-form-mul fkc 2428
 capability-form-div fkc 3027
 capability-form-tree fkc 13113
+capability-form-pipeline fkc 4176


### PR DESCRIPTION
The two threads of the work meet on one artifact. The optimizer (`rewrite-rules`) produced a nested AST; `form-lower` consumed a flat-indexed prog; **nothing connected them**, so the propose→verify→select loop had only run on a node-count proxy. `ast-to-prog` is the bridge — it flattens the optimizer's AST into a form-lower prog, so the optimizer's output becomes a **real native binary**.

The whole flywheel now composes on machine code:
- **PROPOSE** `rw-all` folds `2*3+n → 6+n`
- **VERIFY** `ast-eval` equal over coverage (the gate refuses a wrong fold)
- **LOWER** `ast-to-prog → lo-compile-fn` (optimizer AST → real arm64 bytes)
- **SELECT** admit iff equivalent AND fewer real instructions

**Proof:** `capability-form-pipeline` band **four-way (→ 4176)**, aggregate returned only when the gate says equivalent and the optimized image is strictly smaller. **Execution-verified** (zero clang): both binaries compute `6+n` over n=2..10; the optimized one is **12 B smaller** — the fold removed a real multiply.

Safe precisely because `form-lower` now lowers arbitrary trees (the ADD/SUB hole was the last thing that could have silently miscompiled an optimized tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)