### PR TITLE
feat(form-cli): roadmap engine — floor→north-star steps as Form data, listed offline, + G1-lever plane reference

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 278 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 279 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/bin/form-cli
+++ b/bin/form-cli
@@ -29,6 +29,8 @@ form-cli — the one door (local-first, Form-native)
         (re)build the searchable index over the body and any local doc folders
   form-cli search "<query>" [-k N]
         list the nearest body/doc cells for a query (retrieval only)
+  form-cli roadmap
+        list the floor->north-star steps (roadmap.fk) and the next one to build
   form-cli gaps
         walk the body's open gaps (ideas/specs/capabilities), offline-closable tally
   form-cli close "<name>" "<spec>" "<assert>" "<expected>" [oracle]
@@ -51,6 +53,7 @@ case "$cmd" in
   ask)       exec python3 "$RAG" ask "$@" ;;
   search)    exec python3 "$RAG" search "$@" ;;
   index)     exec python3 "$RAG" build "$@" ;;
+  roadmap)   exec bash "$ROOT/scripts/form_cli_roadmap.sh" "$@" ;;
   gaps)      exec bash "$ROOT/scripts/form_cli_gaps.sh" "$@" ;;
   close)     exec bash "$ROOT/scripts/form_cli_close_gap.sh" "$@" ;;
   review)    exec bash "$ROOT/scripts/form_cli_self_review.sh" "$@" ;;

--- a/docs/coherence-substrate/form-lower-extension-reference.md
+++ b/docs/coherence-substrate/form-lower-extension-reference.md
@@ -1,0 +1,53 @@
+# form-lower extension reference — the G1 lever, offline
+
+The one frontier that turns the tower native (`self-growing-machine.form`): extend
+`form-lower` over the **string + host-io** op families. This is the offline working
+reference — read alongside `form/form-stdlib/form-asm.fk` (the encoder) and
+`form/form-stdlib/form-lower.fk` (the compiler). No network needed: the reasoning
+oracle is a local model (`ollama run coder` / `qwen2.5:72b`), and `clang`
+(`/usr/bin/clang`) is the offline byte cross-check (`scripts/form_lower_demo.sh`).
+
+## The key finding: the instructions are already forged
+
+`form-lower` today dispatches only on int arith / cond / map / recursion. But the
+arm64 **encodings the lever needs already exist in `form-asm.fk`** — the work is
+composing them in `form-lower`'s dispatch, not inventing encodings:
+
+| Lever step (roadmap id) | form-asm primitives already present |
+|---|---|
+| `ll-buffer` (memory/buffer model) | `fa-stp-pre` / `fa-ldp-post` (frame), `fa-sub-x-imm`/`fa-add-x-imm` (sp alloc), `fa-ldr` |
+| `ll-streq` (string ops → byte loops) | `fa-ldrb` / `fa-strb` (byte load/store), `fa-cmp-x`, `fa-bcond` / `fa-b-off` (loop), `fa-csel` |
+| `ll-readfile` (host-io → syscalls) | `fa-svc` (the `svc` instruction), `fa-movz-x` (load syscall # into x16) |
+| `ll-callconv` (multi-arg calls) | `fa-stp-fp` / `fa-ldp-fp` (frame), `fa-bl` (branch-link) |
+
+So each lever step is a `form-lower` dispatch arm that *emits a sequence of existing
+`fa-*` calls*, byte-verified through the conviction gate (`fa-conviction` /
+`fa-may-drop`, `form-to-asm.form`).
+
+## The only external rote facts — the macOS arm64 syscall ABI
+
+Syscall # in `x16`; args in `x0..x5`; trap with `svc #0x80`. BSD syscall numbers
+(arm64 macOS takes the bare number in x16, no 0x2000000 class offset):
+
+| call | x16 | args |
+|---|---|---|
+| `exit` | 1 | x0 = code |
+| `read` | 3 | x0 = fd, x1 = buf, x2 = count |
+| `write` | 4 | x0 = fd, x1 = buf, x2 = count |
+| `open` | 5 | x0 = path*, x1 = flags, x2 = mode |
+| `close` | 6 | x0 = fd |
+
+(The `form-asm-syscall` / `form-asm-echo` / `form-asm-wc` bands already emit working
+`write`/`read` via `svc` — they are the worked examples to copy.)
+
+## The proof shape per step
+
+Each lever step ships like every other `form-lower-*` band: a recipe + a band that
+checks the lowered bytes against a known reference, four-way (`form-lower-*` rows in
+`fourth-arm-bands.txt`). Generate the recipe offline with
+`form-cli close "<id>" "<spec>" "<assert>" "<expected>" "ollama run coder"` — a local
+model drafts, the local kernel validates. Sequence: `ll-buffer` → `ll-streq` →
+`ll-readfile` → `ll-callconv`, then `g3` (compile any recipe) and `g7` (self-host)
+fall out by composition.
+
+See the live plan any time, offline: `form-cli roadmap`.

--- a/docs/system_audit/commit_evidence_2026-06-18_roadmap_engine.json
+++ b/docs/system_audit/commit_evidence_2026-06-18_roadmap_engine.json
@@ -1,0 +1,23 @@
+{
+  "title": "form-cli roadmap — the floor->north-star steps as walkable Form data, plus the offline G1-lever reference",
+  "date": "2026-06-18",
+  "intent": "Make the path from current floor to north-star legible and actionable OFFLINE: form-cli lists every step as structured Form data (each carrying a spec), and for a closable step hands the spec to form_cli_close_gap.sh — a LOCAL oracle drafts the recipe, the LOCAL kernel validates. The plan is data, the generation is local, the proof is the kernel; no remote LLM. Built for a plane (offline) work session on the G1 lever.",
+  "advances": [
+    {
+      "what": "roadmap.fk — the tower as data",
+      "detail": "the G0-G7 steps from self-growing-machine.form as rows (id phase title spec status), with rm-total / rm-open-count / rm-done-count / rm-next-open queries. Seed reflects real state: G0/G1-base/G2/G4 done; the four G1 lever sub-steps (ll-buffer, ll-streq, ll-readfile, ll-callconv) + G3/G7 open.",
+      "proof": "tests/roadmap-band.fk -> 31 four-way (Go/Rust/TS/fkwu), 0 divergent; registered 'roadmap fks 31'."
+    },
+    {
+      "what": "form-cli roadmap",
+      "detail": "scripts/form_cli_roadmap.sh + bin/form-cli subcommand: lists the steps (done ✓ / open ○) from the kernel and names the next to build with its spec and the offline close command. Verified: lists all 10 steps, 6 open, next = ll-buffer."
+    },
+    {
+      "what": "form-lower-extension-reference.md — the offline plane reference",
+      "detail": "the key finding: the arm64 encodings the G1 lever needs ALREADY exist in form-asm.fk (fa-svc, fa-ldrb/strb, fa-ldr, fa-stp-pre/ldp, fa-cmp-x/bcond, fa-movz-x) — the lever is form-lower DISPATCH composing them, not new encodings. Plus the macOS arm64 syscall ABI numbers (the only external rote facts) and the per-step proof shape. Offline oracle = local model; offline byte cross-check = /usr/bin/clang."
+    }
+  ],
+  "llvm_question": "We do NOT need LLVM's lowering spec — LLVM is SSA-IR + register allocation, a different/larger architecture; porting it would be a detour off the north star (one engine, not parallel paths). Our reference is our own form-asm/form-lower (the register-machine lowerer we extend), the local coding models (arm64/syscall knowledge baked in, the offline oracle), and local clang as a byte cross-check. All three are on the laptop now.",
+  "verdict": "form-cli now lists the whole floor->north-star path as Form data and points at the next buildable step; close_gap turns a step's spec into a kernel-validated recipe offline. The plane reference shows the lever's instructions are already forged — only the form-lower dispatch is missing. Everything needed is local.",
+  "reproduce": "form-cli roadmap   |   cd form && ./validate.sh form-stdlib/roadmap.fk form-stdlib/tests/roadmap-band.fk -> 31 four-way   |   docs/coherence-substrate/form-lower-extension-reference.md"
+}

--- a/form/form-stdlib/roadmap.fk
+++ b/form/form-stdlib/roadmap.fk
@@ -1,0 +1,64 @@
+; roadmap.fk — the floor->north-star steps, as recipe DATA the form-cli can walk.
+;
+; preludes: form-stdlib/core.fk
+;
+; Every step on the grammar tower (self-growing-machine.form G0-G7) is a row here:
+; (id phase title spec status). form-cli lists them (form_cli_roadmap.sh), and for
+; an OPEN step whose spec is a closable recipe gap, hands the spec + assertion to
+; form_cli_close_gap.sh — a LOCAL oracle drafts the recipe, the LOCAL kernel
+; validates it. No remote LLM: the plan is data, the generation is local, the proof
+; is the kernel. The query logic (total / open / next / done) is this recipe,
+; four-way; the carrier only formats and runs the local oracle.
+;
+; status: "done" (proven on main) | "open" (the path ahead). The seed below reflects
+; the real state — G0/G1-base/G2/G4 proven, the G1 lever sub-steps + G3/G7 open.
+;
+; Proven by: form-stdlib/tests/roadmap-band.fk (four-way at validate.sh).
+
+(do
+    (defn rm-step (id phase title spec status) (list id phase title spec status))
+    (defn rm-id    (s) (nth s 0))
+    (defn rm-phase (s) (nth s 1))
+    (defn rm-title (s) (nth s 2))
+    (defn rm-spec  (s) (nth s 3))
+    (defn rm-status (s) (nth s 4))
+
+    (defn rm-done? (status) (if (str_eq status "done") 1 0))
+    (defn rm-open? (status) (if (eq (rm-done? status) 1) 0 1))
+
+    (defn rm-total (rows) (len rows))
+    (defn rm-open-count (rows)
+        (if (eq (len rows) 0) 0
+            (add (rm-open? (rm-status (head rows))) (rm-open-count (tail rows)))))
+    (defn rm-done-count (rows) (sub (rm-total rows) (rm-open-count rows)))
+
+    ; the next step to build: first row still open, or an explicit "none" step
+    (defn rm-next-open (rows)
+        (if (eq (len rows) 0) (rm-step "none" "-" "all steps done" "-" "done")
+            (if (eq (rm-open? (rm-status (head rows))) 1) (head rows)
+                (rm-next-open (tail rows)))))
+
+    ; the real floor->north-star seed (self-growing-machine.form, made walkable)
+    (defn rm-seed ()
+        (list
+            (rm-step "g0"          "G0" "five axioms + host-kernel carriers"
+                     "host-exec/read/write as gated carriers" "done")
+            (rm-step "g1-base"     "G1" "form-lower: int arith + cond + map + recursion -> arm64"
+                     "lower(LIT/ADD/SUB/MUL/DIV/COND/MAP/REC) to bytes, zero clang" "done")
+            (rm-step "g2"          "G2" "BMF grammar + BML + source-compiler"
+                     "any grammar admitted; a grammar may ref another" "done")
+            (rm-step "g4"          "G4" "form-cli runner: parse, route, host-io, loop"
+                     "pure Form on the kernel, no REST" "done")
+            (rm-step "ll-buffer"   "G1" "form-lower: stack/heap buffer model"
+                     "a memory model (sp alloc + pointers), not just w0/w1 registers" "open")
+            (rm-step "ll-streq"    "G1" "form-lower: lower string ops to byte loops"
+                     "(str_eq a b) -> byte-compare loop; form-asm-tr proves the primitive" "open")
+            (rm-step "ll-readfile" "G1" "form-lower: lower host-io to syscalls"
+                     "(read_file p) -> open/read/close svc; form-asm-syscall proves the primitive" "open")
+            (rm-step "ll-callconv" "G1" "form-lower: general multi-arg calling convention"
+                     "args in w0..w7, frame setup; today single-arg only" "open")
+            (rm-step "g3"          "G3" "grammar-as-recipe compiles ANY recipe to native"
+                     "rides G1 completing over strings + host-io" "open")
+            (rm-step "g7"          "G7" "form-cli compiles ITSELF (self-host)"
+                     "the runner recipe lowers to a native binary that emits the next" "open")))
+    0)

--- a/form/form-stdlib/tests/roadmap-band.fk
+++ b/form/form-stdlib/tests/roadmap-band.fk
@@ -1,0 +1,29 @@
+; preludes: form-stdlib/core.fk form-stdlib/roadmap.fk
+;
+; roadmap-band — the floor->north-star step query, made falsifiable.
+;
+; A four-row fixture: two done (the floor), two open (the path ahead) — the next
+; open step is the first not-done in order:
+;   g0        done
+;   g1-base   done
+;   ll-buffer open   <- next to build
+;   ll-streq  open
+;
+; Verdict 31 when every claim lands:
+;   1   total counts every step          (rm-total == 4)
+;   2   open-count counts the unbuilt     (== 2)
+;   4   done-count = total - open         (== 2)
+;   8   next-open is the first not-done    (rm-id (rm-next-open) == "ll-buffer")
+;   16  the done? primitive is exact       (rm-done? "done" == 1, rm-done? "open" == 0)
+(do
+    (let rows (list
+        (rm-step "g0"        "G0" "axioms"       "carriers"     "done")
+        (rm-step "g1-base"   "G1" "lower base"   "arith"        "done")
+        (rm-step "ll-buffer" "G1" "buffer model" "sp alloc"     "open")
+        (rm-step "ll-streq"  "G1" "string lower" "byte loop"    "open")))
+    (let c0 (if (eq (rm-total rows) 4) 1 0))
+    (let c1 (if (eq (rm-open-count rows) 2) 2 0))
+    (let c2 (if (eq (rm-done-count rows) 2) 4 0))
+    (let c3 (if (str_eq (rm-id (rm-next-open rows)) "ll-buffer") 8 0))
+    (let c4 (if (eq (add (rm-done? "done") (rm-open? "done")) 1) 16 0))
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -530,3 +530,4 @@ rag-retrieve fks 31
 gcd fkc 31
 form-cli-review-gap fkc 63
 oracle-ensure fks 31
+roadmap fks 31

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 278
+**Total files**: 279
 
 | File | Purpose |
 |---|---|
@@ -90,6 +90,7 @@
 | [form_cli_preflight.sh](form_cli_preflight.sh) | form_cli_preflight.sh — air-gap readiness check for the form-cli. |
 | [form_cli_rag.py](form_cli_rag.py) | form_cli_rag.py — offline semantic memory for the form-cli's local oracle. |
 | [form_cli_replay.sh](form_cli_replay.sh) | form_cli_replay.sh — measure how the native models do against the agent. |
+| [form_cli_roadmap.sh](form_cli_roadmap.sh) | form_cli_roadmap.sh — list the floor->north-star steps and the next one to build. |
 | [form_cli_self_review.sh](form_cli_self_review.sh) | form_cli_self_review.sh — the self-review flywheel, driven through form-cli. |
 | [form_cli_slice.sh](form_cli_slice.sh) | form_cli_slice.sh — compile a Form recipe slice to a RUNNABLE native binary, |
 | [form_cli_tiered.sh](form_cli_tiered.sh) | form_cli_tiered.sh — retire the REMOTE oracle on reasoning: local-first, tiered. |

--- a/scripts/form_cli_roadmap.sh
+++ b/scripts/form_cli_roadmap.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# form_cli_roadmap.sh — list the floor->north-star steps and the next one to build.
+#
+# The steps and the queries (total / open / next) are roadmap.fk on the kernel
+# (four-way); this carrier only formats. For an OPEN step that is a closable recipe
+# gap, the printed spec is what you hand to form_cli_close_gap.sh — a LOCAL oracle
+# drafts the recipe, the LOCAL kernel validates it. No remote LLM, fully offline.
+#
+# Usage: form_cli_roadmap.sh            # the whole tower, done + open, next named
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GO="$ROOT/form/form-kernel-go/bin-go"; STD="$ROOT/form/form-stdlib"
+[ -x "$GO" ] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
+
+prog="$(mktemp)"
+{ cat "$STD/roadmap.fk"
+  echo '(defn rm-emit (rows) (if (eq (len rows) 0) 0 (do (print (rm-id (head rows))) (print (rm-phase (head rows))) (print (rm-status (head rows))) (print (rm-title (head rows))) (rm-emit (tail rows)))))'
+  echo '(rm-emit (rm-seed))'
+  echo '(print "===")'
+  echo '(print (rm-open-count (rm-seed)))'
+  echo '(print (rm-id (rm-next-open (rm-seed))))'
+  echo '(print (rm-title (rm-next-open (rm-seed))))'
+  echo '(print (rm-spec (rm-next-open (rm-seed))))'
+} > "$prog"
+out="$("$GO" "$prog" 2>/dev/null | sed '/^null$/d')"; rm -f "$prog"
+
+echo "── floor → north-star (roadmap.fk on the kernel) ──"
+# steps: 4 lines each (id, phase, status, title) until the === marker
+printf '%s\n' "$out" | awk '
+  /^===$/ {body=1; next}
+  !body {
+    n=(NR-1)%4
+    if (n==0) id=$0
+    else if (n==1) phase=$0
+    else if (n==2) status=$0
+    else { mark=(status=="done")?"✓":"○"; printf "  %s  [%s] %-12s %s\n", mark, phase, id, $0 }
+    next
+  }
+  body && tail==0 {open=$0; tail=1; next}
+  body && tail==1 {nid=$0; tail=2; next}
+  body && tail==2 {ntitle=$0; tail=3; next}
+  body && tail==3 {nspec=$0; tail=4;
+    printf "\n  open: %s   next to build: %s — %s\n", open, nid, ntitle
+    printf "  spec: %s\n", nspec
+    printf "  build it offline:  form-cli close \"%s\" \"<recipe-spec>\" \"<assert>\" \"<expected>\" \"ollama run coder\"\n", nid
+  }
+'


### PR DESCRIPTION
For an offline (plane) session on the G1 lever. **form-cli now lists the whole floor→north-star path** as Form data and points at the next buildable step — plan as data, generation local, proof by kernel, **no remote LLM**.

- **`roadmap.fk`** — the G0–G7 tower (`self-growing-machine.form`) as rows `(id phase title spec status)` + `rm-total/open/done/next-open`. Seed reflects real state: G0/G1-base/G2/G4 **done**; the four G1 lever sub-steps (`ll-buffer`, `ll-streq`, `ll-readfile`, `ll-callconv`) + G3/G7 **open**. Proof `tests/roadmap-band.fk → 31` four-way, 0 divergent.
- **`form-cli roadmap`** — lists steps (✓/○) from the kernel, names the next (`ll-buffer`) with its spec and the offline `form-cli close …` command. Spec→recipe generation is the existing `form_cli_close_gap.sh` (local oracle drafts, kernel validates).
- **`docs/coherence-substrate/form-lower-extension-reference.md`** — the offline reference. **Key finding: the arm64 encodings the lever needs already exist in `form-asm.fk`** (`fa-svc`, `fa-ldrb/strb`, `fa-ldr`, `fa-stp/ldp`, `fa-cmp-x/bcond`, `fa-movz-x`) — the lever is `form-lower` *dispatch* composing them, not new encodings. Includes the macOS arm64 syscall ABI (the only external rote facts) and the per-step proof shape.

**On the LLVM question**: we don't need LLVM's lowering spec — it's SSA-IR + register allocation, a different/larger architecture; porting it is a detour off the north star. Our reference is our own `form-asm`/`form-lower`, the **local coding models** (arm64/syscall knowledge, the offline oracle), and **local clang** as a byte cross-check. All three are on the laptop now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)