### PR TITLE
feat(form): a zero-clang `tr` — shell commands run on Form's own bytes

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 268 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 269 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -151,53 +151,38 @@ ARG/recursion) is what compiles to native today.
 
 ## Shell commands are recipes — lowered to native asm
 
-The carriers used to shell out to `tr`, `cat`, `grep`. The north star is not
-"reimplement the pipeline in interpreted Form to avoid the shell" — it is **the
-shell commands have source, so they are Form recipes, lowered to native asm**.
+The carriers used to shell out to `tr`, `cat`, `grep`. **The north star is direct
+Form → asm** — the Form recipe emitting machine code on its own, no compiler in the
+lowering path. clang is **one oracle** (it assembles the same instructions so we
+can check our bytes against the assembler); understanding the **LLVM / ARM encoding
+spec** is a **second oracle** (independent of clang, it grounds an encoding in the
+documented bitfields — e.g. the two's-complement branch fold). Neither oracle is
+the lane; the four-way band is the truth and stands without either.
 
-[`hati-os-byte-filter-emit.fk`](../../form/form-stdlib/hati-os-byte-filter-emit.fk)
-is the generic shape: a `stdin→stdout` byte filter where the **per-byte transform
-IS the command** — dropped in as data, never a parallel emitter.
-
-```bash
-scripts/form_byte_filter_demo.sh "Hello, World! 123 ABCxyz"
-```
-
-Form emits the whole C program (`tr A-Z a-z` → the transform `(c>=65&&c<=90)?c+32:c`);
-clang lowers it (an allowed host carrier under `host-kernel.form`); the system
-command is the oracle. Measured: `tr A-Z a-z`, `tr a-z A-Z`, `cat`, `rot13` each
-match their Form-lowered native binary **byte-for-byte**. The transform becomes
-real instructions — the lowercase filter's loop is `add w9, w0, #32` + `csel w0,
-w9, w0, lo` in arm64. Proven four-way at `hati-os-byte-filter-emit fks 31` (the
-emitted C is byte-identical across kernels; the name parameterizes the program).
-
-**The north star is direct Form → asm** — the Form recipe emitting machine code on
-its own. clang is not that destination; it is **one oracle**, a way to check our
-bytes against the assembler. Understanding the **LLVM / ARM encoding spec** is a
-**second oracle** — independent of clang, it grounds an encoding in the documented
-bitfields (e.g. the two's-complement branch fold). Neither oracle is the lane; the
-four-way band is the truth, and it stands without either.
-
-Two lowering lanes, named honestly: the **slice lane**
-([`form-lower.fk`](../../form/form-stdlib/form-lower.fk) + `form-asm.fk`) emits
-native arm64 bytes with **zero clang**; the **filter lane** above reaches coreutils
-by emitting C through clang (clang there is a crutch, on its way out). The slice
-lane now carries a real unix filter end to end: the syscall / byte-I/O set (`svc`,
-64-bit `movz`/`movk`, `strb`, stack frame) **and** the read-loop control flow
-(`cmp`, the EOF branch, the backward loop branch) — proven four-way at
-`form-asm-syscall fks 31` and `form-asm-branch fks 31`.
+The **slice lane** ([`form-asm.fk`](../../form/form-stdlib/form-asm.fk) +
+[`form-macho.fk`](../../form/form-stdlib/form-macho.fk)) now carries real unix
+commands end to end, **zero clang**: the syscall / byte-I/O set (`svc`, 64-bit
+`movz`/`movk`, `ldrb`/`strb`, stack frame), the read-loop control flow (`cmp`, the
+EOF branch, the backward loop branch), and the branchless transform (`csel`) —
+proven four-way at `form-asm-syscall`, `form-asm-branch`, and `form-asm-tr` (all 31).
 
 ```bash
-scripts/form_cat_demo.sh   # arm64 macOS — a zero-clang `cat`
+scripts/form_cat_demo.sh   # a zero-clang `cat`
+scripts/form_tr_demo.sh    # a zero-clang `tr A-Z a-z`
 ```
 
-Form encodes `cat` (loop `read(0)` → `write(1)` until EOF), `form-macho.fk` wraps
-it, `ld` links it (**no clang**), and the binary **cats stdin to stdout
-byte-for-byte** through the OS kernel. Both oracles agree: clang assembles the
-same bytes, and the ARM/LLVM spec derives the backward branch's two's-complement
-fold. `tr` is `cat` plus the branchless transform (`cmp` + `csel`); once it lands,
-the clang filter lane retires — the shell commands run on their own bytes, clang
-only ever a check.
+Form encodes the program (`cat` = loop `read(0)`→`write(1)`; `tr` = that plus
+`ldrb` → `(unsigned)(c-65)≤25 ? c+32 : c` via `cmp`+`csel` → `strb`), `ld` links it
+(**no clang**), and the binary runs through the OS read/write syscalls. Measured:
+`cat` round-trips stdin→stdout and the Form `tr` matches the system `tr A-Z a-z`,
+both **byte-for-byte**. clang only assembled the same instructions as the byte
+oracle; the ARM/LLVM spec derived the encodings.
+
+This **retires the earlier filter lane** — `hati-os-byte-filter-emit.fk` emitted C
+for the same commands and leaned on clang to lower it. That lane stays only as the
+bridge for an arbitrary transform whose asm encodings aren't lifted yet (e.g.
+`rot13`'s two-range rotation); once those ops are encoded it composts fully. The
+common filters now run on Form's own bytes, clang only ever a check.
 
 ## The training corpus — samples to try the native models on
 

--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -114,6 +114,17 @@
     ; b #off  (signed, imm26) : base 0x14000000 | off26
     (defn fa-b-off (off) (fa-le (add 335544320 (fa-smask off 67108864))))
 
+    ; ── byte load + branchless select: the transform a filter applies ────────
+    ; tr is cat plus a per-byte transform, and the transform is branchless: load
+    ; the byte, compute, select on a flag. ldrb reads it; csel picks. These are
+    ; the ARM ARM encodings; clang's bytes confirm.
+    ; ldrb w<rt>, [x<rn>, #imm12]  (unsigned offset) : base 0x39400000 | imm<<10 | rn<<5 | rt
+    (defn fa-ldrb (rt rn imm) (fa-le (add 960495616 (add (mul imm 1024) (add (mul rn 32) rt)))))
+    ; csel w<rd>, w<rn>, w<rm>, <cond>  (rd = cond ? rn : rm, 32-bit)
+    ;   base 0x1A800000 | rm<<16 | cond<<12 | rn<<5 | rd   (cond LS=9, the unsigned <=)
+    (defn fa-csel (rd rn rm cond)
+        (fa-le (add 444596224 (add (mul rm 65536) (add (mul cond 4096) (add (mul rn 32) rd))))))
+
     (defn fa-conviction (cand ref)
         (if (eq (len cand) (len ref))
             (if (nil? cand) 1

--- a/form/form-stdlib/tests/form-asm-tr-band.fk
+++ b/form/form-stdlib/tests/form-asm-tr-band.fk
@@ -1,0 +1,47 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk
+;
+; form-asm-tr-band — a zero-clang `tr A-Z a-z`, proven four-way against the
+; assembler. tr is cat plus a per-byte transform, and the transform is BRANCHLESS:
+; load the byte (ldrb), compute c-65 and c+32, compare, and SELECT (csel) on the
+; range flag — no inner branch. ldrb + csel are what tr adds to the cat loop.
+;
+; The reference image is what clang/as emitted for a `tr A-Z a-z` _main (the cat
+; loop with the lowercase transform spliced in before write). The transform:
+;   ldrb w8,[sp]; sub w9,w8,#65; add w10,w8,#32; cmp w9,#25; csel w8,w10,w8,ls; strb w8,[sp]
+; i.e.  (unsigned)(c-65) <= 25  ?  c+32  :  c   — the canonical branchless lowercase.
+; The binary built from this image (ld, no clang) lowercases stdin — form_tr_demo.sh.
+;
+; Verdict 31 when the encoder IS the assembler over tr's new instructions:
+;   1   the whole 100-byte `tr` image byte-equals clang's (the conviction gate)
+;   2   ldrb w8,[sp] is exact (load the byte to transform)
+;   4   csel w8,w10,w8,ls is exact (the branchless pick — rn is the if-true value)
+;   8   the loop's backward branch now folds -20 exactly (longer body, same fold)
+;  16   the forward EOF branch now folds +14 exactly
+
+(do
+    (let img (fa-image (list
+        (fa-sub-x-imm 31 31 16)
+        (fa-movz-x 0 0) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+        (fa-movz-x 16 3) (fa-movk-x-16 16 512) (fa-svc 128)
+        (fa-cmp-x 0 0) (fa-bcond 13 14)
+        (fa-ldrb 8 31 0) (fa-sub 9 8 65) (fa-add 10 8 32) (fa-cmp 9 25) (fa-csel 8 10 8 9) (fa-strb 8 31 0)
+        (fa-movz-x 0 1) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+        (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+        (fa-b-off -20)
+        (fa-movz 0 0) (fa-add-x-imm 31 31 16) (fa-ret))))
+
+    (let ref (list 255 67 0 209   0 0 128 210   225 3 0 145   34 0 128 210
+                   112 0 128 210  16 64 160 242 1 16 0 212    31 0 0 241
+                   205 1 0 84     232 3 64 57   9 5 1 81       10 129 0 17
+                   63 101 0 113   72 145 136 26 232 3 0 57     32 0 128 210
+                   225 3 0 145    34 0 128 210  144 0 128 210  16 64 160 242
+                   1 16 0 212     236 255 255 23 0 0 128 82    255 67 0 145
+                   192 3 95 214))
+
+    (let c0 (if (fa-conviction img ref) 1 0))
+    (let c1 (if (fa-conviction (fa-ldrb 8 31 0) (list 232 3 64 57)) 2 0))
+    (let c2 (if (fa-conviction (fa-csel 8 10 8 9) (list 72 145 136 26)) 4 0))
+    (let c3 (if (fa-conviction (fa-b-off -20) (list 236 255 255 23)) 8 0))
+    (let c4 (if (fa-conviction (fa-bcond 13 14) (list 205 1 0 84)) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -278,6 +278,7 @@ asm-pl-human-emit fks 31
 form-asm fks 31
 form-asm-syscall fks 31
 form-asm-branch fks 31
+form-asm-tr fks 31
 form-constants fks 111111
 form-diagnose fks 31
 form-debug fks 31

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 268
+**Total files**: 269
 
 | File | Purpose |
 |---|---|
@@ -105,6 +105,7 @@
 | [form_provenance_demo.sh](form_provenance_demo.sh) | form_provenance_demo.sh — CELL PROVENANCE, the full chain live: a running |
 | [form_symbol_demo.sh](form_symbol_demo.sh) | form_symbol_demo.sh — SOURCE-SYMBOL LOOKUP FROM FRAMEBUFFER INSPECTION. The spy |
 | [form_syscall_demo.sh](form_syscall_demo.sh) | form_syscall_demo.sh — a program that does I/O, built with ZERO clang. The Form |
+| [form_tr_demo.sh](form_tr_demo.sh) | form_tr_demo.sh — `tr A-Z a-z`, a real unix command, built with ZERO clang and |
 | [form_union_demo.sh](form_union_demo.sh) | form_union_demo.sh — the m4e3/m4e4 union, witnessed: ONE self-contained binary |
 | [form_validate_shards.py](form_validate_shards.py) | Run Form validation workloads as parallel shards. |
 | [framebuffer_viewer.py](framebuffer_viewer.py) | framebuffer_viewer.py — render the kernel's framebuffer as a text panel. |

--- a/scripts/form_tr_demo.sh
+++ b/scripts/form_tr_demo.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# form_tr_demo.sh — `tr A-Z a-z`, a real unix command, built with ZERO clang and
+# direct Form -> asm. tr is the zero-clang cat plus a BRANCHLESS per-byte transform:
+# ldrb the byte, compute (unsigned)(c-65)<=25 ? c+32 : c with cmp + csel, strb it
+# back, then write. form-macho.fk wraps the bytes; `ld` (not clang) links; the
+# binary lowercases stdin -> stdout through the OS read/write syscalls.
+#
+# This is the move that RETIRES the clang filter lane (#3256): the shell commands
+# now run on Form's own machine code. clang is ONE oracle (it assembles the same
+# instructions so we can prove our bytes ARE the assembler's) and the ARM/LLVM
+# encoding spec is the OTHER; the destination is the Form recipe emitting code.
+# The system `tr A-Z a-z` is the behavioral oracle: same output, byte-for-byte.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"; CLANG="${CLANG:-clang}"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS demo; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/ftr.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+# `tr A-Z a-z` as a Form instruction list: cat loop + branchless lowercase transform.
+PROG='(fa-image (list
+    (fa-sub-x-imm 31 31 16)
+    (fa-movz-x 0 0) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+    (fa-movz-x 16 3) (fa-movk-x-16 16 512) (fa-svc 128)
+    (fa-cmp-x 0 0) (fa-bcond 13 14)
+    (fa-ldrb 8 31 0) (fa-sub 9 8 65) (fa-add 10 8 32) (fa-cmp 9 25) (fa-csel 8 10 8 9) (fa-strb 8 31 0)
+    (fa-movz-x 0 1) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+    (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+    (fa-b-off -20)
+    (fa-movz 0 0) (fa-add-x-imm 31 31 16) (fa-ret)))'
+
+{ sed '$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<DRV
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (print (str_concat "MACHO " (hxb (mo-object $PROG))))
+    0)
+DRV
+} > "$work/d.fk"
+hex="$(cd "$FORM" && "$GO" "$work/d.fk" 2>/dev/null | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; exit 1; }
+
+echo "$hex" | xxd -r -p > "$work/ft.o"
+SDK="$(xcrun --show-sdk-path 2>/dev/null)"
+ld -arch arm64 -platform_version macos 13.0 13.0 -L"$SDK/usr/lib" -lSystem -o "$work/tr" "$work/ft.o" 2>/dev/null
+
+IN='Hello, ZERO-Clang TR! Mixed CASE 123.'
+got="$(printf '%s' "$IN" | "$work/tr")"
+want="$(printf '%s' "$IN" | tr 'A-Z' 'a-z')"
+echo "── tr A-Z a-z, built with zero clang and direct Form -> asm ──"
+echo "  in            : $IN"
+echo "  Form-tr (no clang, $(wc -c <"$work/ft.o" | tr -d ' ') byte Mach-O): $got"
+echo "  system tr     : $want"
+if [[ "$got" == "$want" ]]; then
+    echo
+    echo "  IT LOWERCASES — the Form-built tr matches the system \`tr A-Z a-z\` byte-for-byte."
+    echo "  A real shell command on Form's own machine code: read/write syscalls, a backward loop,"
+    echo "  and a branchless transform (ldrb + cmp + csel). The clang filter lane retires."
+else
+    echo "  FAIL: Form-tr [$got] != system tr [$want]"; exit 1
+fi


### PR DESCRIPTION
The named next, landed: **`tr` = the zero-clang `cat` + a branchless per-byte transform.** This **retires the clang filter lane (#3256)** — the common shell commands now run on Form's own machine code.

## The lift

`form-asm.fk` gains the two instructions a transform needs:

| recipe | instruction |
|---|---|
| `fa-ldrb` | `ldrb w8,[sp]` — load the byte to transform |
| `fa-csel` | `csel w8,w10,w8,ls` — branchless select (`rd = cond ? rn : rm`) |

The lowercase transform is branchless: `ldrb` → `sub w9,w8,#65` → `add w10,w8,#32` → `cmp w9,#25` → `csel w8,w10,w8,ls` → `strb` — i.e. `(unsigned)(c-65) ≤ 25 ? c+32 : c`. (Note clang's `csel Rd,Rn,Rm` order: the if-true value `c+32` is `Rn`.) Encodings from the ARM ARM (oracle #2), confirmed against clang's bytes (oracle #1). Four-way: **`form-asm-tr fks 31`** — the full 100-byte `tr` image byte-equals the assembler.

## Proof — a real `tr`, zero clang

`scripts/form_tr_demo.sh`:

```
── tr A-Z a-z, built with zero clang and direct Form -> asm ──
  in            : Hello, ZERO-Clang TR! Mixed CASE 123.
  Form-tr (no clang, 331 byte Mach-O): hello, zero-clang tr! mixed case 123.
  system tr     : hello, zero-clang tr! mixed case 123.
  IT LOWERCASES — the Form-built tr matches the system `tr A-Z a-z` byte-for-byte.
```

Form encodes `tr A-Z a-z`, `form-macho.fk` wraps it, **`ld` links it (no clang)**, and the binary lowercases stdin matching the system `tr` byte-for-byte — read/write syscalls, a backward loop, `ldrb`+`cmp`+`csel`.

## The lane that retired

`hati-os-byte-filter-emit.fk` (#3256) emitted C for these same commands and leaned on clang to lower it. The slice lane (direct Form → asm) is now canonical for `cat`/`tr`; the C-emit lane stays only as the bridge for an arbitrary transform whose asm isn't lifted yet (e.g. `rot13`'s two-range rotation), and composts fully once those ops are encoded. clang is one oracle of two; the destination is the recipe emitting code. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)