### PR TITLE
tend(form): the keyword tokenizer is Form — text-tokenize.fk, four-way

### DIFF
--- a/form/form-stdlib/tests/text-tokenize-band.fk
+++ b/form/form-stdlib/tests/text-tokenize-band.fk
@@ -1,0 +1,26 @@
+; preludes: form-stdlib/core.fk form-stdlib/text-tokenize.fk
+;
+; text-tokenize-band — the keyword tokenizer in Form (lifted from shell tr|grep|awk).
+;
+; Verdict 31 when: a mixed-case sentence lowercases and splits on non-letters with
+; short words dropped; punctuation and digits break words without leaking; the
+; empty string yields the empty result; one uppercase char lowercases via the
+; ord-indexed table; and a digit is not a letter.
+
+(do
+    ; lowercase + split + length filter: "Run"/"the" (len 3) drop, rest lowercase
+    (let c0 (if (str_eq (tk-words "Run the Validate Script" 4) "validate script") 1 0))
+
+    ; punctuation and a digit-bearing token break cleanly, no leak
+    (let c1 (if (str_eq (tk-words "Read spec, then WRITE2 it." 4) "read spec then write") 2 0))
+
+    ; empty text -> empty result
+    (let c2 (if (str_eq (tk-words "" 4) "") 4 0))
+
+    ; one uppercase char lowercases through the ord table
+    (let c3 (if (str_eq (tk-low (char_at "A" 0)) "a") 8 0))
+
+    ; a digit is not an ascii letter
+    (let c4 (if (eq (tk-alpha? (char_at "5" 0)) 0) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/form-stdlib/text-tokenize.fk
+++ b/form/form-stdlib/text-tokenize.fk
@@ -1,0 +1,47 @@
+; text-tokenize.fk — split text into lowercased ascii-letter words, in pure Form.
+;
+; preludes: form-stdlib/core.fk
+;
+; The shell `tr A-Z a-z | grep -oE '[a-z]{4,}'` was a transformation, so it is
+; Form. A char is a letter when ord(c) is A-Z (65-90) or a-z (97-122); an
+; uppercase letter lowercases through an ord-indexed 26-char table (no chr op
+; needed). The scan accumulates the current word as a string and flushes it,
+; space-joined, when a non-letter (or the end) breaks it — words shorter than
+; minlen are dropped. Result is a single space-joined string (no cons needed);
+; a caller splits on spaces. char_at and ord both cross four-way.
+
+(let TK-LOWERS (list "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n"
+                     "o" "p" "q" "r" "s" "t" "u" "v" "w" "x" "y" "z"))
+
+; lowercase one char: uppercase A-Z -> a-z (ord-indexed), others unchanged.
+(defn tk-low (c)
+    (do (let o (ord c))
+        (if (if (ge o 65) (le o 90) 0) (nth TK-LOWERS (sub o 65)) c)))
+
+; is a char an ascii letter? (A-Z or a-z)
+(defn tk-alpha? (c)
+    (do (let o (ord c))
+        (if (if (ge o 65) (le o 90) 0) 1
+            (if (if (ge o 97) (le o 122) 0) 1 0))))
+
+; flush the current word to the space-joined accumulator when it is long enough.
+(defn tk-flush (out cur minlen)
+    (if (ge (str_len cur) minlen)
+        (if (str_eq out "") cur (str_concat out (str_concat " " cur)))
+        out))
+
+; scan the text char by char, lowercasing letters into `cur`, flushing on breaks.
+(defn tk-scan (text i n cur out minlen)
+    (if (ge i n)
+        (tk-flush out cur minlen)
+        (do
+            (let c (char_at text i))
+            (if (eq (tk-alpha? c) 1)
+                (tk-scan text (add i 1) n (str_concat cur (tk-low c)) out minlen)
+                (tk-scan text (add i 1) n "" (tk-flush out cur minlen) minlen)))))
+
+; the entry: text -> space-joined lowercased letter-words of length >= minlen.
+(defn tk-words (text minlen)
+    (tk-scan text 0 (str_len text) "" "" minlen))
+
+0

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -174,6 +174,7 @@ form-cli-score fks 255
 form-cli-predict fks 127
 form-cli-model fks 31
 form-cli-guide fks 31
+text-tokenize fks 31
 form-cli-judge fks 127
 obs-verify fks 31
 world-module-model fks 1023

--- a/scripts/form_native_run.sh
+++ b/scripts/form_native_run.sh
@@ -19,13 +19,15 @@ esc(){ printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
 work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
 
 # ── self-guidance: ask the trained predictor which tools this task needs ──
-# The predictor->runner mapping and the hint assembly are now Form
-# (form-cli-guide.fk) — fcg-guide builds the whole line. The only shell left here
-# is the keyword extraction (lowercase + tokenize): kernel string-tokenization is
-# the named gap that keeps it a carrier for now.
+# The whole self-guidance is Form now: text-tokenize.fk lowercases and splits the
+# task into keywords (char_at + ord, four-way), form-cli-predict/-model/-guide map
+# and assemble the hint. The carrier only splits the tokenizer's space-joined
+# result, dedups, and quotes it into the keyword list — data-munging, not logic.
 GUIDE=""
 if [[ "${FNR_NO_GUIDE:-0}" != "1" && -f "$STD/form-cli-guide.fk" ]]; then
-    kw="$(printf '%s' "$TASK" | tr 'A-Z' 'a-z' | grep -oE '[a-z]{4,}' | awk '!s[$0]++' | head -12 | sed 's/.*/"&"/' | tr '\n' ' ')"
+    { cat "$STD/text-tokenize.fk"; echo "(print (tk-words \"$(esc "$TASK")\" 4))"; } > "$work/tok.fk"
+    words="$("$GO" "$work/tok.fk" 2>/dev/null | sed '/^null$/d' | head -1)"
+    kw="$(printf '%s' "$words" | tr ' ' '\n' | awk 'NF && !s[$0]++' | head -12 | sed 's/.*/"&"/' | tr '\n' ' ')"
     { cat "$STD/form-cli-predict.fk" "$STD/form-cli-model.fk" "$STD/form-cli-guide.fk"
       echo "(print (fcg-guide (fpm-base) (fpm-boosts) (list ${kw:-\"\"}) (fpm-threshold) (fpm-boost-amt)))"
     } > "$work/guide.fk"


### PR DESCRIPTION
The last shell *logic* in the runner's self-guidance was the keyword extraction — `tr A-Z a-z | grep -oE '[a-z]{4,}'`. I'd called kernel string-tokenization "a gap that keeps it a carrier," but the kernel already carries `char_at` and `ord` (both four-way), so the gap was only **unwritten, not unreachable**.

## The lift

**`text-tokenize.fk`** — text → lowercased ascii-letter words of length ≥ minlen, in pure Form. A letter is `ord(c)` in A-Z/a-z; an uppercase letter lowercases through an **`ord`-indexed 26-char table** (no `chr` op needed); the scan accumulates each word as a string and flushes it space-joined on a non-letter break. **No `cons`** — the result is one space-joined string a caller splits. Four-way (`text-tokenize-band` → **31**; `char_at` + `ord` + `nth` + `str_concat` all cross fkwu).

Generic and reusable — any recipe that needs to tokenize text, not just the guide.

## The carrier

`form_native_run.sh` now evals `tk-words` for the keywords. The only shell left in self-guidance splits the space-joined result, dedups, and quotes it into the list — **data-munging, not logic**. The whole hint path is Form now: **tokenize → predict → map → assemble**.

## Proof

Smoke-tested: `"Read the SPEC, run Validate; then WRITE2 it."` → `"read spec validate then write"` (lowercased, short words dropped, the digit breaks `WRITE2` so only the letter-run `write` survives). The self-guided line is unchanged: `bash, read_file, write_file`. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)