### PR TITLE
feat(form): the optimizing compiler handles control flow — COND in the optimizer, four-way

### DIFF
--- a/form/form-stdlib/ast-to-prog.fk
+++ b/form/form-stdlib/ast-to-prog.fk
@@ -7,8 +7,8 @@
 ; prog. a2p flattens one into the other, so the whole flywheel composes on machine code:
 ;   rw-all (propose) -> ast-to-prog (bridge) -> lo-compile-fn (lower) -> real bytes.
 ;
-; rewrite-AST tags:  (0 v)=LIT  (1)=VAR  (2 a b)=ADD  (3 a b)=MUL  (4 a b)=SUB  (5 a b)=DIV.
-; form-lower prog:   (1 v 0 0)=LIT  (2 0 0 0)=ARG  (3..)=ADD  (5..)=MUL  (4..)=SUB  (8..)=DIV.
+; rewrite-AST tags:  (0 v)=LIT  (1)=VAR  (2..)=ADD  (3..)=MUL  (4..)=SUB  (5..)=DIV  (6 k t e)=COND.
+; form-lower prog:   (1 v 0 0)=LIT  (2 0 0 0)=ARG  (3..)=ADD  (5..)=MUL  (4..)=SUB  (8..)=DIV  (6 le t e)=COND.
 ; (VAR is the function's single input n, which form-lower banks as ARG.)
 ;
 ; a2p threads the accumulating row list; each node's index is its position when appended,
@@ -22,7 +22,27 @@
         (list (a2p-app acc (list (list 1 (nth ast 1) 0 0))) (len acc))
     (if (eq (head ast) 1)
         (list (a2p-app acc (list (list 2 0 0 0))) (len acc))
-        (a2p-bin ast acc))))
+    (if (eq (head ast) 6)
+        (a2p-cond ast acc)
+        (a2p-bin ast acc)))))
+; COND (6 k then else) -> form-lower's COND prog: an ARG and LIT-k node feed an LE node
+; (lo-cond reads the threshold from it and compares the banked argr), then the two branch
+; subtrees, then the COND row (6 le then else). The ARG operand is structural — lo-cond
+; always compares w<argr> — but it is emitted to keep the LE node well-formed.
+(defn a2p-cond (ast acc)
+    (do (let acc1 (a2p-app acc (list (list 2 0 0 0))))         ; ARG    @ (len acc)
+        (let arg-idx (len acc))
+        (let acc2 (a2p-app acc1 (list (list 1 (nth ast 1) 0 0)))) ; LIT k @ (len acc1)
+        (let lit-idx (len acc1))
+        (let acc3 (a2p-app acc2 (list (list 5 arg-idx lit-idx 0)))) ; LE   @ (len acc2)
+        (let le-idx (len acc2))
+        (let lt (a2p (nth ast 2) acc3))                        ; then-subtree
+        (let acc4 (nth lt 0))
+        (let then-idx (nth lt 1))
+        (let le2 (a2p (nth ast 3) acc4))                       ; else-subtree
+        (let acc5 (nth le2 0))
+        (let else-idx (nth le2 1))
+        (list (a2p-app acc5 (list (list 6 le-idx then-idx else-idx))) (len acc5))))
 (defn a2p-bin (ast acc)
     (do (let la (a2p (nth ast 1) acc))
         (let acc1 (nth la 0))

--- a/form/form-stdlib/rewrite-propose.fk
+++ b/form/form-stdlib/rewrite-propose.fk
@@ -12,6 +12,7 @@
 ;   (3 a b)   MUL a b      subtrees a * b
 ;   (4 a b)   SUB a b      subtrees a - b   (-> form-lower tag 4)
 ;   (5 a b)   DIV a b      subtrees a / b   (-> form-lower tag 8)
+;   (6 k t e) COND k t e   if x <= k then t else e   (-> form-lower COND, condition LE(VAR,k))
 ; The op vocabulary matches form-lower's, so any expression the body can compile, it can
 ; also reason about and optimize. ast-eval IS the ground-truth evaluator (offer the AST
 ; an input, observe the ack).
@@ -23,16 +24,18 @@
   (do (let t (head n))
       (if (eq t 0) (nth n 1)
           (if (eq t 1) x
+              (if (eq t 6) (if (le x (nth n 1)) (ast-eval (nth n 2) x) (ast-eval (nth n 3) x))
               (if (eq t 2) (add (ast-eval (nth n 1) x) (ast-eval (nth n 2) x))
               (if (eq t 3) (mul (ast-eval (nth n 1) x) (ast-eval (nth n 2) x))
               (if (eq t 4) (sub (ast-eval (nth n 1) x) (ast-eval (nth n 2) x))
-                  (div (ast-eval (nth n 1) x) (ast-eval (nth n 2) x)))))))))
+                  (div (ast-eval (nth n 1) x) (ast-eval (nth n 2) x))))))))))
 
 ; node count — the cost proxy (fewer nodes = cheaper lowering).
 (defn ast-size (n)
   (do (let t (head n))
       (if (if (eq t 0) 1 (eq t 1)) 1
-          (add 1 (add (ast-size (nth n 1)) (ast-size (nth n 2)))))))
+      (if (eq t 6) (add 1 (add (ast-size (nth n 2)) (ast-size (nth n 3))))
+          (add 1 (add (ast-size (nth n 1)) (ast-size (nth n 2))))))))
 
 ; rw-fold — constant folding: fold children first, then if both are LIT, collapse
 ; ADD/MUL of two constants into a single LIT. A pure semantics-preserving rewrite
@@ -40,6 +43,7 @@
 (defn rw-fold (n)
   (do (let t (head n))
       (if (if (eq t 0) 1 (eq t 1)) n
+      (if (eq t 6) (list 6 (nth n 1) (rw-fold (nth n 2)) (rw-fold (nth n 3)))
           (do (let a (rw-fold (nth n 1)))
               (let b (rw-fold (nth n 2)))
               (if (if (eq (head a) 0) (eq (head b) 0) 0)
@@ -47,4 +51,4 @@
                   (if (eq t 3) (list 0 (mul (nth a 1) (nth b 1)))
                   (if (eq t 4) (list 0 (sub (nth a 1) (nth b 1)))
                       (list 0 (div (nth a 1) (nth b 1))))))
-                  (list t a b))))))
+                  (list t a b)))))))

--- a/form/form-stdlib/rewrite-rules.fk
+++ b/form/form-stdlib/rewrite-rules.fk
@@ -55,8 +55,11 @@
 (defn rw-step (n) (rw-strength-shallow (rw-identity-shallow (rw-fold-shallow n))))
 
 ; rw-all: rewrite children, then apply the rule-step at the node (bottom-up, one pass).
+; COND (6 k then else) carries control flow — rewrite each BRANCH; the conditional itself
+; isn't a fold/identity/strength target, so no rw-step at the node.
 (defn rw-all (n)
   (do (let t (head n))
       (if (if (eq t 0) 1 (eq t 1)) n
+      (if (eq t 6) (list 6 (nth n 1) (rw-all (nth n 2)) (rw-all (nth n 3)))
           (do (let a (rw-all (nth n 1))) (let b (rw-all (nth n 2)))
-              (rw-step (list t a b))))))
+              (rw-step (list t a b)))))))

--- a/form/form-stdlib/tests/capability-form-cond-band.fk
+++ b/form/form-stdlib/tests/capability-form-cond-band.fk
@@ -1,0 +1,38 @@
+; capability-form-cond-band.fk — the optimizing compiler handles CONTROL FLOW.
+;
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-lower.fk form-stdlib/recipe-equivalence-gate.fk form-stdlib/rewrite-propose.fk form-stdlib/rewrite-rules.fk form-stdlib/ast-to-prog.fk
+;
+; The flywheel had only ever optimized straight-line arithmetic. A real recipe branches.
+; This proves the whole loop over a CONDITIONAL: the optimizer's AST gains COND (6 k t e =
+; if x<=k then t else e), rw-all rewrites each BRANCH, the bridge emits form-lower's COND
+; prog (an LE node + branch subtrees + the COND row), and lo-compile-fn lowers it to real
+; branching arm64.
+;
+;   PROPOSE  rw-all folds BOTH branches: if n<=1 then 2*3 else 4+5 -> if n<=1 then 6 else 9
+;   VERIFY   ast-eval equal over coverage spanning BOTH branches (n<=1 and n>1)
+;   LOWER    ast-to-prog -> lo-compile-fn (real cmp + conditional branch + computed offsets)
+;   SELECT   admit iff equivalent AND the optimized image is strictly smaller
+;
+; The aggregate is the byte-sum of both images, returned only when the gate says equivalent
+; across both branches and the optimized image is smaller. Execution-verified separately
+; (zero clang): n=1 -> 6 (then), n>=2 -> 9 (else), for both original and optimized binaries.
+
+(do
+  (defn byte-sum (bs) (if (eq (len bs) 0) 0 (add (head bs) (byte-sum (tail bs)))))
+
+  (let ast (list 6 1 (list 3 (list 0 2) (list 0 3)) (list 2 (list 0 4) (list 0 5))))
+  (let opt (rw-all ast))
+
+  (let cov (list (req-obs 0 (ast-eval ast 0) (ast-eval opt 0))     ; then-branch (n<=1)
+                 (req-obs 1 (ast-eval ast 1) (ast-eval opt 1))     ; then-branch boundary
+                 (req-obs 2 (ast-eval ast 2) (ast-eval opt 2))     ; else-branch (n>1)
+                 (req-obs 5 (ast-eval ast 5) (ast-eval opt 5))))   ; else-branch
+
+  (let img-orig (lo-compile-fn (a2p-prog ast) (a2p-root ast)))
+  (let img-opt  (lo-compile-fn (a2p-prog opt) (a2p-root opt)))
+
+  (if (eq (req-equivalent? cov) 1)
+      (if (ge (len img-orig) (add (len img-opt) 1))
+          (add (byte-sum img-orig) (byte-sum img-opt))
+          0)
+      0))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -505,3 +505,4 @@ capability-form-mul fkc 2428
 capability-form-div fkc 3027
 capability-form-tree fkc 13113
 capability-form-pipeline fkc 9024
+capability-form-cond fkc 4156


### PR DESCRIPTION
The flywheel had only optimized straight-line arithmetic. Real recipes branch. This is the leap from arithmetic expressions to **programs**: the optimizer's AST gains COND (`6 k t e` = if x≤k then t else e).

- **rewrite-propose**: `ast-eval`/`ast-size`/`rw-fold` gain COND (then/else subtrees + threshold, dispatched before the arith ops).
- **rewrite-rules**: `rw-all` rewrites each **branch**; the conditional itself is no fold target.
- **ast-to-prog**: COND emits form-lower's prog — an LE node (lo-cond reads the threshold, compares the banked argr) + branch subtrees + the COND row.

`form-lower` already lowered a root COND (cmp + b.gt + computed offsets); now the optimizer can **optimize** one. **Proof:** `capability-form-cond` band **four-way (→ 4156)**, gate verified across **both** branches. **Execution-verified** (zero clang): `if n<=1 then 2*3 else 4+5` folds to `if n<=1 then 6 else 9` — both binaries return 6 at n=1 and 9 at n≥2, saving 12 B. Existing bands unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)