### PR TITLE
feat(form): shell commands are recipes lowered to native asm — byte-filter emitter

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 265 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 266 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -149,6 +149,37 @@ The slice spec is the lowered IR (op-tagged nodes; tags 1=LIT 2=ARG 3=ADD 4=SUB)
 A recipe→IR front-end is a separate cell; the lowered subset (LIT/ADD/SUB/COND/
 ARG/recursion) is what compiles to native today.
 
+## Shell commands are recipes — lowered to native asm
+
+The carriers used to shell out to `tr`, `cat`, `grep`. The north star is not
+"reimplement the pipeline in interpreted Form to avoid the shell" — it is **the
+shell commands have source, so they are Form recipes, lowered to native asm**.
+
+[`hati-os-byte-filter-emit.fk`](../../form/form-stdlib/hati-os-byte-filter-emit.fk)
+is the generic shape: a `stdin→stdout` byte filter where the **per-byte transform
+IS the command** — dropped in as data, never a parallel emitter.
+
+```bash
+scripts/form_byte_filter_demo.sh "Hello, World! 123 ABCxyz"
+```
+
+Form emits the whole C program (`tr A-Z a-z` → the transform `(c>=65&&c<=90)?c+32:c`);
+clang lowers it (an allowed host carrier under `host-kernel.form`); the system
+command is the oracle. Measured: `tr A-Z a-z`, `tr a-z A-Z`, `cat`, `rot13` each
+match their Form-lowered native binary **byte-for-byte**. The transform becomes
+real instructions — the lowercase filter's loop is `add w9, w0, #32` + `csel w0,
+w9, w0, lo` in arm64. Proven four-way at `hati-os-byte-filter-emit fks 31` (the
+emitted C is byte-identical across kernels; the name parameterizes the program).
+
+Two lowering lanes, named honestly: the **slice lane** above
+([`form-lower.fk`](../../form/form-stdlib/form-lower.fk)) reaches native arm64
+bytes with **zero clang**, but its ops are integer arithmetic today; the
+**filter lane** here reaches real coreutils **now** by emitting C through clang.
+Both author the whole program in Form — they differ only in how far the lowering
+walks before a host compiler. The filter lane retires the carriers' `tr`/`cat`
+shell-outs; widening the slice lane to I/O ops is the closing cell that drops
+clang from this lane too.
+
 ## The training corpus — samples to try the native models on
 
 Every slice and gap-close captures its request/response; the agent's own turns

--- a/form/form-stdlib/hati-os-byte-filter-emit.fk
+++ b/form/form-stdlib/hati-os-byte-filter-emit.fk
@@ -1,0 +1,35 @@
+; hati-os-byte-filter-emit.fk — Form emits the C source of a stdin->stdout byte
+; filter; each coreutil filter drops in as its per-byte transform expression
+; (DATA), not a parallel emitter. The shell commands have source, so they ARE
+; Form recipes, lowered to native asm through clang (an allowed host carrier under
+; host-kernel.form host-resource-access) — the intelligence is the recipe, the
+; toolchain and OS loader are dumb carriers. Sibling of hati-os-native-cli-emit.fk
+; (which emits whole compute programs); this widens the lane to the unix filter.
+;
+; preludes: (none — pure str_concat, four-way)
+;
+; The blueprint is one getchar->putchar loop; the transform over byte `c` is the
+; whole command. A new filter is a new transform string, never a new emitter:
+;   tr A-Z a-z  ->  (c >= 65 && c <= 90) ? c + 32 : c
+;   tr a-z A-Z  ->  (c >= 97 && c <= 122) ? c - 32 : c
+;   cat         ->  c
+;   rot13       ->  the two-range rotation
+; No quote char appears in the emitted source, so it travels as a plain
+; content-addressed Form string — identical emissions intern to one NodeID.
+
+; the filter blueprint: a name + a per-byte transform expression -> whole C program.
+(defn bf-filter-c (name transform)
+    (str_concat "extern int getchar(void); extern int putchar(int); static int "
+    (str_concat name
+    (str_concat "_run(void) { int c; while ((c = getchar()) != -1) { int o = "
+    (str_concat transform
+    (str_concat "; putchar(o); } return 0; } int main(void) { return "
+    (str_concat name "_run(); }")))))))
+
+; the commands, as transforms over byte c — the DATA that parameterizes the filter.
+(defn bf-lower () "(c >= 65 && c <= 90) ? c + 32 : c")    ; tr A-Z a-z
+(defn bf-upper () "(c >= 97 && c <= 122) ? c - 32 : c")   ; tr a-z A-Z
+(defn bf-cat   () "c")                                    ; cat (identity)
+(defn bf-rot13 () "(c >= 65 && c <= 90) ? (c - 65 + 13) % 26 + 65 : ((c >= 97 && c <= 122) ? (c - 97 + 13) % 26 + 97 : c)")
+
+0

--- a/form/form-stdlib/tests/hati-os-byte-filter-emit-band.fk
+++ b/form/form-stdlib/tests/hati-os-byte-filter-emit-band.fk
@@ -1,0 +1,26 @@
+; preludes: form-stdlib/core.fk form-stdlib/hati-os-byte-filter-emit.fk
+;
+; hati-os-byte-filter-emit-band — a unix filter (a shell command) emitted from
+; Form, proven four-way: the complete C program for `tr A-Z a-z` is byte-identical
+; across kernels, the name parameterizes the whole program (function, not
+; constant), the transform is dropped in as data (cat/upper), and two emissions of
+; the same filter intern to the same text.
+;
+; Verdict 31 when:
+;   1   the lowercase filter program equals its canonical C text
+;   2   cat is the identity transform (data: "c")
+;   4   upper is its canonical transform string
+;   8   a different name + transform lands a different whole program (parameterized)
+;  16   two emissions of the same filter are str_eq (deterministic, content-addressed)
+
+(do
+    (let low "extern int getchar(void); extern int putchar(int); static int low_run(void) { int c; while ((c = getchar()) != -1) { int o = (c >= 65 && c <= 90) ? c + 32 : c; putchar(o); } return 0; } int main(void) { return low_run(); }")
+    (let up  "extern int getchar(void); extern int putchar(int); static int up_run(void) { int c; while ((c = getchar()) != -1) { int o = (c >= 97 && c <= 122) ? c - 32 : c; putchar(o); } return 0; } int main(void) { return up_run(); }")
+
+    (let c0 (if (str_eq (bf-filter-c "low" (bf-lower)) low) 1 0))
+    (let c1 (if (str_eq (bf-cat) "c") 2 0))
+    (let c2 (if (str_eq (bf-upper) "(c >= 97 && c <= 122) ? c - 32 : c") 4 0))
+    (let c3 (if (str_eq (bf-filter-c "up" (bf-upper)) up) 8 0))
+    (let c4 (if (str_eq (bf-filter-c "low" (bf-lower)) (bf-filter-c "low" (bf-lower))) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -175,6 +175,7 @@ form-cli-predict fks 127
 form-cli-model fks 31
 form-cli-guide fks 31
 text-tokenize fks 31
+hati-os-byte-filter-emit fks 31
 form-cli-judge fks 127
 obs-verify fks 31
 world-module-model fks 1023

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 265
+**Total files**: 266
 
 | File | Purpose |
 |---|---|
@@ -78,6 +78,7 @@
 | [form-convert.sh](form-convert.sh) | form-convert — the machine-native kernel-cli for the goal Urs named: |
 | [form_asm_conviction_demo.sh](form_asm_conviction_demo.sh) | form_asm_conviction_demo.sh — the byte-conviction gate that licenses dropping |
 | [form_branch_demo.sh](form_branch_demo.sh) | form_branch_demo.sh — the FULL asm-pl-human program, compiled by Form and run on |
+| [form_byte_filter_demo.sh](form_byte_filter_demo.sh) | form_byte_filter_demo.sh — a shell command, lowered to native asm from a Form recipe. |
 | [form_cli.py](form_cli.py) | form_cli.py — Form-native CLI: ask, generate, execute, convert. |
 | [form_cli_capture.sh](form_cli_capture.sh) | form_cli_capture.sh — capture agent turns as training samples for the form-cli. |
 | [form_cli_close_gap.sh](form_cli_close_gap.sh) | form_cli_close_gap.sh — close a Form recipe gap OFFLINE with a local oracle. |

--- a/scripts/form_byte_filter_demo.sh
+++ b/scripts/form_byte_filter_demo.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# form_byte_filter_demo.sh — a shell command, lowered to native asm from a Form recipe.
+#
+# hati-os-byte-filter-emit.fk emits the C source of a stdin->stdout byte filter; the
+# per-byte transform IS the command (data, not code). clang (an allowed host carrier
+# under host-kernel.form) makes it a native binary; the system command is the oracle.
+# We prove the Form-lowered native binary's output equals the system command's,
+# byte-for-byte, on real input. This is the north star for composting the shell: not
+# "tokenize in Form to avoid grep" but "the shell commands have source — build them as
+# Form recipes and lower them to native asm."
+#
+# Usage: form_byte_filter_demo.sh ["input string"]
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STD="$ROOT/form/form-stdlib"; GO="$ROOT/form/form-kernel-go/bin-go"
+CLANG="${CLANG:-clang}"
+[[ -x "$GO" ]] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
+command -v "$CLANG" >/dev/null || { echo "no clang — the C toolchain is the lowering carrier"; exit 1; }
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+
+INPUT="${1:-Hello, World! 123 ABCxyz}"
+pass=0; total=0
+
+echo "── shell commands, lowered to native asm from Form recipes ──"
+echo "   Form emits the C · clang lowers it · the system command is the oracle"
+echo "   input: [$INPUT]"
+echo
+
+run_one() { # label  name  transform-recipe  system-cmd...
+    local label="$1" name="$2" tr="$3"; shift 3
+    # Form emits the whole C program for this filter; the kernel is only the mouth.
+    { cat "$STD/hati-os-byte-filter-emit.fk"; echo "(print (bf-filter-c \"$name\" $tr))"; } > "$work/$name.fk"
+    "$GO" "$work/$name.fk" 2>/dev/null | sed '/^null$/d' | head -1 > "$work/$name.c"
+    if ! "$CLANG" -O2 -o "$work/$name" "$work/$name.c" 2>"$work/$name.err"; then
+        printf "  ✗ %-12s clang failed: %s\n" "$label" "$(head -1 "$work/$name.err")"; return 1
+    fi
+    total=$((total+1))
+    local got want
+    got="$(printf '%s' "$INPUT" | "$work/$name")"
+    want="$(printf '%s' "$INPUT" | "$@")"
+    if [[ "$got" == "$want" ]]; then
+        pass=$((pass+1)); printf "  ✓ %-12s native == [%s]  (%d bytes of Form-emitted C)\n" "$label" "$got" "$(wc -c <"$work/$name.c")"
+    else
+        printf "  ✗ %-12s native[%s] != system[%s]\n" "$label" "$got" "$want"
+    fi
+}
+
+run_one "tr A-Z a-z" low   "(bf-lower)" tr 'A-Z' 'a-z'
+run_one "tr a-z A-Z" up    "(bf-upper)" tr 'a-z' 'A-Z'
+run_one "cat"        catf  "(bf-cat)"   cat
+run_one "rot13"      r13   "(bf-rot13)" tr 'A-Za-z' 'N-ZA-Mn-za-m'
+
+echo
+echo "  $pass/$total shell commands match their Form-lowered native binary, byte-for-byte"
+[[ "$pass" -eq "$total" && "$total" -gt 0 ]]


### PR DESCRIPTION
You named the north star, and the tokenizer was a detour: **BMF doesn't need a tokenizer**. The real path — *the shell commands have source, so they are Form recipes, lowered to native asm.*

## The lift

**`hati-os-byte-filter-emit.fk`** — the generic shape, *core-abstraction-first*: a `stdin→stdout` byte filter where the **per-byte transform IS the command**, dropped in as **data**, never a parallel emitter.

| command | transform (the data) |
|---|---|
| `tr A-Z a-z` | `(c>=65 && c<=90) ? c+32 : c` |
| `tr a-z A-Z` | `(c>=97 && c<=122) ? c-32 : c` |
| `cat` | `c` |
| `rot13` | the two-range rotation |

Form emits the whole C program; **clang** (an allowed host carrier under `host-kernel.form`) lowers it; the OS loader runs it. Four-way at **`hati-os-byte-filter-emit fks 31`** — the emitted C is byte-identical across Go/Rust/TS/fkwu, the name parameterizes the whole program, the transform is data.

## Proof — the system command is the oracle

`scripts/form_byte_filter_demo.sh`:

```
  ✓ tr A-Z a-z   native == [hello, world! 123 abcxyz]  (223 bytes of Form-emitted C)
  ✓ tr a-z A-Z   native == [HELLO, WORLD! 123 ABCXYZ]  (222 bytes of Form-emitted C)
  ✓ cat          native == [Hello, World! 123 ABCxyz]  (193 bytes of Form-emitted C)
  ✓ rot13        native == [Uryyb, Jbeyq! 123 NOPklm]  (292 bytes of Form-emitted C)
  4/4 shell commands match their Form-lowered native binary, byte-for-byte
```

The transform becomes **real instructions** — the lowercase loop disassembles to `add w9, w0, #32` + `csel w0, w9, w0, lo` in arm64.

## Two lowering lanes, named honestly

- **slice lane** (`form-lower.fk`): native arm64 bytes, **zero clang** — but integer ops only today.
- **filter lane** (this PR): reaches **real coreutils now** by emitting C through clang.

Both author the whole program in Form; they differ only in how far the lowering walks before a host compiler. Widening the slice lane to I/O ops is the closing cell that drops clang from this lane too. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)