### PR TITLE
tend(form): roster reads its first sovereign native model live (form-cli-predict 553/91)

### DIFF
--- a/form/form-stdlib/tests/model-roster-report-band.fk
+++ b/form/form-stdlib/tests/model-roster-report-band.fk
@@ -16,9 +16,13 @@
     (mrr-row "git-commit-to-diff" "local-llm"            "local"           124  0  0 124)
     (mrr-row "idea-to-spec"       "spec-author-llm"      "remote-membrane" 165  0  0 165)
     (mrr-row "spec-to-code"       "spec-author-llm"      "remote-membrane" 163  0  0 163)
-    (mrr-row "i18n-affine"        "i18n-baseline"        "local"            80 40 80   2)))
+    (mrr-row "i18n-affine"        "i18n-baseline"        "local"            80 40 80   2)
+    (mrr-row "form-cli-predict"   "tool-corpus"          "local"           553 91 100  0)))
   ; i18n-affine fitness 40 is MEASURED (native 8/20 heldout vs oracle 0/20),
   ; trained on 80 real en->fr samples in-kernel — not a placeholder.
+  ; form-cli-predict fitness 91 is MEASURED: native reproduces the tool decision
+  ; on 91% of 553 real session traces (local LLM 52%, baseline ~30%), zero oracle
+  ; calls at inference — fully sovereign (form-cli-corpus/corpus.jsonl).
 
   ; which oracle is USED MOST  -> gpt-5-codex (256 calls)
   (let most-used (mrr-most-used roster))
@@ -26,7 +30,7 @@
   (let needs (mrr-needs-attention roster))
 
   ; aggregate = most-used calls (256) + needs-attention samples (124)
-  ;           + total captured samples (939) + sovereign count (1)  = 1320
+  ;           + total captured samples (1560) + sovereign count (2)  = 1942
   (add (mrr-oracle-calls most-used)
        (add (mrr-samples needs)
             (add (mrr-total-samples roster)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -505,7 +505,7 @@ recipe-equivalence-gate fkc 3
 triangle-lowerings fkc 1
 capability-form-asm fks 106
 tier-router fks 140
-model-roster-report fks 1388
+model-roster-report fks 1942
 lowering-search fks 57
 capability-form-mul fkc 2428
 capability-form-div fkc 3027


### PR DESCRIPTION
The model roster report band now carries `form-cli-predict` as a MEASURED row — the native tool-decision model that reproduces the real session choice on **91% of 553 captured traces** (local LLM 52%, baseline ~30%), with **zero oracle calls** at inference. It is the roster's second fully-sovereign model alongside codex's i18n affine.

- aggregate `1388 -> 1942` four-way (Go/Rust/TS/fkwu): total captured samples `1007 -> 1560`, sovereign count `1 -> 2`
- stale aggregate comment (`939/1320`) corrected to the arithmetic the manifest already attested (`1007 -> 1388`)
- manifest `model-roster-report fks 1388 -> 1942`

This makes "how the models are learning" a live four-way readout: the remote executors (gpt-5-codex 256 calls, gpt-5 219), the captured-but-unfit lanes (idea-to-spec/spec-to-code/git-commit-to-diff, fitness 0 — the code-gen gap), and now the first native model that learned from session history and reaches inference sovereign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)