### PR TITLE
feat(form): RAG memory grounds the form-cli loop — the offline oracle reasons with the body

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 274 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 276 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-06-17_rag_grounds_the_loop.json
+++ b/docs/system_audit/commit_evidence_2026-06-17_rag_grounds_the_loop.json
@@ -1,0 +1,25 @@
+{
+  "title": "RAG memory wired into the form-cli loop — the offline oracle reasons WITH the body, and all the Codex logs are tapped",
+  "date": "2026-06-17",
+  "follows": "commit_evidence_2026-06-17_offline_semantic_memory.json (rag-retrieve.fk four-way + the standalone form_cli_rag.py). This closes the loop: the memory now feeds the runner automatically, and the second half of the session history (Codex) is tapped for training.",
+  "device": "Apple M4 Max, 128 GB, arm64 Darwin — fully offline once the embed + chat models are pulled",
+  "advances": [
+    {
+      "what": "Body memory grounds the form-cli runner",
+      "detail": "form_native_run.sh builds a self-guidance string (Form-computed tool prediction) and prepends it to the oracle prompt via fnr-run-guided. It now also injects BODY MEMORY: rag-retrieve.fk (four-way) ranks the 994-doc index for the task, and the nearest recipes/specs/concepts are appended to the guide, so the offline local oracle reasons WITH the body instead of blind. Gated on the local index + embedder (FNR_RAG=0 disables); graceful when absent. The retrieval ranking is the proven Form recipe; form_cli_rag.py serves it (new 'context' mode emits a terse grounding block).",
+      "proof": "form_native_run.sh on a routing task emits '[body-memory: form/form-stdlib/form-cli-loop.fk ...]' on stderr — the loop received the right body docs as grounding, fully offline."
+    },
+    {
+      "what": "All the Codex logs tapped (the 'use all the session logs' half)",
+      "detail": "scripts/codex_corpus.py reads the Codex rollout format ({type:response_item, payload:{type:message|...}}) the Claude extractor cannot, pairing each genuine user task with the following assistant message into MLX chat instruction pairs. From 16,025 sessions it yielded 2,003 unique non-boilerplate pairs (global dedup on the task's first 120 chars; most sessions open with identical boilerplate, so unique-task yield is far below session count — correct, not a bug). Combined with the 937 Claude pairs: 2,538 train / 283 valid, deduped.",
+      "honest": "Codex tool names (exec_command, write_stdin) differ from Claude's (Bash/Read/Edit), so these pairs train REASONING/voice, not the tool-predictor (which stays the validated frozen model). A v2 LoRA on the combined corpus is a background experiment, reported separately."
+    }
+  ],
+  "honest_remainder": {
+    "small_model_ceiling": "the offline oracle in the demo is llama3.2:3b — its tool-loop choices are weak; the grounding injection is what this proves, not the 3B's agency. A larger local model (qwen2.5:72b, deepseek-r1:32b) uses the identical grounding.",
+    "embedder_latency": "each grounded run adds one local embed call (~100ms) + a python L1 rank; fine for the offline loop, FNR_RAG=0 opts out.",
+    "codex_yield": "global dedup suppressed the bulk; a per-session or semantic dedup would surface more, at the cost of cross-session boilerplate. Named, not silently capped."
+  },
+  "verdict": "The offline form-cli loop now grounds its local oracle in the body's own memory by default, and both halves of the session history (Claude + Codex) are tapped. The offline mind has memory, in the loop, with nothing reaching the network.",
+  "reproduce": "scripts/form_cli_rag.py build  |  FNR_RAG=1 bash scripts/form_native_run.sh 'how does the form-cli route to a local oracle, then echo DONE' 'ollama run llama3.2:3b' 2  -> '[body-memory: ...]' on stderr  |  scripts/codex_corpus.py -> N pairs"
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 274
+**Total files**: 276
 
 | File | Purpose |
 |---|---|
@@ -50,6 +50,7 @@
 | [clear_queue_and_start_flow.sh](clear_queue_and_start_flow.sh) | Clear agent task queue and reset PM so the next pipeline run starts in the right order |
 | [cluster_watch_history.py](cluster_watch_history.py) | Cluster a YouTube/podcast watch-history into main influences. |
 | [code_tool_learning_receipt.py](code_tool_learning_receipt.py) | Emit a bounded code-tool-learning coding-act receipt for a committed turn. |
+| [codex_corpus.py](codex_corpus.py) | codex_corpus.py — tap the local Codex session logs into (task -> response) pairs. |
 | [coh_substrate.py](coh_substrate.py) | coh substrate — unified CLI for the coherence-substrate. |
 | [coherence_reach.py](coherence_reach.py) | coherence_reach — measure where an identity is named across the body. |
 | [compost_resonance_noise.py](compost_resonance_noise.py) | One-shot data cleanup — compost dead-tissue presences and re-attune. |

--- a/scripts/codex_corpus.py
+++ b/scripts/codex_corpus.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""codex_corpus.py — tap the local Codex session logs into (task -> response) pairs.
+
+The form-cli corpus (form_cli_capture.sh) reads Claude Code transcripts. The other
+half of the body's session history lives in ~/.codex as Codex rollouts — a different
+shape: {type:"response_item", payload:{type:"message"|"reasoning"|"function_call"|
+"function_call_output", role, content}}. This carrier pairs each genuine user task
+with the assistant message that follows, into the MLX chat instruction shape a local
+model trains on. It is the "use ALL the session logs" half the Claude extractor can't
+read — a host-IO bootstrap until the kernel reads session ledgers natively.
+
+Honest yield: pairs are deduped globally by the user message's first 120 chars, and
+boilerplate openings (AGENTS.md / permissions / worktree-context dumps) are filtered.
+Most Codex sessions open with near-identical boilerplate, so the unique-task yield is
+far smaller than the session count — that is correct (duplicates are not new signal),
+not a bug. Reasoning/tool-call payloads are skipped; only message turns pair.
+
+Usage: codex_corpus.py [--out PATH] [--per-session N] [--cap TOTAL]
+"""
+from __future__ import annotations
+import argparse, glob, json, os
+
+ROOTS = [os.path.expanduser("~/.codex/sessions"), os.path.expanduser("~/.codex/archived_sessions")]
+BOILER = ("AGENTS.md instructions", "<permissions instructions>", "Repo/worktree context",
+          "Global Codex", "<INSTRUCTIONS>", "# Coherence Network")
+
+
+def _text(payload: dict) -> str:
+    c = payload.get("content")
+    if isinstance(c, list):
+        return " ".join(p.get("text", "") for p in c if isinstance(p, dict))
+    if isinstance(c, str):
+        return c
+    return payload.get("text", "") or ""
+
+
+def _boiler(t: str) -> bool:
+    return any(b in t[:200] for b in BOILER)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=os.path.expanduser("~/.coherence-network/codex-pairs.jsonl"))
+    ap.add_argument("--per-session", type=int, default=6)
+    ap.add_argument("--cap", type=int, default=14000)
+    args = ap.parse_args()
+
+    files = []
+    for r in ROOTS:
+        files += glob.glob(os.path.join(r, "**", "rollout*.jsonl"), recursive=True)
+    print(f"{len(files)} codex sessions", flush=True)
+
+    n = 0; seen: set[int] = set()
+    with open(args.out, "w") as out:
+        for fi, f in enumerate(files):
+            if n >= args.cap:
+                break
+            per = 0; last_user = None
+            try:
+                for line in open(f, encoding="utf-8", errors="ignore"):
+                    if per >= args.per_session:
+                        break
+                    try:
+                        rec = json.loads(line)
+                    except Exception:
+                        continue
+                    if rec.get("type") != "response_item":
+                        continue
+                    p = rec.get("payload", {})
+                    if p.get("type") != "message":
+                        continue
+                    role = p.get("role"); t = _text(p).strip()
+                    if role == "user":
+                        last_user = t if (8 < len(t) < 2000 and not _boiler(t)) else None
+                    elif role == "assistant" and last_user and len(t) > 30:
+                        key = hash(last_user[:120])
+                        if key not in seen:
+                            seen.add(key)
+                            out.write(json.dumps({"messages": [
+                                {"role": "user", "content": last_user[:2000]},
+                                {"role": "assistant", "content": t[:2000]}]}) + "\n")
+                            n += 1; per += 1
+                        last_user = None
+            except Exception:
+                continue
+            if fi % 2000 == 0:
+                print(f"  ...{fi} sessions, {n} pairs", flush=True)
+    print(f"[codex corpus: {n} instruction pairs -> {args.out}]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/form_cli_rag.py
+++ b/scripts/form_cli_rag.py
@@ -109,6 +109,8 @@ def main() -> int:
     b = sub.add_parser("build"); b.add_argument("--index", default=INDEX)
     s = sub.add_parser("search"); s.add_argument("question")
     s.add_argument("-k", type=int, default=5); s.add_argument("--index", default=INDEX)
+    c = sub.add_parser("context"); c.add_argument("question")
+    c.add_argument("-k", type=int, default=3); c.add_argument("--index", default=INDEX)
     a = sub.add_parser("ask"); a.add_argument("question")
     a.add_argument("-k", type=int, default=5); a.add_argument("-m", "--model", default="qwen2.5:72b")
     a.add_argument("--index", default=INDEX)
@@ -118,6 +120,11 @@ def main() -> int:
     if args.cmd == "search":
         for h in retrieve(args.question, args.index, args.k):
             print(f"{h['id']}\t{h['kind']}")
+        return 0
+    if args.cmd == "context":
+        # grounding block for the form-cli loop's guide: nearest body docs, terse
+        for h in retrieve(args.question, args.index, args.k):
+            print(f"[{h['id']}] {' '.join(h['snippet'].split())[:280]}")
         return 0
     hits = retrieve(args.question, args.index, args.k)
     print("── retrieved (Form-ranked: rag-retrieve.fk) ──")

--- a/scripts/form_native_run.sh
+++ b/scripts/form_native_run.sh
@@ -35,6 +35,20 @@ if [[ "${FNR_NO_GUIDE:-0}" != "1" && -f "$STD/form-cli-guide.fk" ]]; then
     [[ -n "$g" && "$g" != "null" ]] && GUIDE="$g\n\n"
 fi
 
+# ── body memory: ground the oracle in the nearest recipes/specs/concepts ──
+# rag-retrieve.fk (four-way) ranks the body index; the carrier serves the nearest
+# docs so the offline oracle reasons WITH the body instead of blind. Gated: needs
+# the local index (scripts/form_cli_rag.py build) + a local embedder; FNR_RAG=0
+# disables. Joined to one line (no newlines/quotes) so the Form string stays intact.
+RAG_INDEX="$HOME/.coherence-network/rag-index/index.jsonl"
+if [[ "${FNR_RAG:-1}" != "0" && -f "$RAG_INDEX" ]]; then
+    mem="$(python3 "$ROOT/scripts/form_cli_rag.py" context "$TASK" -k 3 2>/dev/null | tr '\n' '|' | tr '"' "'")"
+    if [[ -n "$mem" ]]; then
+        GUIDE="${GUIDE}From the body (cite if used): ${mem}\n\n"
+        printf '  [body-memory: %s]\n' "$(printf '%s' "$mem" | cut -c1-70)" >&2
+    fi
+fi
+
 { cat "$STD/form-native-run.fk"
   if [[ -n "$GUIDE" ]]; then
       echo "(print (fnr-run-guided \"$(esc "$TASK")\" \"$(esc "$ORACLE")\" $MAX \"$(esc "$GUIDE")\"))"


### PR DESCRIPTION
Follows #3285 (rag-retrieve.fk four-way + standalone form_cli_rag.py). This **closes the loop**: the memory now feeds the runner automatically, and the second half of the session history is tapped.

## Body memory grounds the runner
`form_native_run.sh` already prepends Form-computed tool guidance to the oracle prompt. It now also injects **body memory** — `rag-retrieve.fk` (four-way) ranks the 994-doc index for the task and the nearest recipes/specs/concepts are appended to the guide, so the offline local oracle reasons **with** the body instead of blind.
- Gated on a local index + embedder; `FNR_RAG=0` disables; graceful when absent.
- `form_cli_rag.py` gains a `context` mode (terse grounding block).
- **Proof**: the runner emits `[body-memory: form/form-stdlib/form-cli-loop.fk ...]` for a routing task, fully offline. `form_cli_preflight.sh` stays **8/8 READY**.

## All the session logs tapped
`scripts/codex_corpus.py` reads the Codex rollout format the Claude extractor can't (`{type:response_item, payload:{type:message|...}}`), pairing user task → assistant response. **2,003 unique** non-boilerplate pairs from 16,025 sessions (global dedup; most sessions open with identical boilerplate, so unique-task yield ≪ session count — correct). Combined with Claude: **2,538 train / 283 valid**.

Honest: Codex tool names differ from Claude's, so these train **reasoning/voice**, not the tool-predictor (which stays the validated frozen model). A v2 LoRA on the combined corpus is a background experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)