### PR TITLE
feat(form): the self-review flywheel — internal review learns toward the oracle, measured four-way

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 276 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 277 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/form/form-stdlib/form-cli-review-gap.fk
+++ b/form/form-stdlib/form-cli-review-gap.fk
@@ -1,0 +1,55 @@
+; form-cli-review-gap.fk — the convergence metric for the self-review lane.
+;
+; preludes: form-stdlib/core.fk
+;
+; The flywheel's hardest rung: the body answers from its OWN knowledge, an INTERNAL
+; judge scores that answer, and an ORACLE (a stronger model — including Claude via
+; the CLI) scores the SAME answer. This recipe measures the GAP between the two
+; reviews. While the gap is wide the oracle is the authority; as the internal judge
+; learns the oracle's eye the gap closes, and when a majority of reviews agree
+; within tolerance the internal review has REACHED the oracle — the remote reviewer
+; can be retired. "Learn from the oracle until your own review is as good as the
+; oracle's", made a measured, four-way-proven number.
+;
+; Input: two equal-length score lists (0..100) — internal[i] and oracle[i] for the
+; same answer i. Output: per-pair gaps, total/worst gap, agreement count within a
+; tolerance, and the convergence verdict (majority within tolerance).
+;
+; Proven by: form-stdlib/tests/form-cli-review-gap-band.fk (four-way at validate.sh).
+
+(do
+    (defn frg-abs (n) (if (lt n 0) (sub 0 n) n))
+
+    ; the gap on one pair: |internal - oracle|
+    (defn frg-gap (internal oracle) (frg-abs (sub internal oracle)))
+
+    ; walk two score lists in lockstep, summing the per-pair gaps
+    (defn frg-total-gap (ins ors)
+        (if (eq (len ins) 0) 0
+            (if (eq (len ors) 0) 0
+                (add (frg-gap (head ins) (head ors))
+                     (frg-total-gap (tail ins) (tail ors))))))
+
+    ; the widest single disagreement — the worst the internal eye is still off by
+    (defn frg-worst-gap (ins ors)
+        (if (eq (len ins) 0) 0
+            (if (eq (len ors) 0) 0
+                (do (let g (frg-gap (head ins) (head ors)))
+                    (let rest (frg-worst-gap (tail ins) (tail ors)))
+                    (if (gt g rest) g rest)))))
+
+    ; a pair agrees when its gap is within tolerance
+    (defn frg-within? (internal oracle tol) (if (le (frg-gap internal oracle) tol) 1 0))
+
+    ; how many pairs agree within tolerance
+    (defn frg-agree-count (ins ors tol)
+        (if (eq (len ins) 0) 0
+            (if (eq (len ors) 0) 0
+                (add (frg-within? (head ins) (head ors) tol)
+                     (frg-agree-count (tail ins) (tail ors) tol)))))
+
+    ; CONVERGED: a majority of reviews agree within tolerance — the internal review
+    ; has reached the oracle's, so the remote reviewer is no longer needed.
+    (defn frg-converged? (ins ors tol)
+        (if (ge (add (frg-agree-count ins ors tol) (frg-agree-count ins ors tol)) (len ins)) 1 0))
+    0)

--- a/form/form-stdlib/tests/form-cli-review-gap-band.fk
+++ b/form/form-stdlib/tests/form-cli-review-gap-band.fk
@@ -1,0 +1,29 @@
+; preludes: form-stdlib/form-cli-review-gap.fk
+;
+; form-cli-review-gap-band — the self-review convergence metric, made falsifiable.
+;
+; Three answers, each scored by the INTERNAL judge and by the ORACLE:
+;   internal [80 40 90]
+;   oracle   [75 70 88]
+;   gaps      5  30   2   — the internal eye agrees on 1 and 3, is far off on 2
+; At tolerance 10 two of three reviews agree -> a majority -> CONVERGED (the internal
+; review has reached the oracle's). At the strict tolerance 1 none agree -> NOT
+; converged: convergence is a real bar, not always true.
+;
+; Verdict 63 when every claim lands:
+;   1   one-pair gap is |a-b|         (frg-gap 80 75 == 5)
+;   2   total gap sums the pairs      (== 37)
+;   4   worst gap is the widest       (== 30)
+;   8   agreement counts within tol   (tol 10 -> 2)
+;   16  majority within tol converges (tol 10 -> 1)
+;   32  a strict tol does NOT converge (tol 1 -> 0)
+(do
+    (let ins (list 80 40 90))
+    (let ors (list 75 70 88))
+    (let c0 (if (eq (frg-gap 80 75) 5) 1 0))
+    (let c1 (if (eq (frg-total-gap ins ors) 37) 2 0))
+    (let c2 (if (eq (frg-worst-gap ins ors) 30) 4 0))
+    (let c3 (if (eq (frg-agree-count ins ors 10) 2) 8 0))
+    (let c4 (if (eq (frg-converged? ins ors 10) 1) 16 0))
+    (let c5 (if (eq (frg-converged? ins ors 1) 0) 32 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -526,3 +526,4 @@ native-code-fit fks 15
 reproduce-from-history fkc 8
 rag-retrieve fks 31
 gcd fkc 31
+form-cli-review-gap fkc 63

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 276
+**Total files**: 277
 
 | File | Purpose |
 |---|---|
@@ -90,6 +90,7 @@
 | [form_cli_preflight.sh](form_cli_preflight.sh) | form_cli_preflight.sh — air-gap readiness check for the form-cli. |
 | [form_cli_rag.py](form_cli_rag.py) | form_cli_rag.py — offline semantic memory for the form-cli's local oracle. |
 | [form_cli_replay.sh](form_cli_replay.sh) | form_cli_replay.sh — measure how the native models do against the agent. |
+| [form_cli_self_review.sh](form_cli_self_review.sh) | form_cli_self_review.sh — the self-review flywheel, driven through form-cli. |
 | [form_cli_slice.sh](form_cli_slice.sh) | form_cli_slice.sh — compile a Form recipe slice to a RUNNABLE native binary, |
 | [form_cli_tiered.sh](form_cli_tiered.sh) | form_cli_tiered.sh — retire the REMOTE oracle on reasoning: local-first, tiered. |
 | [form_cli_train_predict.sh](form_cli_train_predict.sh) | form_cli_train_predict.sh — train a NATIVE tool predictor on the corpus, then |

--- a/scripts/form_cli_self_review.sh
+++ b/scripts/form_cli_self_review.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# form_cli_self_review.sh — the self-review flywheel, driven through form-cli.
+#
+# The body answers from its OWN model; an INTERNAL judge and the ORACLE (Claude via
+# the CLI by default — proof the body can be reviewed by, and learn from, its
+# strongest oracle) both score the SAME answer against the reference; the Form
+# convergence metric (form-cli-review-gap.fk) measures how close the internal review
+# is to the oracle's. While the gap is wide the oracle is the authority; when a
+# majority of reviews agree within tolerance the internal review has REACHED the
+# oracle and the remote reviewer can retire. The judges are carriers; the answer is
+# the body's own; the convergence tally is Form (four-way proven).
+#
+# Every oracle review is captured (form_cli_capture.sh) so the internal judge can be
+# trained toward it — "learn from the oracle until your own review is as good."
+#
+# Usage: form_cli_self_review.sh [N] [native] [internal-judge] [oracle-judge] [tol] [corpus]
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STD="$ROOT/form/form-stdlib"; GO="$ROOT/form/form-kernel-go/bin-go"
+N="${1:-2}"; NATIVE="${2:-ollama run coder}"; INNER="${3:-ollama run llama3.2:3b}"
+ORACLE="${4:-claude -p}"; TOL="${5:-15}"
+CORPUS="${6:-${FORM_CLI_CORPUS:-$HOME/.coherence-network/form-cli-corpus/corpus.jsonl}}"
+[[ -x "$GO" ]] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
+[[ -f "$CORPUS" ]] || { echo "no corpus at $CORPUS"; exit 1; }
+
+echo "── self-review: native ($NATIVE) reviewed by INNER ($INNER) vs ORACLE ($ORACLE) ──"
+
+PICKS="$(python3 - "$CORPUS" "$N" <<'PY'
+import json,sys
+path,n=sys.argv[1],int(sys.argv[2])
+out=[]
+for l in open(path):
+    try: r=json.loads(l)
+    except: continue
+    t=r.get("task","").strip(); a=r.get("answer","").strip()
+    if len(t)<40 or len(a)<120: continue
+    out.append(t.replace("\n"," ")[:280]+"\t"+a.replace("\n"," ")[:1200])
+    if len(out)>=n: break
+print("\n".join(out))
+PY
+)"
+[[ -n "$PICKS" ]] || { echo "no substantive (task,answer) pairs"; exit 1; }
+
+score_of(){ printf '%s' "$1" | grep -oE '[0-9]+' | head -1; }
+judge_prompt(){ printf 'You are grading. REFERENCE answer:\n%s\n\nCANDIDATE answer:\n%s\n\nHow well does the CANDIDATE cover the substance of the REFERENCE? Reply with ONLY an integer 0-100.' "$1" "$2"; }
+
+INNER_SCORES=""; ORACLE_SCORES=""; i=0
+while IFS=$'\t' read -r task agent; do
+    [[ -z "$task" ]] && continue
+    i=$((i+1))
+    # 1. the body answers from its own model (once)
+    af="$(mktemp)"; printf 'Task: %s\nGive a concise, concrete answer or approach (a few sentences).' "$task" > "$af"
+    ans="$($NATIVE < "$af" 2>/dev/null | tr '\n' ' ' | head -c 1200)"; rm -f "$af"
+    # 2. INTERNAL review (a local judge)
+    jf="$(mktemp)"; judge_prompt "$agent" "$ans" > "$jf"
+    is="$(score_of "$($INNER < "$jf" 2>/dev/null)")"; is="${is:-0}"; [[ "$is" -gt 100 ]] && is=100
+    # 3. ORACLE review (Claude via the CLI) — the SAME answer
+    os="$(score_of "$($ORACLE < "$jf" 2>/dev/null)")"; os="${os:-0}"; [[ "$os" -gt 100 ]] && os=100
+    rm -f "$jf"
+    INNER_SCORES="$INNER_SCORES $is"; ORACLE_SCORES="$ORACLE_SCORES $os"
+    printf "  %2d  inner=%3s  oracle=%3s  gap=%3s  task: %s\n" "$i" "$is" "$os" "$(( is>os ? is-os : os-is ))" "$(printf '%s' "$task" | head -c 48)"
+    # 4. capture the oracle's review so the inner judge can learn toward it
+    if [[ -x "$ROOT/scripts/form_cli_capture.sh" ]]; then
+        bash "$ROOT/scripts/form_cli_capture.sh" --gap \
+            "review answer for: $task" "internal judge scored $is; learn the oracle's eye" \
+            "oracle($ORACLE) scored this answer $os/100" "success" "$(printf '%s' "$ORACLE" | awk '{print $1}')" >/dev/null 2>&1
+    fi
+done <<< "$PICKS"
+
+# 5. the convergence metric is Form (form-cli-review-gap.fk, four-way)
+inl="$(printf '%s' "$INNER_SCORES" | sed 's/^ *//; s/  */ /g')"
+orl="$(printf '%s' "$ORACLE_SCORES" | sed 's/^ *//; s/  */ /g')"
+prog="$(mktemp)"
+{ cat "$STD/form-cli-review-gap.fk"
+  echo "(let ins (list $inl))"
+  echo "(let ors (list $orl))"
+  echo "(print (frg-total-gap ins ors))"
+  echo "(print (frg-worst-gap ins ors))"
+  echo "(print (frg-agree-count ins ors $TOL))"
+  echo "(print (len ins))"
+  echo "(print (frg-converged? ins ors $TOL))"
+} > "$prog"
+o="$("$GO" "$prog" 2>/dev/null)"; rm -f "$prog"
+TG=$(sed -n '1p' <<<"$o"); WG=$(sed -n '2p' <<<"$o"); AG=$(sed -n '3p' <<<"$o"); TT=$(sed -n '4p' <<<"$o"); CV=$(sed -n '5p' <<<"$o")
+avg(){ [[ "${2:-0}" -gt 0 ]] && echo $(( $1 / $2 )) || echo 0; }
+
+echo
+echo "── convergence of internal review toward the oracle (Form-tallied) ──"
+printf "  reviews            %s\n" "${TT:-0}"
+printf "  agree within %-3s   %s/%s\n" "$TOL" "${AG:-0}" "${TT:-0}"
+printf "  average gap        %s/100\n" "$(avg "${TG:-0}" "${TT:-0}")"
+printf "  worst gap          %s/100\n" "${WG:-0}"
+if [[ "${CV:-0}" == "1" ]]; then
+    echo "  CONVERGED — the internal review reached the oracle's; the remote reviewer can retire."
+else
+    echo "  NOT YET — the internal review is still learning the oracle's eye (the frontier; captured to train it)."
+fi


### PR DESCRIPTION
The hardest rung of offline self-evolution, made a measured instrument — and proof that **form-cli can call Claude**.

## The loop
The body answers from its **own** model; an **internal** judge and the **oracle** (`claude -p` by default) both score the **same** answer against the reference; `form-cli-review-gap.fk` measures how close the internal review is to the oracle's. When a majority agree within tolerance, the internal review has **reached** the oracle and the remote reviewer retires — *"learn from the oracle until your own review is as good"*, as a number.

## Proof
- `form-cli-review-gap.fk` + `tests/form-cli-review-gap-band.fk` → **63 four-way** (Go/Rust/TS/fkwu), 0 divergent (`form-cli-review-gap fkc 63`).
- `scripts/form_cli_self_review.sh` runs it live and **calls Claude through the CLI** as the reviewing oracle. First run (2 corpus tasks): native=`coder` answers, inner=`llama3.2:3b` reviews (60, 43), **oracle=`claude -p` reviews (5, 0)** → avg gap **49/100**, **NOT YET converged**.

That gap is the honest floor: the small internal judge is far from Claude's eye. Every oracle review is captured (`form_cli_capture.sh`) to train the internal judge toward it. The flywheel turns: as the gap closes, form-cli stops needing the remote reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)