### PR TITLE
tend(form-cli): lift the membrane-crossing friction — core-native.fk replaces the per-carrier nil? shim

### DIFF
--- a/form/form-stdlib/core-native.fk
+++ b/form/form-stdlib/core-native.fk
@@ -1,0 +1,18 @@
+; core-native.fk — core.fk's helpers in the native (Lisp) dialect, for recipes
+; evaluated DIRECTLY on the kernel rather than through validate.sh's BML-compiled
+; core.fk.
+;
+; core.fk is the `section [form.bml]` maintenance dialect; it cannot be raw-cat'd
+; into a Lisp program, so a carrier that evals a stdlib recipe using a core helper
+; (e.g. choice-receipt's nil?) hits "unbound function nil?". Carriers were each
+; hand-shimming the same `(defn nil? ...)` before catting the membrane stack —
+; repeated carrier friction. This is the single native-dialect source for those
+; helpers: a carrier preludes ONE file instead of re-shimming.
+;
+; Mirrors core.fk's contract for the raw-eval context; grows only as a raw-eval
+; recipe needs another helper.
+
+; nil? — the empty-list predicate (core.fk defines it as eq(len(xs), 0)).
+(defn nil? (xs) (eq (len xs) 0))
+
+0

--- a/scripts/form_cli_close_gap.sh
+++ b/scripts/form_cli_close_gap.sh
@@ -77,9 +77,9 @@ esac
 # 5. Ledger the crossing through the Form membrane recipe ----------------------
 # native-avail=0 (this was a gap); surface=local-oracle; the note is the gap.
 led="$(mktemp)"; trap 'rm -f "$pf" "$raw" "$val" "$led"' EXIT
-# nil? lives in core.fk (BML dialect, needs the source-compiler); for a raw Lisp
-# kernel eval we supply the one-line native-dialect shim choice-receipt needs.
-{ echo '(defn nil? (xs) (eq (len xs) 0))'
+# core.fk is BML (needs the source-compiler) and cannot be raw-cat;
+# core-native.fk is the native-dialect prelude that gives nil? for raw kernel eval.
+{ cat "$STD/core-native.fk"
   cat "$STD/tool-channel.fk" "$STD/choice-receipt.fk" "$STD/form-cli-membrane.fk"
   echo "(let cx (fcm-crossing \"close-gap:$GAP\" \"cap.recipe.synthesis\" (fcm-surface-local-oracle) 0 \"gap: $GAP — drafted by local coder oracle\" \"$OUTCOME\" 85 $COST))"
   echo '(print (fcm-x-gap? cx))'

--- a/scripts/form_cli_slice.sh
+++ b/scripts/form_cli_slice.sh
@@ -77,7 +77,7 @@ echo "    or: python3 scripts/coh_substrate.py ingest <path-to-slice>"
 
 # 3. Ledger the slice as a native-recipe crossing (it stayed in the body) -----
 led="$work/led.fk"
-{ echo '(defn nil? (xs) (eq (len xs) 0))'
+{ cat "$STD/core-native.fk"
   cat "$STD/tool-channel.fk" "$STD/choice-receipt.fk" "$STD/form-cli-membrane.fk"
   echo "(let cx (fcm-crossing \"slice:$NAME\" \"cap.compute.native\" (fcm-surface-native) 1 \"native binary slice sha256 $SHA\" \"success\" 100 0))"
   echo '(print (fcm-surface-crossed? (fcm-x-surface cx)))'

--- a/scripts/form_cli_tiered.sh
+++ b/scripts/form_cli_tiered.sh
@@ -57,7 +57,7 @@ fi
 
 # ── ledger the served tier as a membrane crossing (Form judges the surface) ──
 led="$(mktemp)"; trap 'rm -f "$led"' EXIT
-{ echo '(defn nil? (xs) (eq (len xs) 0))'
+{ cat "$STD/core-native.fk"
   cat "$STD/tool-channel.fk" "$STD/choice-receipt.fk" "$STD/form-cli-membrane.fk"
   echo "(let cx (fcm-crossing \"tiered:$served\" \"cap.host.exec\" (fcm-surface-$( [[ "$surface" == remote-oracle ]] && echo remote-oracle || echo local-oracle )) 0 \"tier $served served the task\" \"success\" 80 0))"
   echo '(let rep (fcm-report (list cx)))'


### PR DESCRIPTION
Surveyed the membrane and its crossings **as friction** (repetition × cost) and picked up the highest liftable one.

## The friction map

| friction | carriers | severity |
|---|---|---|
| **`nil?` re-shim** before catting the membrane stack — `core.fk` is BML-dialect and can't be raw-cat'd onto the kernel | close_gap, tiered, slice | **high — root carrier friction** |
| membrane-ledger re-compose | 4 carriers | high (same root) |
| trained model embedded | 2 carriers | medium |
| kernel-build re-check | 11 | low |
| oracle latency (seconds vs ms) | inherent | not liftable — it's *why* the flywheel exists |

## The lift

**`core-native.fk`** — `core.fk`'s helpers in the native (Lisp) dialect for the raw-eval context, one source for `nil?` (grows as raw-eval recipes need more). The three carriers now `cat core-native.fk` instead of hand-shimming the same `(defn nil? …)`.

It's a **prelude helper, not a manifest band** — like `core.fk` itself. `validate.sh` force-prepends BML `core.fk`, and two `nil?` definitions *diverge on the Rust arm*, so it's proven the real way: by the carriers using it where `core.fk` is absent. Smoke-tested — slice ledgers `receipt-valid=1`, tiered serves local-first air-gap-clean, both via `core-native.fk`, no shim.

Carrier-tissue reduction, no behavior change. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)