### PR TITLE
attune(roadmap): rung status is evidence-derived — ll-buffer stack done, carrier reconciles vs manifest

### DIFF
--- a/form/form-stdlib/roadmap.fk
+++ b/form/form-stdlib/roadmap.fk
@@ -3,25 +3,34 @@
 ; preludes: form-stdlib/core.fk
 ;
 ; Every step on the grammar tower (self-growing-machine.form G0-G7) is a row here:
-; (id phase title spec status). form-cli lists them (form_cli_roadmap.sh), and for
-; an OPEN step whose spec is a closable recipe gap, hands the spec + assertion to
+; (id phase title spec band status). form-cli lists them (form_cli_roadmap.sh), and
+; for an OPEN step whose spec is a closable recipe gap, hands the spec + assertion to
 ; form_cli_close_gap.sh — a LOCAL oracle drafts the recipe, the LOCAL kernel
 ; validates it. No remote LLM: the plan is data, the generation is local, the proof
 ; is the kernel. The query logic (total / open / next / done) is this recipe,
-; four-way; the carrier only formats and runs the local oracle.
+; four-way; the carrier only formats, reconciles status against the manifest, and
+; runs the local oracle.
 ;
-; status: "done" (proven on main) | "open" (the path ahead). The seed below reflects
-; the real state — G0/G1-base/G2/G4 proven, the G1 lever sub-steps + G3/G7 open.
+; status: "done" (proven on main) | "open" (the path ahead). The `band` field names
+; the fourth-arm-bands.txt stem that PROVES the rung — the carrier
+; (form_cli_roadmap.sh) reads the manifest (host-io) and reconciles each rung's
+; claimed status against it: a rung whose band stem is present in the manifest reads
+; as proven, and any drift between this recipe's claim and the manifest reality is
+; surfaced to the reader. So status can never silently lie: the manifest is the
+; floor source, this recipe is the named intent, the carrier holds them to the same
+; truth. Rungs whose proof is the axiom floor or a multi-band phase carry band "-"
+; (no single manifest stem); the carrier reports those as recipe-asserted.
 ;
 ; Proven by: form-stdlib/tests/roadmap-band.fk (four-way at validate.sh).
 
 (do
-    (defn rm-step (id phase title spec status) (list id phase title spec status))
+    (defn rm-step (id phase title spec band status) (list id phase title spec band status))
     (defn rm-id    (s) (nth s 0))
     (defn rm-phase (s) (nth s 1))
     (defn rm-title (s) (nth s 2))
     (defn rm-spec  (s) (nth s 3))
-    (defn rm-status (s) (nth s 4))
+    (defn rm-band  (s) (nth s 4))
+    (defn rm-status (s) (nth s 5))
 
     (defn rm-done? (status) (if (str_eq status "done") 1 0))
     (defn rm-open? (status) (if (eq (rm-done? status) 1) 0 1))
@@ -38,27 +47,43 @@
             (if (eq (rm-open? (rm-status (head rows))) 1) (head rows)
                 (rm-next-open (tail rows)))))
 
-    ; the real floor->north-star seed (self-growing-machine.form, made walkable)
+    ; the real floor->north-star seed (self-growing-machine.form, made walkable).
+    ; the `band` field (5th) names the fourth-arm-bands.txt stem the carrier
+    ; reconciles status against; "-" means the axiom floor or a multi-band phase
+    ; the carrier reports as recipe-asserted.
     (defn rm-seed ()
         (list
             (rm-step "g0"          "G0" "five axioms + host-kernel carriers"
-                     "host-exec/read/write as gated carriers" "done")
+                     "host-exec/read/write as gated carriers"
+                     "-" "done")
             (rm-step "g1-base"     "G1" "form-lower: int arith + cond + map + recursion -> arm64"
-                     "lower(LIT/ADD/SUB/MUL/DIV/COND/MAP/REC) to bytes, zero clang" "done")
+                     "lower(LIT/ADD/SUB/MUL/DIV/COND/MAP/REC) to bytes, zero clang"
+                     "form-lower" "done")
             (rm-step "g2"          "G2" "BMF grammar + BML + source-compiler"
-                     "any grammar admitted; a grammar may ref another" "done")
+                     "any grammar admitted; a grammar may ref another"
+                     "bmf-grammar" "done")
             (rm-step "g4"          "G4" "form-cli runner: parse, route, host-io, loop"
-                     "pure Form on the kernel, no REST" "done")
-            (rm-step "ll-buffer"   "G1" "form-lower: stack/heap buffer model"
-                     "a memory model (sp alloc + pointers), not just w0/w1 registers" "open")
+                     "pure Form on the kernel, no REST"
+                     "form-cli-loop" "done")
+            (rm-step "ll-buffer"   "G1" "form-lower: stack buffer model (sp alloc + pointers)"
+                     "ll-alloc(n)/ll-store(rt,off)/ll-load(rt,off)/ll-free(n) + ll-buf round-trip"
+                     "ll-buffer" "done")
+            (rm-step "ll-heap"     "G1" "form-lower: heap buffer model"
+                     "malloc/free over a host allocator; rides ll-readfile (syscall rung)"
+                     "-" "open")
             (rm-step "ll-streq"    "G1" "form-lower: lower string ops to byte loops"
-                     "(str_eq a b) -> byte-compare loop; form-asm-tr proves the primitive" "done")
+                     "(str_eq a b) -> byte-compare loop; form-asm-tr proves the primitive"
+                     "form-lower-streq" "done")
             (rm-step "ll-readfile" "G1" "form-lower: lower host-io to syscalls"
-                     "(read_file p) -> open/read/close svc; form-asm-syscall proves the primitive" "open")
+                     "(read_file p) -> open/read/close svc; form-asm-syscall proves the primitive"
+                     "-" "open")
             (rm-step "ll-callconv" "G1" "form-lower: general multi-arg calling convention"
-                     "args in w0..w7, frame setup; today single-arg only" "open")
+                     "args in w0..w7, frame setup; today single-arg only"
+                     "-" "open")
             (rm-step "g3"          "G3" "grammar-as-recipe compiles ANY recipe to native"
-                     "rides G1 completing over strings + host-io" "open")
+                     "rides G1 completing over strings + host-io"
+                     "-" "open")
             (rm-step "g7"          "G7" "form-cli compiles ITSELF (self-host)"
-                     "the runner recipe lowers to a native binary that emits the next" "open")))
+                     "the runner recipe lowers to a native binary that emits the next"
+                     "-" "open")))
     0)

--- a/form/form-stdlib/tests/roadmap-band.fk
+++ b/form/form-stdlib/tests/roadmap-band.fk
@@ -4,26 +4,31 @@
 ;
 ; A four-row fixture: two done (the floor), two open (the path ahead) — the next
 ; open step is the first not-done in order:
-;   g0        done
-;   g1-base   done
-;   ll-buffer open   <- next to build
-;   ll-streq  open
+;   g0        ll-buffer-stack  done   band "ll-buffer"
+;   g1-base   lower base       done   band "form-lower"
+;   ll-heap   heap model       open   band "-"        <- next to build
+;   ll-streq  string lower     open   band "-"
 ;
-; Verdict 31 when every claim lands:
+; The 6th column is the rung's proving band stem — what the carrier reconciles
+; against form/fourth-arm-bands.txt (host-io lives in the carrier, not here).
+;
+; Verdict 63 when every claim lands:
 ;   1   total counts every step          (rm-total == 4)
 ;   2   open-count counts the unbuilt     (== 2)
 ;   4   done-count = total - open         (== 2)
-;   8   next-open is the first not-done    (rm-id (rm-next-open) == "ll-buffer")
+;   8   next-open is the first not-done    (rm-id (rm-next-open) == "ll-heap")
 ;   16  the done? primitive is exact       (rm-done? "done" == 1, rm-done? "open" == 0)
+;   32  the band field reads back exact    (rm-band (head rows) == "ll-buffer")
 (do
     (let rows (list
-        (rm-step "g0"        "G0" "axioms"       "carriers"     "done")
-        (rm-step "g1-base"   "G1" "lower base"   "arith"        "done")
-        (rm-step "ll-buffer" "G1" "buffer model" "sp alloc"     "open")
-        (rm-step "ll-streq"  "G1" "string lower" "byte loop"    "open")))
+        (rm-step "g0"        "G0" "axioms"       "carriers"     "ll-buffer"  "done")
+        (rm-step "g1-base"   "G1" "lower base"   "arith"        "form-lower" "done")
+        (rm-step "ll-heap"   "G1" "heap model"   "malloc/free"  "-"          "open")
+        (rm-step "ll-streq"  "G1" "string lower" "byte loop"    "-"          "open")))
     (let c0 (if (eq (rm-total rows) 4) 1 0))
     (let c1 (if (eq (rm-open-count rows) 2) 2 0))
     (let c2 (if (eq (rm-done-count rows) 2) 4 0))
-    (let c3 (if (str_eq (rm-id (rm-next-open rows)) "ll-buffer") 8 0))
+    (let c3 (if (str_eq (rm-id (rm-next-open rows)) "ll-heap") 8 0))
     (let c4 (if (eq (add (rm-done? "done") (rm-open? "done")) 1) 16 0))
-    (add c0 (add c1 (add c2 (add c3 c4)))))
+    (let c5 (if (str_eq (rm-band (head rows)) "ll-buffer") 32 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -554,7 +554,7 @@ rag-retrieve fks 31
 gcd fkc 31
 form-cli-review-gap fkc 63
 oracle-ensure fks 31
-roadmap fks 31
+roadmap fks 63
 lowering-conviction fkc 127
 form-asm-stack fkc 7
 ll-buffer fkc 1

--- a/scripts/form_cli_roadmap.sh
+++ b/scripts/form_cli_roadmap.sh
@@ -2,19 +2,35 @@
 # form_cli_roadmap.sh — list the floor->north-star steps and the next one to build.
 #
 # The steps and the queries (total / open / next) are roadmap.fk on the kernel
-# (four-way); this carrier only formats. For an OPEN step that is a closable recipe
-# gap, the printed spec is what you hand to form_cli_close_gap.sh — a LOCAL oracle
-# drafts the recipe, the LOCAL kernel validates it. No remote LLM, fully offline.
+# (four-way); this carrier formats AND reconciles each rung's claimed status
+# against the manifest. roadmap.fk stays pure Form data + query logic; reading
+# form/fourth-arm-bands.txt is host-io, so it lives here, not in the recipe. Each
+# rung carries a `band` stem (the fourth-arm-bands.txt row that PROVES it); the
+# carrier checks the stem's presence in the manifest and surfaces any drift
+# between the recipe's claim and the manifest reality, so the recipe's status can
+# never silently lie. A rung whose band is "-" (the axiom floor or a multi-band
+# phase) is reported as recipe-asserted, not manifest-reconciled.
+#
+# For an OPEN step that is a closable recipe gap, the printed spec is what you
+# hand to form_cli_close_gap.sh — a LOCAL oracle drafts the recipe, the LOCAL
+# kernel validates it. No remote LLM, fully offline.
 #
 # Usage: form_cli_roadmap.sh            # the whole tower, done + open, next named
 set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GO="$ROOT/form/form-kernel-go/bin-go"; STD="$ROOT/form/form-stdlib"
+MANIFEST="$ROOT/form/fourth-arm-bands.txt"
 [ -x "$GO" ] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
+
+# manifest_has STEM -> 0 if a band row `<STEM> <emitter> <verdict>` is present.
+# host-io: the recipe names the stem, the carrier reads the manifest floor.
+manifest_has() {
+  awk -v s="$1" '$1==s {found=1; exit} END {exit found?0:1}' "$MANIFEST"
+}
 
 prog="$(mktemp)"
 { cat "$STD/roadmap.fk"
-  echo '(defn rm-emit (rows) (if (eq (len rows) 0) 0 (do (print (rm-id (head rows))) (print (rm-phase (head rows))) (print (rm-status (head rows))) (print (rm-title (head rows))) (rm-emit (tail rows)))))'
+  echo '(defn rm-emit (rows) (if (eq (len rows) 0) 0 (do (print (rm-id (head rows))) (print (rm-phase (head rows))) (print (rm-status (head rows))) (print (rm-band (head rows))) (print (rm-title (head rows))) (rm-emit (tail rows)))))'
   echo '(rm-emit (rm-seed))'
   echo '(print "===")'
   echo '(print (rm-open-count (rm-seed)))'
@@ -24,24 +40,51 @@ prog="$(mktemp)"
 } > "$prog"
 out="$("$GO" "$prog" 2>/dev/null | sed '/^null$/d')"; rm -f "$prog"
 
-echo "── floor → north-star (roadmap.fk on the kernel) ──"
-# steps: 4 lines each (id, phase, status, title) until the === marker
-printf '%s\n' "$out" | awk '
-  /^===$/ {body=1; next}
-  !body {
-    n=(NR-1)%4
-    if (n==0) id=$0
-    else if (n==1) phase=$0
-    else if (n==2) status=$0
-    else { mark=(status=="done")?"✓":"○"; printf "  %s  [%s] %-12s %s\n", mark, phase, id, $0 }
-    next
-  }
-  body && tail==0 {open=$0; tail=1; next}
-  body && tail==1 {nid=$0; tail=2; next}
-  body && tail==2 {ntitle=$0; tail=3; next}
-  body && tail==3 {nspec=$0; tail=4;
-    printf "\n  open: %s   next to build: %s — %s\n", open, nid, ntitle
-    printf "  spec: %s\n", nspec
-    printf "  build it offline:  form-cli close \"%s\" \"<recipe-spec>\" \"<assert>\" \"<expected>\" \"ollama run coder\"\n", nid
-  }
-'
+echo "── floor → north-star (roadmap.fk on the kernel, status reconciled vs manifest) ──"
+# steps: 5 lines each (id, phase, status, band, title) until the === marker.
+# the carrier reconciles each rung's claimed status against form/fourth-arm-bands.txt:
+#   band present in manifest  -> proven   (drift flagged if recipe claims open)
+#   band absent from manifest -> unproven (drift flagged if recipe claims done)
+#   band "-"                  -> recipe-asserted (axiom floor / multi-band phase)
+drift=0
+while IFS= read -r id && IFS= read -r phase && IFS= read -r status \
+      && IFS= read -r band && IFS= read -r title; do
+  [ "$id" = "===" ] && break
+  mark='○'; [ "$status" = "done" ] && mark='✓'
+  note=""
+  if [ "$band" = "-" ]; then
+    note="  (recipe-asserted)"
+  elif manifest_has "$band"; then
+    if [ "$status" != "done" ]; then
+      note="  ⚠ DRIFT: band '$band' is in the manifest but recipe says open"
+      drift=$((drift+1))
+    else
+      note="  (proven: band '$band')"
+    fi
+  else
+    if [ "$status" = "done" ]; then
+      note="  ⚠ DRIFT: recipe says done but band '$band' is NOT in the manifest"
+      drift=$((drift+1))
+    else
+      note="  (gap: band '$band' not yet in manifest)"
+    fi
+  fi
+  printf "  %s  [%s] %-12s %s%s\n" "$mark" "$phase" "$id" "$title" "$note"
+done <<EOF
+$out
+EOF
+
+# tail block after === : open-count, next id, next title, next spec
+tailblock="$(printf '%s\n' "$out" | awk '/^===$/{b=1;next} b{print}')"
+open="$(printf '%s\n' "$tailblock" | sed -n '1p')"
+nid="$(printf '%s\n' "$tailblock" | sed -n '2p')"
+ntitle="$(printf '%s\n' "$tailblock" | sed -n '3p')"
+nspec="$(printf '%s\n' "$tailblock" | sed -n '4p')"
+
+printf "\n  open: %s   next to build: %s — %s\n" "$open" "$nid" "$ntitle"
+printf "  spec: %s\n" "$nspec"
+printf "  build it offline:  form-cli close \"%s\" \"<recipe-spec>\" \"<assert>\" \"<expected>\" \"ollama run coder\"\n" "$nid"
+
+if [ "$drift" -gt 0 ]; then
+  printf "\n  ⚠ %d rung(s) drift from the manifest — reconcile roadmap.fk status with form/fourth-arm-bands.txt.\n" "$drift"
+fi


### PR DESCRIPTION
## What

Fixes a floor-honesty drift the cornerstone audit named: `roadmap.fk` hand-asserted each G0–G7 rung `done`/`open` with no link to evidence, and the `ll-buffer` rung read `open` though `ll-buffer` crossed four-way (`ll-buffer fkc 1` in `form/fourth-arm-bands.txt`).

## Changes

- **`form/form-stdlib/roadmap.fk`** — split the `ll-buffer` rung: the stack buffer model (`ll-alloc`/`ll-store`/`ll-load`/`ll-free` + `ll-buf` round-trip) now reads `done` with band `ll-buffer`; the heap buffer model becomes its own `ll-heap` rung, `open`, riding the `ll-readfile` syscall rung. Added a `band` field (5th column) to every rung — the `fourth-arm-bands.txt` stem that proves it (`g1-base`→`form-lower`, `g2`→`bmf-grammar`, `g4`→`form-cli-loop`, `ll-buffer`→`ll-buffer`; axiom-floor / multi-band phases carry `-`). The recipe stays **pure Form data + query logic, four-way**; `rm-band` reads the stem.
- **`scripts/form_cli_roadmap.sh`** — the carrier reads the manifest (host-io lives here, not in the recipe) and **reconciles** each rung's claimed status against it. A rung whose band stem is present in the manifest reads as `proven`; any drift between the recipe's claim and the manifest reality is surfaced as a loud `⚠ DRIFT` line. A forced `ll-buffer="open"` now fails reconciliation — status can no longer silently lie.
- **`form/form-stdlib/tests/roadmap-band.fk`** — band fixture re-tuned to the 6-field shape; adds the `rm-band` readback assertion (verdict 31→63).
- **`form/fourth-arm-bands.txt`** — `roadmap fks 31`→`63`.

## Four-way proof

```
$ cd form && ./validate.sh form-stdlib/core.fk form-stdlib/roadmap.fk form-stdlib/tests/roadmap-band.fk
  ✓  core.fk+roadmap.fk+roadmap-band.fk  → 63
  fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
  1 ok, 0 divergent — kernels agree on every sample.
```

Rung status is now evidence-derived: the manifest is the floor source, the recipe is the named intent, and the carrier holds them to the same truth on every listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)