### PR TITLE
feat(form): llama numerics cross four-way — SiLU + SwiGLU + RMSNorm, the floor under a real llama block on the GPU

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-18_llama_numerics_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-18_llama_numerics_four_way.json
@@ -1,0 +1,32 @@
+{
+  "title": "The llama-shaped numerics cross to the four-kernel floor — SiLU, SwiGLU, RMSNorm four-way",
+  "date": "2026-06-18",
+  "advances": "Lays the numeric floor under running a REAL llama3.2:3b transformer block on the M4 GPU next to the whisper block already four-way + on-GPU. transformer-numerics.fk proved the whisper-shaped block math (softmax / layernorm / gelu, 4095 four-way, running on the M4 GPU as brick 3m / PR #3292). A real llama block differs in exactly three numerics: the norm is RMSNorm (not LayerNorm — no mean-subtraction, no bias), the FFN activation is SwiGLU (silu(gate)*up, not gelu), and the activation atom is SiLU (not tanh-gelu). Until now these lived ONLY inside transformer-kernel.fk's tk-emit-llama as emitted C strings (three-way, projecting to a freestanding C unit) — there was no standalone proven Form recipe for them. This run authors llama-numerics.fk and lifts all three to the four-kernel floor. Core-abstraction-first: the recipes COMPOSE transformer-numerics.fk's proven tn-exp (Taylor, square-and-reduce) and tn-sqrt (fixed-count Newton) rather than re-deriving them.",
+  "device": "Apple M4 Max (40-core GPU), arm64 Darwin 26.3.1 — proof is host-independent (pure fp64 arithmetic band)",
+  "recipe_new": {
+    "file": "form/form-stdlib/llama-numerics.fk",
+    "defns": [
+      "ln-sigmoid (x) = 1 / (1 + tn-exp(-x))",
+      "ln-silu (x) = x * ln-sigmoid(x)  -- the llama FFN activation atom",
+      "ln-swiglu (g u) = ln-silu(g) * u  -- the elementwise SwiGLU gate (llama FFN core)",
+      "ln-sumsq-acc / ln-meansq (xs) = mean of squares",
+      "ln-rms (xs eps) = tn-sqrt(meansq + eps)  -- eps inside the sqrt, the llama shape",
+      "ln-mul2 (xs ys) = elementwise vector product (per-channel gain application)",
+      "ln-rmsnorm (xs gs eps) = (xs scaled by 1/rms) (.) gs  -- o_i = g_i * x_i / sqrt(mean(x^2)+eps)"
+    ]
+  },
+  "band_new": {
+    "stem": "llama-numerics",
+    "verdict": 4095,
+    "what": "the three llama-shaped numerics against the libm fp64 reference (exp/sqrt), every value reduced to an integer at 1e-6. Inputs: x = [-1.5, 0.0, 2.0, 0.5], per-channel gain g = [1.0, 0.5, 2.0, 1.0], eps = 1e-5.",
+    "claims": "1: silu(0)=0 (the zero crossing 0*sigmoid(0)=0*0.5=0). 2: silu(1)=731059. 4: silu(-3)=-142278 (the negative lobe stays small, never zeroed). 8: silu(2)=1761594 (approaches x without saturating). 16: swiglu(1,2)=1462117 (silu(gate)*up). 32: sigmoid(-0.75)=320821 (the gate atom alone). 64: meansq(x)=1625000 (the RMS interior, exact). 128: rms(x,eps)=1274759 (Newton sqrt matching libm). 256: rmsnorm(x,g,eps)[0]=-1176693 (a negative channel, gain 1.0). 512: rmsnorm[2]=3137849 (the largest channel, gain 2.0 amplifies). 1024: rmsnorm[3]=392231 (a small channel, gain 1.0). 2048: swiglu(-3,0.5)=-71139 (a negative gate through the FFN core). => 4095.",
+    "preludes": "form-stdlib/core.fk form-stdlib/transformer-numerics.fk (already four-way) form-stdlib/llama-numerics.fk (new)"
+  },
+  "reference": "libm fp64 via python math (exp/sqrt). silu(t)=t/(1+exp(-t)); sigmoid(t)=1/(1+exp(-t)); rms=sqrt(mean(x^2)+eps); rmsnorm o_i=x_i/rms*g_i. Every reference value matched the recipe's Form output bit-for-bit at 1e-6 rounding — the Taylor-exp and Newton-sqrt approximations land within 0.5e-6 of libm on every claim (the same conformance discipline transformer-numerics.fk holds toward torch).",
+  "proof": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/llama-numerics.fk form-stdlib/tests/llama-numerics-band.fk  ->  '-> 4095', 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)', '1 ok, 0 divergent'.",
+  "verdict": "FOUR-WAY (llama-numerics 4095), 0 divergent — Go, Rust, TypeScript, and the emitted fkwu walker all reproduce SiLU, SwiGLU, and RMSNorm bit-for-bit at 1e-6 against the libm reference. Pure fp64 arithmetic + list recursion (head/tail/cons/empty) — the same op family transformer-numerics 4095 crosses on; no unsupported op, no divergence.",
+  "manifest": "registered in form/fourth-arm-bands.txt as 'llama-numerics fks 4095', placed in the transformer family directly after 'transformer-block-assembly fks 63'.",
+  "reading": "With these three numerics on the four-way floor, the components that separate a real llama block from the whisper block (transformer-numerics 4095, transformer-block 511, both four-way + the block running on the M4 GPU as 3m) are now proven Form recipes rather than emitted-C-only. Combined with the load-path dequant math already four-way (Q4_K 4095, Q6_K 4095, f16-decode 4095), the path toward running a real llama3.2:3b block on the M4 GPU now has its norm + FFN-activation numerics on the same proven floor as the whisper block's. Remaining llama-specific component: RoPE (rotary position embedding), which needs a sin/cos primitive floor (transformer-numerics carries exp/tanh/sqrt but not sin/cos) — the named next stone.",
+  "reproduce": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/llama-numerics.fk form-stdlib/tests/llama-numerics-band.fk  (four-way 4095, 0 divergent). Run the band individually: rapid back-to-back validate.sh calls share a temp dir and can report a spurious divergence; a single invocation isolates it.",
+  "read_the_body_note": "Confirmed the gap by grep before authoring (default-to-body): SiLU/SwiGLU/RMSNorm appeared only inside transformer-kernel.fk's tk-emit-llama as emitted C, never as standalone four-way recipes; transformer-numerics.fk had layernorm/softmax/gelu but not the llama variants. So this was a real gap, not a re-implementation. Reused tn-exp/tn-sqrt/tn-flen/tn-scale rather than duplicating the primitive floor. Design (the llama numerics + the libm reference + strange-minimal fixtures) was the cost; the four-way proof was seconds — the autonomous-walk lesson held again."
+}

--- a/form/form-stdlib/llama-numerics.fk
+++ b/form/form-stdlib/llama-numerics.fk
@@ -1,0 +1,39 @@
+; llama-numerics.fk — the llama-shaped numerics: SiLU, SwiGLU, RMSNorm.
+;
+; The whisper-shaped block math (softmax / layernorm / gelu) is proven four-way in
+; transformer-numerics.fk and runs on the M4 GPU (form-native-models.form rung 2,
+; brick 3m). A REAL llama3.2:3b block differs in exactly three numerics: the norm is
+; RMSNorm (not LayerNorm), the FFN activation is SwiGLU (silu(gate)·up, not gelu), and
+; the activation atom is SiLU (not tanh-gelu). Until now these lived only inside
+; transformer-kernel.fk's tk-emit-llama as emitted C (three-way, projecting to a C
+; unit). This file lifts them to standalone proven Form recipes — the numeric floor
+; under running a real llama block on the GPU next to the whisper block.
+;
+; Core-abstraction-first: compose transformer-numerics.fk's proven tn-exp (Taylor,
+; square-and-reduce) and tn-sqrt (fixed-count Newton) rather than re-deriving them.
+; All fp64; the recipe DEFINES the reduction order so every kernel computes the same
+; bits. Conformance pinned to libm (exp/sqrt) at 1e-6 in the band.
+
+; --- SiLU: x·sigmoid(x) = x / (1 + e^-x) ---
+(defn ln-sigmoid (x) (div 1.0 (add 1.0 (tn-exp (sub 0.0 x)))))
+(defn ln-silu (x) (mul x (ln-sigmoid x)))
+
+; --- SwiGLU (elementwise activation core): silu(gate)·up ---
+; The llama FFN is down(swiglu(gate(x), up(x))); this is the per-element gate.
+(defn ln-swiglu (g u) (mul (ln-silu g) u))
+
+; --- RMSNorm: o_i = g_i · x_i / sqrt(mean(x²) + eps) ---
+; The norm llama uses in place of layernorm: no mean-subtraction, no bias — just a
+; root-mean-square rescale times a per-channel gain. eps inside the sqrt (the llama
+; shape). Reuses tn-flen (float-counted length) and tn-scale from transformer-numerics.
+(defn ln-sumsq-acc (acc xs)
+  (if (eq (len xs) 0) acc
+      (ln-sumsq-acc (add acc (mul (head xs) (head xs))) (tail xs))))
+(defn ln-meansq (xs) (div (ln-sumsq-acc 0.0 xs) (tn-flen xs)))
+(defn ln-rms (xs eps) (tn-sqrt (add (ln-meansq xs) eps)))
+; elementwise product of two equal-length vectors (the per-channel gain application)
+(defn ln-mul2 (xs ys)
+  (if (eq (len xs) 0) (empty)
+      (cons (mul (head xs) (head ys)) (ln-mul2 (tail xs) (tail ys)))))
+(defn ln-rmsnorm (xs gs eps)
+  (ln-mul2 (tn-scale xs (div 1.0 (ln-rms xs eps))) gs))

--- a/form/form-stdlib/tests/llama-numerics-band.fk
+++ b/form/form-stdlib/tests/llama-numerics-band.fk
@@ -1,0 +1,39 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/llama-numerics.fk
+;
+; llama-numerics-band — the llama-shaped numerics (SiLU / SwiGLU / RMSNorm) against the
+; libm fp64 reference, lifted to the four-kernel floor. Every claim is a reference value
+; computed by libm (exp/sqrt), reduced to an integer at 1e-6. These are the three numerics
+; that separate a real llama3.2:3b block from the whisper block already four-way (3m).
+; Inputs: x = [-1.5, 0.0, 2.0, 0.5], per-channel gain g = [1.0, 0.5, 2.0, 1.0], eps = 1e-5.
+;
+; Verdict 4095 when every value lands:
+;   1     silu(0.0)          → 0         (the zero crossing: 0·sigmoid(0) = 0·0.5 = 0)
+;   2     silu(1.0)          → 731059
+;   4     silu(-3.0)         → -142278   (the negative lobe stays small, never zeroed)
+;   8     silu(2.0)          → 1761594   (approaches x without saturating)
+;   16    swiglu(1.0, 2.0)   → 1462117   (silu(gate)·up = silu(1)·2)
+;   32    sigmoid(-0.75)     → 320821    (the gate atom on its own)
+;   64    meansq(x)          → 1625000   (the RMS interior: mean of squares, exact)
+;   128   rms(x, eps)        → 1274759   (sqrt(meansq + eps), Newton matching libm)
+;   256   rmsnorm(x,g,eps)[0]→ -1176693  (a negative channel, gain 1.0)
+;   512   rmsnorm(x,g,eps)[2]→ 3137849   (the largest channel, gain 2.0 amplifies)
+;   1024  rmsnorm(x,g,eps)[3]→ 392231    (a small channel, gain 1.0)
+;   2048  swiglu(-3.0, 0.5)  → -71139    (a negative gate through the FFN core: silu(-3)·0.5)
+(do
+    (let x (list -1.5 0.0 2.0 0.5))
+    (let g (list 1.0 0.5 2.0 1.0))
+    (let rn (ln-rmsnorm x g 0.00001))
+    (let c0  (if (eq (round (mul (ln-silu 0.0) 1000000.0)) 0) 1 0))
+    (let c1  (if (eq (round (mul (ln-silu 1.0) 1000000.0)) 731059) 2 0))
+    (let c2  (if (eq (round (mul (ln-silu -3.0) 1000000.0)) -142278) 4 0))
+    (let c3  (if (eq (round (mul (ln-silu 2.0) 1000000.0)) 1761594) 8 0))
+    (let c4  (if (eq (round (mul (ln-swiglu 1.0 2.0) 1000000.0)) 1462117) 16 0))
+    (let c5  (if (eq (round (mul (ln-sigmoid -0.75) 1000000.0)) 320821) 32 0))
+    (let c6  (if (eq (round (mul (ln-meansq x) 1000000.0)) 1625000) 64 0))
+    (let c7  (if (eq (round (mul (ln-rms x 0.00001) 1000000.0)) 1274759) 128 0))
+    (let c8  (if (eq (round (mul (nth rn 0) 1000000.0)) -1176693) 256 0))
+    (let c9  (if (eq (round (mul (nth rn 2) 1000000.0)) 3137849) 512 0))
+    (let c10 (if (eq (round (mul (nth rn 3) 1000000.0)) 392231) 1024 0))
+    (let c11 (if (eq (round (mul (ln-swiglu -3.0 0.5) 1000000.0)) -71139) 2048 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7
+    (add c8 (add c9 (add c10 c11))))))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -343,6 +343,7 @@ transformer-backprop-ffn fks 63
 transformer-backprop-softmax-ln fks 31
 transformer-block-backward fks 31
 transformer-block-assembly fks 63
+llama-numerics fks 4095
 geometric-learning fks 8388607
 transcendental-natives fks 16
 learning-arc fks 127


### PR DESCRIPTION
## The brick

The whisper-shaped block math (softmax/layernorm/gelu) is four-way (`transformer-numerics` 4095) and runs on the M4 GPU (brick 3m, #3292). A **real llama3.2:3b** block differs in exactly three numerics:

- **RMSNorm** — root-mean-square rescale, no mean-subtraction, no bias (not LayerNorm)
- **SwiGLU** — `silu(gate)·up` (not gelu)
- **SiLU** — `x·sigmoid(x)` (not tanh-gelu)

Until now these lived **only** inside `transformer-kernel.fk`'s `tk-emit-llama` as emitted C strings (three-way, projecting to a freestanding C unit). There was no standalone proven Form recipe for them — confirmed by grep before authoring.

This authors `form/form-stdlib/llama-numerics.fk` and lifts all three to the **four-kernel floor**.

## Proof (hard gate)

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk \
  form-stdlib/llama-numerics.fk form-stdlib/tests/llama-numerics-band.fk
  →  ✓ ... → 4095
  →  fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
  →  1 ok, 0 divergent
```

Go, Rust, TypeScript, and the emitted `fkwu` walker all reproduce SiLU, SwiGLU, RMSNorm bit-for-bit at 1e-6 against the **libm fp64** reference. Pure fp64 arithmetic + list recursion — the same op family `transformer-numerics` 4095 crosses on; no unsupported op, no divergence.

## Core-abstraction-first

The recipes **compose** `transformer-numerics.fk`'s proven `tn-exp` (Taylor) and `tn-sqrt` (Newton) rather than re-deriving the primitive floor.

## Why it matters

With the load-path dequant already four-way (Q4_K/Q6_K/f16-decode all 4095), the components separating a real llama block from the whisper block already on the GPU now live on the same proven floor. Named next stone: **RoPE** (needs a sin/cos primitive floor — `transformer-numerics` carries exp/tanh/sqrt but not sin/cos).

Receipt: `docs/system_audit/commit_evidence_2026-06-18_llama_numerics_four_way.json`. Manifest: `llama-numerics fks 4095`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)