### PR TITLE
feat(form): a zero-clang `head -N` — a line counter on the loop, data rows only

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 269 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 270 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -166,21 +166,25 @@ encoding table as a recipe). The **slice lane** (+ [`form-macho.fk`](../../form/
 carries real unix commands end to end, **zero clang**: the syscall / byte-I/O set
 (`svc`, 64-bit `movz`/`movk`, `ldrb`/`strb`, stack frame), the read-loop control flow
 (`cmp`, the EOF branch, the backward loop branch), and the branchless transform
-(`cmp`+`csel`) — proven four-way at `form-asm-syscall`, `form-asm-branch`,
-`form-asm-tr` (31), and `form-asm-rot13` (7).
+(`cmp`+`csel`), and a callee-saved line counter (`head`) — proven four-way at
+`form-asm-syscall`, `form-asm-branch`, `form-asm-tr` (31), and `form-asm-rot13`,
+`form-asm-head` (7).
 
 ```bash
 scripts/form_cat_demo.sh    # a zero-clang `cat`
 scripts/form_tr_demo.sh     # a zero-clang `tr A-Z a-z`
 scripts/form_rot13_demo.sh  # a zero-clang `rot13`
+scripts/form_head_demo.sh   # a zero-clang `head -3`
 ```
 
 Form encodes the program (`cat` = loop `read(0)`→`write(1)`; `tr`/`rot13` = that
-plus a branchless per-byte transform), `ld` links it (**no clang**), and the binary
-runs through the OS read/write syscalls. Measured: `cat` round-trips stdin→stdout,
-Form `tr` matches the system `tr A-Z a-z`, and Form `rot13` matches the system
-rot13 and is its own inverse — all **byte-for-byte**. clang only assembled the same
-instructions as the byte oracle; the ARM/LLVM spec derived the encodings.
+plus a branchless per-byte transform; `head` = that plus a line counter in a
+callee-saved register), `ld` links it (**no clang**), and the binary runs through
+the OS read/write syscalls. Measured: `cat` round-trips stdin→stdout, Form `tr`
+matches the system `tr A-Z a-z`, Form `rot13` matches the system rot13 and is its
+own inverse, and Form `head` matches `head -n 3` — all **byte-for-byte**. clang only
+assembled the same instructions as the byte oracle; the ARM/LLVM spec derived the
+encodings. `tr`/`rot13`/`head` each added **no new encoder** — only data rows.
 
 `rot13` added **no new encoder** — its two-range rotation is `sub`/`add`/`cmp`/`csel`
 data rows — so the earlier **C-emit byte-filter lane composted**: every common filter

--- a/form/form-stdlib/tests/form-asm-head-band.fk
+++ b/form/form-stdlib/tests/form-asm-head-band.fk
@@ -1,0 +1,49 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk
+;
+; form-asm-head-band — a zero-clang `head -N`, proven four-way against the assembler.
+; head is the cat loop plus a line COUNTER: a callee-saved register (w19, preserved
+; across the read/write syscalls) holds lines-remaining; each newline written
+; decrements it; at zero, exit. Adds NO new encoder — the counter uses cmp/sub and
+; two new branch CONDITIONS as data: b.ne (NE=1, byte wasn't newline -> keep going)
+; and b.gt (GT=12, lines remain -> loop). N is fixed at 3 here (argv-parsed N is the
+; next step; cat/tr/rot13/head all take no args yet).
+;
+; The reference image is what clang/as emitted for a `head -3` _main. The binary
+; built from it (ld, no clang) emits the first 3 lines of stdin — form_head_demo.sh.
+;
+; Verdict 7 when:
+;   1   the whole 100-byte head image byte-equals clang's (the conviction gate)
+;   2   b.ne folds a backward signed offset with cond NE=1 (the not-newline branch)
+;   4   b.gt folds a backward signed offset with cond GT=12 (the lines-remain branch)
+
+(do
+    (let img (fa-image (list
+        (fa-sub-x-imm 31 31 16) (fa-movz 19 3)
+        (fa-movz-x 0 0) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+        (fa-movz-x 16 3) (fa-movk-x-16 16 512) (fa-svc 128)
+        (fa-cmp-x 0 0) (fa-bcond 13 13)
+        (fa-movz-x 0 1) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+        (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+        (fa-ldrb 8 31 0) (fa-cmp 8 10) (fa-bcond 1 -16)
+        (fa-sub 19 19 1) (fa-cmp 19 0) (fa-bcond 12 -19)
+        (fa-movz 0 0) (fa-add-x-imm 31 31 16) (fa-ret))))
+
+    (let ref (list 255 67 0 209 115 0 128 82
+                   0 0 128 210 225 3 0 145
+                   34 0 128 210 112 0 128 210
+                   16 64 160 242 1 16 0 212
+                   31 0 0 241 173 1 0 84
+                   32 0 128 210 225 3 0 145
+                   34 0 128 210 144 0 128 210
+                   16 64 160 242 1 16 0 212
+                   232 3 64 57 31 41 0 113
+                   1 254 255 84 115 6 0 81
+                   127 2 0 113 172 253 255 84
+                   0 0 128 82 255 67 0 145
+                   192 3 95 214))
+
+    (let c0 (if (fa-conviction img ref) 1 0))
+    (let c1 (if (fa-conviction (fa-bcond 1 -16) (list 1 254 255 84)) 2 0))
+    (let c2 (if (fa-conviction (fa-bcond 12 -19) (list 172 253 255 84)) 4 0))
+
+    (add c0 (add c1 c2)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -280,6 +280,7 @@ form-asm-syscall fks 31
 form-asm-branch fks 31
 form-asm-tr fks 31
 form-asm-rot13 fks 7
+form-asm-head fks 7
 form-constants fks 111111
 form-diagnose fks 31
 form-debug fks 31

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 269
+**Total files**: 270
 
 | File | Purpose |
 |---|---|
@@ -94,6 +94,7 @@
 | [form_debug_demo.sh](form_debug_demo.sh) | form_debug_demo.sh — LIVE DEBUGGING: the value trace joined with provenance. |
 | [form_diagnose_demo.sh](form_diagnose_demo.sh) | form_diagnose_demo.sh — the live-diagnosis organ on REAL channels. One fib |
 | [form_fib_demo.sh](form_fib_demo.sh) | form_fib_demo.sh — TRUE RECURSION, zero clang. The Form compiler lowers |
+| [form_head_demo.sh](form_head_demo.sh) | form_head_demo.sh — `head -3`, built with ZERO clang and direct Form -> asm. head |
 | [form_lower_demo.sh](form_lower_demo.sh) | form_lower_demo.sh — the Form -> assembly COMPILER. Lower an op-tagged expression |
 | [form_macho_demo.sh](form_macho_demo.sh) | form_macho_demo.sh — a RUNNABLE native binary built with ZERO clang. The Form |
 | [form_map_demo.sh](form_map_demo.sh) | form_map_demo.sh — the FULL asm-to-source mapping for a native 4th-kernel |

--- a/scripts/form_head_demo.sh
+++ b/scripts/form_head_demo.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# form_head_demo.sh — `head -3`, built with ZERO clang and direct Form -> asm. head
+# is the cat loop plus a line COUNTER held in a callee-saved register (w19, preserved
+# across the read/write syscalls): each newline written decrements it; at zero, exit.
+# No new encoder — just cmp/sub data rows and two new branch CONDITIONS (b.ne, b.gt).
+# N is fixed at 3 (argv-parsed N is the next step). Oracle: the system `head -n 3`.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS demo; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/fhead.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+PROG='(fa-image (list
+    (fa-sub-x-imm 31 31 16) (fa-movz 19 3)
+    (fa-movz-x 0 0) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+    (fa-movz-x 16 3) (fa-movk-x-16 16 512) (fa-svc 128)
+    (fa-cmp-x 0 0) (fa-bcond 13 13)
+    (fa-movz-x 0 1) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1)
+    (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+    (fa-ldrb 8 31 0) (fa-cmp 8 10) (fa-bcond 1 -16)
+    (fa-sub 19 19 1) (fa-cmp 19 0) (fa-bcond 12 -19)
+    (fa-movz 0 0) (fa-add-x-imm 31 31 16) (fa-ret)))'
+
+{ sed '$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<DRV
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (print (str_concat "MACHO " (hxb (mo-object $PROG))))
+    0)
+DRV
+} > "$work/d.fk"
+hex="$(cd "$FORM" && "$GO" "$work/d.fk" 2>/dev/null | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; exit 1; }
+echo "$hex" | xxd -r -p > "$work/h.o"
+SDK="$(xcrun --show-sdk-path 2>/dev/null)"
+ld -arch arm64 -platform_version macos 13.0 13.0 -L"$SDK/usr/lib" -lSystem -o "$work/head" "$work/h.o" 2>/dev/null
+
+printf 'line one\nline two\nline three\nline four\nline five\n' > "$work/in.txt"
+"$work/head" < "$work/in.txt" > "$work/got.txt"
+head -n 3 "$work/in.txt" > "$work/want.txt"
+echo "── head -3, built with zero clang and direct Form -> asm (no new encoder) ──"
+echo "  input: 5 lines; Form-head ($(wc -c <"$work/h.o" | tr -d ' ') byte Mach-O) emits:"
+sed 's/^/    | /' "$work/got.txt"
+if cmp -s "$work/got.txt" "$work/want.txt"; then
+    echo
+    echo "  IT HEADS — matches the system \`head -n 3\` byte-for-byte. A real shell command on"
+    echo "  Form's own bytes: a callee-saved line counter, decremented per newline, b.ne/b.gt."
+else
+    echo "  FAIL: Form-head != system head"; diff "$work/want.txt" "$work/got.txt"; exit 1
+fi


### PR DESCRIPTION
`head` is the `cat` loop plus a **line counter** in a callee-saved register (`w19`, preserved across the read/write syscalls): each newline written decrements it; at zero, exit. **No new encoder** — `cmp`/`sub` data rows plus two new branch *conditions* as data: `b.ne` (NE=1, byte wasn't a newline → keep) and `b.gt` (GT=12, lines remain → loop). N is fixed at 3 (argv-parsed N is the next step; the filters take no args yet).

## Proof

**`form-asm-head fks 7`** — the 100-byte image byte-equals clang's, including the two backward signed folds at conds NE and GT.

`scripts/form_head_demo.sh` — `ld` links it (no clang); emits the first 3 lines of stdin matching the system `head -n 3` **byte-for-byte**:

```
  input: 5 lines; Form-head (331 byte Mach-O) emits:
    | line one
    | line two
    | line three
  IT HEADS — matches the system `head -n 3` byte-for-byte.
```

`form-asm.fk` untouched — pure data rows, the table paying off again.

## Next

`wc -l` (loop + a newline counter, then a decimal-print subroutine via `udiv`/`mul`/`sub` — all encoded), then `grep PATTERN` (line buffer + substring search — its own focused breath). No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)