### PR TITLE
feat(form): the kernel signs its own Mach-O — ad-hoc code signature as a Form recipe

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 272 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 273 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-to-asm.form
+++ b/docs/coherence-substrate/form-to-asm.form
@@ -216,9 +216,20 @@
     (load   "form-kernel-go native dylib_call dlopens the dylib, dlsyms _recipe, calls it int64 f(int64); jit_dylib_test.go proves emit->link->load->call across {5,0,10,100}")
     (only-the-recipe "the dylib's __text IS the recipe (20 bytes); the ~16KB is Mach-O + signature overhead ld adds, vs a 4.8MB Go-runtime plugin"))
 
+  # The signature half of the direct (no-ld) dylib is now Form. Apple Silicon's
+  # dyld refuses an unsigned dylib; form-codesign.fk (co-sign) builds the ad-hoc
+  # EmbeddedSignature SuperBlob + CodeDirectory whose code slots are SHA256 of
+  # each 4096-byte page via sha256.fk — no host crypto. It reproduces ld's
+  # signature byte-for-byte on a real dylib, the gate that licenses dropping ld
+  # from the signing step (as form-asm dropped clang on byte-conviction).
+  (code-signature-realized
+    (recipe "form-codesign co-sign emits the ad-hoc CodeDirectory v=20400 + SuperBlob; code slots are sha256.fk over each page — the signature is a Form recipe, sovereign across cells")
+    (agree  "four-way Go/Rust/TS/fkwu at tests/codesign-band.fk -> 632490 (sha256 + big-endian layout agree across kernels)")
+    (convict "scripts/form_codesign_conviction_demo.sh: co-sign over a real dylib's [0:codeLimit] == ld's embedded signature, byte-for-byte (278 bytes); the gate opens"))
+
   # ── Closing cells — what remains beyond the realized runnable path ───
   (closing-cells
-    (recipe-dylib-direct "emit the signed MH_DYLIB directly from Form (MH_DYLIB filetype + LC_ID_DYLIB + export trie + an ad-hoc LC_CODE_SIGNATURE whose CodeDirectory SHA256-hashes each page via form-stdlib/sha256.fk), retiring ld from the dylib path as form-elf-exec already retired it for the ELF executable; and a Linux ELF ET_DYN .so (no signing) for the VPS, dlopen-proven once the Docker Linux/arm64 runner is live")
+    (recipe-dylib-direct "emit the MH_DYLIB STRUCTURE directly from Form (MH_DYLIB filetype + LC_ID_DYLIB + export trie + __LINKEDIT), then place the now-realized form-codesign signature — retiring ld from the dylib path entirely as form-elf-exec already retired it for the ELF executable; the signature half is done, the structural shell remains; and a Linux ELF ET_DYN .so (no signing) for the VPS, dlopen-proven once the Docker Linux/arm64 runner is live")
     (live-lowering   "auto-derive the op-tagged prog from a live closure's AST (the sibling of jit.go's Go-source walker) so jit_leaf_inram fires on real single-i64 closures automatically — the band and test author the prog explicitly today, proving the emit->exec path; the converter is what makes it the default backend")
     (general-encoder "the field-into-byte encoder for high-base instructions (branches, loads,
                       stores) with carry — so any instruction encodes without a > 2^31 word")

--- a/form/form-stdlib/form-codesign.fk
+++ b/form/form-stdlib/form-codesign.fk
@@ -1,0 +1,84 @@
+; form-codesign.fk — the ad-hoc Mach-O code signature as a Form recipe.
+;
+; Apple Silicon's dyld REFUSES an unsigned dylib (proven: dlopen of an unsigned
+; library fails). Today `ld` supplies that signature; this recipe is the Form
+; carrier that retires it — the kernel signs its own binaries. The signature is
+; a SuperBlob wrapping one CodeDirectory whose code slots are SHA256 of each
+; 4096-byte page of the image up to codeLimit (the byte-conviction floor:
+; sha256(page) == the system signer's stored slot, proven exactly). SHA256 is
+; the Form recipe in sha256.fk — no host crypto required; the signature stays
+; sovereign across cells.
+;
+; Layout reproduced byte-for-byte from `ld`'s ad-hoc signature (CodeDirectory
+; v=20400): the conviction demo scripts/form_codesign_conviction_demo.sh signs a
+; real dylib's [0:codeLimit] and the Form blob == ld's blob, byte-identical.
+; Structure proven four-way by tests/codesign-band.fk.
+;
+; co-sign (image codeLimit ident execSegLimit flags execSegFlags) -> the
+; SuperBlob byte-list, where `image` is the byte-list being signed (its length
+; IS codeLimit), `ident` is the identifier byte-list (e.g. "lib.dylib"), and
+; execSegLimit/flags/execSegFlags match the binary (the dylib emitter computes
+; them; the demo passes ld's values — flags 0x20002, execSegFlags 0).
+
+(do
+    (defn co-nil? (xs) (eq (len xs) 0))
+    (defn co-app (xs ys) (if (co-nil? xs) ys (cons (head xs) (co-app (tail xs) ys))))
+    (defn co-cat (xss) (if (eq (len xss) 1) (head xss) (co-app (head xss) (co-cat (tail xss)))))
+
+    ; big-endian integer fields (values < 2^31 -> safe; the high-bit blob magics
+    ; are emitted as raw bytes below, sidestepping the kernels' > 2^31 wrap).
+    (defn co-be-u32 (n) (list (mod (div n 16777216) 256) (mod (div n 65536) 256)
+                              (mod (div n 256) 256) (mod n 256)))
+    (defn co-be-u64 (n) (co-app (list 0 0 0 0) (co-be-u32 n)))
+
+    ; blob magics as bytes: CodeDirectory 0xfade0c02, EmbeddedSignature 0xfade0cc0
+    (defn co-magic-cd () (list 250 222 12 2))
+    (defn co-magic-sb () (list 250 222 12 192))
+
+    ; first n / drop n elements of a byte-list (page slicing).
+    (defn co-take (xs n) (if (eq n 0) (list) (cons (head xs) (co-take (tail xs) (sub n 1)))))
+    (defn co-drop (xs n) (if (eq n 0) xs (co-drop (tail xs) (sub n 1))))
+
+    ; page count = ceil(codeLimit / 4096); a full multiple stays exact.
+    (defn co-npages (n) (if (le n 4096) 1 (add 1 (co-npages (sub n 4096)))))
+
+    ; code slots = SHA256 of each 4096-byte page, concatenated (32 bytes each).
+    (defn co-hashes (xs)
+        (if (le (len xs) 4096)
+            (sha256 xs)
+            (co-app (sha256 (co-take xs 4096)) (co-hashes (co-drop xs 4096)))))
+
+    ; the CodeDirectory header is 88 bytes (magic..execSegFlags), then the
+    ; identifier (null-terminated) at offset 88, then the code-slot hashes.
+    ; hashOffset = 88 + identLen + 1 ; length = hashOffset + nCode*32.
+    (defn co-cd (image codeLimit ident execSegLimit flags execSegFlags)
+        (do
+            (let nCode (co-npages codeLimit))
+            (let identOff 88)
+            (let hashOff (add 89 (len ident)))            ; 88 + identLen + 1
+            (let cdLen (add hashOff (mul nCode 32)))
+            (co-cat (list
+                (co-magic-cd) (co-be-u32 cdLen)           ; magic, length
+                (co-be-u32 132096) (co-be-u32 flags)      ; version 0x20400, flags
+                (co-be-u32 hashOff) (co-be-u32 identOff)  ; hashOffset, identOffset
+                (co-be-u32 0) (co-be-u32 nCode)           ; nSpecialSlots, nCodeSlots
+                (co-be-u32 codeLimit)                     ; codeLimit
+                (list 32 2 0 12)                          ; hashSize, hashType(SHA256), platform, pageLog(4096)
+                (co-be-u32 0) (co-be-u32 0)               ; spare2, scatterOffset
+                (co-be-u32 0) (co-be-u32 0)               ; teamOffset, spare3
+                (co-be-u64 0) (co-be-u64 0)               ; codeLimit64, execSegBase
+                (co-be-u64 execSegLimit) (co-be-u64 execSegFlags) ; execSegLimit, execSegFlags
+                ident (list 0)                            ; identifier + NUL
+                (co-hashes image)))))                     ; the code slots
+
+    ; the EmbeddedSignature SuperBlob: magic, totalLength, count=1; one index
+    ; (CSSLOT_CODEDIRECTORY type 0 at offset 20); then the CodeDirectory.
+    (defn co-sign (image codeLimit ident execSegLimit flags execSegFlags)
+        (do
+            (let cd (co-cd image codeLimit ident execSegLimit flags execSegFlags))
+            (co-cat (list
+                (co-magic-sb) (co-be-u32 (add 20 (len cd))) (co-be-u32 1)  ; magic, length, count
+                (co-be-u32 0) (co-be-u32 20)                               ; index: type CODEDIRECTORY, offset 20
+                cd))))
+
+    0)

--- a/form/form-stdlib/tests/codesign-band.fk
+++ b/form/form-stdlib/tests/codesign-band.fk
@@ -1,0 +1,16 @@
+; codesign-band.fk — form-codesign emits the ad-hoc Mach-O code signature (the
+; SuperBlob + CodeDirectory dyld validates). The band folds a fixed small
+; signature to a position-weighted checksum, so a divergent kernel — in sha256
+; (the code-slot hash) or in the big-endian layout — changes the number. The
+; byte-conviction (Form signature == ld's signature, byte-for-byte on a real
+; dylib) lives in scripts/form_codesign_conviction_demo.sh.
+;
+; preludes: form-stdlib/sha256.fk form-stdlib/form-codesign.fk
+
+(do
+  ; sign image [1 2 3 4 5] (codeLimit 5, one partial page), identifier "x" (120),
+  ; execSegLimit 7, flags 2 (adhoc), execSegFlags 0 — the code slot is
+  ; sha256([1,2,3,4,5]), so the fold exercises the full SHA256 recipe.
+  (let sig (co-sign (list 1 2 3 4 5) 5 (list 120) 7 2 0))
+  (defn ck (xs i) (if (eq (len xs) 0) 0 (add (mul (head xs) i) (ck (tail xs) (add i 1)))))
+  (ck sig 1))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -514,5 +514,6 @@ capability-form-div fkc 3027
 capability-form-tree fkc 13113
 inram-leaf-emit fkc 14073
 recipe-dylib fkc 787349
+codesign fks 632490
 native-code-fit fks 15
 reproduce-from-history fkc 8

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 272
+**Total files**: 273
 
 | File | Purpose |
 |---|---|
@@ -91,6 +91,7 @@
 | [form_cli_slice.sh](form_cli_slice.sh) | form_cli_slice.sh — compile a Form recipe slice to a RUNNABLE native binary, |
 | [form_cli_tiered.sh](form_cli_tiered.sh) | form_cli_tiered.sh — retire the REMOTE oracle on reasoning: local-first, tiered. |
 | [form_cli_train_predict.sh](form_cli_train_predict.sh) | form_cli_train_predict.sh — train a NATIVE tool predictor on the corpus, then |
+| [form_codesign_conviction_demo.sh](form_codesign_conviction_demo.sh) | form_codesign_conviction_demo.sh — byte-conviction for the Form code-signer. |
 | [form_coreutils_diff.sh](form_coreutils_diff.sh) | form_coreutils_diff.sh — differential test of the zero-clang Form coreutils against |
 | [form_debug_demo.sh](form_debug_demo.sh) | form_debug_demo.sh — LIVE DEBUGGING: the value trace joined with provenance. |
 | [form_diagnose_demo.sh](form_diagnose_demo.sh) | form_diagnose_demo.sh — the live-diagnosis organ on REAL channels. One fib |

--- a/scripts/form_codesign_conviction_demo.sh
+++ b/scripts/form_codesign_conviction_demo.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# form_codesign_conviction_demo.sh — byte-conviction for the Form code-signer.
+#
+# The gate that licenses dropping `ld` from the dylib path: the Form recipe
+# form-codesign (co-sign) must produce the EXACT bytes `ld` produces for the
+# same input. We build a real signed dylib, hand its [0:codeLimit] image and
+# `ld`'s own signing parameters to co-sign, and diff the result against `ld`'s
+# embedded signature. Byte-identity opens the gate — same shape as
+# form_asm_conviction_demo.sh (Form asm bytes == clang bytes).
+#
+# Form bytes == ld bytes, byte-for-byte -> the kernel signs its own binaries.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+FORM="$HERE/form"
+BIN="$FORM/form-kernel-go/bin-go"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+[ -x "$BIN" ] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+
+# 1) a real signed dylib via the system linker (the oracle).
+printf 'long recipe(long n){return n*3+7;}\n' > "$WORK/r.c"
+clang -c "$WORK/r.c" -o "$WORK/r.o"
+SDK="$(xcrun --sdk macosx --show-sdk-path)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$WORK/lib.dylib" "$WORK/r.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null
+
+# 2) extract codeLimit, ld's signing params, and ld's signature blob; emit a
+#    Form program that registers the host sha256 (the four-way recipe path is
+#    proven separately by tests/codesign-band.fk) and calls co-sign over the
+#    real [0:codeLimit] image with ld's exact parameters.
+python3 - "$WORK/lib.dylib" "$WORK/sign.fk" "$WORK/ld_blob.txt" <<'PY'
+import struct, sys
+dylib, fk_out, blob_out = sys.argv[1], sys.argv[2], sys.argv[3]
+f = bytearray(open(dylib, 'rb').read())
+ncmds = struct.unpack_from('<I', f, 16)[0]; off = 32
+sig_off = sig_sz = text_vmsize = None
+for _ in range(ncmds):
+    cmd, csz = struct.unpack_from('<II', f, off)
+    if cmd == 0x1d:                                   # LC_CODE_SIGNATURE
+        sig_off, sig_sz = struct.unpack_from('<II', f, off + 8)
+    if cmd == 0x19:                                   # LC_SEGMENT_64
+        segname = bytes(f[off+8:off+24]).split(b'\x00')[0]
+        if segname == b'__TEXT':
+            text_vmsize = struct.unpack_from('<Q', f, off + 32)[0]  # vmsize
+    off += csz
+cd = sig_off + 20
+flags = struct.unpack_from('>I', f, cd + 12)[0]
+codeLimit = struct.unpack_from('>I', f, cd + 32)[0]
+execSegLimit = struct.unpack_from('>Q', f, cd + 72)[0]
+execSegFlags = struct.unpack_from('>Q', f, cd + 80)[0]
+ioff = struct.unpack_from('>I', f, cd + 20)[0]
+ident = bytes(f[cd+ioff:f.index(b'\x00', cd+ioff)])
+image = list(f[:codeLimit])
+identlist = list(ident)
+blob = bytes(f[sig_off:sig_off + sig_sz])
+open(blob_out, 'w').write(','.join(str(b) for b in blob))
+with open(fk_out, 'w') as o:
+    o.write('(do\n')
+    o.write('  (register_jit "sha256" "sha256_bytes")\n')
+    o.write('  (co-sign (list %s) %d (list %s) %d %d %d))\n' % (
+        ' '.join(map(str, image)), codeLimit, ' '.join(map(str, identlist)),
+        execSegLimit, flags, execSegFlags))
+print("codeLimit=%d ident=%r flags=0x%x execSegLimit=0x%x execSegFlags=0x%x" % (
+    codeLimit, ident.decode(), flags, execSegLimit, execSegFlags))
+PY
+
+# 3) run the Form signer and compare to ld's blob (ld pads to 8 bytes; the
+#    SuperBlob content is what co-sign emits — compare on that length).
+"$BIN" "$FORM/form-stdlib/sha256.fk" "$FORM/form-stdlib/form-codesign.fk" "$WORK/sign.fk" 2>/dev/null \
+  | tr -dc '0-9,' | sed 's/^,//; s/,$//' > "$WORK/form_blob.txt"
+
+python3 - "$WORK/form_blob.txt" "$WORK/ld_blob.txt" <<'PY'
+import sys
+form = [int(x) for x in open(sys.argv[1]).read().split(',') if x]
+ld   = [int(x) for x in open(sys.argv[2]).read().split(',') if x]
+n = len(form)
+match = form == ld[:n]
+pad_ok = all(b == 0 for b in ld[n:])
+print("Form signature: %d bytes" % n)
+print("ld   signature: %d bytes (%d trailing pad)" % (len(ld), len(ld) - n))
+print("Form bytes == ld bytes[:%d]: %s" % (n, match))
+print("ld trailing bytes all pad-zero: %s" % pad_ok)
+if match and pad_ok:
+    print("\nCONVICTION: the Form code-signer reproduces ld's ad-hoc signature byte-for-byte.")
+    print("The gate opens — the kernel can sign its own dylibs; ld is droppable.")
+    sys.exit(0)
+print("\nMISMATCH — the gate stays shut.")
+for i, (a, b) in enumerate(zip(form, ld)):
+    if a != b:
+        print("first diff at byte %d: form=%d ld=%d" % (i, a, b)); break
+sys.exit(1)
+PY


### PR DESCRIPTION
## What this is

The **signature half** of the direct (no-`ld`) recipe-dylib path, now in Form. Apple Silicon's dyld *refuses* an unsigned dylib (proven in [#3277](https://github.com/seeker71/Coherence-Network/pull/3277)'s probing) — today `ld` supplies the ad-hoc signature. This retires that step: `form-codesign.fk` (`co-sign`) builds the ad-hoc **EmbeddedSignature SuperBlob + CodeDirectory** (v=20400) whose code slots are **SHA256 of each 4096-byte page** via `sha256.fk` — no host crypto, sovereign across cells.

## Proven both ways

- **agree** (four-way): `tests/codesign-band.fk` → **632490** across Go/Rust/TS/fkwu — the SHA256 recipe + big-endian CodeDirectory/SuperBlob layout agree across all four kernels (manifest `codesign fks 632490`).
- **convict** (byte-identity): `scripts/form_codesign_conviction_demo.sh` signs a **real dylib's `[0:codeLimit]`** and the Form blob **== `ld`'s embedded signature, byte-for-byte** (278 bytes + `ld`'s 2 trailing pad). Same shape as `form_asm_conviction_demo.sh` (Form asm bytes == clang bytes) — the gate that licenses dropping the tool.

```
Form signature: 278 bytes
ld   signature: 280 bytes (2 trailing pad)
Form bytes == ld bytes[:278]: True
CONVICTION: the Form code-signer reproduces ld's ad-hoc signature byte-for-byte.
```

## Why it matters

dyld's signing requirement was the load-bearing wall between "`ld -dylib` makes the recipe binary" and "**Form emits the recipe binary directly**." That wall is now Form. `form-to-asm.form` moves the signature from a closing cell to **realized**; the only remaining direct-dylib work is the `MH_DYLIB` structural shell (filetype + LC_ID_DYLIB + export trie + `__LINKEDIT`) that *places* this signature — no new crypto.

The conviction demo uses `clang`+`ld` only to build the **oracle** dylib it signs against; the signer itself is pure Form over `sha256.fk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)