### PR TITLE
feat(form-cli): close-next — the autonomous self-closer loop (find→draft→validate→load native), 0 remote

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 281 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 282 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/bin/form-cli
+++ b/bin/form-cli
@@ -63,6 +63,7 @@ case "$cmd" in
   asm)       exec bash "$ROOT/scripts/form_cli_asm.sh" "$@" ;;
   gaps)      exec bash "$ROOT/scripts/form_cli_gaps.sh" "$@" ;;
   close)     exec bash "$ROOT/scripts/form_cli_close_gap.sh" "$@" ;;
+  close-next) exec bash "$ROOT/scripts/form_cli_close_next.sh" "$@" ;;
   review)    exec bash "$ROOT/scripts/form_cli_self_review.sh" "$@" ;;
   run)       exec bash "$ROOT/scripts/form_native_run.sh" "$@" ;;
   ensure)    exec bash "$ROOT/scripts/form_cli_ensure.sh" "$@" ;;

--- a/docs/system_audit/commit_evidence_2026-06-18_close_next.json
+++ b/docs/system_audit/commit_evidence_2026-06-18_close_next.json
@@ -1,0 +1,13 @@
+{
+  "title": "form-cli close-next — the autonomous self-closer loop runs: find gap -> draft -> validate -> load native -> next iteration, 0 remote",
+  "date": "2026-06-18",
+  "advance": "scripts/form_cli_close_next.sh + bin/form-cli close-next: one command per iteration finds the next open gap, a LOCAL oracle drafts the recipe, the kernel validates it, and on success the validated recipe is appended to the loaded ledger ($STD/.cache/close-next-loaded.fk) that the NEXT iteration preludes — the new feature available native for the next pass. Run again to advance; when a gap does not close, the loop stops and names the blocker to fix.",
+  "run": "Drained a 4-gap buffer-model queue in 5 runs: ll-alloc16 (fa-sub-x-imm) -> ll-store-w8 (fa-str-w) -> ll-load-w9 (fa-ldr-w) -> ll-free16 (fa-add-x-imm). Each: local coder drafted the recipe, kernel validated byte-correct, loaded native; the 'native features available' prelude grew 0->1->2->3->4. Run 5: queue drained, 4 features loaded. 0 remote oracle calls across all 5.",
+  "honest_remainder": {
+    "gap_source": "the queue is currently a hardcoded fine-gap list (the ll-buffer decomposition). Next: autonomous gap-finding (derive the next gap from roadmap decomposition / what form-lower's dispatch lacks) instead of a fixed queue.",
+    "accumulation_payoff": "the ledger accumulates and the next close preludes it (mechanism proven), but no closed gap YET USES a prior closed recipe. Next: a composed gap (buffer round-trip = alloc+store+load+free) that calls the four loaded recipes — proving the accumulation pays off.",
+    "explicit_dylib": "'load native' currently means the recipe joins the preluded ledger (the kernel runs it; hot closures JIT to a .so). Wiring form_cli_slice.sh to emit an explicit per-recipe native artifact is the next rung toward the literal dylib-per-feature."
+  },
+  "verdict": "The self-closing flywheel runs end-to-end on real lever sub-steps: one form-cli command per iteration self-finds the next gap, drafts + validates locally (0 remote), and loads the feature native for the next pass. The remaining rungs (autonomous gap-finding, composed-gap payoff, explicit dylib) are the night's next fixes.",
+  "reproduce": "form-cli close-next 'ollama run coder'  (run repeatedly; drains the queue, accumulating native features)"
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 281
+**Total files**: 282
 
 | File | Purpose |
 |---|---|
@@ -84,6 +84,7 @@
 | [form_cli_asm.sh](form_cli_asm.sh) | form_cli_asm.sh — interrogate LLVM offline: how does clang lower / optimize this? |
 | [form_cli_capture.sh](form_cli_capture.sh) | form_cli_capture.sh — capture agent turns as training samples for the form-cli. |
 | [form_cli_close_gap.sh](form_cli_close_gap.sh) | form_cli_close_gap.sh — close a Form recipe gap OFFLINE with a local oracle. |
+| [form_cli_close_next.sh](form_cli_close_next.sh) | form_cli_close_next.sh — the autonomous self-closer, one iteration of the flywheel. |
 | [form_cli_demo.sh](form_cli_demo.sh) | form_cli_demo.sh — exercise every form_cli subcommand end-to-end. |
 | [form_cli_ensure.sh](form_cli_ensure.sh) | form_cli_ensure.sh — ensure the form-cli's oracles are present, DECIDED by Form. |
 | [form_cli_gaps.sh](form_cli_gaps.sh) | form_cli_gaps.sh — the catalog of what is OPEN, walked from the live body. |

--- a/scripts/form_cli_close_next.sh
+++ b/scripts/form_cli_close_next.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# form_cli_close_next.sh — the autonomous self-closer, one iteration of the flywheel.
+#
+# Find the next open gap -> learn its shape -> a LOCAL oracle drafts the recipe ->
+# the kernel validates it -> on success, make it AVAILABLE NATIVE for the next
+# iteration by appending the validated recipe to the loaded ledger that the next
+# close preludes. Run it in a loop (form-cli close-next, again, again) and the body
+# grows one native feature at a time, offline, with no remote oracle. When a gap
+# does NOT close, the loop stops and names the blocker — that is the issue to fix
+# before the next pass (the walk-and-fix rhythm).
+#
+# The loaded ledger ($STD/.cache/close-next-loaded.fk, gitignored) is the growing
+# set of closed recipes the next iteration can call — "the new feature available
+# native to run the next iteration." Hot closures JIT to a .so transparently.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STD="$ROOT/form/form-stdlib"
+CN="$HOME/.coherence-network/close-next"; mkdir -p "$CN" "$STD/.cache"
+LOADED="$STD/.cache/close-next-loaded.fk"; [ -f "$LOADED" ] || : > "$LOADED"
+CLOSED="$CN/closed.txt"; touch "$CLOSED"
+ORACLE="${1:-ollama run coder}"
+
+# The gap queue — fine, closable units (the ll-buffer memory model, decomposed).
+# id | recipe-spec | assert-expr | expected. Each builds on form-asm + what's loaded.
+queue() { cat <<'Q'
+ll-alloc16|(alloc16) returns the byte image for the arm64 instruction 'sub sp, sp, #16' by calling (fa-sub-x-imm 31 31 16). Output ONLY the recipe.|(fa-conviction (alloc16) (list 255 67 0 209))|1
+ll-store-w8|(store-w8) returns the byte image for 'str w8, [sp, #8]' by calling (fa-str-w 8 31 8). Output ONLY the recipe.|(fa-conviction (store-w8) (list 232 11 0 185))|1
+ll-load-w9|(load-w9) returns the byte image for 'ldr w9, [sp, #12]' by calling (fa-ldr-w 9 31 12). Output ONLY the recipe.|(fa-conviction (load-w9) (list 233 15 64 185))|1
+ll-free16|(free16) returns the byte image for 'add sp, sp, #16' by calling (fa-add-x-imm 31 31 16). Output ONLY the recipe.|(fa-conviction (free16) (list 255 67 0 145))|1
+Q
+}
+
+next=""
+while IFS='|' read -r id spec assert expected; do
+    [ -z "${id:-}" ] && continue
+    grep -qx "$id" "$CLOSED" && continue
+    next="$id|$spec|$assert|$expected"; break
+done <<< "$(queue)"
+
+if [ -z "$next" ]; then
+    echo "── close-next: queue drained. $(grep -c . "$CLOSED") features loaded native. ──"
+    echo "   add the next gaps to the queue (the composed buffer round-trip uses these), or extend form-lower's dispatch."
+    exit 0
+fi
+
+IFS='|' read -r id spec assert expected <<< "$next"
+echo "── close-next iteration: gap '$id'  (loaded so far: $(grep -c . "$CLOSED")) ──"
+echo "  prelude (native features available): form-asm.fk + $(grep -c '(defn' "$LOADED" 2>/dev/null || echo 0) closed recipes"
+
+bash "$ROOT/scripts/form_cli_close_gap.sh" "$id" "$spec" "$assert" "$expected" "$ORACLE" "form-asm.fk .cache/close-next-loaded.fk" 2>&1 | tee "$CN/last.out" | sed -n '2,8p'
+
+if grep -q 'CLOSED offline' "$CN/last.out"; then
+    cat "$STD/drafts/$id.fk" >> "$LOADED"
+    grep -qx "$id" "$CLOSED" || echo "$id" >> "$CLOSED"
+    echo "── '$id' LOADED native → available to the next iteration ($(grep -c . "$CLOSED") features, 0 remote calls). Run again. ──"
+    exit 0
+else
+    echo "── '$id' did NOT close. The blocker above is the issue to fix before the next pass. ──"
+    exit 1
+fi


### PR DESCRIPTION
The self-closing flywheel, one command per iteration: **`form-cli close-next`** finds the next open gap → a **local** oracle drafts the recipe → the kernel validates it → on success the recipe is **loaded native** (appended to the ledger the next iteration preludes) — *the new feature available native for the next pass*. Run it again to advance; a gap that doesn't close stops the loop and names the blocker to fix.

**Proven run** — drained a 4-gap buffer-model queue in 5 runs:
`ll-alloc16` (`fa-sub-x-imm`) → `ll-store-w8` (`fa-str-w`) → `ll-load-w9` (`fa-ldr-w`) → `ll-free16` (`fa-add-x-imm`). Each: local coder drafted, kernel validated byte-correct, loaded native; the "native features available" prelude grew **0→1→2→3→4**. **0 remote calls** across all five.

**Honest next rungs** (tonight's fixes):
1. **autonomous gap-finding** — derive the next gap instead of a hardcoded queue
2. **accumulation payoff** — a composed gap (buffer round-trip) that *uses* the four loaded recipes
3. **explicit dylib** — wire `form_cli_slice.sh` to emit a per-recipe native artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)