### PR TITLE
attune(form): lowering-conviction — the LLVM oracle is a teacher, not a byte-master

### DIFF
--- a/docs/coherence-substrate/form-lower-extension-reference.md
+++ b/docs/coherence-substrate/form-lower-extension-reference.md
@@ -21,8 +21,12 @@ composing them in `form-lower`'s dispatch, not inventing encodings:
 | `ll-callconv` (multi-arg calls) | `fa-stp-fp` / `fa-ldp-fp` (frame), `fa-bl` (branch-link) |
 
 So each lever step is a `form-lower` dispatch arm that *emits a sequence of existing
-`fa-*` calls*, byte-verified through the conviction gate (`fa-conviction` /
-`fa-may-drop`, `form-to-asm.form`).
+`fa-*` calls*. Two gates, kept distinct: the **encoder** is byte-exact (`fa-conviction`,
+`form-to-asm.form`) — one instruction has one correct encoding, and matching the
+assembler is how we drop clang *as the assembler*. The **lowering choice** (which
+instructions, how optimized) is judged by `lowering-conviction.fk`, NOT byte-identity:
+clang is an oracle, and a different sequence that returns the same result within a
+healthy order of magnitude is fine — smaller/faster is a win.
 
 ## The only external rote facts — the macOS arm64 syscall ABI
 
@@ -70,9 +74,12 @@ The door is `form-cli asm "<C>"`:
 Worked example — `form-cli asm "int streq(const char*a,const char*b){...}"` returns
 `ldrb / cmp / b.ne / cbnz / cset`, which maps one-to-one onto the form-asm
 primitives (`fa-ldrb`, `fa-cmp-x`, `fa-bcond`, `fa-csel`). **That asm IS the
-blueprint for the `ll-streq` lowering arm.** The loop closes through the
-`clang-compiler` teacher lane (oracle-catalog.fk): form-lower drafts a lowering,
-`form-cli asm` shows clang's reference bytes, and the byte-conviction gate
-(`fa-conviction`) measures the match — clang drops out only when our bytes ARE its
-bytes. Second offline oracle for the *why*: the local coding models carry LLVM
+starting shape for the `ll-streq` lowering arm — to learn from, not to copy
+byte-for-byte.** The loop closes through the `clang-compiler` teacher lane
+(oracle-catalog.fk): form-lower drafts a lowering, `form-cli asm` shows clang's
+sequence, and `lowering-conviction.fk` judges ours — **same result is required, and
+the size/speed difference must be understood and within a healthy order of
+magnitude** (smaller/faster than clang is a win). Byte-identity is the *encoder's*
+gate, never the lowering's; demanding it here would be a ceiling that forbids us from
+being different and better. Second offline oracle for the *why*: the local coding models carry LLVM
 internals. Between them, the laptop answers any lowering question with no network.

--- a/docs/system_audit/commit_evidence_2026-06-18_lowering_conviction.json
+++ b/docs/system_audit/commit_evidence_2026-06-18_lowering_conviction.json
@@ -1,0 +1,16 @@
+{
+  "title": "Two gates, not one — the lowering oracle is a teacher, not a byte-master; byte-accuracy was a ceiling",
+  "date": "2026-06-18",
+  "correction": "Earlier docs (form-lower-extension-reference.md) applied byte-identity (fa-conviction, 'our bytes ARE clang's bytes') to the LOWERING. That is wrong: demanding byte-accuracy to LLVM forbids us being different and as-good-or-better. clang/LLVM is an ORACLE to compare against and learn from, not a conformance target.",
+  "distinction": {
+    "encoder_gate": "fa-conviction / form-to-asm.form: 'does THIS instruction encode to the right bytes?' has ONE right answer; byte-identity to the assembler is correct, because it proves form-asm faithfully REPLACES clang as the assembler. Unchanged — legitimately byte-exact.",
+    "lowering_gate": "lowering-conviction.fk (new): 'which instructions do we emit / how optimized?' has MANY valid answers. Gate = same SEMANTICS (run ours, same result as the oracle) + the size/speed DIFFERENCE understood and within a HEALTHY order of magnitude. Smaller/faster than the oracle is BETTER, not a fail."
+  },
+  "advance": {
+    "recipe": "form/form-stdlib/lowering-conviction.fk: lc-equiv? (semantics, the only hard floor), lc-better? (smaller/faster), lc-ratio-ok? (within limit x, limit=10 -> same order of magnitude), lc-verdict (0 WRONG / 1 BLOATED / 2 HEALTHY / 3 BETTER), lc-may-ship? (verdict >= 2 — ship on better-or-healthy, NOT only on byte-match).",
+    "proof": "tests/lowering-conviction-band.fk -> 127 four-way (Go/Rust/TS/fkwu), 0 divergent; registered 'lowering-conviction fkc 127'.",
+    "doc": "form-lower-extension-reference.md corrected: encoder byte-exact; lowering judged by lowering-conviction (oracle = teacher); byte-identity named explicitly as a ceiling for the lowering."
+  },
+  "verdict": "The bar for a lowering is correctness + an understood, healthy difference from the oracle — not byte-accuracy. clang is reviewed and compared, not copied. This keeps the door open to being different and better, while the encoder stays byte-exact where one right answer exists.",
+  "reproduce": "cd form && ./validate.sh form-stdlib/lowering-conviction.fk form-stdlib/tests/lowering-conviction-band.fk -> 127 four-way, 0 divergent"
+}

--- a/form/form-stdlib/lowering-conviction.fk
+++ b/form/form-stdlib/lowering-conviction.fk
@@ -1,0 +1,50 @@
+; lowering-conviction.fk — judge a lowering against an ORACLE, not against byte-identity.
+;
+; preludes: form-stdlib/core.fk
+;
+; Two different gates live in this body, and they are NOT the same:
+;
+;   ENCODER gate (fa-conviction, form-to-asm.form): "does this INSTRUCTION encode
+;     to the right bytes?" has ONE right answer — byte-identity to the assembler is
+;     correct, because that is how form-asm faithfully REPLACES clang as the
+;     assembler. Keep it byte-exact.
+;
+;   LOWERING gate (THIS recipe): "which instructions do we emit for a construct, and
+;     how do we optimize?" has MANY valid answers. clang/LLVM is an ORACLE — a
+;     teacher to compare against — NOT a master to match byte-for-byte. Demanding
+;     byte-identity here is a CEILING: it forbids us being different and as-good or
+;     better. The honest gate is: same SEMANTICS (our lowering, run, returns the same
+;     result as the oracle's), and the DIFFERENCE (size/speed) understood and within a
+;     HEALTHY order of magnitude. Smaller/faster than the oracle is a WIN, not a fail.
+;
+; Inputs are measured by the carrier (run ours, run the oracle): the two results and
+; the two sizes (bytes or cycles). This recipe is the verdict over them, four-way.
+;
+; Proven by: form-stdlib/tests/lowering-conviction-band.fk (four-way at validate.sh).
+
+(do
+    ; SEMANTICS first — the only hard requirement: ours computes what the oracle does.
+    (defn lc-equiv? (ours-result oracle-result)
+        (if (eq ours-result oracle-result) 1 0))
+
+    ; better = strictly smaller/faster than the oracle (our whole point).
+    (defn lc-better? (ours oracle) (if (lt ours oracle) 1 0))
+
+    ; healthy = within a `limit`x factor of the oracle (limit=10 -> same order of
+    ; magnitude). Difference is allowed; only an unexplained blow-up is not.
+    (defn lc-ratio-ok? (ours oracle limit) (if (le ours (mul oracle limit)) 1 0))
+
+    ; the verdict (a code, not a pass/fail):
+    ;   0 WRONG    — different result; semantics broken; the one hard fail, must fix
+    ;   3 BETTER   — same result, strictly smaller/faster than the oracle
+    ;   2 HEALTHY  — same result, within an order of magnitude (different, fine)
+    ;   1 BLOATED  — same result but beyond the limit; understood-or-not, investigate
+    (defn lc-verdict (ours-result oracle-result ours-size oracle-size limit)
+        (if (eq (lc-equiv? ours-result oracle-result) 0) 0
+            (if (eq (lc-better? ours-size oracle-size) 1) 3
+                (if (eq (lc-ratio-ok? ours-size oracle-size limit) 1) 2 1))))
+
+    ; ship when semantics hold AND the difference is healthy or better — NOT only
+    ; when bytes match. (Bloated is held back for understanding, not for conformance.)
+    (defn lc-may-ship? (verdict) (if (ge verdict 2) 1 0))
+    0)

--- a/form/form-stdlib/tests/lowering-conviction-band.fk
+++ b/form/form-stdlib/tests/lowering-conviction-band.fk
@@ -1,0 +1,27 @@
+; preludes: form-stdlib/core.fk form-stdlib/lowering-conviction.fk
+;
+; lowering-conviction-band — the oracle is a teacher, not a byte-master, made falsifiable.
+;
+; Our lowering vs the oracle's, by RESULT (semantics) and SIZE (bytes), limit 10x:
+;   same result, 3 bytes vs oracle 5   -> BETTER  (3)  smaller, a win
+;   same result, 40 bytes vs oracle 5  -> HEALTHY (2)  8x, within an order of magnitude
+;   same result, 60 bytes vs oracle 5  -> BLOATED (1)  12x, understood-or-not, hold back
+;   result 7 vs oracle 9               -> WRONG   (0)  semantics broken, the hard fail
+;
+; Verdict 127 when every claim lands:
+;   1   semantic equivalence is the floor   (lc-equiv? 7 7 == 1)
+;   2   smaller than the oracle is better    (lc-better? 3 5 == 1)
+;   4   within limit is healthy              (lc-ratio-ok? 40 5 10 == 1)
+;   8   equiv + smaller -> BETTER (3)         (lc-verdict 7 7 3 5 10 == 3)
+;   16  equiv + bloated -> BLOATED (1)        (lc-verdict 7 7 60 5 10 == 1)
+;   32  different result -> WRONG (0)         (lc-verdict 7 9 3 5 10 == 0)
+;   64  ship on healthy, not on wrong         (may-ship 2 == 1 AND may-ship 0 == 0)
+(do
+    (let c0 (if (eq (lc-equiv? 7 7) 1) 1 0))
+    (let c1 (if (eq (lc-better? 3 5) 1) 2 0))
+    (let c2 (if (eq (lc-ratio-ok? 40 5 10) 1) 4 0))
+    (let c3 (if (eq (lc-verdict 7 7 3 5 10) 3) 8 0))
+    (let c4 (if (eq (lc-verdict 7 7 60 5 10) 1) 16 0))
+    (let c5 (if (eq (lc-verdict 7 9 3 5 10) 0) 32 0))
+    (let c6 (if (and (eq (lc-may-ship? 2) 1) (eq (lc-may-ship? 0) 0)) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -531,3 +531,4 @@ gcd fkc 31
 form-cli-review-gap fkc 63
 oracle-ensure fks 31
 roadmap fks 31
+lowering-conviction fkc 127


### PR DESCRIPTION
**Correction to a wrong frame I'd shipped.** Earlier docs applied byte-identity (`fa-conviction`, "our bytes ARE clang's bytes") to the *lowering*. That's a ceiling — demanding byte-accuracy to LLVM forbids us being different and as-good-or-better. clang/LLVM is an **oracle** to compare against and learn from, not a conformance target.

**Two gates, now kept distinct:**
- **Encoder** (`fa-conviction`, `form-to-asm.form`) — one instruction has one correct encoding; byte-identity to the assembler is correct there (it's how `form-asm` faithfully *replaces* clang as the assembler). **Unchanged.**
- **Lowering choice** (`lowering-conviction.fk`, new) — many valid answers. Gate = same **semantics** (run ours → same result as the oracle) + the size/speed **difference understood and within a healthy order of magnitude**. Smaller/faster than the oracle is **better**, not a fail.

`lowering-conviction.fk`: `lc-equiv?` (the only hard floor), `lc-better?`, `lc-ratio-ok?` (limit×, 10 = same order of magnitude), `lc-verdict` (0 WRONG / 1 BLOATED / 2 HEALTHY / 3 BETTER), `lc-may-ship?` (ships on better-or-healthy, **not** on byte-match). Proof `tests/lowering-conviction-band.fk → 127` four-way, 0 divergent.

`form-lower-extension-reference.md` corrected to name byte-identity as the *encoder's* gate only, never the lowering's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)