### PR TITLE
feat(form): the converged optimizer reaches the fourth arm — the wall was never there

### DIFF
--- a/form/form-stdlib/tests/fk-opt-band.fk
+++ b/form/form-stdlib/tests/fk-opt-band.fk
@@ -1,0 +1,18 @@
+; fk-opt-band.fk — the converged optimizer (fk-opt) on the Hati-OS fourth arm.
+;
+; preludes: form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/fk-opt.fk
+;
+; The convergence moved the optimizer onto content-addressed fk-* cells; the three walkers
+; prove it, and the flattener (form-flatten.fk) carries the node/substrate ops
+; (intern_node/node_children/node_value) onto the universal fkw binary — so fk-opt reaches
+; the FOURTH arm too, restoring four-way coverage of the optimizer.
+;
+; (50-8)+(6*7) = 42+42 = 84. fk-opt folds both products and the sum to a single LIT 84.
+; The fold is checked STRUCTURALLY — tag == LIT(1), value == 84 — using only carried ops
+; (intern_node / node_children / node_value), so the band flattens (fk-run/fk-walk is a
+; defn, not a carried op, and isn't needed to witness the fold).
+
+(do
+  (let tree (fk-add (fk-sub (fk-lit 50) (fk-lit 8)) (fk-mul (fk-lit 6) (fk-lit 7))))
+  (let opt (fk-opt tree))
+  (if (eq (fk-tag opt) 1) (ms-value (fk-body opt)) 0))

--- a/scripts/hati_os_kernel_audit.sh
+++ b/scripts/hati_os_kernel_audit.sh
@@ -822,6 +822,36 @@ echo "                     (its band-scale allocation melts mid-call on the valu
 echo "  bands-on-Hati-OS-arm so far: $((mp_pass + 1)) (learning-trend + $mp_pass multi-param bands, four-way gated)"
 
 echo
+# ── 22b. the CONVERGED optimizer (fk-opt) on the Hati-OS arm ──────────────
+# The compiler converged onto content-addressed fk-* cells (fk-opt + fk-to-prog),
+# which moved the optimizer's proof off the numeric rewrite-AST fkwu could walk.
+# This restores its fourth arm: fk-opt depends on the cell substrate, so the
+# flattener carries that whole chain — the node/substrate ops intern_node(47)/
+# node_children(48)/node_value(49) are in flt-ops — onto the SAME universal binary.
+# fk-opt-band folds (50-8)+(6*7) to a single LIT 84 and checks it STRUCTURALLY
+# (tag/value, no walker), so it flattens cleanly across the dependency chain.
+cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/hati-os-kernel.fk" \
+    "$FORMDIR/form-stdlib/fk-opt.fk" > "$work/fkopt-mod.fk"
+cat "$FORMDIR/form-stdlib/minimal-surface.fk" "$FORMDIR/form-stdlib/hati-os-kernel.fk" \
+    "$FORMDIR/form-stdlib/hati-os-kernel-emit.fk" "$FORMDIR/form-stdlib/form-parse.fk" \
+    "$FORMDIR/form-stdlib/form-flatten.fk" > "$work/fkopt-flt-driver.fk"
+cat >> "$work/fkopt-flt-driver.fk" <<EOF
+(print "==FKOPT==")
+(print (fkc-table-file (flt-band-fns (read_file "$work/fkopt-mod.fk") (read_file "form-stdlib/tests/fk-opt-band.fk"))))
+(print "==END==")
+EOF
+(cd "$FORMDIR" && "$GO_BIN" "$work/fkopt-flt-driver.fk" 2>/dev/null) > "$work/fkopt-flt.out"
+sed -n '/^==FKOPT==$/,/^==END==$/p' "$work/fkopt-flt.out" | sed -e '1d' -e '$d' > "$work/t-fkopt.txt"
+fkopt_three="$(cd "$FORMDIR" && ./validate.sh form-stdlib/core.fk form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/fk-opt.fk form-stdlib/tests/fk-opt-band.fk 2>/dev/null | sed -n 's/.*→ //p' | head -1)"
+fkopt_fkw="$("$work/fkwu" "$work/t-fkopt.txt" 0 2>/dev/null | head -1)"
+echo "converged optimizer fk-opt on the Hati-OS arm (cell substrate flattened too):"
+echo "  three-walker (validate.sh) = $fkopt_three   fkw = $fkopt_fkw   (expect 84)"
+if [[ -z "$fkopt_three" || "$fkopt_three" != "$fkopt_fkw" || "$fkopt_fkw" != "84" ]]; then
+    echo "FAIL  fk-opt (converged optimizer) disagrees across arms"; exit 1
+fi
+echo "  fk-opt is FOUR-way: convergence onto content-addressed cells kept the fourth arm"
+
+echo
 # ── 23. live delivery priority — multiple offers pending in ONE window; WHICH ──
 # delivers first is a POLICY ROW (afferent-priority.fk): scheduler.fk's proven
 # row shape read by the afferent engine. Two offers pend together — a latched


### PR DESCRIPTION
The convergence (fk-opt + fk-to-prog) moved the optimizer's proof off the numeric rewrite-AST fkwu could walk, dropping it to three-way. I'd named the flattener route as the way back — **and it works, because the wall I'd assumed isn't there**: the m4e3 flattener (`form-flatten.fk`) carries the node/substrate ops onto the universal binary — `intern_node`(47), `node_children`(48), `node_value`(49) are in `flt-ops`, the very builtins `fk-*` cells are made of.

`fk-opt-band` folds `(50-8)+(6*7)` to a single LIT 84 and checks the fold **structurally** (tag/value, no walker) so it flattens cleanly. The hati-os audit's **section 22b** now flattens fk-opt *with* its cell substrate (minimal-surface + hati-os-kernel → 105 functions) and runs it on the SAME emitted universal `fkw` binary: three walkers (validate.sh) = 84, fkw = 84.

**The converged optimizer is FOUR-way** — the convergence onto content-addressed cells lost no proof after all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)