### PR TITLE
feat(form): optimizer vocabulary matches the codegen — SUB/DIV in the AST, four-way

### DIFF
--- a/form/form-stdlib/ast-to-prog.fk
+++ b/form/form-stdlib/ast-to-prog.fk
@@ -7,8 +7,8 @@
 ; prog. a2p flattens one into the other, so the whole flywheel composes on machine code:
 ;   rw-all (propose) -> ast-to-prog (bridge) -> lo-compile-fn (lower) -> real bytes.
 ;
-; rewrite-AST tags:  (0 v)=LIT  (1)=VAR  (2 a b)=ADD  (3 a b)=MUL.
-; form-lower prog:   (1 v 0 0)=LIT  (2 0 0 0)=ARG  (3 ia ib 0)=ADD  (5 ia ib 0)=MUL.
+; rewrite-AST tags:  (0 v)=LIT  (1)=VAR  (2 a b)=ADD  (3 a b)=MUL  (4 a b)=SUB  (5 a b)=DIV.
+; form-lower prog:   (1 v 0 0)=LIT  (2 0 0 0)=ARG  (3..)=ADD  (5..)=MUL  (4..)=SUB  (8..)=DIV.
 ; (VAR is the function's single input n, which form-lower banks as ARG.)
 ;
 ; a2p threads the accumulating row list; each node's index is its position when appended,
@@ -30,7 +30,8 @@
         (let lb (a2p (nth ast 2) acc1))
         (let acc2 (nth lb 0))
         (let ib (nth lb 1))
-        (list (a2p-app acc2 (list (list (if (eq (head ast) 2) 3 5) ia ib 0))) (len acc2))))
+        (let tag (if (eq (head ast) 2) 3 (if (eq (head ast) 3) 5 (if (eq (head ast) 4) 4 8))))
+        (list (a2p-app acc2 (list (list tag ia ib 0))) (len acc2))))
 
 ; the door: AST -> (list prog root-index), ready for lo-compile-fn.
 (defn ast-to-prog (ast) (a2p ast (list)))

--- a/form/form-stdlib/rewrite-propose.fk
+++ b/form/form-stdlib/rewrite-propose.fk
@@ -10,7 +10,11 @@
 ;   (1)       VAR          the single input x
 ;   (2 a b)   ADD a b      subtrees a + b
 ;   (3 a b)   MUL a b      subtrees a * b
-; ast-eval IS the ground-truth evaluator (offer the AST an input, observe the ack).
+;   (4 a b)   SUB a b      subtrees a - b   (-> form-lower tag 4)
+;   (5 a b)   DIV a b      subtrees a / b   (-> form-lower tag 8)
+; The op vocabulary matches form-lower's, so any expression the body can compile, it can
+; also reason about and optimize. ast-eval IS the ground-truth evaluator (offer the AST
+; an input, observe the ack).
 ; rw-fold is one rewrite rule (constant folding); more rules (identity, strength
 ; reduction, CSE) drop in the same way, each verified by the gate, never assumed.
 
@@ -20,7 +24,9 @@
       (if (eq t 0) (nth n 1)
           (if (eq t 1) x
               (if (eq t 2) (add (ast-eval (nth n 1) x) (ast-eval (nth n 2) x))
-                  (mul (ast-eval (nth n 1) x) (ast-eval (nth n 2) x)))))))
+              (if (eq t 3) (mul (ast-eval (nth n 1) x) (ast-eval (nth n 2) x))
+              (if (eq t 4) (sub (ast-eval (nth n 1) x) (ast-eval (nth n 2) x))
+                  (div (ast-eval (nth n 1) x) (ast-eval (nth n 2) x)))))))))
 
 ; node count — the cost proxy (fewer nodes = cheaper lowering).
 (defn ast-size (n)
@@ -37,7 +43,8 @@
           (do (let a (rw-fold (nth n 1)))
               (let b (rw-fold (nth n 2)))
               (if (if (eq (head a) 0) (eq (head b) 0) 0)
-                  (if (eq t 2)
-                      (list 0 (add (nth a 1) (nth b 1)))
-                      (list 0 (mul (nth a 1) (nth b 1))))
+                  (if (eq t 2) (list 0 (add (nth a 1) (nth b 1)))
+                  (if (eq t 3) (list 0 (mul (nth a 1) (nth b 1)))
+                  (if (eq t 4) (list 0 (sub (nth a 1) (nth b 1)))
+                      (list 0 (div (nth a 1) (nth b 1))))))
                   (list t a b))))))

--- a/form/form-stdlib/rewrite-rules.fk
+++ b/form/form-stdlib/rewrite-rules.fk
@@ -13,27 +13,35 @@
 (defn rr-lit1? (n) (if (eq (head n) 0) (eq (nth n 1) 1) 0))
 (defn rr-lit2? (n) (if (eq (head n) 0) (eq (nth n 1) 2) 0))
 
-; constant folding at the node: ADD/MUL of two LITs -> one LIT.
+; constant folding at the node: ADD/SUB/MUL/DIV of two LITs -> one LIT.
 (defn rw-fold-shallow (n)
   (do (let t (head n))
       (if (if (eq t 0) 1 (eq t 1)) n
           (do (let a (nth n 1)) (let b (nth n 2))
               (if (if (eq (head a) 0) (eq (head b) 0) 0)
                   (if (eq t 2) (list 0 (add (nth a 1) (nth b 1)))
-                      (list 0 (mul (nth a 1) (nth b 1))))
+                  (if (eq t 3) (list 0 (mul (nth a 1) (nth b 1)))
+                  (if (eq t 4) (list 0 (sub (nth a 1) (nth b 1)))
+                      (list 0 (div (nth a 1) (nth b 1))))))
                   n)))))
 
-; identity elimination: x+0 -> x, 0+x -> x, x*1 -> x, 1*x -> x, x*0 -> 0, 0*x -> 0.
+; identity elimination: x+0/0+x -> x, x*1/1*x -> x, x*0/0*x -> 0, x-0 -> x, x/1 -> x.
 (defn rw-identity-shallow (n)
   (do (let t (head n))
       (if (eq t 2)
           (do (let a (nth n 1)) (let b (nth n 2))
               (if (rr-lit0? b) a (if (rr-lit0? a) b n)))
-          (if (eq t 3)
-              (do (let a (nth n 1)) (let b (nth n 2))
-                  (if (if (rr-lit0? a) 1 (rr-lit0? b)) (list 0 0)
-                      (if (rr-lit1? b) a (if (rr-lit1? a) b n))))
-              n))))
+      (if (eq t 3)
+          (do (let a (nth n 1)) (let b (nth n 2))
+              (if (if (rr-lit0? a) 1 (rr-lit0? b)) (list 0 0)
+                  (if (rr-lit1? b) a (if (rr-lit1? a) b n))))
+      (if (eq t 4)
+          (do (let a (nth n 1)) (let b (nth n 2))
+              (if (rr-lit0? b) a n))
+      (if (eq t 5)
+          (do (let a (nth n 1)) (let b (nth n 2))
+              (if (rr-lit1? b) a n))
+          n))))))
 
 ; strength reduction: x*2 -> x+x (an add is cheaper than a multiply).
 (defn rw-strength-shallow (n)

--- a/form/form-stdlib/tests/capability-form-pipeline-band.fk
+++ b/form/form-stdlib/tests/capability-form-pipeline-band.fk
@@ -2,32 +2,43 @@
 ;
 ; preludes: form-stdlib/form-asm.fk form-stdlib/form-lower.fk form-stdlib/recipe-equivalence-gate.fk form-stdlib/rewrite-propose.fk form-stdlib/rewrite-rules.fk form-stdlib/ast-to-prog.fk
 ;
-; The whole flywheel composed on one artifact, no proxy:
-;   PROPOSE  rw-all folds 2*3+n -> 6+n         (rewrite-rules)
+; The whole flywheel composed on one artifact, no proxy, over the FULL op vocabulary:
+;   PROPOSE  rw-all folds 2*3+n -> 6+n  and  ((10-4)/2)+n -> 3+n   (ADD/MUL and SUB/DIV)
 ;   VERIFY   ast-eval equal over coverage      (recipe-equivalence gate — a wrong fold refused)
 ;   LOWER    ast-to-prog -> lo-compile-fn       (the bridge: optimizer AST -> real arm64 bytes)
 ;   SELECT   admit iff equivalent AND cheaper   (the optimized image is FEWER real instructions)
 ;
-; The aggregate is the byte-sum of both lowered images, returned ONLY when the gate says
-; equivalent and the optimized image is strictly smaller — so the four kernels agree on
-; the whole pipeline's output, not just one stage. Execution-verified separately (zero
-; clang): both binaries compute 6+n over n=2..10; the optimized one is 12 B smaller.
+; The aggregate is the byte-sum of all four lowered images, returned ONLY when BOTH cases
+; verify equivalent and lower to a strictly smaller image — so the four kernels agree on
+; the whole pipeline's output across the full op set. Execution-verified separately (zero
+; clang): the binaries compute 6+n and 3+n; the SUB/DIV fold removes the whole (10-4)/2
+; subtree (24 B), the ADD/MUL fold removes the multiply (12 B).
 
 (do
   (defn byte-sum (bs) (if (eq (len bs) 0) 0 (add (head bs) (byte-sum (tail bs)))))
 
-  (let ast (list 2 (list 3 (list 0 2) (list 0 3)) (list 1)))   ; 2*3 + n
+  (let ast (list 2 (list 3 (list 0 2) (list 0 3)) (list 1)))   ; 2*3 + n        (ADD/MUL)
   (let opt (rw-all ast))                                        ; -> 6 + n
+  (let ast2 (list 2 (list 5 (list 4 (list 0 10) (list 0 4)) (list 0 2)) (list 1)))  ; ((10-4)/2)+n (SUB/DIV)
+  (let opt2 (rw-all ast2))                                      ; -> 3 + n
 
-  (let cov (list (req-obs 2 (ast-eval ast 2) (ast-eval opt 2))
-                 (req-obs 5 (ast-eval ast 5) (ast-eval opt 5))
-                 (req-obs 9 (ast-eval ast 9) (ast-eval opt 9))))
+  (let cov  (list (req-obs 2 (ast-eval ast 2)  (ast-eval opt 2))
+                  (req-obs 5 (ast-eval ast 5)  (ast-eval opt 5))
+                  (req-obs 9 (ast-eval ast 9)  (ast-eval opt 9))))
+  (let cov2 (list (req-obs 2 (ast-eval ast2 2) (ast-eval opt2 2))
+                  (req-obs 5 (ast-eval ast2 5) (ast-eval opt2 5))
+                  (req-obs 9 (ast-eval ast2 9) (ast-eval opt2 9))))
 
-  (let img-orig (lo-compile-fn (a2p-prog ast) (a2p-root ast)))
-  (let img-opt  (lo-compile-fn (a2p-prog opt) (a2p-root opt)))
+  (let img-orig  (lo-compile-fn (a2p-prog ast)  (a2p-root ast)))
+  (let img-opt   (lo-compile-fn (a2p-prog opt)  (a2p-root opt)))
+  (let img-orig2 (lo-compile-fn (a2p-prog ast2) (a2p-root ast2)))
+  (let img-opt2  (lo-compile-fn (a2p-prog opt2) (a2p-root opt2)))
 
+  ; both cases must verify equivalent over coverage AND lower to a strictly smaller image
   (if (eq (req-equivalent? cov) 1)
-      (if (ge (len img-orig) (add (len img-opt) 1))
-          (add (byte-sum img-orig) (byte-sum img-opt))
-          0)
-      0))
+  (if (eq (req-equivalent? cov2) 1)
+  (if (ge (len img-orig)  (add (len img-opt)  1))
+  (if (ge (len img-orig2) (add (len img-opt2) 1))
+      (add (add (byte-sum img-orig) (byte-sum img-opt))
+           (add (byte-sum img-orig2) (byte-sum img-opt2)))
+      0) 0) 0) 0))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -502,4 +502,4 @@ rewrite-rules fkc 13
 capability-form-mul fkc 2428
 capability-form-div fkc 3027
 capability-form-tree fkc 13113
-capability-form-pipeline fkc 4176
+capability-form-pipeline fkc 9024


### PR DESCRIPTION
The pipeline was lopsided: `form-lower` lowers ADD/SUB/MUL/DIV, but the optimizer's AST knew only ADD/MUL — it couldn't **represent** a subtraction or division, so it couldn't optimize any expression using them (and `ast-eval`/`rw-fold`'s else branches silently *assumed* MUL, which would mis-fold a SUB/DIV of constants). Aligned:

- **rewrite-propose**: `ast-eval` + `rw-fold` gain SUB(4)/DIV(5), explicit dispatch.
- **rewrite-rules**: `rw-fold-shallow` folds all four; `rw-identity-shallow` adds `x-0→x`, `x/1→x`.
- **ast-to-prog**: the bridge maps AST 4→form-lower 4 (SUB), AST 5→form-lower 8 (DIV).

Any arithmetic the body can compile, it can now also optimize. **Proof:** `capability-form-pipeline` extended to a SUB/DIV expression, **four-way (→ 9024)**. **Execution-verified**: `((10-4)/2)+n` folds to `3+n` — the optimizer removes the whole `(10-4)/2` subtree (24 B) — both binaries compute `3+n` over n=2..10. Existing `rewrite-propose` (7), `rewrite-rules` (13) bands unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)