### PR TITLE
feat(form-cli): walk-g1-g7 skill + close --prelude — the walk surfaced and fixed a real form-cli gap (0 remote calls)

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-18_walk_g1_g7.json
+++ b/docs/system_audit/commit_evidence_2026-06-18_walk_g1_g7.json
@@ -1,0 +1,19 @@
+{
+  "title": "Walking G1 via form-cli only — the walk surfaced a real form-cli gap (close validates in isolation) and the fix shipped a lever sub-step with 0 remote calls",
+  "date": "2026-06-18",
+  "experiment": "skills/walk-g1-g7 drives the roadmap using ONLY form-cli: roadmap (plan) -> asm (learn LLVM's lowering from local clang) -> close (local oracle drafts, kernel validates). Measure remote-oracle calls, shipped count, and for each not-shipped the form-cli gap + fix.",
+  "findings": {
+    "remote_oracle_calls": "0 across the whole walk — clang (asm) is local, coder (close) is local; claude -p was never touched.",
+    "first_pass_shipped": "0 — and the reason was form-cli's, not the model's. On ll-streq's first sub-step the LOCAL coder drafted the CORRECT recipe `(defn ldrb-w8 () (fa-ldrb 8 0 0))`, but the kernel rejected it: `(len (ldrb-w8)) = ''` — `fa-ldrb` UNBOUND, because form_cli_close_gap.sh validated the draft in ISOLATION (no stdlib prelude). Every lever step builds on form-asm/form-lower primitives, so none could validate.",
+    "fix_shipped": "form_cli_close_gap.sh gains a 6th arg: space-separated stdlib basenames preluded BEFORE the draft (and named in the oracle prompt). Re-running the SAME step with `form-asm.fk` -> `(len (ldrb-w8)) = 4` -> CLOSED offline. The lever sub-step shipped via form-cli alone, 0 remote calls.",
+    "honest_scope": "What shipped is one instruction-emit SUB-recipe (ldrb), proving the mechanism + the fix — not the entire ll-streq byte-loop. The coarse roadmap steps (ll-buffer/ll-streq/...) still do not close in one shot; they must be decomposed into instruction-emit sub-recipes, each validated against form-asm and (next) byte-checked against `form-cli asm`'s clang reference."
+  },
+  "how_to_ship_the_full_lever_via_form_cli": [
+    "1. close --prelude (DONE) — lever recipes validate against form-asm.",
+    "2. finer roadmap steps — decompose each lever step into instruction-emit sub-recipes (ldrb, cmp, branch-loop), each close-able with a byte/length assertion.",
+    "3. byte-conviction assertion — the assert compares emitted bytes to `form-cli asm`'s clang reference (fa-conviction), so 'correct' means 'matches LLVM', checkable offline.",
+    "4. an iterative close loop — on a failed validate, feed the kernel error + clang's reference bytes back to the local oracle and re-draft, so it converges instead of one-shotting."
+  ],
+  "verdict": "form-cli can walk the lever entirely locally (0 remote). The blocker to shipping was a real form-cli limitation — close validated drafts in isolation — now fixed with --prelude. A lever sub-step now closes via form-cli alone. The full lever is reachable by decomposing the coarse steps into instruction-emit sub-recipes with clang-referenced byte assertions; the skill records this as the next move.",
+  "reproduce": "form-cli roadmap | form-cli asm '<C>' | form-cli close 'll-streq-ldrb' '(ldrb-w8) returns the bytes for ldrb w8,[x0] via (fa-ldrb 8 0 0)' '(len (ldrb-w8))' 4 'ollama run coder' 'form-asm.fk' -> CLOSED"
+}

--- a/scripts/form_cli_close_gap.sh
+++ b/scripts/form_cli_close_gap.sh
@@ -24,6 +24,11 @@ GO_DIR="$ROOT/form/form-kernel-go"; GO="$GO_DIR/bin-go"
 STD="$ROOT/form/form-stdlib"
 GAP="${1:?gap-name}"; SPEC="${2:?recipe-spec}"; ASSERT="${3:?assert-expr}"; EXPECT="${4:?expected}"
 ORACLE="${5:-ollama run coder}"
+# optional 6th arg: space-separated stdlib basenames preluded BEFORE the draft, so a
+# recipe that composes existing cells (e.g. form-asm primitives for a lowering step)
+# validates against them instead of failing on unbound symbols. The lever steps all
+# need this — they build on form-asm/form-lower.
+PRELUDE="${6:-}"
 [[ -x "$GO" ]] || ( cd "$GO_DIR" && go build -o bin-go . ) 2>/dev/null
 
 echo "── close gap: $GAP (oracle: $ORACLE, offline) ──"
@@ -40,6 +45,8 @@ EXAMPLE — a recipe (sq n) = n*n:
 ;;;BEGIN
 (defn sq (n) (mul n n))
 ;;;END
+
+You MAY call functions already defined in these preludes (do not redefine them): ${PRELUDE:-none}
 
 TASK: write a recipe for: $SPEC
 Output ONLY the recipe between ;;;BEGIN and ;;;END markers. No prose.
@@ -67,7 +74,7 @@ sed 's/^/     /' "$draft"
 
 # 4. VALIDATE on the kernel: does the draft + assertion evaluate to expected? --
 val="$(mktemp)"; trap 'rm -f "$pf" "$raw" "$val"' EXIT
-{ cat "$draft"; echo "(print $ASSERT)"; } > "$val"
+{ for p in $PRELUDE; do cat "$STD/$p" 2>/dev/null; done; cat "$draft"; echo "(print $ASSERT)"; } > "$val"
 GOT="$("$GO" "$val" 2>/dev/null | tr -d '[:space:]')"
 case "$GOT" in
     ${EXPECT}*) OUTCOME="success"; echo "[2] kernel validated: $ASSERT = $GOT (expected $EXPECT) ✓" ;;

--- a/skills/walk-g1-g7/SKILL.md
+++ b/skills/walk-g1-g7/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: walk-g1-g7
+description: "Walk the floor->north-star roadmap (self-growing-machine.form G1-G7) using ONLY form-cli — nothing else. For each open step: form-cli roadmap (the plan) -> form-cli asm (learn LLVM's lowering offline from clang) -> form-cli close (a LOCAL oracle drafts the recipe, the kernel validates) -> validate.sh four-way -> ship. Measure: how many times the loop had to escalate to a REMOTE oracle (claude -p) vs stay local; how many steps shipped; and for each that did not ship, why not and the smallest fix to form-cli that would let it. Use to drive an offline self-build session and produce an honest report. Triggers on: walk the roadmap, G1 to G7, build the lever via form-cli, form-lower lever, offline self-build, can form-cli ship a step."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🧗",
+        "requires": { "bins": ["form-cli", "ollama"] }
+      }
+  }
+---
+
+# walk-g1-g7 — build the tower with only form-cli
+
+The discipline: **only `form-cli` subcommands.** No hand-written recipes, no Edit/Write,
+no remote LLM unless the loop itself escalates. Local oracle is `ollama run coder`
+(or `qwen2.5:72b`); the remote tier is `claude -p` and every use of it is COUNTED.
+
+## The loop, per open step
+
+```bash
+form-cli roadmap                     # the plan; read the next open step + its spec
+form-cli asm "<C for the construct>" # learn LLVM's lowering offline (clang, local)
+form-cli close "<id>" "<spec informed by the asm>" "<assert>" "<expected>" "ollama run coder"
+# close: a LOCAL oracle drafts the recipe; the kernel validates it against the assert.
+# if it validates -> register a band + run: cd form && ./validate.sh ... (four-way) -> ship.
+# if it does not -> record WHY, do not hand-write the fix; the point is to find what
+#   form-cli itself still lacks.
+```
+
+## What to measure and report
+
+- **remote calls**: count every time the loop used `claude -p` (target: 0).
+- **shipped**: how many steps produced a four-way-validated recipe via form-cli alone.
+- **for each not shipped**: the exact reason (the kernel error, the missing capability),
+  and the smallest fix *to form-cli* that would let it ship next time.
+
+## The honest frame
+
+A step "shipped via form-cli" only if a `form-cli` command (not the operator) produced
+the validated recipe. If the operator had to write the recipe by hand, that step did
+NOT ship via form-cli — record it as a gap in form-cli and name the fix. The report's
+value is the gap list + fixes, not a green count.


### PR DESCRIPTION
Installed a skill to walk G1→G7 **using only form-cli**, ran it, and report honestly.

## The walk (form-cli only)
`form-cli roadmap` (plan) → `form-cli asm` (learn LLVM's lowering from **local** clang) → `form-cli close` (a **local** oracle drafts, the kernel validates).

## Findings
- **Remote oracle calls: 0** — clang (asm) and coder (close) are both local; `claude -p` was never touched.
- **First pass shipped 0 — and it was form-cli's gap, not the model's.** On `ll-streq`'s first sub-step the local coder drafted the *correct* recipe `(defn ldrb-w8 () (fa-ldrb 8 0 0))`, but the kernel rejected it: `(len (ldrb-w8)) = ''` — `fa-ldrb` **unbound**, because `form_cli_close_gap.sh` validated the draft **in isolation** (no stdlib prelude). Every lever step builds on `form-asm`, so none could validate.
- **Fix shipped**: `close_gap` gains a 6th arg — stdlib basenames preluded before the draft (and named in the oracle prompt). Re-running the *same* step with `form-asm.fk` → `(len (ldrb-w8)) = 4` → **CLOSED offline**. A lever sub-step shipped via form-cli alone, 0 remote.

## Honest scope
What shipped is one **instruction-emit sub-recipe** (`ldrb`), proving the mechanism + the fix — not the whole `ll-streq` byte-loop. The coarse roadmap steps still don't close one-shot. The path to the full lever (recorded in `skills/walk-g1-g7` + the evidence):
1. `close --prelude` ✅
2. decompose each lever step into instruction-emit sub-recipes
3. byte-conviction assertions — assert against `form-cli asm`'s clang reference (`fa-conviction`), so "correct" = "matches LLVM", offline
4. an iterative close loop (feed the kernel error + clang bytes back, re-draft) so the local model converges

🤖 Generated with [Claude Code](https://claude.com/claude-code)