### PR TITLE
feat(form): zero-clang lane reaches syscall I/O — C as oracle, not crutch

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 266 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 267 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -171,14 +171,28 @@ real instructions — the lowercase filter's loop is `add w9, w0, #32` + `csel w
 w9, w0, lo` in arm64. Proven four-way at `hati-os-byte-filter-emit fks 31` (the
 emitted C is byte-identical across kernels; the name parameterizes the program).
 
-Two lowering lanes, named honestly: the **slice lane** above
-([`form-lower.fk`](../../form/form-stdlib/form-lower.fk)) reaches native arm64
-bytes with **zero clang**, but its ops are integer arithmetic today; the
-**filter lane** here reaches real coreutils **now** by emitting C through clang.
-Both author the whole program in Form — they differ only in how far the lowering
-walks before a host compiler. The filter lane retires the carriers' `tr`/`cat`
-shell-outs; widening the slice lane to I/O ops is the closing cell that drops
-clang from this lane too.
+Two lowering lanes, named honestly: the **slice lane**
+([`form-lower.fk`](../../form/form-stdlib/form-lower.fk) + `form-asm.fk`) reaches
+native arm64 bytes with **zero clang**; the **filter lane** above reaches real
+coreutils **now** by emitting C through clang. Both author the whole program in
+Form — they differ only in how far the lowering walks before a host compiler.
+Here clang is the **crutch**; the north star is clang as **oracle only**.
+
+The slice lane is now walking there. `form-asm.fk` carries the syscall / byte-I/O
+instruction set (`svc`, 64-bit `movz`/`movk`, `strb`, stack-frame `add`/`sub`) —
+proven four-way at `form-asm-syscall fks 31`, byte-for-byte against the assembler.
+
+```bash
+scripts/form_syscall_demo.sh   # arm64 macOS
+```
+
+Form encodes a `write`-to-stdout program, wraps it in a Mach-O (`form-macho.fk`),
+`ld` links it (**no clang**), and the binary writes `Hi\n` through the OS kernel —
+clang only assembled the same instructions as the byte **oracle**. The encodings
+are lifted from the ARM ARM / LLVM's ARM target, verified against `as`, never
+copied. This is the syscall primitive a unix filter composes from; the read-loop
+(making the zero-clang `cat`/`tr` that retires the clang filter lane) is the next
+move.
 
 ## The training corpus — samples to try the native models on
 

--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -82,6 +82,24 @@
     ; conviction(candidate, reference): 1 if byte-for-byte identical (FULL — the
     ; witnesses agree), 0 if any byte differs (REFUTED). Silence (no candidate
     ; produced) is the absent third state, handled by the caller.
+    ; ── the syscall / byte-I/O instruction set ──────────────────────────────
+    ; What a unix filter needs beyond arithmetic: a stack frame, a byte buffer,
+    ; the syscall number in x16, and svc. Each base is the ARM ARM opcode template;
+    ; every encoding here is byte-verified against clang/as (form_syscall_demo.sh),
+    ; so the conviction gate licenses these too. SP is register 31.
+    ; movz x<rd>, #imm16  (64-bit) : base 0xD2800000 | imm<<5 | rd
+    (defn fa-movz-x (rd imm)    (fa-le (add 3531603968 (add (mul imm 32) rd))))
+    ; movk x<rd>, #imm16, lsl #16  (64-bit, hw=1) : base 0xF2A00000 | imm<<5 | rd
+    (defn fa-movk-x-16 (rd imm) (fa-le (add 4070572032 (add (mul imm 32) rd))))
+    ; strb w<rt>, [x<rn>, #imm12]  (unsigned offset) : base 0x39000000 | imm<<10 | rn<<5 | rt
+    (defn fa-strb (rt rn imm)   (fa-le (add 956301312 (add (mul imm 1024) (add (mul rn 32) rt)))))
+    ; add x<rd>, x<rn>, #imm12  (64-bit) : base 0x91000000 | imm<<10 | rn<<5 | rd
+    (defn fa-add-x-imm (rd rn imm) (fa-le (add 2432696320 (add (mul imm 1024) (add (mul rn 32) rd)))))
+    ; sub x<rd>, x<rn>, #imm12  (64-bit) : base 0xD1000000 | imm<<10 | rn<<5 | rd
+    (defn fa-sub-x-imm (rd rn imm) (fa-le (add 3506438144 (add (mul imm 1024) (add (mul rn 32) rd)))))
+    ; svc #imm16 : base 0xD4000001 | imm<<5
+    (defn fa-svc (imm)          (fa-le (add 3556769793 (mul imm 32))))
+
     (defn fa-conviction (cand ref)
         (if (eq (len cand) (len ref))
             (if (nil? cand) 1

--- a/form/form-stdlib/tests/form-asm-syscall-band.fk
+++ b/form/form-stdlib/tests/form-asm-syscall-band.fk
@@ -1,0 +1,43 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk
+;
+; form-asm-syscall-band — the syscall / byte-I/O instruction set, proven four-way
+; against the assembler. These are what carry a unix FILTER (read/write/exit) past
+; pure arithmetic: a stack frame, a byte buffer, the syscall number in x16, svc.
+;
+; The reference image is what clang/as emitted for a write-"Hi\n"-to-stdout _main:
+;   sub sp,sp,#16; movz w8,#72; strb w8,[sp,#0]; movz w8,#105; strb w8,[sp,#1];
+;   movz w8,#10; strb w8,[sp,#2]; movz x0,#1; add x1,sp,#0; movz x2,#3;
+;   movz x16,#4; movk x16,#0x200,lsl#16; svc #0x80; movz w0,#0; add sp,sp,#16; ret
+; words: d10043ff 52800908 390003e8 52800d28 390007e8 52800148 39000be8 d2800020
+;        910003e1 d2800062 d2800090 f2a04010 d4001001 52800000 910043ff d65f03c0
+; The binary built from this image (ld, no clang) prints "Hi\n" — form_syscall_demo.sh.
+;
+; Verdict 31 when the encoder IS the assembler over the filter's new instructions:
+;   1   the whole 64-byte image byte-equals clang's (the conviction gate over syscall I/O)
+;   2   svc #0x80 is exact (the boundary cross to the OS kernel)
+;   4   strb at a nonzero offset is exact (buffer addressing — [sp,#1])
+;   8   64-bit movz into x16 is exact (the syscall-number register)
+;  16   movk #0x200,lsl#16 is exact (the write class bits, 0x2000004)
+
+(do
+    (let img (fa-image (list
+        (fa-sub-x-imm 31 31 16)
+        (fa-movz 8 72)  (fa-strb 8 31 0)
+        (fa-movz 8 105) (fa-strb 8 31 1)
+        (fa-movz 8 10)  (fa-strb 8 31 2)
+        (fa-movz-x 0 1) (fa-add-x-imm 1 31 0) (fa-movz-x 2 3)
+        (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+        (fa-movz 0 0) (fa-add-x-imm 31 31 16) (fa-ret))))
+
+    (let ref (list 255 67 0 209   8 9 128 82    232 3 0 57    40 13 128 82
+                   232 7 0 57     72 1 128 82   232 11 0 57   32 0 128 210
+                   225 3 0 145    98 0 128 210  144 0 128 210 16 64 160 242
+                   1 16 0 212     0 0 128 82    255 67 0 145  192 3 95 214))
+
+    (let c0 (if (fa-conviction img ref) 1 0))
+    (let c1 (if (fa-conviction (fa-svc 128) (list 1 16 0 212)) 2 0))
+    (let c2 (if (fa-conviction (fa-strb 8 31 1) (list 232 7 0 57)) 4 0))
+    (let c3 (if (fa-conviction (fa-movz-x 16 4) (list 144 0 128 210)) 8 0))
+    (let c4 (if (fa-conviction (fa-movk-x-16 16 512) (list 16 64 160 242)) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -276,6 +276,7 @@ evidence-grounding fks 127
 forget-stale fks 127
 asm-pl-human-emit fks 31
 form-asm fks 31
+form-asm-syscall fks 31
 form-constants fks 111111
 form-diagnose fks 31
 form-debug fks 31

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 266
+**Total files**: 267
 
 | File | Purpose |
 |---|---|
@@ -103,6 +103,7 @@
 | [form_os_channel_demo.sh](form_os_channel_demo.sh) | form_os_channel_demo.sh — the MINIMAL living surface. Emit a native binary from |
 | [form_provenance_demo.sh](form_provenance_demo.sh) | form_provenance_demo.sh — CELL PROVENANCE, the full chain live: a running |
 | [form_symbol_demo.sh](form_symbol_demo.sh) | form_symbol_demo.sh — SOURCE-SYMBOL LOOKUP FROM FRAMEBUFFER INSPECTION. The spy |
+| [form_syscall_demo.sh](form_syscall_demo.sh) | form_syscall_demo.sh — a program that does I/O, built with ZERO clang. The Form |
 | [form_union_demo.sh](form_union_demo.sh) | form_union_demo.sh — the m4e3/m4e4 union, witnessed: ONE self-contained binary |
 | [form_validate_shards.py](form_validate_shards.py) | Run Form validation workloads as parallel shards. |
 | [framebuffer_viewer.py](framebuffer_viewer.py) | framebuffer_viewer.py — render the kernel's framebuffer as a text panel. |

--- a/scripts/form_syscall_demo.sh
+++ b/scripts/form_syscall_demo.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# form_syscall_demo.sh — a program that does I/O, built with ZERO clang. The Form
+# encoder (form-asm.fk) now carries the syscall / byte-I/O instruction set (svc,
+# 64-bit movz/movk, strb, stack-frame add/sub); form-macho.fk wraps the bytes into
+# a Mach-O object; `ld` (not clang) links it; the binary RUNS and writes to stdout
+# via the macOS arm64 write syscall. clang is the ORACLE only — it assembles the
+# same instructions so we can prove our bytes ARE the assembler's, byte-for-byte —
+# never the lowering crutch. This is the syscall primitive a unix filter (cat, tr)
+# composes from; the read-loop is the next move.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"; CLANG="${CLANG:-clang}"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS demo; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/fsys.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+# The program, as a Form instruction list: write "Hi\n" to stdout, return 0.
+PROG='(fa-image (list
+    (fa-sub-x-imm 31 31 16)
+    (fa-movz 8 72)  (fa-strb 8 31 0)
+    (fa-movz 8 105) (fa-strb 8 31 1)
+    (fa-movz 8 10)  (fa-strb 8 31 2)
+    (fa-movz-x 0 1) (fa-add-x-imm 1 31 0) (fa-movz-x 2 3)
+    (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+    (fa-movz 0 0) (fa-add-x-imm 31 31 16) (fa-ret)))'
+
+# ── 1. Form emits the code image + the whole Mach-O object (hex). No clang. ──
+{ sed '$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<DRV
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code $PROG)
+    (print (str_concat "CODE " (hxb code)))
+    (print (str_concat "MACHO " (hxb (mo-object code))))
+    0)
+DRV
+} > "$work/d.fk"
+form_code="$(cd "$FORM" && "$GO" "$work/d.fk" 2>/dev/null | grep '^CODE ' | sed 's/^CODE //')"
+hex="$(cd "$FORM" && "$GO" "$work/d.fk" 2>/dev/null | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; exit 1; }
+
+# ── 2. clang as ORACLE: assemble the same instructions, compare bytes ──
+cat > "$work/ref.s" <<'EOF'
+.text
+.globl _main
+_main:
+    sub  sp, sp, #16
+    movz w8, #72
+    strb w8, [sp, #0]
+    movz w8, #105
+    strb w8, [sp, #1]
+    movz w8, #10
+    strb w8, [sp, #2]
+    movz x0, #1
+    add  x1, sp, #0
+    movz x2, #3
+    movz x16, #4
+    movk x16, #0x200, lsl #16
+    svc  #0x80
+    movz w0, #0
+    add  sp, sp, #16
+    ret
+EOF
+ref_code=""
+if "$CLANG" -c "$work/ref.s" -o "$work/ref.o" 2>/dev/null; then
+    for w in $(otool -t "$work/ref.o" | awk 'NR>=3{for(i=2;i<=NF;i++)print $i}'); do
+        ref_code+="${w:6:2}${w:4:2}${w:2:2}${w:0:2}"
+    done
+fi
+echo "── a program that writes to stdout, built with zero clang ──"
+echo "  Form encoder bytes : $form_code"
+echo "  clang/as  (oracle) : $ref_code"
+if [[ -n "$ref_code" && "$form_code" == "$ref_code" ]]; then
+    echo "  CONVICTION: the Form encoder IS the assembler over the syscall set, byte-for-byte"
+else
+    echo "  (oracle unavailable or mismatch — running the Form binary is still the proof below)"
+fi
+
+# ── 3. ld (NOT clang) links the Form-emitted object; run it ──
+echo "$hex" | xxd -r -p > "$work/fs.o"
+SDK="$(xcrun --show-sdk-path 2>/dev/null)"
+ld -arch arm64 -platform_version macos 13.0 13.0 -L"$SDK/usr/lib" -lSystem -o "$work/fs" "$work/fs.o" 2>/dev/null
+echo
+echo "  running the Form-built binary ($(wc -c <"$work/fs.o" | tr -d ' ') bytes of Mach-O, no clang):"
+out="$("$work/fs")"; rc=$?
+printf '    stdout = [%s]  exit = %s\n' "$out" "$rc"
+if [[ "$out" == $'Hi\n'* || "$out" == "Hi" ]]; then
+    echo
+    echo "  RUNNABLE I/O, ZERO CLANG — Form encoded the syscall, emitted the Mach-O, ld linked it,"
+    echo "  and the binary wrote to stdout through the OS kernel. clang stayed the oracle."
+else
+    echo "  FAIL: expected stdout 'Hi', got '$out'"; exit 1
+fi


### PR DESCRIPTION
You named it: **we don't need C as a crutch, only as an oracle.** The byte-filter lane (#3256) leaned on clang to *lower*; the zero-clang slice lane (`form-lower`/`form-asm` → arm64 bytes → Mach-O → `ld`) only lacked I/O. So the filter belongs there, with clang kept solely to *check* the bytes.

## The lift — the syscall / byte-I/O instruction set

`form-asm.fk` gains what a unix filter needs past arithmetic, lifted from the ARM ARM / LLVM's ARM target, each **byte-verified against `clang`/`as`**:

| recipe | instruction |
|---|---|
| `fa-svc` | `svc #imm16` — the boundary cross to the OS kernel |
| `fa-movz-x` / `fa-movk-x-16` | 64-bit `movz`/`movk` — the syscall number in x16 |
| `fa-strb` | `strb w,[xn,#imm]` — byte buffer |
| `fa-add-x-imm` / `fa-sub-x-imm` | 64-bit stack frame |

Four-way: **`form-asm-syscall fks 31`** — the encoder *is* the assembler over the syscall set, byte-for-byte across Go/Rust/TS/fkwu.

## Proof — running I/O, zero clang

`scripts/form_syscall_demo.sh`:

```
  Form encoder bytes : ff4300d108098052e8030039...011000d400008052ff430091c0035fd6
  clang/as  (oracle) : ff4300d108098052e8030039...011000d400008052ff430091c0035fd6
  CONVICTION: the Form encoder IS the assembler over the syscall set, byte-for-byte

  running the Form-built binary (295 bytes of Mach-O, no clang):
    stdout = [Hi]  exit = 0
  RUNNABLE I/O, ZERO CLANG — Form encoded the syscall, emitted the Mach-O, ld linked it,
  and the binary wrote to stdout through the OS kernel. clang stayed the oracle.
```

Form encodes a `write`-to-stdout program, `form-macho.fk` wraps it, **`ld` links it (no clang)**, and the binary writes `Hi\n` through the macOS arm64 `write` syscall. clang only assembled the same instructions as the byte **oracle**.

## Next

This is the syscall primitive `cat`/`tr` compose from. The **read-loop** (a backward branch + the `read` syscall + EOF check — all encodings the lane already has or can lift the same way) makes a zero-clang `cat`/`tr` that *retires* the clang filter lane entirely. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)