### PR TITLE
feat(form-cli): asm — interrogate LLVM offline (clang IS the lowering oracle, no source/network)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 279 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 281 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/bin/form-cli
+++ b/bin/form-cli
@@ -31,6 +31,9 @@ form-cli — the one door (local-first, Form-native)
         list the nearest body/doc cells for a query (retrieval only)
   form-cli roadmap
         list the floor->north-star steps (roadmap.fk) and the next one to build
+  form-cli asm "<C>" [--ir|--opt|--x86|--passes]
+        ask LLVM offline how it lowers/optimizes — clang emits the arm64 asm, IR,
+        opt-delta, other targets, or per-pass pipeline (the lowering teacher)
   form-cli gaps
         walk the body's open gaps (ideas/specs/capabilities), offline-closable tally
   form-cli close "<name>" "<spec>" "<assert>" "<expected>" [oracle]
@@ -57,6 +60,7 @@ case "$cmd" in
   search)    exec python3 "$RAG" search "$@" ;;
   index)     exec python3 "$RAG" build "$@" ;;
   roadmap)   exec bash "$ROOT/scripts/form_cli_roadmap.sh" "$@" ;;
+  asm)       exec bash "$ROOT/scripts/form_cli_asm.sh" "$@" ;;
   gaps)      exec bash "$ROOT/scripts/form_cli_gaps.sh" "$@" ;;
   close)     exec bash "$ROOT/scripts/form_cli_close_gap.sh" "$@" ;;
   review)    exec bash "$ROOT/scripts/form_cli_self_review.sh" "$@" ;;

--- a/docs/coherence-substrate/form-lower-extension-reference.md
+++ b/docs/coherence-substrate/form-lower-extension-reference.md
@@ -51,3 +51,28 @@ model drafts, the local kernel validates. Sequence: `ll-buffer` → `ll-streq` �
 fall out by composition.
 
 See the live plan any time, offline: `form-cli roadmap`.
+
+## Learning LLVM's lowering offline — clang IS the oracle
+
+No internet, no LLVM source — the binary answers every question by *showing* you.
+`clang`/`opt`/`llc`/`llvm-objdump` are all local; you observe behavior, not source.
+The door is `form-cli asm "<C>"`:
+
+| Question | Command | What you read |
+|---|---|---|
+| How does LLVM lower X to arm64? | `form-cli asm "<C>"` | the arm64 asm at -O2 — the actual instructions |
+| What did the optimizer DO? | `form-cli asm "<C>" --opt` | -O0 vs -O2 asm; the *delta* is the optimization |
+| What's the optimization path? | `form-cli asm "<C>" --passes` | per-pass IR (`opt -print-after-all`) — each pass's effect |
+| How does it differ by target? | `form-cli asm "<C>" --x86` | x86_64 asm from the same source |
+| What's the SSA substrate? | `form-cli asm "<C>" --ir` | the LLVM IR (mul nsw / range analysis / attrs) |
+| How does it handle an edge case? | feed the edge case as C | overflow, unaligned, odd widths — read the asm |
+
+Worked example — `form-cli asm "int streq(const char*a,const char*b){...}"` returns
+`ldrb / cmp / b.ne / cbnz / cset`, which maps one-to-one onto the form-asm
+primitives (`fa-ldrb`, `fa-cmp-x`, `fa-bcond`, `fa-csel`). **That asm IS the
+blueprint for the `ll-streq` lowering arm.** The loop closes through the
+`clang-compiler` teacher lane (oracle-catalog.fk): form-lower drafts a lowering,
+`form-cli asm` shows clang's reference bytes, and the byte-conviction gate
+(`fa-conviction`) measures the match — clang drops out only when our bytes ARE its
+bytes. Second offline oracle for the *why*: the local coding models carry LLVM
+internals. Between them, the laptop answers any lowering question with no network.

--- a/docs/system_audit/commit_evidence_2026-06-18_clang_lowering_oracle.json
+++ b/docs/system_audit/commit_evidence_2026-06-18_clang_lowering_oracle.json
@@ -1,0 +1,14 @@
+{
+  "title": "form-cli asm — interrogate LLVM offline: clang IS the lowering oracle, no source, no network",
+  "date": "2026-06-18",
+  "answers": "How to learn LLVM's optimization path / target lowering / edge-case handling offline without the source: you observe the binary, not the source. clang/opt/llc/llvm-objdump are all local and emit IR, per-pass IR, per-target asm, and the -O0->-O2 delta for any C input.",
+  "advance": {
+    "tool": "scripts/form_cli_asm.sh + bin/form-cli asm: '<C>' -> arm64 asm (-O2, LLVM's lowering); --ir (LLVM IR); --opt (-O0 vs -O2 delta = what the optimizer did); --x86 (target-specific lowering); --passes (opt -print-after-all, the per-pass pipeline).",
+    "worked_example": "form-cli asm 'int streq(const char*a,const char*b){while(*a&&*a==*b){a++;b++;}return *a==*b;}' -> ldrb/cmp/b.ne/cbnz/cset, which maps 1:1 onto form-asm primitives fa-ldrb/fa-cmp-x/fa-bcond/fa-csel. That asm IS the ll-streq lowering blueprint, learned from clang offline. --x86 on a sum loop shows clang auto-vectorizing (optimizer behavior, visible).",
+    "loop": "the clang-compiler teacher lane (oracle-catalog.fk): form-lower drafts a lowering, form-cli asm shows clang's reference bytes, the byte-conviction gate (fa-conviction) measures the match; clang drops out only when our bytes ARE its bytes. Second offline oracle for the why: local coding models carry LLVM internals.",
+    "doc": "docs/coherence-substrate/form-lower-extension-reference.md gains the 'Learning LLVM's lowering offline' section (the command table + the worked example + the teacher loop)."
+  },
+  "no_llvm_source_needed": "We do not check out or read LLVM source. clang (/usr/bin/clang) + brew llvm (opt/llc/llvm-mc/llvm-objdump) are the queryable oracle; observing their output for chosen inputs IS the lowering/optimization/target/edge-case knowledge. Bug found and fixed in the carrier: a `}` inside a ${1:?...} message prematurely closed the expansion (appended `\"}` to the snippet); replaced with a plain arg check.",
+  "verdict": "form-cli can now ask LLVM how it lowers, optimizes, targets, and handles edge cases — entirely offline. The asm it returns is the direct blueprint for each form-lower lever arm; the conviction gate measures the match. No source, no internet.",
+  "reproduce": "form-cli asm 'int f(int x){return x*x+3;}'  |  form-cli asm '<C>' --opt  |  form-cli asm '<C>' --x86  |  form-cli asm '<C>' --passes"
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 279
+**Total files**: 281
 
 | File | Purpose |
 |---|---|
@@ -81,6 +81,7 @@
 | [form_branch_demo.sh](form_branch_demo.sh) | form_branch_demo.sh — the FULL asm-pl-human program, compiled by Form and run on |
 | [form_cat_demo.sh](form_cat_demo.sh) | form_cat_demo.sh — `cat`, a real unix command, built with ZERO clang and direct |
 | [form_cli.py](form_cli.py) | form_cli.py — Form-native CLI: ask, generate, execute, convert. |
+| [form_cli_asm.sh](form_cli_asm.sh) | form_cli_asm.sh — interrogate LLVM offline: how does clang lower / optimize this? |
 | [form_cli_capture.sh](form_cli_capture.sh) | form_cli_capture.sh — capture agent turns as training samples for the form-cli. |
 | [form_cli_close_gap.sh](form_cli_close_gap.sh) | form_cli_close_gap.sh — close a Form recipe gap OFFLINE with a local oracle. |
 | [form_cli_demo.sh](form_cli_demo.sh) | form_cli_demo.sh — exercise every form_cli subcommand end-to-end. |

--- a/scripts/form_cli_asm.sh
+++ b/scripts/form_cli_asm.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# form_cli_asm.sh — interrogate LLVM offline: how does clang lower / optimize this?
+#
+# clang IS LLVM. Without the source and without the network, the binary still
+# answers every lowering question — feed it C, read what it emits at each stage:
+#   (default)  arm64 asm at -O2 — LLVM's actual lowering + optimizations
+#   --ir       the LLVM IR (the SSA optimization substrate)
+#   --opt      -O0 vs -O2 asm, side by side — what the optimizer DID (the path)
+#   --x86      x86_64 asm — target-specific lowering, same source
+#   --passes   per-pass IR via opt -print-after-all (brew llvm) — the full pipeline
+# This is the clang-compiler teacher lane (oracle-catalog.fk): form-lower drafts a
+# lowering, compares its bytes to clang's here (the conviction gate, fa-conviction),
+# and learns LLVM's answer — all offline. Thin host-tool carrier; clang is the oracle.
+#
+# Usage: form_cli_asm.sh "<C snippet or function>" [--ir|--opt|--x86|--passes]
+set -u
+SNIP="${1:-}"; [ -n "$SNIP" ] || { echo 'usage: form_cli_asm.sh "<C snippet>" [--ir|--opt|--x86|--passes]' >&2; exit 2; }
+MODE="${2:-}"
+CLANG="${CLANG:-clang}"
+LLVM="$(brew --prefix llvm 2>/dev/null)/bin"
+
+emit(){ printf '%s\n' "$SNIP" | "$CLANG" -x c "$@" -o - - 2>/dev/null; }
+
+case "$MODE" in
+  --ir)
+    echo "── LLVM IR (-O2) — the optimization substrate ──"
+    emit -S -emit-llvm -O2 | grep -vE '^[[:space:]]*$|^source_filename|^target ' ;;
+  --x86)
+    echo "── x86_64 asm (-O2) — target-specific lowering ──"
+    emit -S -O2 -arch x86_64 | grep -vE '^[[:space:]]*[.;]|^[[:space:]]*$|cfi' ;;
+  --opt)
+    echo "── -O0 (literal) ──";  emit -S -O0 -arch arm64 | grep -vE '^[[:space:]]*[.;]|^[[:space:]]*$|cfi' | head -20
+    echo "── -O2 (optimized) — the delta IS what the optimizer did ──"
+    emit -S -O2 -arch arm64 | grep -vE '^[[:space:]]*[.;]|^[[:space:]]*$|cfi' | head -20 ;;
+  --passes)
+    if [ -x "$LLVM/opt" ]; then
+      echo "── per-pass IR (opt -print-after-all) — the optimization pipeline ──"
+      printf '%s\n' "$SNIP" | "$CLANG" -x c -S -emit-llvm -O0 -o - - 2>/dev/null \
+        | "$LLVM/opt" -O2 -print-after-all -S 2>&1 | grep -E '^\*\*\*|define|%[0-9]| = ' | head -60
+    else echo "brew llvm 'opt' not found — install: brew install llvm"; fi ;;
+  *)
+    echo "── arm64 asm (-O2) — LLVM's actual lowering ──"
+    emit -S -O2 -arch arm64 | grep -vE '^[[:space:]]*[.;]|^[[:space:]]*$|cfi' ;;
+esac


### PR DESCRIPTION
**How to learn LLVM's optimization path / target lowering / edge-case handling offline, without the source: observe the binary, not the source.** `clang` (`/usr/bin/clang`) + brew `llvm` (`opt`/`llc`/`llvm-mc`/`llvm-objdump`) are local and emit IR, per-pass IR, per-target asm, and the optimization delta for any C input. They are the queryable oracle.

- **`form-cli asm "<C>"`** → arm64 asm at -O2 (LLVM's actual lowering)
- **`--ir`** → LLVM IR (the SSA substrate) · **`--opt`** → -O0 vs -O2 (the delta *is* the optimization) · **`--x86`** → target-specific lowering · **`--passes`** → `opt -print-after-all` (the per-pass pipeline)

**Worked example**: `form-cli asm` on a string byte-compare returns `ldrb / cmp / b.ne / cbnz / cset` — which maps **1:1** onto the form-asm primitives `fa-ldrb` / `fa-cmp-x` / `fa-bcond` / `fa-csel`. That asm **is** the `ll-streq` lowering blueprint, learned from clang with no internet. (`--x86` on a sum loop shows clang auto-vectorizing — optimizer behavior, visible.)

**The loop closes** through the `clang-compiler` teacher lane (`oracle-catalog.fk`): form-lower drafts a lowering, `form-cli asm` shows clang's reference bytes, the byte-conviction gate (`fa-conviction`) measures the match — clang drops out only when our bytes ARE its bytes. Second offline oracle for the *why*: local coding models carry LLVM internals.

`docs/coherence-substrate/form-lower-extension-reference.md` gains the offline-learning section.

Bugs fixed: a `}` in a `${1:?...}` message closed the expansion early (corrupted the snippet); `\s` isn't POSIX in BSD `grep -E` → switched filters to `[[:space:]]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)