### PR TITLE
feat(form): oracle-ensure.fk — the form-cli's own oracle-install decision, four-way

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-17_oracle_ensure.json
+++ b/docs/system_audit/commit_evidence_2026-06-17_oracle_ensure.json
@@ -1,0 +1,16 @@
+{
+  "title": "oracle-ensure.fk — the form-cli's own oracle-install decision, as a four-way recipe",
+  "date": "2026-06-17",
+  "intent": "Move the 'ensure the oracles I need are present' brain from the bash installer into Form: a recipe that reads the oracle-catalog and computes which lanes still need install, which to fetch next, and whether the body is ready. The decision is Form (four-way); the effect (ollama pull / brew install) stays a host-exec carrier. A step on the self-growing-machine.form path where the form-cli is built from recipes and tends its own oracles.",
+  "advance": {
+    "recipe": "form/form-stdlib/oracle-ensure.fk (preludes oracle-catalog.fk): oe-present? / oe-needs? / oe-need-count / oe-plan / oe-next / oe-ready? — pure list logic over the catalog rows, no host call in the decision.",
+    "proof": "form/form-stdlib/tests/oracle-ensure-band.fk -> 31 four-way (Go/Rust/TS/fkwu), 0 divergent; registered 'oracle-ensure fks 31'. Fixture: three teachers (installed / absent / source-pending) -> 2 need install, not ready, next = the absent local-llm, plan = the 2 needed rows.",
+    "north_star": "self-growing-machine.form: the brain is Form (this recipe), the hands are host-io (G0 host-exec carrier). As G1 (form-lower over host-io) lands, the host-exec install step folds into the same native binary as the decision."
+  },
+  "honest_remainder": {
+    "carrier_wiring": "the install-command per lane (ollama pull <model>, brew install <formula>) is not in the catalog yet; the recipe names WHICH lanes need install and which is next, the carrier still maps lane->command. Wiring oracle-ensure into form-cli-install.sh (read catalog -> ask oe-plan -> host-exec) is the next step.",
+    "fkwu_host_io": "the DECISION crosses fkwu (pure logic); the install EFFECT uses host-io, which is the named G1 lever, not yet in fkwu/native."
+  },
+  "verdict": "The decision half of 'a form-cli built from recipes that installs its own oracles' is now a four-way-proven Form recipe. The body can compute its own oracle-install plan with no host call; the host-exec carrier executes it.",
+  "reproduce": "cd form && ./validate.sh form-stdlib/oracle-catalog.fk form-stdlib/oracle-ensure.fk form-stdlib/tests/oracle-ensure-band.fk -> 31, fourth arm four-way, 0 divergent"
+}

--- a/form/form-stdlib/oracle-ensure.fk
+++ b/form/form-stdlib/oracle-ensure.fk
@@ -1,0 +1,42 @@
+; oracle-ensure.fk — decide which oracles the body still needs, as a recipe.
+;
+; preludes: form-stdlib/core.fk form-stdlib/oracle-catalog.fk
+;
+; A form-cli built from recipes ensures its own oracles. It reads the
+; oracle-catalog (the teachers the body knows about, each with a state —
+; installed / source-pending / absent) and computes the INSTALL PLAN: which lanes
+; are not yet present, which to bring in next, and whether the body is ready. The
+; DECISION is this recipe (pure list logic, four-way); the EFFECT — running
+; `ollama pull` / `brew install` — is a host-exec carrier that walks the plan.
+; The brain is Form, the hands are host-io. As G1 (form-lower over host-io) lands,
+; the hands fold into the same native binary as the brain (self-growing-machine.form).
+;
+; Proven by: form-stdlib/tests/oracle-ensure-band.fk (four-way at validate.sh).
+
+(do
+    ; a lane is present only when its state is exactly "installed"
+    (defn oe-present? (state) (if (str_eq state "installed") 1 0))
+    ; so it still needs bringing in when it is anything else (absent / source-pending)
+    (defn oe-needs? (state) (if (eq (oe-present? state) 1) 0 1))
+
+    ; how many catalog rows still need install
+    (defn oe-need-count (rows)
+        (if (eq (len rows) 0) 0
+            (add (oe-needs? (oc-state (head rows))) (oe-need-count (tail rows)))))
+
+    ; the PLAN: the sublist of rows that still need install (catalog order preserved)
+    (defn oe-plan (rows)
+        (if (eq (len rows) 0) (empty)
+            (if (eq (oe-needs? (oc-state (head rows))) 1)
+                (cons (head rows) (oe-plan (tail rows)))
+                (oe-plan (tail rows)))))
+
+    ; the NEXT lane to bring in (first that needs it), or an explicit absent "none" row
+    (defn oe-next (rows)
+        (if (eq (len rows) 0) (oc-teacher "none" "none" "none" "none" "none" "absent")
+            (if (eq (oe-needs? (oc-state (head rows))) 1) (head rows)
+                (oe-next (tail rows)))))
+
+    ; READY when nothing in the catalog still needs install
+    (defn oe-ready? (rows) (if (eq (oe-need-count rows) 0) 1 0))
+    0)

--- a/form/form-stdlib/tests/oracle-ensure-band.fk
+++ b/form/form-stdlib/tests/oracle-ensure-band.fk
@@ -1,0 +1,29 @@
+; preludes: form-stdlib/core.fk form-stdlib/oracle-catalog.fk form-stdlib/oracle-ensure.fk
+;
+; oracle-ensure-band — the form-cli's own oracle-install decision, made falsifiable.
+;
+; Three teachers in three states — the whole point is that the recipe tells the
+; carrier what to fetch without any host call:
+;   ear / stt          whisper-cli   installed       -> present, skip
+;   inner-voice / llm  ollama        absent          -> bring in (next)
+;   eye / camera       vision.swift  source-pending  -> bring in
+; So 2 of 3 still need install, the body is NOT ready, and the NEXT lane to fetch
+; is the absent local-llm (catalog order: it precedes the source-pending eye).
+;
+; Verdict 31 when every claim lands:
+;   1   counts what still needs install     (oe-need-count == 2)
+;   2   not ready while anything is missing (oe-ready? == 0)
+;   4   next-to-fetch is the first needed   (oe-next -> lane "local-llm")
+;   8   the plan is exactly the needed rows (len (oe-plan) == 2)
+;   16  the present primitive is exact      (oe-present? "installed" == 1)
+(do
+    (let rows (list
+        (oc-teacher "ear"         "stt"       "whisper-cli"  "generate" "local" "installed")
+        (oc-teacher "inner-voice" "local-llm" "ollama"       "generate" "local" "absent")
+        (oc-teacher "eye"         "camera"    "vision.swift" "label"    "local" "source-pending")))
+    (let c0 (if (eq (oe-need-count rows) 2) 1 0))
+    (let c1 (if (eq (oe-ready? rows) 0) 2 0))
+    (let c2 (if (str_eq (oc-lane (oe-next rows)) "local-llm") 4 0))
+    (let c3 (if (eq (len (oe-plan rows)) 2) 8 0))
+    (let c4 (if (eq (oe-present? "installed") 1) 16 0))
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -529,3 +529,4 @@ reproduce-from-history fkc 8
 rag-retrieve fks 31
 gcd fkc 31
 form-cli-review-gap fkc 63
+oracle-ensure fks 31


### PR DESCRIPTION
A form-cli built from recipes tends its own oracles. `oracle-ensure.fk` reads the `oracle-catalog` and computes — with **no host call in the decision** — which lanes still need install, which to fetch next, the full plan, and whether the body is ready.

- The **decision** is Form (`oe-present?` / `oe-needs?` / `oe-need-count` / `oe-plan` / `oe-next` / `oe-ready?`), proven `tests/oracle-ensure-band.fk → 31` four-way (Go/Rust/TS/**fkwu**), 0 divergent (`oracle-ensure fks 31`).
- The **effect** (`ollama pull` / `brew install`) stays a host-exec carrier — the hands. Per `self-growing-machine.form`, as G1 (form-lower over host-io) lands, the hands fold into the same native binary as the brain.

This is the reachable half of "a form-cli built from recipes that installs its own oracles": the body now computes its own oracle-install plan natively. Next: wire it into `form-cli-install.sh` (read catalog → `oe-plan` → host-exec) with a lane→command map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)