### PR TITLE
tend(form): ground the zero-clang coreutils in the REAL source — edge surface + differential oracle

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 270 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 271 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/coreutils-edge-surface.md
+++ b/docs/coherence-substrate/coreutils-edge-surface.md
@@ -1,0 +1,89 @@
+# Coreutils edge surface — grounded in the real source, not invented
+
+The zero-clang Form coreutils (`cat`, `tr`, `rot13`, `head` — see
+[`form-cli-offline.md`](form-cli-offline.md) "Shell commands are recipes") began as
+happy-path recipes written from memory. That is *making it up*. This catalog
+replaces that with the **actual behavior surface read from the canonical source**,
+so every edge case is known and every Form version is measured against it — never
+asserted.
+
+## Method — three oracles, no invention
+
+1. **Source as spec.** GNU coreutils `cat.c` (975 lines) and `tr.c` (1906 lines) are
+   fetched and cached offline at `~/.coherence-network/coreutils-src/`. The option
+   sets and grammars below are extracted from them, with line references.
+2. **The real tool as differential oracle.** `scripts/form_coreutils_diff.sh` runs
+   each Form binary and the system tool (`/bin/cat`, `/usr/bin/tr` — BSD on macOS)
+   over an edge-input battery and compares **byte-for-byte**.
+3. **POSIX as the common contract** where GNU and BSD diverge (noted inline).
+
+The edge-input battery (from the source's own concerns, not picked at random):
+empty input · no trailing newline · only newlines · embedded NUL bytes · high-bit /
+UTF-8 bytes · a line larger than the page size (9000 bytes) · mixed content.
+
+**Measured (2026-06-16):** 14/14 edge inputs match byte-for-byte for the operations
+implemented (`cat` passthrough, `tr A-Z a-z`). A byte-at-a-time `read`/`write` loop
+is inherently content-agnostic, so the *core operation* is faithful across every
+byte input — the gap is the **option/mode surface**, enumerated below.
+
+## `cat` — `cat.c` surface
+
+| Feature | Source | Form-native |
+|---|---|---|
+| plain copy stdin→stdout (`simple_cat`, byte loop) | cat.c:169 | **✓ zero-clang**, matches `/bin/cat` over all edge inputs |
+| file arguments; `-` = stdin; missing-file error + exit 1 | cat.c:808,822,832 | ○ stdin only (no argv, no open, no error path) |
+| `-n` number-all / `-b` number-nonblank | cat.c usage | ○ |
+| `-s` squeeze-blank (collapse repeated blank lines) | cat.c usage | ○ |
+| `-E`/`-T`/`-A`/`-v`/`-e`/`-t` show ends/tabs/all/nonprinting | cat.c usage | ○ |
+| EINTR retry, partial-write handling, page-aligned buffer, `copy_file_range`/`splice` fast paths | cat.c:182,536,597 | ○ (our loop is 1-byte, correct but unoptimized; the fast paths are an optimization, not a behavior) |
+
+## `tr` — `tr.c` surface
+
+**Options** (tr.c:271): `-c`/`-C` complement set1 · `-d` delete set1 · `-s`
+squeeze-repeats · `-t` truncate-set1.
+
+**SET grammar** — a SET is a sequence of these tokens (tr.c:93, `RE_*`):
+
+| Token | Form | Source | Form-native |
+|---|---|---|---|
+| normal char | `x` | RE_NORMAL_CHAR | **✓** (for A–Z) |
+| range | `a-z` | RE_RANGE (tr.c:684) | **✓** only `A-Z`→`a-z`; other ranges ○ |
+| character class | `[:alpha:] [:upper:] [:lower:] [:digit:] [:space:] [:blank:] [:punct:] [:print:] [:graph:] [:cntrl:] [:alnum:] [:xdigit:]` | RE_CHAR_CLASS (tr.c:706) | ○ |
+| equivalence class | `[=c=]` | RE_EQUIV_CLASS (tr.c:746) | ○ |
+| repeat | `[c*n]` (n octal if leading 0; `[c*]` fills) | RE_REPEATED_CHAR (tr.c:724,775) | ○ |
+| escapes | `\\ \a \b \f \n \r \t \v \ooo` (octal) | tr.c:321,849 | ○ (we map raw bytes, no escape parse) |
+
+**Semantic rules** (the easy-to-get-wrong edges): SET2 is **extended to SET1's
+length by repeating its last char** unless `-t` (tr.c:218); `-d` with both sets is
+an error unless `-s` is also given; `-c` complements set1 against all 256 byte
+values; squeeze applies to the *last* set. None of these arise for our single
+`A-Z`→`a-z` map (equal-length, no options), which is why the toy matched — but they
+are the surface a real `tr` must satisfy.
+
+## `rot13`, `head` — covered, with named bounds
+
+`rot13` (`tr A-Za-z N-ZA-Mn-za-m`) matches the system rot13 and round-trips. `head`
+matches `head -n 3` but **N is hardcoded** — argv parsing (`atoi`, `-n N`) is the
+shared gap for every tool that takes arguments.
+
+## `bash` — scope, named honestly
+
+bash is not a byte filter; it is the **POSIX shell**, and "its edge cases" are the
+whole language: the lexer (quoting, here-docs, line continuation), the parser
+(pipelines, lists, compound commands, functions), word expansions (brace, tilde,
+parameter `${...}`, command `$(...)`, arithmetic `$((...))`, word-splitting,
+filename globbing, quote removal — in that order), redirections, ~40 builtins, and
+job control. Grounding that is a multi-stage arc whose honest home is the **BML
+grammar + Form recipe** path (lexer→parser→evaluator), not hand-encoded asm. The
+asm lane gives bash its *syscall floor* (`fork`/`exec`/`wait`/`dup2`/`pipe`, which
+extend the `read`/`write`/`svc` set already proven); the language itself is grammar
+work. This catalog marks the boundary so we build bash as a shell, not as a filter.
+
+## The honest shape
+
+The Form coreutils' **core operations are faithful** (measured byte-for-byte across
+the source's own edge inputs); their **option/mode surface is the open frontier**,
+now enumerated from the real source rather than guessed. Closing it is ordinary
+table work — each option is more data rows + a flag check, each class a 256-entry
+membership table, argv a small parse loop — with `form_coreutils_diff.sh` as the
+standing oracle that every addition must pass against the real tool.

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -192,6 +192,14 @@ now runs on Form's own bytes, clang only ever a check. (The whole-program C-emit
 [`hati-os-native-cli-emit.fk`](../../form/form-stdlib/hati-os-native-cli-emit.fk),
 remains for programs not yet asm-lowered.)
 
+These began as happy-path recipes from memory — toys. The real behavior surface is
+now read from the **actual GNU source** (cached offline), enumerated in
+[`coreutils-edge-surface.md`](coreutils-edge-surface.md), and the Form versions are
+held honest by `scripts/form_coreutils_diff.sh` — a differential test against the
+system tools over edge inputs (empty, NUL, UTF-8, >page-size, no-trailing-newline).
+Measured: the implemented operations match **14/14 byte-for-byte**; the option/mode
+surface (tr `-d`/`-s`/classes, cat `-n`/files, argv) is the named-from-source frontier.
+
 ## The training corpus — samples to try the native models on
 
 Every slice and gap-close captures its request/response; the agent's own turns

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 270
+**Total files**: 271
 
 | File | Purpose |
 |---|---|
@@ -91,6 +91,7 @@
 | [form_cli_slice.sh](form_cli_slice.sh) | form_cli_slice.sh — compile a Form recipe slice to a RUNNABLE native binary, |
 | [form_cli_tiered.sh](form_cli_tiered.sh) | form_cli_tiered.sh — retire the REMOTE oracle on reasoning: local-first, tiered. |
 | [form_cli_train_predict.sh](form_cli_train_predict.sh) | form_cli_train_predict.sh — train a NATIVE tool predictor on the corpus, then |
+| [form_coreutils_diff.sh](form_coreutils_diff.sh) | form_coreutils_diff.sh — differential test of the zero-clang Form coreutils against |
 | [form_debug_demo.sh](form_debug_demo.sh) | form_debug_demo.sh — LIVE DEBUGGING: the value trace joined with provenance. |
 | [form_diagnose_demo.sh](form_diagnose_demo.sh) | form_diagnose_demo.sh — the live-diagnosis organ on REAL channels. One fib |
 | [form_fib_demo.sh](form_fib_demo.sh) | form_fib_demo.sh — TRUE RECURSION, zero clang. The Form compiler lowers |

--- a/scripts/form_coreutils_diff.sh
+++ b/scripts/form_coreutils_diff.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# form_coreutils_diff.sh — differential test of the zero-clang Form coreutils against
+# the REAL system tools, over a battery of edge-case INPUTS derived from the actual
+# GNU/POSIX source (docs/coherence-substrate/coreutils-edge-surface.md), not invented.
+# The system tool is the behavioral oracle; we throw the hard inputs (empty, no
+# trailing newline, NUL bytes, high-bit/UTF-8, >page-size lines, all-newlines) and
+# confirm the Form binary matches byte-for-byte — or name the gap honestly.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS demo; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/fdiff.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+SDK="$(xcrun --show-sdk-path 2>/dev/null)"
+
+# Build a Form tool: name + the fa-* instruction list -> a linked binary at $work/<name>.
+build() {
+    local name="$1" prog="$2"
+    { sed '$ d' "$FORM/form-stdlib/form-asm.fk"
+      sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+      printf '%s\n' \
+        '(defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))' \
+        '(defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))' \
+        '(defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))' \
+        "(print (str_concat \"MACHO \" (hxb (mo-object $prog))))" '0)'
+    } > "$work/$name.fk"
+    (cd "$FORM" && "$GO" "$work/$name.fk" 2>/dev/null) | grep '^MACHO ' | sed 's/^MACHO //' | xxd -r -p > "$work/$name.o"
+    ld -arch arm64 -platform_version macos 13.0 13.0 -L"$SDK/usr/lib" -lSystem -o "$work/$name" "$work/$name.o" 2>/dev/null
+}
+
+CAT='(fa-image (list (fa-sub-x-imm 31 31 16)
+  (fa-movz-x 0 0) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1) (fa-movz-x 16 3) (fa-movk-x-16 16 512) (fa-svc 128)
+  (fa-cmp-x 0 0) (fa-bcond 13 8)
+  (fa-movz-x 0 1) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1) (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+  (fa-b-off -14) (fa-movz 0 0) (fa-add-x-imm 31 31 16) (fa-ret)))'
+TR='(fa-image (list (fa-sub-x-imm 31 31 16)
+  (fa-movz-x 0 0) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1) (fa-movz-x 16 3) (fa-movk-x-16 16 512) (fa-svc 128)
+  (fa-cmp-x 0 0) (fa-bcond 13 14)
+  (fa-ldrb 8 31 0) (fa-sub 9 8 65) (fa-add 10 8 32) (fa-cmp 9 25) (fa-csel 8 10 8 9) (fa-strb 8 31 0)
+  (fa-movz-x 0 1) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1) (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+  (fa-b-off -20) (fa-movz 0 0) (fa-add-x-imm 31 31 16) (fa-ret)))'
+
+build cat "$CAT"; build tr "$TR"
+
+# the edge-case input battery (derived from the source surface, not invented)
+mk() { case "$1" in
+  empty)      : > "$work/in";;
+  no_nl)      printf 'abc XYZ' > "$work/in";;
+  only_nls)   printf '\n\n\n' > "$work/in";;
+  nul)        printf 'A\000B\000C\n' > "$work/in";;
+  highbit)    printf 'caf\303\251 ZURICH \342\230\203\n' > "$work/in";;   # UTF-8: café, snowman
+  longline)   { head -c 9000 /dev/zero | tr '\0' 'A'; printf '\n'; } > "$work/in";;
+  mixed)      printf 'Hello, World!\nLine TWO\n123 abcABC\n' > "$work/in";;
+esac; }
+
+pass=0; total=0
+run() { # tool  form-bin  system-cmd...
+  local label="$1" bin="$2"; shift 2
+  for c in empty no_nl only_nls nul highbit longline mixed; do
+    mk "$c"
+    "$bin" < "$work/in" > "$work/f.out" 2>/dev/null
+    "$@" < "$work/in" > "$work/s.out" 2>/dev/null
+    total=$((total+1))
+    if cmp -s "$work/f.out" "$work/s.out"; then pass=$((pass+1)); printf "  ok   %-4s %-9s (%s bytes)\n" "$label" "$c" "$(wc -c <"$work/f.out"|tr -d ' ')"
+    else printf "  DIFF %-4s %-9s  form=%sB system=%sB\n" "$label" "$c" "$(wc -c <"$work/f.out"|tr -d ' ')" "$(wc -c <"$work/s.out"|tr -d ' ')"; fi
+  done
+}
+
+echo "── Form coreutils vs system tools, over edge-case inputs from the real source ──"
+echo "  cat (Form) vs /bin/cat:"
+run cat "$work/cat" /bin/cat
+echo "  tr (Form, A-Z a-z) vs /usr/bin/tr A-Z a-z:"
+run tr "$work/tr" /usr/bin/tr 'A-Z' 'a-z'
+echo
+echo "  $pass/$total edge inputs match byte-for-byte across the implemented operations"
+echo
+echo "  NOT YET COVERED (named gaps from the source surface — see coreutils-edge-surface.md):"
+echo "    tr  : -d -s -c -t, [:classes:], [=equiv=], [c*n] repeats, octal/\\ escapes, ranges other than A-Z"
+echo "    cat : -n -b -s -A -E -T -v, file args, '-'=stdin, missing-file error + exit code"
+echo "    bash: the whole POSIX shell (lexer, parser, expansions, builtins, control flow) — a separate arc"
+[[ "$pass" -eq "$total" ]]


### PR DESCRIPTION
You named the method gap: I'd been writing `cat`/`tr`/`head` from memory — happy-path toys — and calling them by the tools' names. **This grounds them in the actual source instead of making it up.**

## Source as spec (fetched + cached offline)

`~/.coherence-network/coreutils-src/`: GNU coreutils **`cat.c` (975 lines)** and **`tr.c` (1906 lines)**. `docs/coherence-substrate/coreutils-edge-surface.md` extracts the full behavior surface from them with line refs and a per-feature **"Form-native covers / gap"** column:

- **tr**: 4 options (`-c`/`-d`/`-s`/`-t`) + a 5-token SET grammar — range `a-z`, `[:class:]`, `[=equiv=]`, `[c*n]` repeat, escapes incl. octal — plus SET2-extension / `-d` / `-c` rules.
- **cat**: `-n`/`-b`/`-s`/`-A`/`-E`/`-T`/`-v`, file args, `-`=stdin, missing-file error + exit code, buffering.
- **bash**: named as the whole POSIX shell (lexer→parser→expansions→builtins→job-control) — a grammar arc, not a byte filter.

## The real tool as a standing differential oracle

`scripts/form_coreutils_diff.sh` runs each Form binary and the system tool (BSD `/bin/cat`, `/usr/bin/tr`) over an edge battery from the source's own concerns — empty · no-trailing-newline · only-newlines · embedded NUL · high-bit/UTF-8 · >page-size line · mixed:

```
  14/14 edge inputs match byte-for-byte across the implemented operations
  NOT YET COVERED (named gaps from the source surface): tr -d/-s/-c/classes/escapes; cat -n/files; bash
```

## The honest shape

The byte-at-a-time loop is content-agnostic, so the **core operations are faithful** (measured, not assumed). The **option/mode surface is the open frontier**, now enumerated from real source — each option is more data rows + a flag, each class a 256-entry table, with the diff harness as the oracle every addition must pass. No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)