### PR TITLE
feat(form-cli): one-command Mac onboarding — clone the body, run the kernel, pick a provider, question local docs

### DIFF
--- a/bin/form-cli
+++ b/bin/form-cli
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# form-cli — the one door into the Form-native organism.
+#
+# Everything routes through here: ask a question (answered local-first, grounded
+# in the body's recipes/specs/concepts and any local docs you index), see your own
+# open gaps, close one offline with a local oracle, review your own thinking
+# against an oracle, run the self-guided agent loop, or evaluate a Form expression
+# directly on the kernel. Local-first by design — a remote oracle (incl. Claude via
+# `claude -p`) is consulted only to review, never required to answer.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GO="$ROOT/form/form-kernel-go/bin-go"
+RAG="$ROOT/scripts/form_cli_rag.py"
+
+usage() {
+  cat <<EOF
+form-cli — the one door (local-first, Form-native)
+
+  form-cli ask "<question>" [-k N] [-m MODEL]
+        answer from the body + local docs, grounded (local oracle, no network)
+  form-cli index [--docs DIR ...]
+        (re)build the searchable index over the body and any local doc folders
+  form-cli search "<query>" [-k N]
+        list the nearest body/doc cells for a query (retrieval only)
+  form-cli gaps
+        walk the body's open gaps (ideas/specs/capabilities), offline-closable tally
+  form-cli close "<name>" "<spec>" "<assert>" "<expected>" [oracle]
+        let a LOCAL oracle draft the missing recipe; the kernel validates it
+  form-cli review [N] [native] [inner-judge] [oracle] [tol]
+        the body answers; an inner judge + an oracle review it; the gap is measured
+  form-cli run "<task>" [oracle] [max-steps]
+        the self-guided agent loop (tool prediction + body memory in the prompt)
+  form-cli eval "<form-expression>"
+        evaluate a Form expression on the kernel, e.g. form-cli eval '(add 20 22)'
+  form-cli preflight
+        air-gap readiness check (kernel, oracles, body on disk, offline loop, memory)
+
+Models are local (ollama): coder, qwen2.5:72b, deepseek-r1:32b, llama3.2:3b.
+EOF
+}
+
+cmd="${1:-help}"; shift 2>/dev/null || true
+case "$cmd" in
+  ask)       exec python3 "$RAG" ask "$@" ;;
+  search)    exec python3 "$RAG" search "$@" ;;
+  index)     exec python3 "$RAG" build "$@" ;;
+  gaps)      exec bash "$ROOT/scripts/form_cli_gaps.sh" "$@" ;;
+  close)     exec bash "$ROOT/scripts/form_cli_close_gap.sh" "$@" ;;
+  review)    exec bash "$ROOT/scripts/form_cli_self_review.sh" "$@" ;;
+  run)       exec bash "$ROOT/scripts/form_native_run.sh" "$@" ;;
+  preflight) exec bash "$ROOT/scripts/form_cli_preflight.sh" "$@" ;;
+  eval)
+    [ -n "${1:-}" ] || { echo "usage: form-cli eval '<form-expression>'" >&2; exit 2; }
+    [ -x "$GO" ] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
+    tf="$(mktemp)"; printf '(print %s)\n' "$1" > "$tf"
+    "$GO" "$tf" 2>&1 | sed '/^null$/d'; rc=${PIPESTATUS[0]}; rm -f "$tf"; exit "$rc" ;;
+  help|-h|--help|*) usage ;;
+esac

--- a/docs/FORM-CLI-INSTALL.md
+++ b/docs/FORM-CLI-INSTALL.md
@@ -1,0 +1,64 @@
+# form-cli — install on a new Mac
+
+A local-first, Form-native organism: ask any question and get an answer grounded
+in this body's recipes/specs/concepts and your own local documents, fully offline
+on a local LLM. A remote oracle (Claude, codex, gemini, grok, cursor) is consulted
+only to *review* — never required to answer.
+
+## One-line install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/seeker71/Coherence-Network/main/install/form-cli-install.sh | bash
+```
+
+It prints every step before running it, asks before anything heavy, and is
+re-runnable. It will:
+
+1. **clone the source** to `~/coherence-network` (all recipes + content, local)
+2. **set up the Form kernel** — builds from source if you have Go, otherwise
+   downloads the prebuilt macOS arm64 binary from the [latest release](https://github.com/seeker71/Coherence-Network/releases)
+3. **set up a local oracle** — installs [ollama](https://ollama.com) (if you allow)
+   and pulls `llama3.2:3b` (reasoning) + `nomic-embed-text` (memory)
+4. **ask which agent CLI** to install — `claude` / `codex` / `gemini` / `grok` /
+   `cursor` / none. (`codex` and `gemini` install via Homebrew; `claude` via its
+   official installer; `grok`/`cursor` print the official command to verify first.)
+5. **index the body** so questions are grounded
+6. **install the Claude skill** (`~/.claude/skills/form-cli`) that routes questions to form-cli
+7. **put `form-cli` on your PATH** (`~/.local/bin/form-cli`)
+
+### Manual (if you prefer)
+
+```bash
+git clone https://github.com/seeker71/Coherence-Network.git ~/coherence-network
+cd ~/coherence-network/form/form-kernel-go && go build -o bin-go .   # or download the release binary
+brew install ollama && ollama pull llama3.2:3b && ollama pull nomic-embed-text
+ln -s ~/coherence-network/bin/form-cli ~/.local/bin/form-cli
+form-cli index
+```
+
+## Using it
+
+```bash
+form-cli ask "how does the form-cli route to a local oracle?"   # grounded, offline
+form-cli index --docs ~/Documents/notes                         # add your own docs
+form-cli ask "what did my notes say about the budget?"          # then question them
+form-cli gaps                                                    # the body's open gaps
+form-cli close "lcm" "(lcm a b) = a*b/gcd(a,b)" "(lcm 4 6)" 12 "ollama run coder"
+form-cli review                                                 # review the body vs an oracle
+form-cli preflight                                              # confirm you can lose the network
+```
+
+## Requirements
+
+- macOS on Apple silicon (arm64). The prebuilt kernel is `arm64`; on other
+  platforms, build from source (needs [Go](https://go.dev/dl/)).
+- For offline answers: [ollama](https://ollama.com) + the two pulled models. Without
+  them the kernel, recipes, gaps, and `eval` still work; `ask` needs the models.
+
+## What "local-first" means here
+
+`form-cli` answers from the body and your local models with **no network**. The
+agent CLI you pick is used only when you explicitly ask it to *review* or escalate
+(`form-cli review`), and the body learns from those reviews until its own answer
+and its own review match the oracle — at which point it stops needing the network
+at all. Run `form-cli preflight` to confirm the kit is whole.

--- a/docs/system_audit/commit_evidence_2026-06-17_form_cli_installer.json
+++ b/docs/system_audit/commit_evidence_2026-06-17_form_cli_installer.json
@@ -1,0 +1,35 @@
+{
+  "title": "form-cli onboarding — a new Mac clones the body, runs the kernel, picks a provider, and questions local docs through one door",
+  "date": "2026-06-17",
+  "intent": "Make the Form-native organism installable by a new Mac user as a self-contained, local-first tool: the GitHub-hosted binary + source, a single `form-cli` command, the agent CLI of their choice, and a Claude skill that routes questions to form-cli including over their own local documents.",
+  "device": "Apple M4 Max, arm64 Darwin — the kernel binary is arm64; other platforms build from source (Go)",
+  "advances": [
+    {
+      "what": "One door: bin/form-cli",
+      "detail": "A single entry point routing ask / search / index / gaps / close / review / run / eval / preflight through the kernel and the existing form-cli carriers. `form-cli eval '(add 20 22)'` -> 42 verified. Local-first: a remote oracle is consulted only to review, never to answer."
+    },
+    {
+      "what": "Local documents become questionable",
+      "detail": "scripts/form_cli_rag.py build gains --docs DIR (repeatable): it walks a user's folder (common text/code extensions), embeds each file with the local nomic-embed-text, and adds it to the index alongside the body. Verified end-to-end: indexed /tmp/mydocs, asked a question only that doc answered, and llama3.2:3b returned 'port 7741 ... Coldharbor' citing the doc — fully offline."
+    },
+    {
+      "what": "The installer",
+      "detail": "install/form-cli-install.sh: clone source -> build/download kernel -> ollama + llama3.2:3b + nomic-embed-text -> ASK which agent CLI (claude/codex/gemini/grok/cursor/none) and install it (codex+gemini via Homebrew, claude via official installer, grok/cursor print the official command to verify first — no fabricated install commands) -> build the index -> install the Claude skill -> link form-cli onto PATH. Transparent (prints each step), consent-based (asks before heavy/external steps), re-runnable, stock bash 3.2."
+    },
+    {
+      "what": "The Claude skill",
+      "detail": "skills/form-cli/SKILL.md routes any question to form-cli, including local-doc Q&A (index a folder, then ask), gap-closing, and self-review. Follows the repo skill format with an openclaw install pointer to the one-line installer."
+    },
+    {
+      "what": "GitHub-hosted binary + docs",
+      "detail": "Release form-cli-v0.1.0 carries the prebuilt arm64 kernel (form-cli-kernel-macos-arm64) + the install script, so a user without Go can still run. docs/FORM-CLI-INSTALL.md is the new-Mac-user guide and release notes."
+    }
+  ],
+  "honest_remainder": {
+    "provider_installs": "claude (official installer), codex, and gemini-cli (both Homebrew) are verified on this host. grok and cursor installers change and were NOT fabricated — the installer prints the official command/URL for the user to verify before running.",
+    "binary_version_drift": "the release binary matches this commit's source; the installer prefers building from source (go) so the kernel always matches the cloned recipes, and only downloads the prebuilt binary as a fallback.",
+    "arm64_only": "the prebuilt binary is Apple-silicon; Intel/Linux build from source."
+  },
+  "verdict": "A new Mac user runs one command and ends with the full body local, a working Form kernel, a local reasoning+memory oracle, the agent CLI they chose, and `form-cli` answering questions grounded in the body and their own documents — offline. The remote provider is a reviewer, not a requirement.",
+  "reproduce": "curl -fsSL https://raw.githubusercontent.com/seeker71/Coherence-Network/main/install/form-cli-install.sh | bash  |  form-cli ask '...'  |  form-cli index --docs ~/notes && form-cli ask 'what did my notes say?'"
+}

--- a/install/form-cli-install.sh
+++ b/install/form-cli-install.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# form-cli-install.sh — bring the Form-native organism to a new Mac, local-first.
+#
+# What it does (each step prints before it runs; nothing destructive, no sudo):
+#   1. clone the Coherence-Network source so all recipes + content are local
+#   2. ensure the Form kernel binary (build with Go, or download the release binary)
+#   3. ensure a local reasoning oracle + embedder (ollama: llama3.2:3b + nomic-embed-text)
+#   4. ask which agent CLI to install (claude / codex / gemini / grok / cursor / none)
+#   5. build the searchable index over the body (so questions are grounded)
+#   6. install the Claude skill that routes questions to form-cli
+#   7. put `form-cli` on your PATH and print next steps
+#
+# Written for stock macOS bash 3.2. Re-runnable: it detects what is already present.
+set -u
+REPO_URL="https://github.com/seeker71/Coherence-Network.git"
+REL_TAG="form-cli-v0.1.0"
+DEST="${FORM_CLI_HOME:-$HOME/coherence-network}"
+BINDIR="$HOME/.local/bin"
+say(){ printf "\n\033[1m── %s\033[0m\n" "$1"; }
+ok(){ printf "  ✓ %s\n" "$1"; }
+ask(){ printf "  %s " "$1"; read -r REPLY < /dev/tty; }
+
+say "form-cli installer (local-first, Form-native)"
+echo "  destination: $DEST"
+echo "  source:      $REPO_URL"
+
+# 1. clone (or update) the source -------------------------------------------------
+say "[1/7] source"
+if [ -d "$DEST/.git" ]; then
+  ok "already cloned — pulling latest"; git -C "$DEST" pull --ff-only origin main 2>/dev/null || true
+else
+  command -v git >/dev/null 2>&1 || { echo "  git is required — install Xcode CLT: xcode-select --install"; exit 1; }
+  git clone --depth 1 "$REPO_URL" "$DEST" && ok "cloned to $DEST"
+fi
+
+# 2. the Form kernel binary -------------------------------------------------------
+say "[2/7] Form kernel"
+GO_DIR="$DEST/form/form-kernel-go"; GO_BIN="$GO_DIR/bin-go"
+if command -v go >/dev/null 2>&1; then
+  ( cd "$GO_DIR" && go build -o bin-go . ) && ok "built kernel from source (go)"
+elif command -v gh >/dev/null 2>&1; then
+  gh release download "$REL_TAG" --repo seeker71/Coherence-Network -p 'form-cli-kernel-macos-arm64' -O "$GO_BIN" 2>/dev/null \
+    && chmod +x "$GO_BIN" && ok "downloaded prebuilt kernel from release $REL_TAG"
+else
+  echo "  no Go toolchain and no gh — install Go (brew install go) then re-run, or download"
+  echo "  $REL_TAG from GitHub and place it at $GO_BIN"
+fi
+if [ -x "$GO_BIN" ]; then
+  smoke="$(printf '(print (add 20 22))' > /tmp/.fcsmoke.fk; "$GO_BIN" /tmp/.fcsmoke.fk 2>/dev/null | tr -d '[:space:]')"
+  case "$smoke" in 42*) ok "kernel evaluates (20+22=42)";; *) echo "  kernel smoke failed ($smoke)";; esac
+fi
+
+# 3. local oracle + embedder ------------------------------------------------------
+say "[3/7] local oracle (offline reasoning + memory)"
+if command -v ollama >/dev/null 2>&1; then
+  ok "ollama present"
+else
+  ask "ollama not found — install via Homebrew now? [y/N]"
+  case "$REPLY" in y|Y) brew install ollama 2>/dev/null && ok "ollama installed" || echo "  see https://ollama.com/download";; *) echo "  skipped — install from https://ollama.com/download";; esac
+fi
+if command -v ollama >/dev/null 2>&1; then
+  ask "pull local models llama3.2:3b (~2GB) + nomic-embed-text (~270MB)? [y/N]"
+  case "$REPLY" in y|Y) ollama pull llama3.2:3b; ollama pull nomic-embed-text; ok "models pulled";; *) echo "  skipped — pull later for offline answers";; esac
+fi
+
+# 4. agent CLI provider (asked) ---------------------------------------------------
+say "[4/7] agent CLI — which provider? form-cli calls it only to review/escalate"
+echo "  1) claude   2) codex   3) gemini   4) grok   5) cursor   6) none"
+ask "choose [1-6]:"
+case "$REPLY" in
+  1) command -v claude >/dev/null 2>&1 && ok "claude already installed" || { echo "  installing claude (official):"; echo "    curl -fsSL https://claude.ai/install.sh | bash"; curl -fsSL https://claude.ai/install.sh | bash; } ;;
+  2) command -v codex  >/dev/null 2>&1 && ok "codex already installed"  || brew install codex ;;
+  3) command -v gemini >/dev/null 2>&1 && ok "gemini already installed" || brew install gemini-cli ;;
+  4) command -v grok   >/dev/null 2>&1 && ok "grok already installed"   || echo "  grok CLI: see official install at https://docs.x.ai (xAI) — installer changes; verify before running" ;;
+  5) command -v cursor >/dev/null 2>&1 && ok "cursor already installed" || { echo "  cursor agent CLI (verify at https://cursor.com/cli):"; echo "    curl https://cursor.com/install -fsS | bash"; } ;;
+  *) ok "no provider CLI — pure local. form-cli answers from your models alone" ;;
+esac
+
+# 5. build the searchable index over the body ------------------------------------
+say "[5/7] index the body (grounds your questions)"
+if command -v ollama >/dev/null 2>&1 && ollama list 2>/dev/null | grep -q nomic-embed; then
+  python3 "$DEST/scripts/form_cli_rag.py" build && ok "index built — add local docs later: form-cli index --docs ~/your-folder"
+else
+  echo "  skipped — needs ollama + nomic-embed-text. Run later: form-cli index"
+fi
+
+# 6. install the Claude skill -----------------------------------------------------
+say "[6/7] Claude skill (routes any question to form-cli)"
+SKILL_SRC="$DEST/skills/form-cli"; SKILL_DST="$HOME/.claude/skills/form-cli"
+if [ -d "$SKILL_SRC" ]; then
+  mkdir -p "$HOME/.claude/skills"; cp -R "$SKILL_SRC" "$SKILL_DST" && ok "skill installed to $SKILL_DST"
+else
+  echo "  skill source not found (older checkout?) — skipped"
+fi
+
+# 7. put form-cli on PATH ---------------------------------------------------------
+say "[7/7] the one door"
+mkdir -p "$BINDIR"; ln -sf "$DEST/bin/form-cli" "$BINDIR/form-cli" && ok "linked form-cli -> $BINDIR/form-cli"
+case ":$PATH:" in *":$BINDIR:"*) :;; *) echo "  add to your shell: export PATH=\"$BINDIR:\$PATH\"";; esac
+
+say "ready"
+cat <<EOF
+  form-cli ask "how does the form-cli route to a local oracle?"
+  form-cli index --docs ~/Documents/notes      # add your own docs
+  form-cli gaps                                 # see what's open
+  form-cli preflight                            # confirm you can lose the network
+EOF

--- a/scripts/form_cli_rag.py
+++ b/scripts/form_cli_rag.py
@@ -64,24 +64,45 @@ def _snippet(path: str) -> str:
     return "\n".join(lines[:18])[:1200]
 
 
-def build(index_path: str) -> None:
+LOCAL_DOC_EXTS = (".md", ".txt", ".org", ".rst", ".py", ".ts", ".tsx", ".js",
+                  ".go", ".rs", ".fk", ".form", ".json", ".yaml", ".yml", ".sh", ".html")
+
+
+def _local_doc_paths(root: str):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if not d.startswith(".") and d != "node_modules"]
+        for fn in sorted(filenames):
+            if fn.lower().endswith(LOCAL_DOC_EXTS):
+                yield os.path.join(dirpath, fn)
+
+
+def build(index_path: str, doc_roots=None) -> None:
     os.makedirs(os.path.dirname(index_path), exist_ok=True)
     n = 0
     with open(index_path, "w") as out:
+        def emit(rel_id, kind, sn):
+            nonlocal n
+            try:
+                vec = quantize(embed(sn))
+            except Exception:
+                return
+            out.write(json.dumps({"id": rel_id, "kind": kind, "snippet": sn[:400], "vec": vec}) + "\n")
+            n += 1
+            if n % 100 == 0:
+                print(f"  ...{n} docs embedded", flush=True)
+        # the body itself (recipes, specs, concepts, substrate)
         for kind, pat in SOURCES:
             for path in sorted(glob.glob(os.path.join(ROOT, pat))):
                 sn = _snippet(path)
-                if len(sn) < 20:
-                    continue
-                try:
-                    vec = quantize(embed(sn))
-                except Exception:
-                    continue
-                out.write(json.dumps({"id": os.path.relpath(path, ROOT),
-                                      "kind": kind, "snippet": sn[:400], "vec": vec}) + "\n")
-                n += 1
-                if n % 100 == 0:
-                    print(f"  ...{n} docs embedded", flush=True)
+                if len(sn) >= 20:
+                    emit(os.path.relpath(path, ROOT), kind, sn)
+        # any local document folders the user points at
+        for root in (doc_roots or []):
+            root = os.path.abspath(os.path.expanduser(root))
+            for path in _local_doc_paths(root):
+                sn = _snippet(path)
+                if len(sn) >= 20:
+                    emit(path, "local", sn)
     print(f"[rag index built: {n} docs -> {index_path}]")
 
 
@@ -107,6 +128,7 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     sub = ap.add_subparsers(dest="cmd", required=True)
     b = sub.add_parser("build"); b.add_argument("--index", default=INDEX)
+    b.add_argument("--docs", action="append", default=[], help="extra local folder(s) to index, repeatable")
     s = sub.add_parser("search"); s.add_argument("question")
     s.add_argument("-k", type=int, default=5); s.add_argument("--index", default=INDEX)
     c = sub.add_parser("context"); c.add_argument("question")
@@ -116,7 +138,7 @@ def main() -> int:
     a.add_argument("--index", default=INDEX)
     args = ap.parse_args()
     if args.cmd == "build":
-        build(args.index); return 0
+        build(args.index, args.docs); return 0
     if args.cmd == "search":
         for h in retrieve(args.question, args.index, args.k):
             print(f"{h['id']}\t{h['kind']}")

--- a/skills/form-cli/SKILL.md
+++ b/skills/form-cli/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: form-cli
+description: "Route any question to form-cli — the local-first, Form-native organism on this Mac. form-cli answers from its own recipes, specs, concepts, and any local documents you have indexed, grounded and offline (a local LLM via ollama), and consults a remote oracle (Claude/codex/gemini/grok/cursor via CLI) only to review or escalate — never to answer. Use this skill to: ask a question and get a grounded local answer with cited sources; question your own local documents (index a folder, then ask); see the body's open gaps and close one offline; review the body's reasoning against an oracle; run the self-guided agent loop; or evaluate a Form expression on the kernel. Triggers on: form-cli, ask the body, offline answer, local documents, question my notes, my docs, air-gap, self-contained, local LLM, no network, ollama, close a gap, review my thinking, Form kernel, form recipe."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🌀",
+        "requires": { "bins": ["form-cli"] },
+        "install":
+          [
+            {
+              "id": "form-cli",
+              "kind": "script",
+              "script": "curl -fsSL https://raw.githubusercontent.com/seeker71/Coherence-Network/main/install/form-cli-install.sh | bash",
+              "bins": ["form-cli"],
+              "label": "Install form-cli (clone source + kernel + local oracle + skill)"
+            }
+          ]
+      }
+  }
+---
+
+# form-cli — the one door
+
+`form-cli` is a local-first, Form-native organism on this Mac. It answers from its
+own body (recipes, specs, concepts) and any local documents you index, runs fully
+offline on a local LLM, and treats a remote oracle (Claude, codex, gemini, grok,
+cursor — whichever you installed) as a *reviewer*, never a requirement.
+
+**When to use this skill:** any time the user wants an answer grounded in this
+repo or in their own local files, wants to work offline, wants to see/close the
+body's gaps, or wants the body's reasoning reviewed.
+
+## Answer a question (grounded, local, offline)
+
+```bash
+form-cli ask "how does the form-cli route between a local and a remote oracle?"
+form-cli ask "what does rag-retrieve.fk do?" -m coder        # pick the local model
+```
+
+`ask` retrieves the nearest cells (Form-ranked by `rag-retrieve.fk`) and has a
+local model answer using only those excerpts, citing the doc ids. No network.
+
+## Question local documents
+
+```bash
+form-cli index --docs ~/Documents/notes --docs ~/projects/spec   # index your folders (once)
+form-cli ask "what did my notes say about the Q3 plan?"          # then ask
+form-cli search "deadline" -k 8                                  # retrieval only
+```
+
+Indexing embeds each document locally (`nomic-embed-text`); the index lives at
+`~/.coherence-network/rag-index/`. Re-run `index` after the docs change.
+
+## See and close the body's gaps (offline)
+
+```bash
+form-cli gaps                                                    # what's open
+form-cli close "lcm" "(lcm a b) = a*b / gcd(a,b)" "(lcm 4 6)" 12 "ollama run coder"
+```
+
+A local oracle drafts the missing recipe; the local kernel validates it against
+the assertion. Nothing leaves the machine.
+
+## Review the body's thinking against an oracle
+
+```bash
+form-cli review 2 "ollama run coder" "ollama run llama3.2:3b" "claude -p" 15
+```
+
+The body answers; an internal judge and the oracle both score the same answer;
+the Form metric reports how close the internal review is to the oracle's. As the
+gap closes, the oracle retires.
+
+## Other doors
+
+```bash
+form-cli run "use bash to list the recipes, then summarize" "ollama run coder" 4
+form-cli eval '(add 20 22)'        # evaluate a Form expression on the kernel
+form-cli preflight                 # confirm the kit is whole — you can lose the network
+```
+
+## How to route a user's question here
+
+1. If the question is about this repo or the user's local files → `form-cli ask`.
+2. If it needs the user's own documents → `form-cli index --docs <dir>` first, then `ask`.
+3. Prefer the local answer; only mention escalating to a remote oracle if the local
+   answer is thin and the user wants a second opinion (`form-cli review`).
+4. Always surface the cited doc ids form-cli returns — they are the grounding.
+
+Full install instructions for a new Mac: [`docs/FORM-CLI-INSTALL.md`](https://github.com/seeker71/Coherence-Network/blob/main/docs/FORM-CLI-INSTALL.md).


### PR DESCRIPTION
A new Mac user runs **one command** and ends with the full source local, a working Form kernel, a local reasoning+memory oracle, the agent CLI they chose, and `form-cli` answering questions grounded in the body **and their own documents** — offline.

```bash
curl -fsSL https://raw.githubusercontent.com/seeker71/Coherence-Network/main/install/form-cli-install.sh | bash
```

## What ships
- **`bin/form-cli`** — the one door: `ask / search / index / gaps / close / review / run / eval / preflight`. Local-first; a remote oracle reviews, never required to answer. (`form-cli eval '(add 20 22)'` → 42 verified.)
- **local document Q&A** — `form_cli_rag.py build --docs DIR` indexes any folder. **Verified end-to-end**: indexed a test folder, asked a question only it answered, `llama3.2:3b` returned the right fact citing the doc, fully offline.
- **`install/form-cli-install.sh`** — clone → kernel (build with Go, else download the release binary) → ollama + `llama3.2:3b` + `nomic-embed-text` → **ask which agent CLI** (`claude`/`codex`/`gemini`/`grok`/`cursor`/none) → index → install skill → PATH. Transparent, consent-based, re-runnable. `codex`+`gemini` via Homebrew, `claude` via its official installer; `grok`/`cursor` print the official command to verify (no fabricated installs).
- **`skills/form-cli/SKILL.md`** — routes any question to form-cli, incl. local-doc Q&A.
- **`docs/FORM-CLI-INSTALL.md`** — the new-Mac-user guide. Release `form-cli-v0.1.0` carries the prebuilt arm64 kernel for users without Go (created alongside this PR).

## Honest notes
- arm64 prebuilt; Intel/Linux build from source.
- The installer prefers building the kernel from source so it always matches the cloned recipes; the release binary is the no-Go fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)