### PR TITLE
feat(form): the offline mind closes its own gap — gcd, drafted by a local oracle, four-way

### DIFF
--- a/form/form-stdlib/gcd.fk
+++ b/form/form-stdlib/gcd.fk
@@ -1,0 +1,19 @@
+; gcd.fk — greatest common divisor by subtractive Euclid.
+;
+; (gcd a b) for two positive integers: if a equals b the answer is a; otherwise
+; subtract the smaller from the larger and recurse. No modulo (the kernel has
+; none) — repeated subtraction is the whole algorithm. Integers only.
+;
+; Provenance: this recipe was DRAFTED OFFLINE by the local coder oracle
+; (ollama run coder) closing the 'gcd' gap via scripts/form_cli_close_gap.sh —
+; the local kernel validated it, no remote oracle touched. The body absorbing a
+; recipe its own offline mind wrote is the form-cli flywheel made concrete.
+;
+; Proven by: form-stdlib/tests/gcd-band.fk (four-way at validate.sh).
+
+(defn gcd (a b)
+    (if (eq a b)
+        a
+        (if (gt a b)
+            (gcd (sub a b) b)
+            (gcd a (sub b a)))))

--- a/form/form-stdlib/tests/gcd-band.fk
+++ b/form/form-stdlib/tests/gcd-band.fk
@@ -1,0 +1,25 @@
+; preludes: form-stdlib/gcd.fk
+;
+; gcd-band — subtractive Euclid made falsifiable, drafted offline by the local
+; coder oracle and now held to the four-kernel bar.
+;
+; The strange-minimal cases that pin the whole algorithm:
+;   (gcd 48 36) -> 12   the worked example the closer validated
+;   (gcd 17 5)  -> 1    coprime — the floor, no common factor but 1
+;   (gcd 7 7)   -> 7    the base case — a == b returns a, no recursion
+;   (gcd 1071 462) -> 21  the classic large Euclid case, many subtractions deep
+;   commutativity: (gcd 36 48) == (gcd 48 36)  — a<b and a>b reach the same answer
+;
+; Verdict 31 when every claim lands:
+;   1   the worked example          (gcd 48 36 == 12)
+;   2   coprime floors at 1         (gcd 17 5 == 1)
+;   4   the equal-args base case    (gcd 7 7 == 7)
+;   8   a deep large case           (gcd 1071 462 == 21)
+;   16  order does not matter       (gcd 36 48 == 12)
+(do
+    (let c0 (if (eq (gcd 48 36) 12) 1 0))
+    (let c1 (if (eq (gcd 17 5) 1) 2 0))
+    (let c2 (if (eq (gcd 7 7) 7) 4 0))
+    (let c3 (if (eq (gcd 1071 462) 21) 8 0))
+    (let c4 (if (eq (gcd 36 48) 12) 16 0))
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -525,3 +525,4 @@ export-trie fkc 6391
 native-code-fit fks 15
 reproduce-from-history fkc 8
 rag-retrieve fks 31
+gcd fkc 31


### PR DESCRIPTION
A live demonstration of offline self-evolution — **no remote oracle, no network**.

1. **See the gaps**: `scripts/form_cli_gaps.sh` walked the body and rendered 27 open gaps through the Form gaps recipe (26 offline-closable).
2. **Close one offline**: `scripts/form_cli_close_gap.sh "gcd" ... "ollama run coder"` — the **local** coder model drafted the missing `gcd` recipe (subtractive Euclid, since the kernel has no modulo), the **local** kernel validated `(gcd 48 36) = 12 ✓`, and the crossing ledgered `surface=local-oracle, outcome=success`. I was only the orchestrator; the recipe is the local model's.
3. **Absorb it at the real bar**: this PR elevates that local-drafted recipe to four-way. `gcd.fk` + `tests/gcd-band.fk → 31` across **Go / Rust / TS / fkwu**, 0 divergent, registered `gcd fkc 31`.

Verified correct beyond the closer's one assertion: `(gcd 17 5)=1`, `(gcd 7 7)=7`, `(gcd 1071 462)=21`, commutative.

The body absorbing a recipe its own offline mind wrote is the form-cli flywheel made concrete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)