### PR TITLE
feat(form): the transformer block crosses to the four-kernel floor — M3 numerics + M4 forward + backward, four-way 0 divergent

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-17_transformer_block_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-17_transformer_block_four_way.json
@@ -1,0 +1,34 @@
+{
+  "title": "The transformer block — M3 numerics + M4 forward + the block's backward pass — crosses to the four-kernel floor",
+  "date": "2026-06-17",
+  "advances": "form-native-models.form rung (2) 'full transformer block on the GPU': the block's MATH was proven three-way (Go/Rust/TS) against the PyTorch fp64 reference but had never been run on the emitted universal walker fkwu. Lifting it to four-way makes the whole forward+backward block a gated four-kernel invariant on every suite run — the proven floor under emitting it to Metal next to the matvec/backprop kernels already on the M4 GPU.",
+  "device": "Apple M4 Max (40-core GPU), arm64 Darwin 26.3.1 — proof is host-independent (pure fp64 arithmetic bands)",
+  "bands_lifted": [
+    {
+      "stem": "transformer-numerics",
+      "verdict": 4095,
+      "what": "M3: softmax (max-subtract stable) / layernorm (eps inside sqrt, torch shape) / gelu (tanh approx), built from exp (Taylor square-and-reduce), sqrt (fixed-count Newton), tanh (from exp) — the transcendental floor every attention+FFN block needs. Pinned to torch fp64 (softmax / layer_norm eps=1e-5 / gelu approximate='tanh'), each value reduced to int at 1e-6."
+    },
+    {
+      "stem": "transformer-block",
+      "verdict": 511,
+      "what": "M4: one whisper-shaped pre-LN block h = x + Wo*attn(LN1(x)) + bo with attn = softmax(q*k^T/sqrt(d_k))-weighted sum of v; y = h + W2*gelu(W1*LN2(h)+b1) + b2. Weights are arguments (recipe DATA all the way down). Reference: torch layer_norm -> q/k/v/out projections -> softmax(q*k^T/sqrt2) -> residual -> layer_norm -> fc2(gelu_tanh(fc1)) -> residual, T=2, d=2, FFN hidden 4."
+    },
+    {
+      "stem": "transformer-backprop",
+      "verdict": 127,
+      "what": "the block's BACKWARD pass — gradients of affine/gelu/softmax+ln/attention-core — proven against the torch fp64 reference. Forward AND backward of the transformer block now agree on all four kernels."
+    }
+  ],
+  "proof": "cd form && ./validate.sh <core + the band's prelude chain> per band -> 4095 / 511 / 127, each 'fourth arm: 1 band four-way (fkwu + pre-flattened tables)', 1 ok, 0 divergent",
+  "verdict": "FOUR-WAY (4095 / 511 / 127), 0 divergent — Go, Rust, TypeScript, and the emitted fkwu walker all reproduce the PyTorch fp64 reference for the transformer block's forward numerics and its backward pass, bit-for-bit at 1e-6.",
+  "manifest": "registered in form/fourth-arm-bands.txt as 'transformer-numerics fks 4095', 'transformer-block fks 511', 'transformer-backprop fks 127'",
+  "honest_3kernel_remainder": {
+    "stem": "transformer-block-assembly",
+    "state": "3-kernel only (511 -> three-way 63); NOT registered four-way",
+    "blocker": "fkwu SEGFAULTS on this band — a fourth-arm robustness limit, NOT a value-divergence and NOT an unsupported op family. Every op family it uses crosses four-way (the block forward 511 and backprop 127 bands use the SAME recipes and cross clean). The assembly band adds the generic typed-layer stack engine: heterogeneous layer-cells tagged by string ('attn'/'ffn'), dispatched through one tbp-stk-fwd/tbp-stk-step engine, trained 50 steps over a deeply nested list-of-layer-cells. The combination (string-tag dispatch + deep heterogeneous nesting + 50-step train recursion) overflows the walker on the largest composed pre-flattened table. Owned and tracked as a walker-emitter robustness fix (raise fkwu recursion/table capacity), not buried: the band stays out of the manifest until fkwu runs it, which is the honest 3-kernel-only state.",
+    "for_urs": "the one fourth-arm item this run could not cross is an fkwu crash on the biggest composed band, not a wrong answer — a walker capacity fix, separable from the proven block."
+  },
+  "reading": "The forward numerics and the backward pass of a real pre-LN transformer block are now four-kernel proven against PyTorch fp64. With the dequant math (Q4_K) and f16 decode already four-way, the load path and the block math both live on the four-way floor; the remaining rungs toward full real-model inference on the M4 GPU are emitting this proven block to Metal (the matvec/backprop kernels already run there), then the generation loop (tokenizer + KV cache + greedy decode). The generic typed-layer STACK that assembles many such blocks is the one piece still three-way, blocked only by fkwu's capacity on the largest table.",
+  "reproduce": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/tests/transformer-numerics-band.fk  (4095); add transformer-block.fk + its band (511); add transformer-backprop.fk + its band (127) — each four-way, 0 divergent. Run bands individually: rapid back-to-back validate.sh calls share a temp dir and can report a spurious divergence; the canonical suite isolates them."
+}

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -320,6 +320,9 @@ tensor-quant fks 4095
 q4k-dequant fks 4095
 q6k-dequant fks 4095
 f16-decode fks 4095
+transformer-numerics fks 4095
+transformer-block fks 511
+transformer-backprop fks 127
 transcendental-natives fks 16
 learning-arc fks 127
 living-equation fks 111111


### PR DESCRIPTION
## The stone

The transformer block's MATH was proven **three-way** (Go/Rust/TS) against the PyTorch fp64 reference but had never touched the emitted universal walker **fkwu**. This lifts the forward numerics **and** the backward pass to the four-kernel floor:

| band | verdict | what |
|---|---|---|
| `transformer-numerics` | **4095** | M3 — softmax / layernorm / gelu over exp(Taylor square-and-reduce) / sqrt(Newton) / tanh(from exp) — the transcendental floor every attention+FFN block needs |
| `transformer-block` | **511** | M4 — whisper-shaped pre-LN block `h = x + Wo·attn(softmax q·kᵀ/√d)·v + bo`, `y = h + W2·gelu(W1·LN2(h)+b1) + b2`, weights as recipe data |
| `transformer-backprop` | **127** | the block's gradients (affine / gelu / softmax+ln / attention-core) — forward AND backward now agree on all four kernels |

Each crosses **four-way, 0 divergent** — Go, Rust, TypeScript, and fkwu all reproduce the torch fp64 reference bit-for-bit at 1e-6. Registered in `form/fourth-arm-bands.txt`, so they're gated four-kernel invariants on every suite run.

This advances `form-native-models.form` rung (2) *full transformer block on the GPU*: the block math is now on the proven four-way floor, the floor under emitting it to Metal next to the matvec/backprop kernels already running on the M4 GPU.

## Honest 3-kernel remainder (NOT registered)

`transformer-block-assembly` — the generic typed-layer **stack** engine (string-tag dispatch `"attn"`/`"ffn"` + deep heterogeneous nesting + 50-step train recursion) **segfaults fkwu** on the largest composed table. This is **not a value-divergence** and **not an unsupported op family** — the block forward (511) and backprop (127) use the *same recipes* and cross clean. It's a walker capacity limit, owned and tracked to an fkwu robustness fix, kept out of the manifest until fkwu runs it (the honest `3-kernel only` state).

Receipt: `docs/system_audit/commit_evidence_2026-06-17_transformer_block_four_way.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>