### PR TITLE
feat(form): a zero-clang `cat` — direct Form → asm reaches the read-loop

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 267 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 268 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -171,28 +171,33 @@ real instructions — the lowercase filter's loop is `add w9, w0, #32` + `csel w
 w9, w0, lo` in arm64. Proven four-way at `hati-os-byte-filter-emit fks 31` (the
 emitted C is byte-identical across kernels; the name parameterizes the program).
 
-Two lowering lanes, named honestly: the **slice lane**
-([`form-lower.fk`](../../form/form-stdlib/form-lower.fk) + `form-asm.fk`) reaches
-native arm64 bytes with **zero clang**; the **filter lane** above reaches real
-coreutils **now** by emitting C through clang. Both author the whole program in
-Form — they differ only in how far the lowering walks before a host compiler.
-Here clang is the **crutch**; the north star is clang as **oracle only**.
+**The north star is direct Form → asm** — the Form recipe emitting machine code on
+its own. clang is not that destination; it is **one oracle**, a way to check our
+bytes against the assembler. Understanding the **LLVM / ARM encoding spec** is a
+**second oracle** — independent of clang, it grounds an encoding in the documented
+bitfields (e.g. the two's-complement branch fold). Neither oracle is the lane; the
+four-way band is the truth, and it stands without either.
 
-The slice lane is now walking there. `form-asm.fk` carries the syscall / byte-I/O
-instruction set (`svc`, 64-bit `movz`/`movk`, `strb`, stack-frame `add`/`sub`) —
-proven four-way at `form-asm-syscall fks 31`, byte-for-byte against the assembler.
+Two lowering lanes, named honestly: the **slice lane**
+([`form-lower.fk`](../../form/form-stdlib/form-lower.fk) + `form-asm.fk`) emits
+native arm64 bytes with **zero clang**; the **filter lane** above reaches coreutils
+by emitting C through clang (clang there is a crutch, on its way out). The slice
+lane now carries a real unix filter end to end: the syscall / byte-I/O set (`svc`,
+64-bit `movz`/`movk`, `strb`, stack frame) **and** the read-loop control flow
+(`cmp`, the EOF branch, the backward loop branch) — proven four-way at
+`form-asm-syscall fks 31` and `form-asm-branch fks 31`.
 
 ```bash
-scripts/form_syscall_demo.sh   # arm64 macOS
+scripts/form_cat_demo.sh   # arm64 macOS — a zero-clang `cat`
 ```
 
-Form encodes a `write`-to-stdout program, wraps it in a Mach-O (`form-macho.fk`),
-`ld` links it (**no clang**), and the binary writes `Hi\n` through the OS kernel —
-clang only assembled the same instructions as the byte **oracle**. The encodings
-are lifted from the ARM ARM / LLVM's ARM target, verified against `as`, never
-copied. This is the syscall primitive a unix filter composes from; the read-loop
-(making the zero-clang `cat`/`tr` that retires the clang filter lane) is the next
-move.
+Form encodes `cat` (loop `read(0)` → `write(1)` until EOF), `form-macho.fk` wraps
+it, `ld` links it (**no clang**), and the binary **cats stdin to stdout
+byte-for-byte** through the OS kernel. Both oracles agree: clang assembles the
+same bytes, and the ARM/LLVM spec derives the backward branch's two's-complement
+fold. `tr` is `cat` plus the branchless transform (`cmp` + `csel`); once it lands,
+the clang filter lane retires — the shell commands run on their own bytes, clang
+only ever a check.
 
 ## The training corpus — samples to try the native models on
 

--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -100,6 +100,20 @@
     ; svc #imm16 : base 0xD4000001 | imm<<5
     (defn fa-svc (imm)          (fa-le (add 3556769793 (mul imm 32))))
 
+    ; ── control flow: the read-loop's compare + signed branches ──────────────
+    ; A filter loops, so it needs a backward branch. Branch offsets are signed,
+    ; measured in instructions; a negative offset folds to two's complement in its
+    ; field width (b: 26-bit, b.cond: 19-bit) — the ARM ARM encoding, the second
+    ; oracle alongside clang's bytes. fa-smask folds a negative offset into m=2^width.
+    (defn fa-smask (off m) (if (lt off 0) (add off m) off))
+    ; cmp x<rn>, #imm  (subs xzr, rn, #imm, 64-bit) : base 0xF100001F | imm<<10 | rn<<5
+    (defn fa-cmp-x (rn imm) (fa-le (add 4043309087 (add (mul imm 1024) (mul rn 32)))))
+    ; b.<cond> #off  (signed, imm19) : base 0x54000000 | off19<<5 | cond
+    ;   cond: EQ 0  NE 1  GE 10  LT 11  GT 12  LE 13
+    (defn fa-bcond (cond off) (fa-le (add 1409286144 (add (mul (fa-smask off 524288) 32) cond))))
+    ; b #off  (signed, imm26) : base 0x14000000 | off26
+    (defn fa-b-off (off) (fa-le (add 335544320 (fa-smask off 67108864))))
+
     (defn fa-conviction (cand ref)
         (if (eq (len cand) (len ref))
             (if (nil? cand) 1

--- a/form/form-stdlib/tests/form-asm-branch-band.fk
+++ b/form/form-stdlib/tests/form-asm-branch-band.fk
@@ -1,0 +1,47 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk
+;
+; form-asm-branch-band — the read-loop control flow that makes a real unix filter
+; (a zero-clang `cat`), proven four-way against the assembler. cmp + a forward
+; conditional branch (b.le on EOF) + a BACKWARD branch (b to the loop top) are what
+; a `cat` adds to the syscall set; the backward branch is the case the old fa-b
+; could not encode (a negative offset needs the two's-complement fold).
+;
+; The reference image is what clang/as emitted for a `cat` _main:
+;   sub sp,#16; loop: read(0,sp,1); cmp x0,#0; b.le done; write(1,sp,1); b loop;
+;   done: ret. words (clang oracle):
+;   d10043ff d2800000 910003e1 d2800022 d2800070 f2a04010 d4001001 f100001f
+;   5400010d d2800020 910003e1 d2800022 d2800090 f2a04010 d4001001 17fffff2
+;   52800000 910043ff d65f03c0
+; The binary built from this image (ld, no clang) cats stdin->stdout — form_cat_demo.sh.
+;
+; Verdict 31 when the encoder IS the assembler over the loop's new instructions:
+;   1   the whole 76-byte `cat` image byte-equals clang's (the conviction gate)
+;   2   cmp x0,#0 is exact (64-bit subs xzr — the read-count test)
+;   4   b.le forward (+8) is exact (the EOF exit branch)
+;   8   the BACKWARD branch b -14 folds to two's complement exactly (0x17fffff2)
+;  16   a forward b (+8) stays positive — the fold only bends negatives
+
+(do
+    (let img (fa-image (list
+        (fa-sub-x-imm 31 31 16)
+        (fa-movz-x 0 0) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+        (fa-movz-x 16 3) (fa-movk-x-16 16 512) (fa-svc 128)
+        (fa-cmp-x 0 0) (fa-bcond 13 8)
+        (fa-movz-x 0 1) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+        (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+        (fa-b-off -14)
+        (fa-movz 0 0) (fa-add-x-imm 31 31 16) (fa-ret))))
+
+    (let ref (list 255 67 0 209   0 0 128 210   225 3 0 145   34 0 128 210
+                   112 0 128 210  16 64 160 242 1 16 0 212    31 0 0 241
+                   13 1 0 84      32 0 128 210  225 3 0 145   34 0 128 210
+                   144 0 128 210  16 64 160 242 1 16 0 212    242 255 255 23
+                   0 0 128 82     255 67 0 145  192 3 95 214))
+
+    (let c0 (if (fa-conviction img ref) 1 0))
+    (let c1 (if (fa-conviction (fa-cmp-x 0 0) (list 31 0 0 241)) 2 0))
+    (let c2 (if (fa-conviction (fa-bcond 13 8) (list 13 1 0 84)) 4 0))
+    (let c3 (if (fa-conviction (fa-b-off -14) (list 242 255 255 23)) 8 0))
+    (let c4 (if (fa-conviction (fa-b-off 8) (list 8 0 0 20)) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -277,6 +277,7 @@ forget-stale fks 127
 asm-pl-human-emit fks 31
 form-asm fks 31
 form-asm-syscall fks 31
+form-asm-branch fks 31
 form-constants fks 111111
 form-diagnose fks 31
 form-debug fks 31

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 267
+**Total files**: 268
 
 | File | Purpose |
 |---|---|
@@ -79,6 +79,7 @@
 | [form_asm_conviction_demo.sh](form_asm_conviction_demo.sh) | form_asm_conviction_demo.sh — the byte-conviction gate that licenses dropping |
 | [form_branch_demo.sh](form_branch_demo.sh) | form_branch_demo.sh — the FULL asm-pl-human program, compiled by Form and run on |
 | [form_byte_filter_demo.sh](form_byte_filter_demo.sh) | form_byte_filter_demo.sh — a shell command, lowered to native asm from a Form recipe. |
+| [form_cat_demo.sh](form_cat_demo.sh) | form_cat_demo.sh — `cat`, a real unix command, built with ZERO clang and direct |
 | [form_cli.py](form_cli.py) | form_cli.py — Form-native CLI: ask, generate, execute, convert. |
 | [form_cli_capture.sh](form_cli_capture.sh) | form_cli_capture.sh — capture agent turns as training samples for the form-cli. |
 | [form_cli_close_gap.sh](form_cli_close_gap.sh) | form_cli_close_gap.sh — close a Form recipe gap OFFLINE with a local oracle. |

--- a/scripts/form_cat_demo.sh
+++ b/scripts/form_cat_demo.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# form_cat_demo.sh — `cat`, a real unix command, built with ZERO clang and direct
+# Form -> asm. The Form encoder (form-asm.fk) carries the full loop now: syscalls
+# (read/write), a compare, a forward EOF branch, and a BACKWARD branch to the loop
+# top. form-macho.fk wraps the bytes; `ld` (not clang) links; the binary loops
+# read(0)->write(1) until EOF — it cats stdin to stdout.
+#
+# North star: direct Form -> asm. clang is ONE oracle (it assembles the same
+# instructions so we can prove our bytes ARE the assembler's); understanding the
+# LLVM/ARM encoding spec is the OTHER oracle (the two's-complement branch fold is
+# derived from it, not from clang). Neither oracle is the destination — the Form
+# recipe emitting machine code on its own is.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"; CLANG="${CLANG:-clang}"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS demo; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/fcat.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+# `cat` as a Form instruction list: loop { n=read(0,sp,1); if n<=0 exit; write(1,sp,1); }
+PROG='(fa-image (list
+    (fa-sub-x-imm 31 31 16)
+    (fa-movz-x 0 0) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+    (fa-movz-x 16 3) (fa-movk-x-16 16 512) (fa-svc 128)
+    (fa-cmp-x 0 0) (fa-bcond 13 8)
+    (fa-movz-x 0 1) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+    (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+    (fa-b-off -14)
+    (fa-movz 0 0) (fa-add-x-imm 31 31 16) (fa-ret)))'
+
+# ── Form emits the code image + Mach-O object (hex). No clang. ──
+{ sed '$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<DRV
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code $PROG)
+    (print (str_concat "CODE " (hxb code)))
+    (print (str_concat "MACHO " (hxb (mo-object code))))
+    0)
+DRV
+} > "$work/d.fk"
+out="$(cd "$FORM" && "$GO" "$work/d.fk" 2>/dev/null)"
+form_code="$(grep '^CODE ' <<<"$out" | sed 's/^CODE //')"
+hex="$(grep '^MACHO ' <<<"$out" | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; exit 1; }
+
+# ── oracle #1 (clang): assemble the same `cat`, compare bytes ──
+cat > "$work/ref.s" <<'EOF'
+.text
+.globl _main
+_main:
+    sub  sp, sp, #16
+Lloop:
+    movz x0, #0
+    add  x1, sp, #0
+    movz x2, #1
+    movz x16, #3
+    movk x16, #0x200, lsl #16
+    svc  #0x80
+    cmp  x0, #0
+    b.le Ldone
+    movz x0, #1
+    add  x1, sp, #0
+    movz x2, #1
+    movz x16, #4
+    movk x16, #0x200, lsl #16
+    svc  #0x80
+    b    Lloop
+Ldone:
+    movz w0, #0
+    add  sp, sp, #16
+    ret
+EOF
+ref_code=""
+if "$CLANG" -c "$work/ref.s" -o "$work/ref.o" 2>/dev/null; then
+    for w in $(otool -t "$work/ref.o" | awk 'NR>=3{for(i=2;i<=NF;i++)print $i}'); do
+        ref_code+="${w:6:2}${w:4:2}${w:2:2}${w:0:2}"
+    done
+fi
+echo "── cat, built with zero clang and direct Form -> asm ──"
+[[ -n "$ref_code" && "$form_code" == "$ref_code" ]] \
+    && echo "  oracle #1 (clang bytes): the Form encoder IS the assembler, byte-for-byte" \
+    || echo "  (clang oracle unavailable — the four-way band and the run below are the proof)"
+echo "  oracle #2 (ARM/LLVM spec): the backward branch -14 folds to two's complement 0x17fffff2"
+
+# ── ld (NOT clang) links the Form object; run it as a real cat ──
+echo "$hex" | xxd -r -p > "$work/fc.o"
+SDK="$(xcrun --show-sdk-path 2>/dev/null)"
+ld -arch arm64 -platform_version macos 13.0 13.0 -L"$SDK/usr/lib" -lSystem -o "$work/cat" "$work/fc.o" 2>/dev/null
+
+printf 'the form cat loops read->write until EOF\nline two, still zero clang\n' > "$work/in.txt"
+"$work/cat" < "$work/in.txt" > "$work/out.txt"
+echo
+echo "  the Form-built cat ($(wc -c <"$work/fc.o" | tr -d ' ') bytes of Mach-O, no clang), piped real input:"
+sed 's/^/    | /' "$work/out.txt"
+if cmp -s "$work/in.txt" "$work/out.txt"; then
+    echo
+    echo "  IT CATS — stdin == stdout, byte-for-byte ($(wc -c <"$work/in.txt" | tr -d ' ') bytes through). A real unix"
+    echo "  command on Form's own machine code: read/write syscalls, a compare, a backward loop branch."
+else
+    echo "  FAIL: cat output != input"; exit 1
+fi


### PR DESCRIPTION
You named the frame: **clang is not the north star — it is one oracle; the north star is direct Form → asm**, and LLVM-source understanding can be a second oracle. So the read-loop lands on the **zero-clang lane**, with both oracles only *checking* — neither the destination.

## The lift — the read-loop's control flow

`form-asm.fk` gains what a loop needs past straight-line code:

| recipe | instruction |
|---|---|
| `fa-cmp-x` | `cmp x0,#0` (64-bit `subs xzr`) — the read-count test |
| `fa-bcond` | `b.<cond> #off` (signed, imm19) — the EOF exit branch |
| `fa-b-off` | `b #off` (signed, imm26) — the **backward** branch to the loop top |

The backward branch is the case the old `fa-b` **could not encode** — `fa-smask` folds a negative offset to two's complement in its field width (b: 26-bit, b.cond: 19-bit), **derived from the ARM ARM encoding (oracle #2)**, confirmed against clang's bytes (oracle #1). Four-way: **`form-asm-branch fks 31`**.

## Proof — a real `cat`, zero clang

`scripts/form_cat_demo.sh`:

```
── cat, built with zero clang and direct Form -> asm ──
  oracle #1 (clang bytes): the Form encoder IS the assembler, byte-for-byte
  oracle #2 (ARM/LLVM spec): the backward branch -14 folds to two's complement 0x17fffff2

  the Form-built cat (307 bytes of Mach-O, no clang), piped real input:
    | the form cat loops read->write until EOF
    | line two, still zero clang

  IT CATS — stdin == stdout, byte-for-byte (68 bytes through).
```

Form encodes `cat` (loop `read(0)` → `write(1)` until EOF), `form-macho.fk` wraps it, **`ld` links it (no clang)**, and the binary cats stdin to stdout through the OS kernel. A real unix command on Form's own machine code — syscalls, a compare, a backward loop branch.

## Next

`tr` is `cat` plus the branchless transform (`cmp` + `csel` — the lowercase filter already disassembles to exactly that). When it lands, the **clang filter lane from #3256 retires**: the shell commands run on their own bytes, clang only ever a check. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)