### PR TITLE
feat(form-asm): word str/ldr — walking ll-buffer via form-cli found the gap and fixed it (0 remote)

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-18_form_asm_word_mem.json
+++ b/docs/system_audit/commit_evidence_2026-06-18_form_asm_word_mem.json
@@ -1,0 +1,15 @@
+{
+  "title": "Walking ll-buffer via form-cli found the gap (form-asm lacked word memory ops) and fixed it — 0 remote calls",
+  "date": "2026-06-18",
+  "walk": "100% via form-cli: form-cli roadmap (next = ll-buffer) -> form-cli asm (clang's stack-buffer lowering: sub sp / str w / ldr w / add sp) -> checked form-asm primitives.",
+  "finding": "form-asm had byte ops (fa-strb/fa-ldrb), a 64-bit fa-ldr, and sp alloc/free (fa-sub-x-imm/fa-add-x-imm) — but NOT the 32-bit WORD str/ldr the buffer model needs. That missing pair blocked every ll-buffer sub-recipe. Found entirely via form-cli; 0 remote oracle calls.",
+  "ground_truth_offline": "form-cli asm + llvm-mc gave the exact encodings (no internet): str w8,[sp,#8] = [232 11 0 185] (0xB9000BE8), ldr w9,[sp,#12] = [233 15 64 185] (0xB9400FE9), sub sp,sp,#16 = [255 67 0 209].",
+  "fix": {
+    "primitives": "form-asm.fk gains fa-str-w (STR Wt, base 0xB9000000) and fa-ldr-w (LDR Wt, base 0xB9400000), byte offset scaled /4 via mult 256. These are ENCODER cells (one instruction = one correct encoding), so byte-identity to the assembler is the right gate here — verified offline.",
+    "proof": "tests/form-asm-stack-band.fk -> 7 four-way (Go/Rust/TS/fkwu), 0 divergent ('form-asm-stack fkc 7'): str-w, ldr-w, and alloc each fa-conviction-match the assembler bytes.",
+    "walk_continued": "form-cli close 'll-store-slot' --prelude form-asm.fk -> local coder drafted (store-slot) = (fa-str-w 8 31 8) -> kernel validated byte-correct -> CLOSED offline. With the primitive added, form-cli now closes buffer-model sub-recipes."
+  },
+  "honest_scope": "Shipped the word-memory ENCODER primitives + a closed store-slot sub-recipe, proving the gap is resolved and form-cli can now compose the buffer model's loads/stores. The full ll-buffer form-lower dispatch (frame setup + slot allocation policy for arbitrary locals) is the remaining lowering work — and per lowering-conviction it is judged by semantics + healthy difference, not byte-identity to clang.",
+  "verdict": "Walking the next step via form-cli surfaced a precise missing primitive (32-bit word str/ldr); we learned its encoding from clang offline and fixed form-asm (byte-exact encoder, four-way). The buffer model's memory ops now exist and a sub-recipe closes via form-cli alone, 0 remote.",
+  "reproduce": "form-cli roadmap | form-cli asm 'int f(int n){volatile int b[4];b[0]=n;b[1]=n+1;return b[0]+b[1];}' | cd form && ./validate.sh form-stdlib/form-asm.fk form-stdlib/tests/form-asm-stack-band.fk -> 7 four-way"
+}

--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -141,6 +141,15 @@
     ;   This is how argv is read: at _main, x1 = argv; argv[1] is [x1, #8] (scaled 1).
     (defn fa-ldr (rt rn imm) (fa-asm 4181721088 (list 1 32 1024) (list rt rn imm)))
 
+    ; 32-bit WORD store/load to/from a stack slot — the buffer model's load-bearing
+    ; pair (clang lowers `int b[..]` as `str/ldr w, [sp, #off]`). base STR Wt
+    ; 0xB9000000 / LDR Wt 0xB9400000; off is the BYTE offset, scaled /4 via mult 256
+    ; (imm12 = off/4 at bit 10). Verified against the assembler offline:
+    ;   (fa-str-w 8 31 8)  == str w8,[sp,#8]  == [232 11 0 185]
+    ;   (fa-ldr-w 9 31 12) == ldr w9,[sp,#12] == [233 15 64 185]
+    (defn fa-str-w (rt rn off) (fa-asm 3103784960 (list 1 32 256) (list rt rn off)))
+    (defn fa-ldr-w (rt rn off) (fa-asm 3107979264 (list 1 32 256) (list rt rn off)))
+
     (defn fa-conviction (cand ref)
         (if (eq (len cand) (len ref))
             (if (nil? cand) 1

--- a/form/form-stdlib/tests/form-asm-stack-band.fk
+++ b/form/form-stdlib/tests/form-asm-stack-band.fk
@@ -1,0 +1,19 @@
+; preludes: form-stdlib/form-asm.fk
+;
+; form-asm-stack-band — the buffer model's memory primitives, byte-exact against the
+; assembler. These are ENCODER cells (one instruction = one correct encoding), so
+; byte-identity to clang is the right gate here (verified offline via llvm-mc):
+;   sub sp, sp, #16  -> [255 67 0 209]   (alloc — existing fa-sub-x-imm)
+;   str w8, [sp, #8]  -> [232 11 0 185]   (store word — new fa-str-w)
+;   ldr w9, [sp, #12] -> [233 15 64 185]  (load word  — new fa-ldr-w)
+; fa-conviction is the byte-equality witness.
+;
+; Verdict 7 when every claim lands:
+;   1   store word encodes correctly   (fa-str-w 8 31 8  == str w8,[sp,#8])
+;   2   load word encodes correctly    (fa-ldr-w 9 31 12 == ldr w9,[sp,#12])
+;   4   stack alloc encodes correctly  (fa-sub-x-imm 31 31 16 == sub sp,sp,#16)
+(do
+    (let c0 (if (eq (fa-conviction (fa-str-w 8 31 8)  (list 232 11 0 185)) 1) 1 0))
+    (let c1 (if (eq (fa-conviction (fa-ldr-w 9 31 12) (list 233 15 64 185)) 1) 2 0))
+    (let c2 (if (eq (fa-conviction (fa-sub-x-imm 31 31 16) (list 255 67 0 209)) 1) 4 0))
+    (add c0 (add c1 c2)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -546,3 +546,4 @@ form-cli-review-gap fkc 63
 oracle-ensure fks 31
 roadmap fks 31
 lowering-conviction fkc 127
+form-asm-stack fkc 7


### PR DESCRIPTION
Walked the next roadmap step (`ll-buffer`) **100% via form-cli**, found the precise gap, and fixed it — zero remote oracle calls.

## The walk (form-cli only)
`form-cli roadmap` (next = `ll-buffer`) → `form-cli asm` (clang's stack buffer: `sub sp` / `str w` / `ldr w` / `add sp`) → checked form-asm.

## The finding
form-asm had **byte** ops (`fa-strb`/`fa-ldrb`), a **64-bit** `fa-ldr`, and sp alloc/free — but **not** the **32-bit word `str`/`ldr`** the buffer model needs. That missing pair blocked every `ll-buffer` sub-recipe. Found entirely via form-cli.

## The fix (byte-exact encoder — one right answer)
Ground-truth encodings from `form-cli asm` + `llvm-mc` (offline): `str w8,[sp,#8]`=`[232,11,0,185]`, `ldr w9,[sp,#12]`=`[233,15,64,185]`. Added `fa-str-w` (STR Wt `0xB9000000`) + `fa-ldr-w` (LDR Wt `0xB9400000`), byte offset scaled /4 via mult 256.
- `tests/form-asm-stack-band.fk → 7` four-way (Go/Rust/TS/fkwu), 0 divergent (`form-asm-stack fkc 7`).

## Walk continued — it closes now
`form-cli close "ll-store-slot" … --prelude form-asm.fk` → local coder drafted `(store-slot) → (fa-str-w 8 31 8)` → validated byte-correct → **CLOSED offline**. With the primitive added, form-cli composes the buffer model's loads/stores.

Honest scope: shipped the word-memory **encoder primitives** + a closed sub-recipe. The full `ll-buffer` form-lower dispatch (frame + slot policy) is the remaining *lowering* work — judged by `lowering-conviction` (semantics + healthy difference), not byte-identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)