### PR TITLE
tend(form-cli): compost shell logic to Form — form-cli-guide.fk builds the guidance

### DIFF
--- a/form/form-stdlib/form-cli-guide.fk
+++ b/form/form-stdlib/form-cli-guide.fk
@@ -1,0 +1,42 @@
+; form-cli-guide.fk — the runner's self-guidance line, built in Form.
+;
+; preludes: form-stdlib/form-cli-predict.fk form-stdlib/form-cli-model.fk
+;
+; The runner (form_native_run.sh) used to map predictor tools to its own tool
+; vocabulary and assemble the GUIDANCE hint in SHELL (a `case` + string concat).
+; That is a transformation, so it is Form, not shell — carrier-last means the
+; shell shrinks to host-io as the logic lifts. Given the trained model and the
+; task keywords, this builds the hint the runner prepends, in the runner's tool
+; words (bash / read_file / write_file / search; Agent has no runner tool). Each
+; runner tool is checked once and appended in order — no dedup needed.
+
+; is a RUNNER tool wanted? — any of its (up to two) predictor tools predicted.
+; p2 = "" when the runner tool maps from a single predictor tool.
+(defn fcg-want? (base boosts kw thr amt p1 p2)
+    (if (or (eq (fcp-predicted? base boosts kw p1 thr amt) 1)
+            (if (str_eq p2 "") 0 (eq (fcp-predicted? base boosts kw p2 thr amt) 1)))
+        1 0))
+
+; append a runner tool to the comma-joined accumulator when it is wanted.
+(defn fcg-append (acc want name)
+    (if (eq want 1)
+        (if (str_eq acc "") name (str_concat acc (str_concat ", " name)))
+        acc))
+
+; the runner-tool list as a string, in fixed order: bash, read_file, write_file, search.
+(defn fcg-tools (base boosts kw thr amt)
+    (do
+        (let a (fcg-append "" (fcg-want? base boosts kw thr amt "Bash" "") "bash"))
+        (let b (fcg-append a (fcg-want? base boosts kw thr amt "Read" "") "read_file"))
+        (let c (fcg-append b (fcg-want? base boosts kw thr amt "Write" "Edit") "write_file"))
+        (fcg-append c (fcg-want? base boosts kw thr amt "Grep" "Glob") "search")))
+
+; the full guidance line — empty when the model wants nothing.
+(defn fcg-guide (base boosts kw thr amt)
+    (do
+        (let tools (fcg-tools base boosts kw thr amt))
+        (if (str_eq tools "") ""
+            (str_concat "GUIDANCE: similar past tasks needed these tools — reach for them when relevant: "
+                        (str_concat tools ".")))))
+
+0

--- a/form/form-stdlib/tests/form-cli-guide-band.fk
+++ b/form/form-stdlib/tests/form-cli-guide-band.fk
@@ -1,0 +1,40 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-cli-predict.fk form-stdlib/form-cli-model.fk form-stdlib/form-cli-guide.fk
+;
+; form-cli-guide-band - the self-guidance-in-Form proof (lifted from shell).
+;
+; Verdict 31 when, over the trained model: a runner tool is wanted iff a predictor
+; tool maps to it; the comma-join appends only wanted tools; the frequent four
+; resolve to "bash, read_file, write_file"; the full guidance line carries them;
+; and a model that wants nothing yields the empty hint.
+
+(do
+    (let base (fpm-base))
+    (let boosts (fpm-boosts))
+    (let thr (fpm-threshold))
+    (let amt (fpm-boost-amt))
+    (let kw (list "read" "spec"))
+
+    ; want? — Bash wanted, Grep/Glob not (base 0)
+    (let c0 (if (eq (fcg-want? base boosts kw thr amt "Bash" "") 1)
+                (if (eq (fcg-want? base boosts kw thr amt "Grep" "Glob") 0) 1 0)
+                0))
+
+    ; append — joins when wanted, leaves the accumulator when not
+    (let c1 (if (str_eq (fcg-append "" 1 "bash") "bash")
+                (if (str_eq (fcg-append "bash" 1 "read_file") "bash, read_file")
+                    (if (str_eq (fcg-append "bash" 0 "read_file") "bash") 2 0)
+                    0)
+                0))
+
+    ; the runner-tool string — the frequent four, no grep/glob
+    (let c2 (if (str_eq (fcg-tools base boosts kw thr amt) "bash, read_file, write_file") 4 0))
+
+    ; the full guidance line carries them
+    (let c3 (if (str_eq (fcg-guide base boosts kw thr amt)
+                    "GUIDANCE: similar past tasks needed these tools — reach for them when relevant: bash, read_file, write_file.")
+                8 0))
+
+    ; a threshold nothing clears yields the empty hint
+    (let c4 (if (str_eq (fcg-guide base boosts kw 200 amt) "") 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -173,6 +173,7 @@ form-cli-sample fks 1023
 form-cli-score fks 255
 form-cli-predict fks 127
 form-cli-model fks 31
+form-cli-guide fks 31
 form-cli-judge fks 127
 obs-verify fks 31
 world-module-model fks 1023

--- a/scripts/form_native_run.sh
+++ b/scripts/form_native_run.sh
@@ -19,30 +19,18 @@ esc(){ printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
 work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
 
 # ── self-guidance: ask the trained predictor which tools this task needs ──
+# The predictor->runner mapping and the hint assembly are now Form
+# (form-cli-guide.fk) — fcg-guide builds the whole line. The only shell left here
+# is the keyword extraction (lowercase + tokenize): kernel string-tokenization is
+# the named gap that keeps it a carrier for now.
 GUIDE=""
-if [[ "${FNR_NO_GUIDE:-0}" != "1" && -f "$STD/form-cli-predict.fk" ]]; then
-    # task keywords (lowercase 4+ letter words, deduped)
+if [[ "${FNR_NO_GUIDE:-0}" != "1" && -f "$STD/form-cli-guide.fk" ]]; then
     kw="$(printf '%s' "$TASK" | tr 'A-Z' 'a-z' | grep -oE '[a-z]{4,}' | awk '!s[$0]++' | head -12 | sed 's/.*/"&"/' | tr '\n' ' ')"
-    { cat "$STD/form-cli-predict.fk" "$STD/form-cli-model.fk"
-      echo '(let base (fpm-base))'
-      echo '(let boosts (fpm-boosts))'
-      echo "(let kw (list ${kw:-\"\"}))"
-      for t in Bash Read Write Edit Grep Glob Agent; do echo "(print (fcp-predicted? base boosts kw \"$t\" (fpm-threshold) (fpm-boost-amt)))"; done
-    } > "$work/predict.fk"
-    # map predictor tools -> the runner's tool vocabulary (bash/read_file/write_file/search)
-    j=0; runner_tools=""
-    while IFS= read -r v; do
-        j=$((j+1)); pt=$(echo "Bash Read Write Edit Grep Glob Agent" | cut -d' ' -f$j)
-        [[ "$(printf '%s' "$v" | tr -d '[:space:]')" == "1" ]] || continue
-        case "$pt" in
-            Bash) runner_tools="$runner_tools bash";;
-            Read) runner_tools="$runner_tools read_file";;
-            Write|Edit) runner_tools="$runner_tools write_file";;
-            Grep|Glob) runner_tools="$runner_tools search";;
-        esac
-    done < <("$GO" "$work/predict.fk" 2>/dev/null | head -7)
-    runner_tools="$(printf '%s\n' $runner_tools | awk '!s[$0]++' | tr '\n' ' ' | sed 's/ *$//')"
-    [[ -n "$runner_tools" ]] && GUIDE="GUIDANCE: similar past tasks needed these tools — reach for them when relevant: ${runner_tools// /, }.\n\n"
+    { cat "$STD/form-cli-predict.fk" "$STD/form-cli-model.fk" "$STD/form-cli-guide.fk"
+      echo "(print (fcg-guide (fpm-base) (fpm-boosts) (list ${kw:-\"\"}) (fpm-threshold) (fpm-boost-amt)))"
+    } > "$work/guide.fk"
+    g="$("$GO" "$work/guide.fk" 2>/dev/null | sed '/^null$/d' | head -1)"
+    [[ -n "$g" && "$g" != "null" ]] && GUIDE="$g\n\n"
 fi
 
 { cat "$STD/form-native-run.fk"


### PR DESCRIPTION
You named the correction: **shell tissue is bootstrap, compostable to Form** — "carrier-last" doesn't mean carrier-forever. The runner's self-guidance mapped predictor tools to its vocabulary and assembled the hint in *shell* (a `case` + string concat). A transformation is Form.

## The lift

**`form-cli-guide.fk`** — the predictor→runner mapping (`bash`/`read_file`/`write_file`/`search`; `Agent` has no runner tool) **and** the comma-joined hint assembly, in Form. Each runner tool is checked once and appended in order — no dedup. Four-way (`form-cli-guide-band` → **31**; `str_concat` crosses fkwu, so the whole line is *proven*, not a named gap).

`form_native_run.sh` now evals `fcg-guide` instead of the shell `case`+concat: **22 lines of shell composted** (net −12). The only shell left in self-guidance is the keyword extraction (lowercase + tokenize) — **kernel string-tokenization is the honestly named gap** that keeps it a carrier for now (the next thing to ingest/learn into Form, per your framing).

## Proof

Smoke-tested: the self-guided line is identical — `bash, read_file, write_file` — now built by Form, not shell. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)