### PR TITLE
fix(form-cli): installer + entry point work on the real install path (two sandbox-caught bugs)

### DIFF
--- a/bin/form-cli
+++ b/bin/form-cli
@@ -8,7 +8,14 @@
 # directly on the kernel. Local-first by design — a remote oracle (incl. Claude via
 # `claude -p`) is consulted only to review, never required to answer.
 set -u
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# resolve through symlinks — the installer links this onto PATH (~/.local/bin),
+# so BASH_SOURCE is the symlink; follow it to the real file in the cloned repo.
+src="${BASH_SOURCE[0]}"
+while [ -h "$src" ]; do
+  d="$(cd -P "$(dirname "$src")" && pwd)"; src="$(readlink "$src")"
+  case "$src" in /*) ;; *) src="$d/$src";; esac
+done
+ROOT="$(cd -P "$(dirname "$src")/.." && pwd)"
 GO="$ROOT/form/form-kernel-go/bin-go"
 RAG="$ROOT/scripts/form_cli_rag.py"
 

--- a/docs/FORM-CLI-INSTALL.md
+++ b/docs/FORM-CLI-INSTALL.md
@@ -36,6 +36,16 @@ ln -s ~/coherence-network/bin/form-cli ~/.local/bin/form-cli
 form-cli index
 ```
 
+### Unattended (CI / scripted)
+
+The installer prompts on a terminal by default; preset the answers to run it with no tty:
+
+```bash
+FORM_CLI_PROVIDER=6 FORM_CLI_PULL=y \
+  curl -fsSL https://raw.githubusercontent.com/seeker71/Coherence-Network/main/install/form-cli-install.sh | bash
+# provider: 1 claude · 2 codex · 3 gemini · 4 grok · 5 cursor · 6 none
+```
+
 ## Using it
 
 ```bash

--- a/docs/system_audit/commit_evidence_2026-06-17_form_cli_installer_sandbox_fixes.json
+++ b/docs/system_audit/commit_evidence_2026-06-17_form_cli_installer_sandbox_fixes.json
@@ -1,0 +1,20 @@
+{
+  "title": "form-cli installer + entry point: two install-breaking bugs caught by a real sandbox run and fixed",
+  "date": "2026-06-17",
+  "context": "Ran the documented one-liner installer against an isolated sandbox HOME (a fresh-Mac simulation). It surfaced two bugs that only appear on the real install path — neither visible when running from inside the repo, which is how the prior session tested.",
+  "bugs_found_and_fixed": [
+    {
+      "bug": "installer crashed without a tty",
+      "detail": "install/form-cli-install.sh read prompts from /dev/tty; under set -u with no controlling terminal (curl|bash in CI/sandbox/pipe) the read failed and REPLY was unbound -> 'REPLY: unbound variable', killing the run at the first prompt (step 3).",
+      "fix": "ask() now takes an env-override arg, falls back to /dev/tty when readable, else a safe empty default — never crashes. Added FORM_CLI_PROVIDER / FORM_CLI_PULL / FORM_CLI_INSTALL_OLLAMA / FORM_CLI_HOME for fully unattended runs, documented in the header and FORM-CLI-INSTALL.md."
+    },
+    {
+      "bug": "installed form-cli could not find the kernel",
+      "detail": "bin/form-cli resolved ROOT from ${BASH_SOURCE[0]} via dirname/... — correct when run inside the repo, but the installer links it onto PATH as a SYMLINK (~/.local/bin/form-cli). Through the symlink, ROOT resolved to ~/.local (the symlink's parent's parent), so GO and RAG pointed at non-existent paths and every command failed with 'No such file or directory'. This broke the primary install path entirely.",
+      "fix": "bin/form-cli now follows the symlink chain (portable readlink loop) to the real file before computing ROOT."
+    }
+  ],
+  "verified_in_sandbox": "After both fixes, the installer ran all 7 steps unattended (FORM_CLI_PROVIDER=6 FORM_CLI_PULL=n): clone/pull, build kernel (20+22=42), detect ollama, provider none, index 999 docs, install the Claude skill, link form-cli onto PATH. Then the INSTALLED symlink worked end-to-end: `form-cli eval '(add 20 22)' -> 42`, `form-cli gaps` -> the 27-gap tally, `form-cli ask '...local vs remote oracle...'` -> retrieved form-cli-loop/north-star/sample and a grounded offline answer (llama3.2:3b) citing form-cli-north-star.form. No network in the answer path.",
+  "verdict": "The one-command onboarding now works on the real install path (symlink on PATH) and in unattended/CI contexts, not only from inside the repo. The release install-script asset is updated to match.",
+  "honest_remainder": "A full clean-HOME run that re-clones from main confirms end-to-end only after this PR merges (the installer clones main); each fix was verified in the sandbox against the real artifacts. arm64 prebuilt binary unchanged."
+}

--- a/install/form-cli-install.sh
+++ b/install/form-cli-install.sh
@@ -11,6 +11,13 @@
 #   7. put `form-cli` on your PATH and print next steps
 #
 # Written for stock macOS bash 3.2. Re-runnable: it detects what is already present.
+#
+# Interactive by default (prompts on the terminal). Unattended/CI: preset answers
+# with env vars and it never blocks on a tty:
+#   FORM_CLI_PROVIDER=6   # 1 claude 2 codex 3 gemini 4 grok 5 cursor 6 none
+#   FORM_CLI_PULL=y       # pull the local models (else skip)
+#   FORM_CLI_INSTALL_OLLAMA=y   # install ollama via brew if missing
+#   FORM_CLI_HOME=/path   # where to clone (default ~/coherence-network)
 set -u
 REPO_URL="https://github.com/seeker71/Coherence-Network.git"
 REL_TAG="form-cli-v0.1.0"
@@ -18,7 +25,16 @@ DEST="${FORM_CLI_HOME:-$HOME/coherence-network}"
 BINDIR="$HOME/.local/bin"
 say(){ printf "\n\033[1m── %s\033[0m\n" "$1"; }
 ok(){ printf "  ✓ %s\n" "$1"; }
-ask(){ printf "  %s " "$1"; read -r REPLY < /dev/tty; }
+# ask "<prompt>" "<override>" — an env override wins (unattended/CI), else a real
+# tty, else a safe empty default. Never crashes under set -u when there is no
+# controlling terminal (e.g. piped, CI, sandbox): an empty answer takes the safe path.
+REPLY=""
+ask(){
+  if [ -n "${2:-}" ]; then REPLY="$2"; printf "  %s %s\n" "$1" "$REPLY"; return; fi
+  printf "  %s " "$1"
+  if [ -r /dev/tty ]; then read -r REPLY < /dev/tty 2>/dev/null || REPLY=""; printf "\n"
+  else REPLY=""; printf "(no tty — default: skip)\n"; fi
+}
 
 say "form-cli installer (local-first, Form-native)"
 echo "  destination: $DEST"
@@ -55,18 +71,18 @@ say "[3/7] local oracle (offline reasoning + memory)"
 if command -v ollama >/dev/null 2>&1; then
   ok "ollama present"
 else
-  ask "ollama not found — install via Homebrew now? [y/N]"
+  ask "ollama not found — install via Homebrew now? [y/N]" "${FORM_CLI_INSTALL_OLLAMA:-}"
   case "$REPLY" in y|Y) brew install ollama 2>/dev/null && ok "ollama installed" || echo "  see https://ollama.com/download";; *) echo "  skipped — install from https://ollama.com/download";; esac
 fi
 if command -v ollama >/dev/null 2>&1; then
-  ask "pull local models llama3.2:3b (~2GB) + nomic-embed-text (~270MB)? [y/N]"
+  ask "pull local models llama3.2:3b (~2GB) + nomic-embed-text (~270MB)? [y/N]" "${FORM_CLI_PULL:-}"
   case "$REPLY" in y|Y) ollama pull llama3.2:3b; ollama pull nomic-embed-text; ok "models pulled";; *) echo "  skipped — pull later for offline answers";; esac
 fi
 
 # 4. agent CLI provider (asked) ---------------------------------------------------
 say "[4/7] agent CLI — which provider? form-cli calls it only to review/escalate"
 echo "  1) claude   2) codex   3) gemini   4) grok   5) cursor   6) none"
-ask "choose [1-6]:"
+ask "choose [1-6]:" "${FORM_CLI_PROVIDER:-}"
 case "$REPLY" in
   1) command -v claude >/dev/null 2>&1 && ok "claude already installed" || { echo "  installing claude (official):"; echo "    curl -fsSL https://claude.ai/install.sh | bash"; curl -fsSL https://claude.ai/install.sh | bash; } ;;
   2) command -v codex  >/dev/null 2>&1 && ok "codex already installed"  || brew install codex ;;


### PR DESCRIPTION
Ran the documented one-liner installer in an isolated sandbox HOME (fresh-Mac simulation). It caught **two install-breaking bugs** invisible from inside the repo:

1. **Installer crashed without a tty.** `read < /dev/tty` under `set -u` left `REPLY` unbound — `curl | bash` in CI/sandbox/pipe died at the first prompt. `ask()` now takes an env override → tty (when readable) → safe default; never crashes. Unattended via `FORM_CLI_PROVIDER` / `FORM_CLI_PULL` / `FORM_CLI_INSTALL_OLLAMA`.
2. **Installed `form-cli` couldn't find the kernel.** `bin/form-cli` resolved `ROOT` from `BASH_SOURCE` — fine inside the repo, but the installer links it onto PATH as a **symlink**, so `ROOT` became `~/.local` and every command failed. It now follows the symlink to the real repo file. This broke the entire primary install path.

### Verified in the sandbox (after the fixes)
- Installer ran all 7 steps unattended: clone/pull → build kernel (20+22=42) → ollama detected → provider none → **index 999 docs** → skill installed → `form-cli` linked.
- The **installed symlink** then ran: `form-cli eval '(add 20 22)'` → 42 · `form-cli gaps` → the 27-gap tally · `form-cli ask "...local vs remote oracle..."` → grounded offline answer (`llama3.2:3b`) citing `form-cli-north-star.form`. No network in the answer path.

Release install-script asset updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)