### PR TITLE
feat(form): metabolic-learning crosses four-way (NEVER-ADDED)

### DIFF
--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -179,6 +179,7 @@ lora-adapter fks 31
 oracle-flywheel fks 31
 oracle-distillation-learning fks 4095
 oracle-distill-corpus fks 255
+metabolic-learning fks 4095
 form-cli-loop fks 31
 form-cli-router fks 31
 form-cli-membrane fks 1023


### PR DESCRIPTION
metabolic-learning already computes 4095 byte-for-byte on Go/Rust/TS/fkwu (0 divergent) — it was never listed in the four-way manifest. Registering it (`fks 4095`) so validate.sh gates it on every run.

learning-style-space was checked too and stays OUT — fkwu hits the documented table-capacity wall (Segmentation fault on the large composed table, not a value divergence), so it is honestly 3-kernel-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)