### PR TITLE
feat(form): the recipe becomes a dynamic library that is only the recipe

### DIFF
--- a/docs/coherence-substrate/form-to-asm.form
+++ b/docs/coherence-substrate/form-to-asm.form
@@ -201,8 +201,24 @@
     (host    "darwin/arm64 + cgo only (MAP_JIT + pthread_jit_write_protect_np); every other target keeps the Go-plugin path or walker via the no-op stub jit_inram_other.go")
     (no-disk "zero go build, zero plugin .so — the image is mmapped from the Form emitter's bytes, not a host plugin"))
 
+  # The DURABLE counterpart to the in-RAM path: the recipe becomes a dynamic
+  # library that is NOTHING but the recipe. form-macho's mo-object-sym wraps the
+  # lo-compile bytes as a Mach-O .o exporting _recipe; `ld -dylib` links and
+  # ad-hoc signs it (the macOS arm64 signing requirement, met by the same linker
+  # the executable floor already uses — no clang) into a ~16KB dlopen-able dylib
+  # whose __text is the 20-byte recipe. The kernel's dylib_call native dlopens
+  # it, dlsyms _recipe, and calls it. Unlike the in-RAM image this survives
+  # process restarts, so it is the on-disk, content-addressable JIT cache — and
+  # at ~16KB it is ~286x smaller than the 4.8MB Go plugin it replaces.
+  (recipe-dylib-realized
+    (emit   "form-macho mo-object-sym wraps the lo-compile recipe as a .o exporting _recipe, four-way Go/Rust/TS/fkwu at tests/recipe-dylib-band.fk -> 787349")
+    (link   "ld -dylib links + ad-hoc signs the Form .o into a dlopen-able dylib (zero clang; ld is the same linker the executable floor uses)")
+    (load   "form-kernel-go native dylib_call dlopens the dylib, dlsyms _recipe, calls it int64 f(int64); jit_dylib_test.go proves emit->link->load->call across {5,0,10,100}")
+    (only-the-recipe "the dylib's __text IS the recipe (20 bytes); the ~16KB is Mach-O + signature overhead ld adds, vs a 4.8MB Go-runtime plugin"))
+
   # ── Closing cells — what remains beyond the realized runnable path ───
   (closing-cells
+    (recipe-dylib-direct "emit the signed MH_DYLIB directly from Form (MH_DYLIB filetype + LC_ID_DYLIB + export trie + an ad-hoc LC_CODE_SIGNATURE whose CodeDirectory SHA256-hashes each page via form-stdlib/sha256.fk), retiring ld from the dylib path as form-elf-exec already retired it for the ELF executable; and a Linux ELF ET_DYN .so (no signing) for the VPS, dlopen-proven once the Docker Linux/arm64 runner is live")
     (live-lowering   "auto-derive the op-tagged prog from a live closure's AST (the sibling of jit.go's Go-source walker) so jit_leaf_inram fires on real single-i64 closures automatically — the band and test author the prog explicitly today, proving the emit->exec path; the converter is what makes it the default backend")
     (general-encoder "the field-into-byte encoder for high-base instructions (branches, loads,
                       stores) with carry — so any instruction encodes without a > 2^31 word")

--- a/form/form-kernel-go/jit_dylib_test.go
+++ b/form/form-kernel-go/jit_dylib_test.go
@@ -1,0 +1,107 @@
+//go:build darwin && arm64 && cgo
+
+// jit_dylib_test.go — the recipe-as-dylib path proven end to end, zero clang:
+// the Form emitter (form-macho's mo-object-sym, four-way in
+// tests/recipe-dylib-band.fk) produces a Mach-O .o carrying only the lo-compile
+// recipe and exporting _recipe; `ld -dylib` links+signs it into a tiny
+// dlopen-able binary; the kernel's dylib_call native loads it and calls the
+// recipe. Emitter (Form) and loader (host dlopen) meet on one object file.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// emitRecipeObject runs form-macho over the lo-compile recipe (f(n)=n*3+7) and
+// returns the Mach-O .o byte image exporting _recipe.
+func emitRecipeObject(t *testing.T) []byte {
+	t.Helper()
+	stdlib := filepath.Join("..", "form-stdlib")
+	preludes := readFiles(t,
+		filepath.Join(stdlib, "form-asm.fk"),
+		filepath.Join(stdlib, "form-lower.fk"),
+		filepath.Join(stdlib, "form-macho.fk"),
+	)
+	// _recipe = 95 114 101 99 105 112 101
+	src := preludes + `
+(do
+  (let prog (list (list 1 7) (list 2) (list 1 3) (list 5 1 2) (list 3 3 0)))
+  (let code (lo-compile-fn prog 4))
+  (mo-object-sym code (list 95 114 101 99 105 112 101)))`
+	k := NewKernel()
+	res := k.walk(readRootFromSource(k, src), NewFrame(nil))
+	if res.Kind != VList {
+		t.Fatalf("mo-object-sym did not return a byte list (kind %v)", res.Kind)
+	}
+	out := make([]byte, len(res.List))
+	for i, b := range res.List {
+		if b.Kind != VInt || b.Int < 0 || b.Int > 255 {
+			t.Fatalf("object byte %d not a 0..255 int: %v", i, b)
+		}
+		out[i] = byte(b.Int)
+	}
+	return out
+}
+
+func TestRecipeDylibLoadsAndCalls(t *testing.T) {
+	ld, err := exec.LookPath("ld")
+	if err != nil {
+		t.Skip("ld not available — recipe-dylib link step needs the system linker")
+	}
+	sdkOut, err := exec.Command("xcrun", "--sdk", "macosx", "--show-sdk-path").Output()
+	if err != nil {
+		t.Skip("macOS SDK not available")
+	}
+	sdk := strings.TrimSpace(string(sdkOut))
+
+	obj := emitRecipeObject(t)
+	dir := t.TempDir()
+	oPath := filepath.Join(dir, "recipe.o")
+	if err := os.WriteFile(oPath, obj, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dylibPath := filepath.Join(dir, "librecipe.dylib")
+
+	// ld -dylib links the Form .o into a dlopen-able dylib and ad-hoc signs it
+	// (the macOS arm64 signing requirement) — no clang, the same linker the
+	// executable floor already uses.
+	cmd := exec.Command(ld, "-dylib", "-arch", "arm64",
+		"-platform_version", "macos", "11.0", "11.0",
+		"-o", dylibPath, oPath,
+		"-lSystem", "-L", filepath.Join(sdk, "usr/lib"), "-syslibroot", sdk)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("ld -dylib failed: %v\n%s", err, out)
+	}
+
+	// Call the recipe through the kernel's dylib_call native: emit (Form) ->
+	// ld -dylib -> dlopen+dlsym+call (host). f(n) = n*3 + 7.
+	for _, tc := range []struct{ arg, want int64 }{{5, 22}, {0, 7}, {10, 37}, {100, 307}} {
+		src := fmt.Sprintf(`(dylib_call "%s" "recipe" %d)`, dylibPath, tc.arg)
+		k := NewKernel()
+		got := k.walk(readRootFromSource(k, src), NewFrame(nil))
+		if got.Kind != VInt || got.Int != tc.want {
+			t.Fatalf("dylib_call recipe(%d) = %v, want %d (n*3+7)", tc.arg, got, tc.want)
+		}
+	}
+}
+
+// TestDylibCallRefusesMissing — a missing library or symbol answers null (never
+// crashes), so the caller stays on the fallback path.
+func TestDylibCallRefusesMissing(t *testing.T) {
+	k := NewKernel()
+	for _, src := range []string{
+		`(dylib_call "/nonexistent/path.dylib" "recipe" 5)`,
+		`(dylib_call "/usr/lib/libSystem.B.dylib" "no_such_symbol_xyz" 5)`,
+	} {
+		got := k.walk(readRootFromSource(k, src), NewFrame(nil))
+		if got.Kind != VNull {
+			t.Fatalf("%s: want null refusal, got %v", src, got)
+		}
+	}
+}

--- a/form/form-kernel-go/jit_inram_darwin_arm64.go
+++ b/form/form-kernel-go/jit_inram_darwin_arm64.go
@@ -18,16 +18,24 @@
 // cgo + darwin/arm64 only; every other target uses the no-op stub
 // (jit_inram_other.go) and Form callers fall back to the Go-plugin path.
 //
-// Surface: the Form-callable native `jit_leaf_inram` takes (image, arg) where
-// image is a List of byte ints (lo-compile-fn's output) and arg is the single
-// i64 argument; it returns the i64 result, or null on bad input / mmap refusal.
+// Two host-native doors live here, both Form-callable:
+//   • `jit_leaf_inram` (image, arg) — run an arm64 leaf image IN-RAM via MAP_JIT
+//     (ephemeral, this process).
+//   • `dylib_call` (path, sym, arg) — dlopen a DURABLE recipe binary (a Mach-O
+//     dylib that form-macho emits + `ld -dylib` signs), dlsym the recipe symbol,
+//     and call it. The dylib carries ONLY the recipe (~16KB vs the 4.8MB Go
+//     plugin); it survives process restarts, so it is the on-disk counterpart
+//     to the in-RAM path — the durable, content-addressable JIT cache.
 
 package main
 
 /*
+#cgo LDFLAGS: -ldl
 #include <sys/mman.h>
 #include <pthread.h>
 #include <string.h>
+#include <stdlib.h>
+#include <dlfcn.h>
 
 // form_run_leaf — map a MAP_JIT page, write the image while jit-write-protect
 // is off, flip to executable, clear the instruction cache, call f(arg), unmap.
@@ -45,6 +53,21 @@ static long form_run_leaf(unsigned char *code, int n, long arg, int *ok) {
     long (*fn)(long) = (long (*)(long))mem;
     long r = fn(arg);
     munmap(mem, 4096);
+    *ok = 1;
+    return r;
+}
+
+// form_dylib_call — dlopen a recipe dylib, dlsym the symbol, call it as
+// long f(long), dlclose. *ok is 0 if the library or symbol could not be
+// resolved (the result is then meaningless), 1 on a real call.
+static long form_dylib_call(const char *path, const char *sym, long arg, int *ok) {
+    *ok = 0;
+    void *h = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    if (!h) return 0;
+    long (*fn)(long) = (long (*)(long))dlsym(h, sym);
+    if (!fn) { dlclose(h); return 0; }
+    long r = fn(arg);
+    dlclose(h);
     *ok = 1;
     return r;
 }
@@ -69,9 +92,23 @@ func runLeafInRAM(code []byte, arg int64) (int64, bool) {
 	return int64(r), ok != 0
 }
 
-// registerInRAMJIT — bind `jit_leaf_inram` so Form code can emit an image with
-// lo-compile-fn and run it natively in the same breath. Present only where the
-// host can execute it; the stub registers nothing.
+// dylibCall — load a recipe dylib at path, resolve sym, call it as int64
+// f(int64). Returns (result, true) on a real call, (0, false) if the library
+// or symbol could not be resolved.
+func dylibCall(path, sym string, arg int64) (int64, bool) {
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+	csym := C.CString(sym)
+	defer C.free(unsafe.Pointer(csym))
+	var ok C.int
+	r := C.form_dylib_call(cpath, csym, C.long(arg), &ok)
+	return int64(r), ok != 0
+}
+
+// registerInRAMJIT — bind the host-native execution doors. `jit_leaf_inram`
+// runs an image in-RAM; `dylib_call` loads a durable recipe dylib and calls it.
+// Present only where the host can execute them; the stub registers nothing and
+// Form callers fall back to the Go-plugin path or the walker.
 func (k *Kernel) registerInRAMJIT() {
 	k.registerNative("jit_leaf_inram", catMethod(), func(_ *Kernel, args []Value) Value {
 		if len(args) != 2 || args[0].Kind != VList || args[1].Kind != VInt {
@@ -85,6 +122,17 @@ func (k *Kernel) registerInRAMJIT() {
 			code[i] = byte(b.Int)
 		}
 		r, ok := runLeafInRAM(code, args[1].Int)
+		if !ok {
+			return Value{Kind: VNull}
+		}
+		return Value{Kind: VInt, Int: r}
+	})
+	// dylib_call (path, sym, arg) — dlopen a recipe binary and call its symbol.
+	k.registerNative("dylib_call", catMethod(), func(_ *Kernel, args []Value) Value {
+		if len(args) != 3 || args[0].Kind != VStr || args[1].Kind != VStr || args[2].Kind != VInt {
+			return Value{Kind: VNull}
+		}
+		r, ok := dylibCall(args[0].Str, args[1].Str, args[2].Int)
 		if !ok {
 			return Value{Kind: VNull}
 		}

--- a/form/form-stdlib/form-macho.fk
+++ b/form/form-stdlib/form-macho.fk
@@ -5,15 +5,23 @@
 ; a host carrier (like the C ABI), `ld` is the linker carrier, and `ld`'s ad-hoc
 ; signature meets the macOS arm64 signing requirement — named, not a compiler.
 ;
-; A minimal valid .o for a leaf `_main` (no relocations): mach_header_64 +
+; A minimal valid .o for a leaf symbol (no relocations): mach_header_64 +
 ; LC_SEGMENT_64 (one __text section) + LC_SYMTAB + the code + the symbol table +
 ; the string table. Offsets are computed from the code length, so any compiled
-; program wraps. High-bit constants (magic 0xfeedfacf, section flags 0x80000400)
-; are emitted as BYTES, sidestepping the kernels' > 2^31 literal wrap (form-asm.fk).
+; program wraps. The exported symbol name is data (mo-object-sym), so the same
+; emitter serves `_main` for the executable floor and `_recipe` for a
+; recipe-as-dylib. High-bit constants (magic 0xfeedfacf, section flags
+; 0x80000400) are emitted as BYTES, sidestepping the kernels' > 2^31 literal
+; wrap (form-asm.fk).
 ;
-; Witnessed by scripts/form_macho_demo.sh: form-lower compiles ((40+1)-1) -> code,
-; form-macho wraps it -> .o, `ld` links it -> the binary runs and exits 40.
-; Structure proven three-way by tests/form-macho-band.fk.
+; Two carriers off the same .o, both zero-clang:
+;   • executable — `ld` links _main -> a binary that runs (form_macho_demo.sh).
+;   • recipe dylib — `ld -dylib` links + ad-hoc signs the _recipe .o into a tiny
+;     dlopen-able binary carrying ONLY the recipe; the kernel's dylib_call native
+;     loads and calls it. The durable counterpart to the in-RAM MAP_JIT path —
+;     the on-disk JIT cache, ~286x smaller than a Go plugin (form-to-asm.form).
+; Structure proven four-way by tests/form-macho-band.fk (_main) and
+; tests/recipe-dylib-band.fk (_recipe); the dylib load+call by jit_dylib_test.go.
 
 (do
     (defn mo-nil? (xs) (eq (len xs) 0))
@@ -55,21 +63,32 @@
             (list 0 4 0 128)                ; flags 0x80000400 (PURE|SOME_INSTRUCTIONS)
             (mo-u32 0) (mo-u32 0) (mo-u32 0))))   ; reserved1,2,3
 
-    (defn mo-symtab (clen)
+    ; strsize = leading \0 + name bytes + trailing \0; the symbol name is data,
+    ; so one .o emitter serves any exported symbol — _main for the executable
+    ; floor, _recipe for a recipe-as-dylib that `ld -dylib` turns into a tiny
+    ; dlopen-able binary carrying only the recipe.
+    (defn mo-symtab-sym (clen strsize)
         (mo-cat (list
-            (mo-u32 2) (mo-u32 24)                 ; LC_SYMTAB, cmdsize
-            (mo-u32 (add 208 clen)) (mo-u32 1)     ; symoff, nsyms
-            (mo-u32 (add 224 clen)) (mo-u32 7))))  ; stroff (208+clen+16), strsize
+            (mo-u32 2) (mo-u32 24)                       ; LC_SYMTAB, cmdsize
+            (mo-u32 (add 208 clen)) (mo-u32 1)           ; symoff, nsyms
+            (mo-u32 (add 224 clen)) (mo-u32 strsize))))  ; stroff (208+clen+16), strsize
 
-    ; one symbol: _main, N_SECT|N_EXT, section 1, value 0
+    ; one symbol: <name>, N_SECT|N_EXT (0x0f), section 1, value 0 — exported.
     (defn mo-nlist () (mo-cat (list (mo-u32 1) (list 15) (list 1) (mo-u16 0) (mo-u64 0))))
-    ; string table: \0 _main \0
-    (defn mo-strtab () (list 0 95 109 97 105 110 0))
+    ; string table: \0 <name> \0  (the symbol begins at strtab offset 1)
+    (defn mo-strtab-sym (name) (cons 0 (mo-app name (list 0))))
 
-    ; the whole object file for the given code byte-list
-    (defn mo-object (code)
+    ; the whole object file for the given code byte-list, exporting `name`
+    ; (a byte-list, e.g. "_recipe"). The leaf code lives at __text offset 0, so
+    ; the exported symbol (value 0) addresses the recipe entry directly.
+    (defn mo-object-sym (code name)
         (mo-cat (list
-            (mo-header) (mo-segment (len code)) (mo-section (len code)) (mo-symtab (len code))
-            code (mo-nlist) (mo-strtab))))
+            (mo-header) (mo-segment (len code)) (mo-section (len code))
+            (mo-symtab-sym (len code) (add (len name) 2))
+            code (mo-nlist) (mo-strtab-sym name))))
+
+    ; the executable floor's .o exports _main (95 109 97 105 110) — byte-identical
+    ; to the prior hardcoded form, so form-macho-band's checksum is unchanged.
+    (defn mo-object (code) (mo-object-sym code (list 95 109 97 105 110)))
 
     0)

--- a/form/form-stdlib/tests/recipe-dylib-band.fk
+++ b/form/form-stdlib/tests/recipe-dylib-band.fk
@@ -1,0 +1,19 @@
+; recipe-dylib-band.fk — form-macho wraps the lo-compile recipe as a Mach-O .o
+; exporting _recipe: the bytes `ld -dylib` turns into a tiny dlopen-able binary
+; carrying ONLY the recipe (no host runtime — ~286x smaller than a Go plugin).
+; The band folds the whole .o image to a position-weighted checksum so a
+; divergent kernel changes the number. The dlopen+dlsym+call half is proven on
+; this same .o (linked by ld, zero clang) by the Go kernel test jit_dylib_test.go
+; — emitter (Form, four-way) and loader (host, dlopen) meet on one object file.
+;
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-lower.fk form-stdlib/form-macho.fk
+
+(do
+  ; f(n) = n*3 + 7 as an op-tagged prog (1=LIT 2=ARG 3=ADD 5=MUL), lowered to a
+  ; leaf recipe, then wrapped as a .o exporting _recipe (95 114 101 99 105 112 101).
+  (let prog (list (list 1 7) (list 2) (list 1 3) (list 5 1 2) (list 3 3 0)))
+  (let code (lo-compile-fn prog 4))
+  (let obj (mo-object-sym code (list 95 114 101 99 105 112 101)))
+  ; position-weighted fold over the whole object image: Σ byte_i · i (i from 1).
+  (defn ck (xs i) (if (eq (len xs) 0) 0 (add (mul (head xs) i) (ck (tail xs) (add i 1)))))
+  (ck obj 1))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -512,5 +512,6 @@ capability-form-mul fkc 2428
 capability-form-div fkc 3027
 capability-form-tree fkc 13113
 inram-leaf-emit fkc 14073
+recipe-dylib fkc 787349
 native-code-fit fks 15
 reproduce-from-history fkc 8


### PR DESCRIPTION
## What Urs asked

> we should try 4th kernel with recipe binaries as dynamic libs, to only contain the recipe itself

This is the **durable, cross-restart counterpart** to the in-RAM MAP_JIT path ([#3274](https://github.com/seeker71/Coherence-Network/pull/3274)): instead of an ephemeral mmap, the recipe becomes a **dynamic library that is nothing but the recipe** — `dlopen` + `dlsym` + call.

## Ground truth (probed first, like MAP_JIT)

| | Go-plugin (jit.go) | recipe dylib (this PR) |
|---|---|---|
| artifact | ~4.8 MB Go-runtime `.so` | **~16 KB** signed dylib |
| `__text` (the recipe) | buried in runtime | **20 bytes**, IS the dylib |
| durable across restarts | yes (but huge) | **yes** |
| emitter | Go source | **form-macho (Form)** |

Empirically confirmed on this Apple Silicon Mac: dlopen **requires** an ad-hoc code signature (an unsigned dylib is refused by dyld), and `ld -dylib` supplies it — the same linker the executable floor already uses, so the path stays **zero clang**.

## The path

`form-macho` mo-object-sym wraps the lo-compile recipe as a Mach-O `.o` exporting `_recipe` → `ld -dylib` links + ad-hoc signs it → a tiny dlopen-able binary → the kernel's new **`dylib_call`** native loads and calls it. The exported symbol is now **data**, so one `.o` emitter serves `_main` (executable floor) and `_recipe` (dylib) — `mo-object` stays byte-identical, so `form-macho-band` is unchanged at 31.

## Proof — emitter and loader meet on one object file

- **Emit (Form, four-way):** `tests/recipe-dylib-band.fk` → **787349** across Go/Rust/TS/fkwu (manifest `recipe-dylib fkc 787349`).
- **Load+call (host):** `jit_dylib_test.go` — Form emits the `.o`, `ld -dylib` links it, `dylib_call` loads+calls `recipe(n)=n*3+7` for `{5,0,10,100}`. A missing lib/symbol answers `null`, never a crash.

## Containment

`dylib_call` lives with `jit_leaf_inram` (darwin/arm64 + cgo, `dlfcn`); the no-op stub keeps Linux/CI/the VPS pure-Go. Verified: `CGO_ENABLED=0` and `GOOS=linux` builds green, in-RAM + existing JIT tests green.

## Named next (closing cells in form-to-asm.form)

- Emit the signed `MH_DYLIB` **directly from Form** (MH_DYLIB filetype + LC_ID_DYLIB + export trie + ad-hoc `LC_CODE_SIGNATURE` whose CodeDirectory SHA256-hashes each page via `sha256.fk`), retiring `ld` from the dylib path as `form-elf-exec` already retired it for the ELF executable.
- A Linux ELF `ET_DYN` `.so` (no signing) for the VPS — dlopen-proven once the Docker Linux/arm64 runner is live (daemon is currently down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)