### PR TITLE
tend(form-cli): lift the model duplication — form-cli-model.fk single source

### DIFF
--- a/form/form-stdlib/form-cli-model.fk
+++ b/form/form-stdlib/form-cli-model.fk
@@ -1,0 +1,32 @@
+; form-cli-model.fk — the corpus-trained tool-predictor model, as ONE data cell.
+;
+; preludes: form-stdlib/form-cli-predict.fk
+;
+; The base-rates (% of corpus turns using each tool) and Agent keyword-boosts
+; learned by scripts/form_cli_train_predict.sh, frozen here as the single source
+; the runner (form_native_run.sh) and the guided demo (form_cli_guided.sh) read —
+; instead of each carrier hardcoding its own copy, which drifts. Re-learn with the
+; trainer and update this one cell; every reader follows.
+
+; the learned base-rates (Bash 93% of turns, down to Agent 9%).
+(defn fpm-base ()
+    (list (fcp-base-pair "Bash" 93)
+          (fcp-base-pair "Edit" 56)
+          (fcp-base-pair "Read" 54)
+          (fcp-base-pair "Write" 47)
+          (fcp-base-pair "Agent" 9)))
+
+; the learned Agent keyword-boosts — task words that lift the rare Agent tool.
+(defn fpm-boosts ()
+    (list (fcp-boost-pair "parallel" "Agent")
+          (fcp-boost-pair "explore" "Agent")
+          (fcp-boost-pair "spawn" "Agent")
+          (fcp-boost-pair "audit" "Agent")
+          (fcp-boost-pair "sweep" "Agent")
+          (fcp-boost-pair "review" "Agent")))
+
+; the threshold a tool must clear to be predicted, and the boost a keyword adds.
+(defn fpm-threshold () 40)
+(defn fpm-boost-amt () 50)
+
+0

--- a/form/form-stdlib/tests/form-cli-model-band.fk
+++ b/form/form-stdlib/tests/form-cli-model-band.fk
@@ -1,0 +1,35 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-cli-predict.fk form-stdlib/form-cli-model.fk
+;
+; form-cli-model-band - the trained-model invariant proof.
+;
+; Verdict 31 when: Bash sits in the model at its corpus rate; the frequent four
+; (Bash/Edit/Read/Write) clear the threshold on base alone so they are ALWAYS
+; predicted (closing the LLM's Bash-omission); and the rare Agent is predicted
+; only when a learned keyword triggers it.
+
+(do
+    (let base (fpm-base))
+    (let boosts (fpm-boosts))
+    (let thr (fpm-threshold))
+    (let amt (fpm-boost-amt))
+
+    ; Bash is in the model at its learned corpus rate
+    (let c0 (if (eq (fcp-base base "Bash") 93) 1 0))
+
+    ; Bash is ALWAYS predicted — base clears the threshold with no keywords
+    (let c1 (if (eq (fcp-predicted? base boosts (list "") "Bash" thr amt) 1) 2 0))
+
+    ; Agent is NOT predicted without a trigger keyword
+    (let c2 (if (eq (fcp-predicted? base boosts (list "read" "file") "Agent" thr amt) 0) 4 0))
+
+    ; Agent IS predicted when a learned keyword triggers it
+    (let c3 (if (eq (fcp-predicted? base boosts (list "parallel" "work") "Agent" thr amt) 1) 8 0))
+
+    ; the frequent four all clear the threshold on base alone
+    (let c4 (if (eq (fcp-predicted? base boosts (list "") "Edit" thr amt) 1)
+                (if (eq (fcp-predicted? base boosts (list "") "Read" thr amt) 1)
+                    (if (eq (fcp-predicted? base boosts (list "") "Write" thr amt) 1) 16 0)
+                    0)
+                0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -172,6 +172,7 @@ form-cli-gaps fks 4095
 form-cli-sample fks 1023
 form-cli-score fks 255
 form-cli-predict fks 127
+form-cli-model fks 31
 form-cli-judge fks 127
 obs-verify fks 31
 world-module-model fks 1023

--- a/scripts/form_cli_guided.sh
+++ b/scripts/form_cli_guided.sh
@@ -22,9 +22,9 @@ KNOWN="Bash Read Write Edit Grep Glob Agent"
 
 echo "── guided vs unguided: the predictor guides $MODEL, on $N tasks ──"
 
-# the learned model (base-rates + Agent boosts), as Form lets we reuse per task
-MODEL_FK='(let base (list (fcp-base-pair "Bash" 93) (fcp-base-pair "Edit" 56) (fcp-base-pair "Read" 54) (fcp-base-pair "Write" 47) (fcp-base-pair "Agent" 9)))
-(let boosts (list (fcp-boost-pair "parallel" "Agent") (fcp-boost-pair "explore" "Agent") (fcp-boost-pair "spawn" "Agent") (fcp-boost-pair "audit" "Agent") (fcp-boost-pair "sweep" "Agent") (fcp-boost-pair "review" "Agent")))'
+# the learned model lives in form-cli-model.fk (single source); reuse per task
+MODEL_FK='(let base (fpm-base))
+(let boosts (fpm-boosts))'
 
 PICKS="$(python3 - "$CORPUS" "$N" <<'PY'
 import json,sys,re
@@ -58,9 +58,9 @@ while IFS=$'\t' read -r agent_tools kw task; do
     i=$((i+1))
     # predictor's likely tools for this task (Form: form-cli-predict)
     pp="$(mktemp)"
-    { cat "$STD/form-cli-predict.fk"; echo "$MODEL_FK"
+    { cat "$STD/form-cli-predict.fk" "$STD/form-cli-model.fk"; echo "$MODEL_FK"
       echo "(let kw $(flist "$kw"))"
-      for t in $KNOWN; do echo "(print (fcp-predicted? base boosts kw \"$t\" 40 50))"; done
+      for t in $KNOWN; do echo "(print (fcp-predicted? base boosts kw \"$t\" (fpm-threshold) (fpm-boost-amt)))"; done
     } > "$pp"
     mapfile_pred=""; j=0; pred=""
     while IFS= read -r v; do j=$((j+1)); tool=$(echo $KNOWN | cut -d' ' -f$j); [[ "$(echo "$v"|tr -d '[:space:]')" == "1" ]] && pred="$pred $tool"; done < <("$GO" "$pp" 2>/dev/null | head -7)

--- a/scripts/form_native_run.sh
+++ b/scripts/form_native_run.sh
@@ -23,11 +23,11 @@ GUIDE=""
 if [[ "${FNR_NO_GUIDE:-0}" != "1" && -f "$STD/form-cli-predict.fk" ]]; then
     # task keywords (lowercase 4+ letter words, deduped)
     kw="$(printf '%s' "$TASK" | tr 'A-Z' 'a-z' | grep -oE '[a-z]{4,}' | awk '!s[$0]++' | head -12 | sed 's/.*/"&"/' | tr '\n' ' ')"
-    { cat "$STD/form-cli-predict.fk"
-      echo '(let base (list (fcp-base-pair "Bash" 93) (fcp-base-pair "Edit" 56) (fcp-base-pair "Read" 54) (fcp-base-pair "Write" 47) (fcp-base-pair "Agent" 9)))'
-      echo '(let boosts (list (fcp-boost-pair "parallel" "Agent") (fcp-boost-pair "explore" "Agent") (fcp-boost-pair "spawn" "Agent") (fcp-boost-pair "audit" "Agent") (fcp-boost-pair "sweep" "Agent")))'
+    { cat "$STD/form-cli-predict.fk" "$STD/form-cli-model.fk"
+      echo '(let base (fpm-base))'
+      echo '(let boosts (fpm-boosts))'
       echo "(let kw (list ${kw:-\"\"}))"
-      for t in Bash Read Write Edit Grep Glob Agent; do echo "(print (fcp-predicted? base boosts kw \"$t\" 40 50))"; done
+      for t in Bash Read Write Edit Grep Glob Agent; do echo "(print (fcp-predicted? base boosts kw \"$t\" (fpm-threshold) (fpm-boost-amt)))"; done
     } > "$work/predict.fk"
     # map predictor tools -> the runner's tool vocabulary (bash/read_file/write_file/search)
     j=0; runner_tools=""


### PR DESCRIPTION
The next-highest friction from the membrane survey: the corpus-trained predictor model (base-rates + Agent boosts) was **hardcoded in two carriers** (`form_native_run.sh`, `form_cli_guided.sh`) — duplicated data that drifts.

## The lift

**`form-cli-model.fk`** — the model as one data cell (`fpm-base` / `fpm-boosts` / `fpm-threshold` / `fpm-boost-amt`). Both carriers now `cat` it and read `fpm-*` instead of embedding their own copy. Re-learn with `form_cli_train_predict.sh`, update this one cell, every reader follows.

`form-cli-model-band` proves the invariant **four-way (31)**: the frequent four (Bash/Edit/Read/Write) clear the threshold on base alone — **always predicted** (closing the LLM's Bash-omission) — and the rare `Agent` only fires on a learned keyword.

## Proof

Smoke-tested both readers: self-guidance computes the same `bash, read_file, write_file` hint; the guided demo still lifts the live model **50% → 100%** — both reading the single cell.

No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)