### PR TITLE
feat(form): a zero-clang `wc -l` — itoa closes the number-in/number-out symmetry

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 273 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 274 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-cli-offline.md
+++ b/docs/coherence-substrate/form-cli-offline.md
@@ -166,10 +166,11 @@ encoding table as a recipe). The **slice lane** (+ [`form-macho.fk`](../../form/
 carries real unix commands end to end, **zero clang**: the syscall / byte-I/O set
 (`svc`, 64-bit `movz`/`movk`, `ldrb`/`strb`, stack frame), the read-loop control flow
 (`cmp`, the EOF branch, the backward loop branch), and the branchless transform
-(`cmp`+`csel`), a callee-saved line counter, **argv** (`ldr [x1,#8]`), and **atoi**
-(a `mul`-by-10 digit loop, so `head N` reads its real count) — proven four-way at
+(`cmp`+`csel`), a callee-saved line counter, **argv** (`ldr [x1,#8]`), **atoi**
+(a `mul`-by-10 digit loop, so `head N` reads its real count), and **itoa** (`udiv`/
+`mul`/`sub` digits out, so `wc -l` prints a number) — proven four-way at
 `form-asm-syscall`, `form-asm-branch`, `form-asm-tr` (31), and `form-asm-rot13`,
-`form-asm-headn`, `form-asm-echo` (7).
+`form-asm-headn`, `form-asm-echo`, `form-asm-wc` (7).
 
 ```bash
 scripts/form_cat_demo.sh    # a zero-clang `cat`
@@ -177,17 +178,22 @@ scripts/form_tr_demo.sh     # a zero-clang `tr A-Z a-z`
 scripts/form_rot13_demo.sh  # a zero-clang `rot13`
 scripts/form_echo_demo.sh   # a zero-clang `echo $1` — reads argv
 scripts/form_headn_demo.sh  # a zero-clang `head N` — N parsed from argv
+scripts/form_wc_demo.sh     # a zero-clang `wc -l` — prints the count
 ```
 
 Form encodes the program (`cat` = loop `read(0)`→`write(1)`; `tr`/`rot13` = that
-plus a branchless per-byte transform; `head N` = that plus a line counter, with N
-atoi'd from `argv[1]`), `ld` links it (**no clang**), and the binary runs through
-the OS read/write syscalls. Measured: `cat` round-trips stdin→stdout, Form `tr`
-matches the system `tr A-Z a-z`, Form `rot13` matches the system rot13 and is its
-own inverse, Form `echo` matches `echo`, and Form `head N` matches `head -n N` for
-N∈{1,2,3,5,8} — all **byte-for-byte**. clang only assembled the same instructions
-as the byte oracle; the ARM/LLVM spec derived the encodings. `tr`/`rot13`/`head`/
-`echo`/`atoi` each added **no new encoder** beyond `ldr` — only data rows.
+plus a branchless per-byte transform; `head N` = that plus a line counter, N
+atoi'd from `argv[1]`; `wc -l` = count newlines, itoa the count out), `ld` links it
+(**no clang**), and the binary runs through the OS read/write syscalls. Measured
+byte-for-byte: `cat` round-trips stdin→stdout, Form `tr` matches `tr A-Z a-z`, Form
+`rot13` matches rot13 and is its own inverse, Form `echo` matches `echo`, Form
+`head N` matches `head -n N`, and Form `wc -l` matches `/usr/bin/wc -l` **including
+BSD's right-justified 8-char padding** — a format read from the real tool, not
+invented (the grounding earning its keep). clang only assembled the same
+instructions as the byte oracle; the ARM/LLVM spec derived the encodings.
+`tr`/`rot13`/`head`/`echo`/`atoi`/`wc`/`itoa` each added **no new encoder** beyond
+`ldr` — only data rows. (`wc`'s fixed-8 field matches BSD up to 8-digit counts; BSD
+widens beyond — a named bound, not pretended.)
 
 `rot13` added **no new encoder** — its two-range rotation is `sub`/`add`/`cmp`/`csel`
 data rows — so the earlier **C-emit byte-filter lane composted**: every common filter

--- a/form/form-stdlib/tests/form-asm-wc-band.fk
+++ b/form/form-stdlib/tests/form-asm-wc-band.fk
@@ -1,0 +1,71 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk
+;
+; form-asm-wc-band — a zero-clang `wc -l`, proven four-way against the assembler.
+; This closes the read-number / print-number symmetry: head atoi'd a count IN;
+; wc counts newlines and itoa's the count OUT. The new piece is itoa, and it adds
+; NO new encoder — udiv/mul/sub/mov register forms already in the table:
+;   q = n/10 (udiv); r = n - q*10 (mul + sub); digit = r+'0'; emit right-to-left.
+;
+; The output format is read FROM the real BSD `wc -l`, not invented: the count is
+; right-justified in an 8-char space-padded field + newline (9 bytes) — e.g.
+; "       3\n", "   12345\n". The recipe fills 8 spaces, writes the digits backward
+; into the field's right edge, then a newline, and writes all 9 bytes at once.
+; Matched byte-for-byte vs /usr/bin/wc -l for counts 0,1,7,12,123,1234 —
+; form_wc_demo.sh. (Bound: the fixed-8 field matches BSD up to 8-digit counts; BSD
+; widens beyond, ours would need the dynamic field — named, not pretended.)
+;
+; Verdict 7 when:
+;   1   the whole 188-byte wc image byte-equals clang's (the conviction gate)
+;   2   the itoa core is exact: udiv, mul, sub (register), mov w19,w11 (register orr)
+;   4   the field-fill (strb at offsets) and the right-justified write are exact
+
+(do
+    (let img (fa-image (list
+        (fa-sub-x-imm 31 31 32) (fa-movz 19 0)
+        (fa-movz-x 0 0) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1) (fa-movz-x 16 3) (fa-movk-x-16 16 512) (fa-svc 128)
+        (fa-cmp-x 0 0) (fa-bcond 13 6)
+        (fa-ldrb 8 31 0) (fa-cmp 8 10) (fa-bcond 1 -10) (fa-add 19 19 1) (fa-b-off -12)
+        (fa-add-x-imm 10 31 8) (fa-movz 8 32)
+        (fa-strb 8 10 0) (fa-strb 8 10 1) (fa-strb 8 10 2) (fa-strb 8 10 3)
+        (fa-strb 8 10 4) (fa-strb 8 10 5) (fa-strb 8 10 6) (fa-strb 8 10 7)
+        (fa-movz 8 10) (fa-strb 8 10 8)
+        (fa-add-x-imm 9 10 8) (fa-movz 20 10)
+        (fa-udiv 11 19 20) (fa-mul 12 11 20) (fa-sub-r 13 19 12) (fa-add 13 13 48)
+        (fa-sub-x-imm 9 9 1) (fa-strb 13 9 0) (fa-mov 19 11) (fa-cmp 19 0) (fa-bcond 1 -8)
+        (fa-movz-x 0 1) (fa-add-x-imm 1 10 0) (fa-movz-x 2 9) (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+        (fa-movz 0 0) (fa-add-x-imm 31 31 32) (fa-ret))))
+
+    (let ref (list 255 131 0 209 19 0 128 82
+                   0 0 128 210 225 3 0 145
+                   34 0 128 210 112 0 128 210
+                   16 64 160 242 1 16 0 212
+                   31 0 0 241 205 0 0 84
+                   232 3 64 57 31 41 0 113
+                   193 254 255 84 115 6 0 17
+                   244 255 255 23 234 35 0 145
+                   8 4 128 82 72 1 0 57
+                   72 5 0 57 72 9 0 57
+                   72 13 0 57 72 17 0 57
+                   72 21 0 57 72 25 0 57
+                   72 29 0 57 72 1 128 82
+                   72 33 0 57 73 33 0 145
+                   84 1 128 82 107 10 212 26
+                   108 125 20 27 109 2 12 75
+                   173 193 0 17 41 5 0 209
+                   45 1 0 57 243 3 11 42
+                   127 2 0 113 1 255 255 84
+                   32 0 128 210 65 1 0 145
+                   34 1 128 210 144 0 128 210
+                   16 64 160 242 1 16 0 212
+                   0 0 128 82 255 131 0 145
+                   192 3 95 214))
+
+    (let c0 (if (fa-conviction img ref) 1 0))
+    (let c1 (if (fa-conviction (fa-udiv 11 19 20) (list 107 10 212 26))
+            (if (fa-conviction (fa-mul 12 11 20) (list 108 125 20 27))
+            (if (fa-conviction (fa-sub-r 13 19 12) (list 109 2 12 75))
+            (if (fa-conviction (fa-mov 19 11) (list 243 3 11 42)) 2 0) 0) 0) 0))
+    (let c2 (if (fa-conviction (fa-strb 8 10 7) (list 72 29 0 57))
+            (if (fa-conviction (fa-add-x-imm 1 10 0) (list 65 1 0 145)) 4 0) 0))
+
+    (add c0 (add c1 c2)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -281,6 +281,7 @@ form-asm-branch fks 31
 form-asm-tr fks 31
 form-asm-rot13 fks 7
 form-asm-headn fks 7
+form-asm-wc fks 7
 form-asm-echo fks 7
 form-constants fks 111111
 form-diagnose fks 31

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 273
+**Total files**: 274
 
 | File | Purpose |
 |---|---|
@@ -112,6 +112,7 @@
 | [form_tr_demo.sh](form_tr_demo.sh) | form_tr_demo.sh — `tr A-Z a-z`, a real unix command, built with ZERO clang and |
 | [form_union_demo.sh](form_union_demo.sh) | form_union_demo.sh — the m4e3/m4e4 union, witnessed: ONE self-contained binary |
 | [form_validate_shards.py](form_validate_shards.py) | Run Form validation workloads as parallel shards. |
+| [form_wc_demo.sh](form_wc_demo.sh) | form_wc_demo.sh — `wc -l`, built with ZERO clang and direct Form -> asm. It closes |
 | [framebuffer_viewer.py](framebuffer_viewer.py) | framebuffer_viewer.py — render the kernel's framebuffer as a text panel. |
 | [frequency_references.py](frequency_references.py) | Frequency reference corpus for the Living Collective scoring engine. |
 | [gen_bp_table.py](gen_bp_table.py) | Generate the kernel-resident bp lookup table for all three Form kernels. |

--- a/scripts/form_wc_demo.sh
+++ b/scripts/form_wc_demo.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# form_wc_demo.sh — `wc -l`, built with ZERO clang and direct Form -> asm. It closes
+# the read-number / print-number symmetry: head atoi'd a count IN; wc counts
+# newlines and itoa's the count OUT. itoa adds NO new encoder — udiv/mul/sub/mov
+# register forms already in the table. The output format is read FROM the real BSD
+# `wc -l` (count right-justified in an 8-char space-padded field + newline, 9 bytes),
+# not invented — the recipe fills 8 spaces, writes the digits backward into the
+# field's right edge, and writes all 9 bytes at once. Oracle: /usr/bin/wc -l.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS demo; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/fwc.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+PROG='(fa-image (list
+    (fa-sub-x-imm 31 31 32) (fa-movz 19 0)
+    (fa-movz-x 0 0) (fa-add-x-imm 1 31 0) (fa-movz-x 2 1) (fa-movz-x 16 3) (fa-movk-x-16 16 512) (fa-svc 128)
+    (fa-cmp-x 0 0) (fa-bcond 13 6)
+    (fa-ldrb 8 31 0) (fa-cmp 8 10) (fa-bcond 1 -10) (fa-add 19 19 1) (fa-b-off -12)
+    (fa-add-x-imm 10 31 8) (fa-movz 8 32)
+    (fa-strb 8 10 0) (fa-strb 8 10 1) (fa-strb 8 10 2) (fa-strb 8 10 3)
+    (fa-strb 8 10 4) (fa-strb 8 10 5) (fa-strb 8 10 6) (fa-strb 8 10 7)
+    (fa-movz 8 10) (fa-strb 8 10 8)
+    (fa-add-x-imm 9 10 8) (fa-movz 20 10)
+    (fa-udiv 11 19 20) (fa-mul 12 11 20) (fa-sub-r 13 19 12) (fa-add 13 13 48)
+    (fa-sub-x-imm 9 9 1) (fa-strb 13 9 0) (fa-mov 19 11) (fa-cmp 19 0) (fa-bcond 1 -8)
+    (fa-movz-x 0 1) (fa-add-x-imm 1 10 0) (fa-movz-x 2 9) (fa-movz-x 16 4) (fa-movk-x-16 16 512) (fa-svc 128)
+    (fa-movz 0 0) (fa-add-x-imm 31 31 32) (fa-ret)))'
+
+{ sed '$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<DRV
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (print (str_concat "MACHO " (hxb (mo-object $PROG))))
+    0)
+DRV
+} > "$work/d.fk"
+hex="$(cd "$FORM" && "$GO" "$work/d.fk" 2>/dev/null | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; exit 1; }
+echo "$hex" | xxd -r -p > "$work/wc.o"
+SDK="$(xcrun --show-sdk-path 2>/dev/null)"
+ld -arch arm64 -platform_version macos 13.0 13.0 -L"$SDK/usr/lib" -lSystem -o "$work/wc" "$work/wc.o" 2>/dev/null
+
+echo "── wc -l, zero clang, vs the real /usr/bin/wc -l (byte-for-byte incl. the padding) ──"
+pass=0; total=0
+for n in 0 1 7 42 123 1234; do
+    if [ "$n" = 0 ]; then printf 'no trailing newline' > "$work/in"; else yes 2>/dev/null | head -n "$n" > "$work/in"; fi
+    "$work/wc"   < "$work/in" > "$work/got"
+    /usr/bin/wc -l < "$work/in" > "$work/want"
+    total=$((total+1))
+    if cmp -s "$work/got" "$work/want"; then pass=$((pass+1)); printf "  ok   %-5s -> [%s]\n" "$n" "$(tr '\n' '/' <"$work/got")"
+    else printf "  DIFF %-5s form[%s] bsd[%s]\n" "$n" "$(od -An -c <"$work/got"|tr -s ' ')" "$(od -An -c <"$work/want"|tr -s ' ')"; fi
+done
+echo
+if [[ "$pass" -eq "$total" ]]; then
+    echo "  $pass/$total — Form \`wc -l\` matches /usr/bin/wc -l byte-for-byte, padding and all."
+    echo "  itoa out + atoi in (head N) closes the number-in/number-out symmetry, zero new encoder."
+else echo "  FAIL: $pass/$total"; exit 1; fi


### PR DESCRIPTION
The atoi↔itoa pair completes: `head` reads a count **in** (atoi), `wc -l` counts newlines and prints the count **out** (itoa). itoa adds **no new encoder** — `udiv`/`mul`/`sub`/`mov` register forms already in the table:

```
q = n/10 (udiv); r = n - q*10 (mul + sub); digit = r+'0'; emit right-to-left
```

## Grounding earned its keep

The output format was **read from the real BSD `wc -l`**, not invented: the count is right-justified in an **8-char space-padded field + newline** (9 bytes) — `       3\n`, `   12345\n`. My instinct (bare `3\n`) would have diverged from the local tool; checking the real one caught it. The recipe fills 8 spaces, writes the digits backward into the field's right edge, and writes all 9 bytes at once.

## Proof

**`form-asm-wc fks 7`** — the 188-byte image byte-equals clang's (itoa core + field-fill exact). `scripts/form_wc_demo.sh`:

```
  ok   0     -> [       0/]    ok   1   -> [       1/]    ok   7    -> [       7/]
  ok   42    -> [      42/]    ok   123 -> [     123/]    ok   1234 -> [    1234/]
  6/6 — matches /usr/bin/wc -l byte-for-byte, padding and all.
```

Bound named honestly: the fixed-8 field matches BSD up to 8-digit counts; BSD widens beyond. `form-asm.fk` untouched — pure data rows.

## Next

`tr SET1 SET2` (the general translate — reads its sets from argv, then `-d`/`-s`/`[:classes:]` from the catalog), then `cat FILE` (`openat` + the missing-file error path). No `api`/`web` — no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)