### PR TITLE
feat(form-cli): close-next is 4th-kernel-native — gate every self-closed recipe on fkwu four-way (end-to-end proof)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 283 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 284 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-06-18_close_next_fourway.json
+++ b/docs/system_audit/commit_evidence_2026-06-18_close_next_fourway.json
@@ -1,0 +1,14 @@
+{
+  "title": "The self-closer is now 4th-kernel-native — close-next gates every recipe on fkwu four-way before loading; end-to-end proof",
+  "date": "2026-06-18",
+  "the_gap_fixed": "close-next previously validated drafts on the Go kernel ONLY (form_cli_close_gap.sh '$GO' '$val'), so self-closed recipes were Go-native, not 4th-kernel-native. That is the integrity hole at the center of the 'native' claim. Fixed.",
+  "fix": {
+    "prover": "scripts/form_cli_prove4.sh — promotes a Go-validated draft to a FOUR-WAY-proven stdlib cell: moves the draft into the stdlib, auto-generates a verdict-1 band (the assertion), registers it NEWLINE-SAFE in form/fourth-arm-bands.txt (a row that lands mid-line is invisible to fkwu — a real gotcha caught via a sub-agent root-cause), runs validate.sh, and only succeeds if the band crosses the 4th kernel (fkwu) four-way with 0 divergent.",
+    "loop": "scripts/form_cli_close_next.sh now gates on prove4: draft -> Go-validate -> FOUR-WAY (incl fkwu) -> only then LOAD native. A recipe that Go-validates but does not cross fkwu is NOT loaded. The proven recipes accumulate as the native prelude the next iteration builds on."
+  },
+  "end_to_end_proof": "Ran the gated self-closer for the ll-buffer memory model, clean slate, 4 iterations, 0 remote oracle calls. Each: local coder drafted the recipe, Go validated, then prove4 reported 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)' and '0 divergent', then loaded native. The prelude grew form-asm -> +ll-alloc16 -> +ll-store-w8 -> +ll-load-w9 -> +ll-free16. Four recipes self-closed AND proven on the 4th kernel by the loop itself.",
+  "shipped_artifacts": "form-stdlib/ll-alloc16.fk (sub sp,#16), ll-store-w8.fk (str w8,[sp,#8]), ll-load-w9.fk (ldr w9,[sp,#12]), ll-free16.fk (add sp,#16) + their -band.fk + manifest rows (each fkc 1, four-way). These are the buffer model's memory cells, self-closed offline and fkwu-proven — the durable record that the loop crossed the 4th kernel.",
+  "honest_remainder": "Remaining rungs toward the full self-hosting vision: (a) the recipes are register/offset-specific demonstrations; a general ll-alloc(n)/ll-store(rt,off) is the next lift; (b) a composed gap (buffer round-trip) that USES the four loaded recipes; (c) autonomous gap-finding instead of the queue; (d) an explicit per-recipe arm64 dylib via form_cli_slice.sh. The INTEGRITY proof the user demanded — the self-closer is 4th-kernel-native, not Go-only — is done.",
+  "verdict": "form-cli close-next now finds the next gap, drafts the recipe locally, tests it, PROVES it four-way on the 4th kernel (fkwu), and loads it native for the next iteration — proven end-to-end across 4 recipes, 0 remote. Go-only can no longer masquerade as native.",
+  "reproduce": "form-cli close-next 'ollama run coder'  (run repeatedly; each iteration gates on 'fourth arm: 1 band four-way, 0 divergent' before loading)"
+}

--- a/form/form-stdlib/fourth-arm-bands.txt
+++ b/form/form-stdlib/fourth-arm-bands.txt
@@ -1,0 +1,1 @@
+ll-alloc16 fkc 1

--- a/form/form-stdlib/ll-alloc16.fk
+++ b/form/form-stdlib/ll-alloc16.fk
@@ -1,0 +1,4 @@
+; ll-alloc16.fk — self-closed by form-cli close-next (local oracle), proven four-way.
+; preludes: form-asm.fk 
+(do (defn alloc16 () (fa-sub-x-imm 31 31 16))
+ 0)

--- a/form/form-stdlib/ll-free16.fk
+++ b/form/form-stdlib/ll-free16.fk
@@ -1,0 +1,4 @@
+; ll-free16.fk — self-closed by form-cli close-next (local oracle), proven four-way.
+; preludes: form-asm.fk ll-alloc16.fk ll-store-w8.fk ll-load-w9.fk 
+(do (defn free16 () (fa-add-x-imm 31 31 16))
+ 0)

--- a/form/form-stdlib/ll-load-w9.fk
+++ b/form/form-stdlib/ll-load-w9.fk
@@ -1,0 +1,4 @@
+; ll-load-w9.fk — self-closed by form-cli close-next (local oracle), proven four-way.
+; preludes: form-asm.fk ll-alloc16.fk ll-store-w8.fk 
+(do (defn load-w9 () (fa-ldr-w 9 31 12))
+ 0)

--- a/form/form-stdlib/ll-store-w8.fk
+++ b/form/form-stdlib/ll-store-w8.fk
@@ -1,0 +1,4 @@
+; ll-store-w8.fk — self-closed by form-cli close-next (local oracle), proven four-way.
+; preludes: form-asm.fk ll-alloc16.fk 
+(do (defn store-w8 () (fa-str-w 8 31 8))
+ 0)

--- a/form/form-stdlib/tests/ll-alloc16-band.fk
+++ b/form/form-stdlib/tests/ll-alloc16-band.fk
@@ -1,0 +1,3 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/ll-alloc16.fk
+; ll-alloc16-band — self-closed recipe ll-alloc16, proven four-way incl. fkwu.
+(do (if (eq (fa-conviction (alloc16) (list 255 67 0 209)) 1) 1 0))

--- a/form/form-stdlib/tests/ll-free16-band.fk
+++ b/form/form-stdlib/tests/ll-free16-band.fk
@@ -1,0 +1,3 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/ll-alloc16.fk form-stdlib/ll-store-w8.fk form-stdlib/ll-load-w9.fk form-stdlib/ll-free16.fk
+; ll-free16-band — self-closed recipe ll-free16, proven four-way incl. fkwu.
+(do (if (eq (fa-conviction (free16) (list 255 67 0 145)) 1) 1 0))

--- a/form/form-stdlib/tests/ll-load-w9-band.fk
+++ b/form/form-stdlib/tests/ll-load-w9-band.fk
@@ -1,0 +1,3 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/ll-alloc16.fk form-stdlib/ll-store-w8.fk form-stdlib/ll-load-w9.fk
+; ll-load-w9-band — self-closed recipe ll-load-w9, proven four-way incl. fkwu.
+(do (if (eq (fa-conviction (load-w9) (list 233 15 64 185)) 1) 1 0))

--- a/form/form-stdlib/tests/ll-store-w8-band.fk
+++ b/form/form-stdlib/tests/ll-store-w8-band.fk
@@ -1,0 +1,3 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/ll-alloc16.fk form-stdlib/ll-store-w8.fk
+; ll-store-w8-band — self-closed recipe ll-store-w8, proven four-way incl. fkwu.
+(do (if (eq (fa-conviction (store-w8) (list 232 11 0 185)) 1) 1 0))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -550,3 +550,7 @@ oracle-ensure fks 31
 roadmap fks 31
 lowering-conviction fkc 127
 form-asm-stack fkc 7
+ll-alloc16 fkc 1
+ll-store-w8 fkc 1
+ll-load-w9 fkc 1
+ll-free16 fkc 1

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 283
+**Total files**: 284
 
 | File | Purpose |
 |---|---|
@@ -84,7 +84,7 @@
 | [form_cli_asm.sh](form_cli_asm.sh) | form_cli_asm.sh — interrogate LLVM offline: how does clang lower / optimize this? |
 | [form_cli_capture.sh](form_cli_capture.sh) | form_cli_capture.sh — capture agent turns as training samples for the form-cli. |
 | [form_cli_close_gap.sh](form_cli_close_gap.sh) | form_cli_close_gap.sh — close a Form recipe gap OFFLINE with a local oracle. |
-| [form_cli_close_next.sh](form_cli_close_next.sh) | form_cli_close_next.sh — the autonomous self-closer, one iteration of the flywheel. |
+| [form_cli_close_next.sh](form_cli_close_next.sh) | form_cli_close_next.sh — the autonomous self-closer, FOUR-WAY gated. |
 | [form_cli_demo.sh](form_cli_demo.sh) | form_cli_demo.sh — exercise every form_cli subcommand end-to-end. |
 | [form_cli_distill_receipt.sh](form_cli_distill_receipt.sh) | form_cli_distill_receipt.sh — run the oracle->native distillation on the real |
 | [form_cli_ensure.sh](form_cli_ensure.sh) | form_cli_ensure.sh — ensure the form-cli's oracles are present, DECIDED by Form. |
@@ -92,6 +92,7 @@
 | [form_cli_guided.sh](form_cli_guided.sh) | form_cli_guided.sh — the trained native model makes the live model better. |
 | [form_cli_judge.sh](form_cli_judge.sh) | form_cli_judge.sh — measure the REASONING lane: how well a native model's answer |
 | [form_cli_preflight.sh](form_cli_preflight.sh) | form_cli_preflight.sh — air-gap readiness check for the form-cli. |
+| [form_cli_prove4.sh](form_cli_prove4.sh) | form_cli_prove4.sh — promote a closed recipe to a FOUR-WAY-proven stdlib cell. |
 | [form_cli_rag.py](form_cli_rag.py) | form_cli_rag.py — offline semantic memory for the form-cli's local oracle. |
 | [form_cli_replay.sh](form_cli_replay.sh) | form_cli_replay.sh — measure how the native models do against the agent. |
 | [form_cli_roadmap.sh](form_cli_roadmap.sh) | form_cli_roadmap.sh — list the floor->north-star steps and the next one to build. |

--- a/scripts/form_cli_close_next.sh
+++ b/scripts/form_cli_close_next.sh
@@ -1,29 +1,23 @@
 #!/usr/bin/env bash
-# form_cli_close_next.sh — the autonomous self-closer, one iteration of the flywheel.
+# form_cli_close_next.sh — the autonomous self-closer, FOUR-WAY gated.
 #
-# Find the next open gap -> learn its shape -> a LOCAL oracle drafts the recipe ->
-# the kernel validates it -> on success, make it AVAILABLE NATIVE for the next
-# iteration by appending the validated recipe to the loaded ledger that the next
-# close preludes. Run it in a loop (form-cli close-next, again, again) and the body
-# grows one native feature at a time, offline, with no remote oracle. When a gap
-# does NOT close, the loop stops and names the blocker — that is the issue to fix
-# before the next pass (the walk-and-fix rhythm).
-#
-# The loaded ledger ($STD/.cache/close-next-loaded.fk, gitignored) is the growing
-# set of closed recipes the next iteration can call — "the new feature available
-# native to run the next iteration." Hot closures JIT to a .so transparently.
+# One iteration: find the next open gap -> a LOCAL oracle drafts the recipe ->
+# the kernel validates it (Go) -> form_cli_prove4 proves it FOUR-WAY (Go/Rust/TS +
+# the 4th kernel fkwu, 0 divergent) -> only then is it LOADED native (a proven
+# stdlib cell the next iteration preludes). A recipe that drafts and Go-validates
+# but does NOT cross fkwu is NOT loaded — Go-only is not native. Run again to
+# advance; a blocker stops the loop and names itself. 0 remote oracle calls.
 set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STD="$ROOT/form/form-stdlib"
-CN="$HOME/.coherence-network/close-next"; mkdir -p "$CN" "$STD/.cache"
-LOADED="$STD/.cache/close-next-loaded.fk"; [ -f "$LOADED" ] || : > "$LOADED"
+CN="$HOME/.coherence-network/close-next"; mkdir -p "$CN"
 CLOSED="$CN/closed.txt"; touch "$CLOSED"
+LOADED="$CN/loaded.txt"; touch "$LOADED"   # proven recipe basenames, accumulating native
 ORACLE="${1:-ollama run coder}"
 
-# The gap queue — fine, closable units (the ll-buffer memory model, decomposed).
-# id | recipe-spec | assert-expr | expected. Each builds on form-asm + what's loaded.
+# the gap queue — fine closable units (the ll-buffer memory model, decomposed).
 queue() { cat <<'Q'
-ll-alloc16|(alloc16) returns the byte image for the arm64 instruction 'sub sp, sp, #16' by calling (fa-sub-x-imm 31 31 16). Output ONLY the recipe.|(fa-conviction (alloc16) (list 255 67 0 209))|1
+ll-alloc16|(alloc16) returns the byte image for 'sub sp, sp, #16' by calling (fa-sub-x-imm 31 31 16). Output ONLY the recipe.|(fa-conviction (alloc16) (list 255 67 0 209))|1
 ll-store-w8|(store-w8) returns the byte image for 'str w8, [sp, #8]' by calling (fa-str-w 8 31 8). Output ONLY the recipe.|(fa-conviction (store-w8) (list 232 11 0 185))|1
 ll-load-w9|(load-w9) returns the byte image for 'ldr w9, [sp, #12]' by calling (fa-ldr-w 9 31 12). Output ONLY the recipe.|(fa-conviction (load-w9) (list 233 15 64 185))|1
 ll-free16|(free16) returns the byte image for 'add sp, sp, #16' by calling (fa-add-x-imm 31 31 16). Output ONLY the recipe.|(fa-conviction (free16) (list 255 67 0 145))|1
@@ -36,25 +30,23 @@ while IFS='|' read -r id spec assert expected; do
     grep -qx "$id" "$CLOSED" && continue
     next="$id|$spec|$assert|$expected"; break
 done <<< "$(queue)"
-
-if [ -z "$next" ]; then
-    echo "── close-next: queue drained. $(grep -c . "$CLOSED") features loaded native. ──"
-    echo "   add the next gaps to the queue (the composed buffer round-trip uses these), or extend form-lower's dispatch."
-    exit 0
-fi
-
+[ -n "$next" ] || { echo "── close-next: queue drained. $(grep -c . "$CLOSED") features loaded native (four-way). ──"; exit 0; }
 IFS='|' read -r id spec assert expected <<< "$next"
-echo "── close-next iteration: gap '$id'  (loaded so far: $(grep -c . "$CLOSED")) ──"
-echo "  prelude (native features available): form-asm.fk + $(grep -c '(defn' "$LOADED" 2>/dev/null || echo 0) closed recipes"
 
-bash "$ROOT/scripts/form_cli_close_gap.sh" "$id" "$spec" "$assert" "$expected" "$ORACLE" "form-asm.fk .cache/close-next-loaded.fk" 2>&1 | tee "$CN/last.out" | sed -n '2,8p'
+prelude="form-asm.fk $(tr '\n' ' ' < "$LOADED")"
+echo "── close-next: '$id'  (loaded native so far: $(grep -c . "$CLOSED"); prelude: $prelude) ──"
 
-if grep -q 'CLOSED offline' "$CN/last.out"; then
-    cat "$STD/drafts/$id.fk" >> "$LOADED"
-    grep -qx "$id" "$CLOSED" || echo "$id" >> "$CLOSED"
-    echo "── '$id' LOADED native → available to the next iteration ($(grep -c . "$CLOSED") features, 0 remote calls). Run again. ──"
+# 1. draft + Go-validate
+bash "$ROOT/scripts/form_cli_close_gap.sh" "$id" "$spec" "$assert" "$expected" "$ORACLE" "$prelude" 2>&1 | tee "$CN/last.out" | sed -n '2,4p'
+grep -q 'CLOSED offline' "$CN/last.out" || { echo "── '$id' did not draft/Go-validate. Blocker above. ──"; exit 1; }
+
+# 2. FOUR-WAY gate — incl. the 4th kernel fkwu. Go-only does not load.
+echo "  [4-way gate] proving '$id' across Go/Rust/TS/fkwu …"
+if bash "$ROOT/scripts/form_cli_prove4.sh" "$id" "$assert" "$expected" "$prelude"; then
+    echo "$id" >> "$CLOSED"; echo "$id.fk" >> "$LOADED"
+    echo "── '$id' LOADED native (FOUR-WAY incl. fkwu). $(grep -c . "$CLOSED") features, 0 remote. Run again. ──"
     exit 0
 else
-    echo "── '$id' did NOT close. The blocker above is the issue to fix before the next pass. ──"
+    echo "── '$id' drafted + Go-validated but did NOT cross the 4th kernel — NOT loaded. Fix the blocker. ──"
     exit 1
 fi

--- a/scripts/form_cli_prove4.sh
+++ b/scripts/form_cli_prove4.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# form_cli_prove4.sh — promote a closed recipe to a FOUR-WAY-proven stdlib cell.
+#
+# close validates a draft on the Go kernel only. This is the integrity gate: it
+# moves the draft into the stdlib, auto-generates a verdict-1 band (the assertion),
+# registers it in the fourth-arm manifest (NEWLINE-SAFE — a row that lands mid-line
+# is invisible to fkwu), runs validate.sh, and only succeeds if the band crosses the
+# 4th kernel (fkwu) FOUR-WAY with 0 divergent. A recipe the self-closer "loads" must
+# have crossed fkwu, never passed on Go alone.
+#
+# Usage: form_cli_prove4.sh <id> <assert-expr> <expected> <dep-basenames>
+#   dep-basenames: space-separated stdlib files the recipe needs (e.g. "form-asm.fk")
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STD="$ROOT/form/form-stdlib"; MAN="$ROOT/form/fourth-arm-bands.txt"
+ID="${1:?id}"; ASSERT="${2:?assert}"; EXPECT="${3:?expected}"; DEPS="${4:-}"
+DRAFT="$STD/drafts/$ID.fk"; RECIPE="$STD/$ID.fk"; BAND="$STD/tests/$ID-band.fk"
+[ -f "$DRAFT" ] || { echo "prove4: no draft at $DRAFT"; exit 2; }
+
+# 1. promote the draft to a real stdlib recipe (wrapped, headered)
+{ printf '; %s.fk — self-closed by form-cli close-next (local oracle), proven four-way.\n' "$ID"
+  printf '; preludes: %s\n(do ' "${DEPS:-form-stdlib/core.fk}"
+  cat "$DRAFT"
+  printf ' 0)\n'
+} > "$RECIPE"
+
+# 2. auto-generate the verdict-1 band (the assertion, four-way checkable)
+deppaths=""; for d in $DEPS; do deppaths="$deppaths form-stdlib/$d"; done
+{ printf '; preludes:%s form-stdlib/%s.fk\n' "$deppaths" "$ID"
+  printf '; %s-band — self-closed recipe %s, proven four-way incl. fkwu.\n' "$ID" "$ID"
+  printf '(do (if (eq %s %s) 1 0))\n' "$ASSERT" "$EXPECT"
+} > "$BAND"
+
+# 3. register in the manifest — NEWLINE-SAFE (the gotcha: a mid-line row is invisible)
+emitter="fkc"; case "$ASSERT$(cat "$DRAFT")" in *'"'*) emitter="fks";; esac
+grep -qx "$ID $emitter 1" "$MAN" || {
+    [ -s "$MAN" ] && [ -n "$(tail -c1 "$MAN")" ] && printf '\n' >> "$MAN"
+    printf '%s %s 1\n' "$ID" "$emitter" >> "$MAN"
+}
+
+# 4. run validate.sh and REQUIRE the fourth arm (fkwu) four-way, 0 divergent
+out="$(cd "$ROOT/form" && ./validate.sh $deppaths "form-stdlib/$ID.fk" "form-stdlib/tests/$ID-band.fk" 2>&1)"
+echo "$out" | grep -E '→|fourth arm|divergent' | sed 's/^/    /'
+if echo "$out" | grep -q 'fourth arm: 1 band(s) four-way' && echo "$out" | grep -q '0 divergent'; then
+    echo "  ✓ $ID PROVEN four-way (incl. fkwu) — loaded as a native stdlib cell"
+    exit 0
+else
+    echo "  ✗ $ID did NOT cross the 4th kernel — NOT loaded (Go-only is not native)"
+    exit 1
+fi


### PR DESCRIPTION
**The integrity fix you demanded.** `close-next` was validating drafts on the **Go kernel only** — so self-closed recipes were Go-native, not 4th-kernel-native. That hole is closed.

## The gate
- **`scripts/form_cli_prove4.sh`** — promotes a Go-validated draft to a **four-way-proven** stdlib cell: writes the recipe + an auto-generated verdict-1 band (the assertion), registers it **newline-safe** in `fourth-arm-bands.txt` (a mid-line row is invisible to fkwu — a real gotcha a sub-agent root-caused), runs `validate.sh`, and **only succeeds on `fourth arm: 1 band four-way` + `0 divergent`**.
- **`scripts/form_cli_close_next.sh`** now gates on it: draft → Go-validate → **FOUR-WAY (incl. fkwu)** → load native. Go-only does **not** load. Proven recipes accumulate as the next iteration's prelude.

## End-to-end proof
Gated self-closer ran the `ll-buffer` model, clean slate, **4 iterations, 0 remote calls**. Each: local coder drafted → Go-validated → **crossed fkwu four-way (0 divergent)** → loaded. The native prelude grew `form-asm → +alloc16 → +store-w8 → +load-w9 → +free16`.

Ships the 4 self-closed, **fkwu-proven** recipes (`ll-alloc16`/`ll-store-w8`/`ll-load-w9`/`ll-free16`) + bands + manifest rows — the durable record that the loop crossed the 4th kernel.

## Honest remainder (the night continues)
General `ll-alloc(n)`/`ll-store(rt,off)`; a composed round-trip gap that *uses* the four; autonomous gap-finding; explicit per-recipe arm64 dylib. The **integrity proof — the self-closer is 4th-kernel-native, not Go-only — is done.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)