### PR TITLE
feat(form): the export trie is a Form recipe — the last novel encoder for the no-ld dylib

### DIFF
--- a/docs/coherence-substrate/form-to-asm.form
+++ b/docs/coherence-substrate/form-to-asm.form
@@ -227,9 +227,29 @@
     (agree  "four-way Go/Rust/TS/fkwu at tests/codesign-band.fk -> 632490 (sha256 + big-endian layout agree across kernels)")
     (convict "scripts/form_codesign_conviction_demo.sh: co-sign over a real dylib's [0:codeLimit] == ld's embedded signature, byte-for-byte (278 bytes); the gate opens"))
 
+  # dlsym finds an exported symbol through the export trie, not the classic
+  # symbol table. form-export-trie.fk (et-trie) emits the LC_DYLD_EXPORTS_TRIE
+  # for one symbol at a vm address — the same root->child node shape ld emits,
+  # byte-for-byte. It is the last novel encoder for the direct (no-ld) dylib.
+  (export-trie-realized
+    (recipe "form-export-trie et-trie emits the minimal export trie (root edge = symbol name, terminal node = flags+address ULEB) — the bytes dlsym reads")
+    (agree  "four-way Go/Rust/TS/fkwu at tests/export-trie-band.fk -> 6391; reproduces ld's trie for _recipe at 0x2f0 byte-for-byte"))
+
+  # The whole signed dylib is proven buildable from scratch — zero ld, zero
+  # codesign, zero clang. A from-scratch MH_DYLIB (header + __TEXT/__LINKEDIT
+  # segments + LC_ID_DYLIB + the form-export-trie trie + LC_SYMTAB/DYSYMTAB +
+  # LC_BUILD_VERSION + LC_CODE_SIGNATURE), self-signed with the form-codesign
+  # algorithm, dlopens and runs (recipe(5)=22) on this Apple Silicon host. Every
+  # encoder it needs is now a four-way Form recipe; what remains is the assembler
+  # that composes them at the (fixed, for a _recipe leaf) Mach-O offsets.
+  (dylib-from-scratch-proven
+    (encoders "form-macho (header + segment/section + symtab LE bytes), form-export-trie (the trie), form-codesign (the ad-hoc signature) — all four-way")
+    (floor   "the minimal dlopen+dlsym-able MH_DYLIB needs 8 load commands: __TEXT, __LINKEDIT, LC_ID_DYLIB, LC_DYLD_EXPORTS_TRIE, LC_SYMTAB, LC_DYSYMTAB, LC_BUILD_VERSION, LC_CODE_SIGNATURE; code carries slack so an added signature command can't clobber it")
+    (proven  "the complete self-signed binary dlopens+calls on darwin/arm64 — the last toolchain (ld) is droppable; the open cell is form-dylib.fk assembling the proven encoders, validated by dylib_call dlopen"))
+
   # ── Closing cells — what remains beyond the realized runnable path ───
   (closing-cells
-    (recipe-dylib-direct "emit the MH_DYLIB STRUCTURE directly from Form (MH_DYLIB filetype + LC_ID_DYLIB + export trie + __LINKEDIT), then place the now-realized form-codesign signature — retiring ld from the dylib path entirely as form-elf-exec already retired it for the ELF executable; the signature half is done, the structural shell remains; and a Linux ELF ET_DYN .so (no signing) for the VPS, dlopen-proven once the Docker Linux/arm64 runner is live")
+    (form-dylib-assembler "form-dylib.fk: splice the lo-compile recipe code into the fixed MH_DYLIB template (form-macho header/segments/symtab + form-export-trie trie), append the form-codesign signature, and prove the Form-emitted dylib dlopens via dylib_call — composing proven four-way encoders at fixed offsets, no new format work; and a Linux ELF ET_DYN .so (no signing) for the VPS, dlopen-proven once the Docker Linux/arm64 runner is live")
     (live-lowering   "auto-derive the op-tagged prog from a live closure's AST (the sibling of jit.go's Go-source walker) so jit_leaf_inram fires on real single-i64 closures automatically — the band and test author the prog explicitly today, proving the emit->exec path; the converter is what makes it the default backend")
     (general-encoder "the field-into-byte encoder for high-base instructions (branches, loads,
                       stores) with carry — so any instruction encodes without a > 2^31 word")

--- a/form/form-stdlib/form-export-trie.fk
+++ b/form/form-stdlib/form-export-trie.fk
@@ -1,0 +1,46 @@
+; form-export-trie.fk — the Mach-O LC_DYLD_EXPORTS_TRIE as a Form recipe.
+;
+; dlsym finds an exported symbol in a dylib through the export trie, not the
+; classic symbol table. This emits the minimal trie for a SINGLE exported symbol
+; at a virtual address: a root node whose one child edge is the whole symbol
+; name, leading to a terminal node carrying (flags=0, address). It is the last
+; novel encoder for the direct (no-ld) recipe dylib — composed with form-macho
+; (.o/segment bytes) and form-codesign (the ad-hoc signature), Form emits the
+; whole signed dlopen-able binary with zero ld.
+;
+; Proven against ld's own trie: ld exports `_recipe` at 0x2f0 as the same
+; root->child shape this builds. Four-way by tests/export-trie-band.fk.
+;
+; et-trie (name addr) -> the trie byte-list, where `name` is the exported symbol
+; byte-list INCLUDING its leading underscore (e.g. "_recipe").
+
+(do
+    (defn et-nil? (xs) (eq (len xs) 0))
+    (defn et-app (xs ys) (if (et-nil? xs) ys (cons (head xs) (et-app (tail xs) ys))))
+    (defn et-cat (xss) (if (eq (len xss) 1) (head xss) (et-app (head xss) (et-cat (tail xss)))))
+
+    ; unsigned LEB128: 7 bits per byte, low byte first, high bit = continue.
+    (defn et-uleb (n) (if (lt n 128) (list n)
+                          (cons (add (mod n 128) 128) (et-uleb (div n 128)))))
+
+    ; pad a byte-list up with zeros to a multiple of 8 (ld aligns the trie).
+    (defn et-zeros (n) (if (eq n 0) (list) (cons 0 (et-zeros (sub n 1)))))
+    (defn et-pad8 (xs) (et-app xs (et-zeros (sub (mul (div (add (len xs) 7) 8) 8) (len xs)))))
+
+    ; the terminal (child) node: terminalSize, then (flags=0, address ULEB),
+    ; then childCount=0.
+    (defn et-child (addr)
+        (do (let term (et-app (et-uleb 0) (et-uleb addr)))
+            (et-cat (list (list (len term)) term (list 0)))))
+
+    ; the whole trie: root node (terminalSize=0, childCount=1, edge=name+NUL,
+    ; childNodeOffset) then the terminal node. childOffset = length of the root
+    ; node = 2 + (len name + 1) + width(ULEB childOffset); for any name under
+    ; ~123 bytes the offset is a single ULEB byte, so childOffset = 4 + len name.
+    (defn et-trie (name addr)
+        (do (let sym (et-app name (list 0)))
+            (let childOff (add 4 (len name)))
+            (let root (et-cat (list (list 0 1) sym (et-uleb childOff))))
+            (et-pad8 (et-app root (et-child addr)))))
+
+    0)

--- a/form/form-stdlib/tests/export-trie-band.fk
+++ b/form/form-stdlib/tests/export-trie-band.fk
@@ -1,0 +1,13 @@
+; export-trie-band.fk — form-export-trie emits the LC_DYLD_EXPORTS_TRIE that
+; dlsym reads to find an exported symbol. The band folds the trie for `_recipe`
+; at address 0x200 to a position-weighted checksum, so a divergent kernel (ULEB
+; or node layout) changes the number. These are the exact bytes ld emits for the
+; same symbol and the bytes the proven self-signed recipe dylib carries.
+;
+; preludes: form-stdlib/form-export-trie.fk
+
+(do
+  ; _recipe = 95 114 101 99 105 112 101, exported at vm address 512 (0x200).
+  (let trie (et-trie (list 95 114 101 99 105 112 101) 512))
+  (defn ck (xs i) (if (eq (len xs) 0) 0 (add (mul (head xs) i) (ck (tail xs) (add i 1)))))
+  (ck trie 1))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -518,5 +518,6 @@ capability-form-tree fkc 13113
 inram-leaf-emit fkc 14073
 recipe-dylib fkc 787349
 codesign fks 632490
+export-trie fkc 6391
 native-code-fit fks 15
 reproduce-from-history fkc 8


### PR DESCRIPTION
## What this is

`dlsym` finds an exported symbol in a dylib through the Mach-O **export trie**, not the classic symbol table. `form-export-trie.fk` (`et-trie`) emits `LC_DYLD_EXPORTS_TRIE` for one symbol at a vm address — the same root→child node shape `ld` emits, **byte-for-byte** (verified against `ld`'s `_recipe` trie at 0x2f0). Four-way Go/Rust/TS/fkwu at `tests/export-trie-band.fk` → **6391**.

## The wall is down

This is the **last novel encoder** for the direct (no-`ld`) recipe dylib. With it, a from-scratch `MH_DYLIB` — self-signed with the `form-codesign` algorithm — **dlopens and runs `recipe(5)=22`** on this Apple Silicon host, with zero `ld`, zero `codesign`, zero `clang`.

Every encoder the dylib needs is now a four-way Form recipe: form-macho (header/segment/symtab, 31), form-export-trie (the trie, 6391), form-codesign (ad-hoc signature, 632490).

## The proven floor

`form-to-asm.form` records the minimal dlopen+dlsym-able dylib: **8 load commands**, with code carrying slack so an added signature command can't clobber it (a real bug I hit and fixed in the prototype). The one open cell is named: `form-dylib.fk`, the assembler that composes these proven encoders at fixed Mach-O offsets — validated by `dylib_call` dlopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
