### PR TITLE
feat(form): str_eq lowers to native arm64 byte-compare loop — ll-streq rung four-way

### DIFF
--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -120,6 +120,10 @@
     (defn fa-smask (off m) (if (lt off 0) (add off m) off))
     ; cmp x<rn>, #imm  (subs xzr, rn, #imm, 64-bit) : base 0xF100001F | imm<<10 | rn<<5
     (defn fa-cmp-x (rn imm) (fa-asm 4043309087 (list 32 1024) (list rn imm)))
+    ; cmp w<rn>, w<rm>  (subs wzr, rn, rm — register form) : base 0x6B00001F | rm<<16 | rn<<5
+    ;   the byte-loop's per-position compare (str_eq is cmp two LOADED bytes, not a
+    ;   byte vs an immediate); verified against the assembler — cmp w8,w9 == 6b09011f.
+    (defn fa-cmp-r (rn rm) (fa-asm 1795162143 (list 32 65536) (list rn rm)))
     ; b.<cond> #off  (signed, imm19) : base 0x54000000 | off19<<5 | cond
     ;   cond: EQ 0  NE 1  GE 10  LT 11  GT 12  LE 13
     (defn fa-bcond (cond off) (fa-asm 1409286144 (list 1 32) (list cond (fa-smask off 524288))))

--- a/form/form-stdlib/form-lower.fk
+++ b/form/form-stdlib/form-lower.fk
@@ -45,7 +45,8 @@
         (if (eq (lo-tag prog i) 5) (lo-mul prog i argr)
         (if (eq (lo-tag prog i) 8) (lo-div prog i argr)
         (if (eq (lo-tag prog i) 6) (lo-cond prog i argr)
-            (list)))))))))
+        (if (eq (lo-tag prog i) 9) (lo-streq)
+            (list))))))))))
     ; ADD: (x, LIT i) -> lower(x); add w0,w0,#i · (ARG, x) -> lower(x); add w0,w<argr>,w0 ·
     ; else (two subtrees) -> lo-tree. The (ARG, x) fast path needs c1=ARG; without that
     ; guard the general case would silently add w<argr> in place of the left subtree.
@@ -129,6 +130,35 @@
             ecode)))
     (defn lo-cat (xss) (if (eq (len xss) 1) (head xss) (lo-app (head xss) (lo-cat (tail xss)))))
 
+    ; STR_EQ(a, b) — the byte-compare LOOP, the ll-streq rung (roadmap.fk). Strings
+    ; are POINTERS (a in x0, b in x1, the C convention); the result lands in w0 (1 if
+    ; the null-terminated bytes match, else 0). Unlike arith this is a loop with a
+    ; back-edge, so it composes the SAME proven encoders form-asm-tr/branch/headn
+    ; convict — ldrb (byte load), fa-cmp-r (register compare of two loaded bytes, the
+    ; one new primitive the rung needs), fa-bcond (NE/EQ exits), fa-b-off (the loop
+    ; back-edge and the false-skip). Branch offsets are computed from the block layout
+    ; in instructions (bytes/4), never labels — the lo-cond2 discipline at loop scale:
+    ;   loop: ldrb w8,[x0] ; ldrb w9,[x1] ; cmp w8,w9 ; b.ne +6(->ne) ;
+    ;         cmp w8,#0 ; b.eq +6(->eq) ; add x0,x0,#1 ; add x1,x1,#1 ; b -8(loop) ;
+    ;   ne:   movz w0,#0 ; b +2(->end) ; eq: movz w0,#1 ; end:  (caller appends ret)
+    ; The mismatch/terminator exits are symmetric +6 (4 body instrs + the 2 between),
+    ; the back-edge folds -8 (whole block to the top), the false arm skips the true arm
+    ; (+2). A 13th ret is added by lo-compile; lo-streq is the pure value-in-w0 block.
+    (defn lo-streq ()
+        (lo-cat (list
+            (fa-ldrb 8 0 0)              ; loop: load a's byte
+            (fa-ldrb 9 1 0)             ;       load b's byte
+            (fa-cmp-r 8 9)             ;       compare the two loaded bytes
+            (fa-bcond 1 6)            ; b.ne -> not_equal (skip 5, land on movz #0)
+            (fa-cmp 8 0)            ;        both bytes equal — is it the terminator?
+            (fa-bcond 0 6)        ; b.eq -> equal (skip 5, land on movz #1)
+            (fa-add-x-imm 0 0 1) ;          advance a
+            (fa-add-x-imm 1 1 1);           advance b
+            (fa-b-off -8)      ; b loop (back over the 8-instruction body)
+            (fa-movz 0 0)     ; not_equal: result 0
+            (fa-b-off 2)     ; b end (skip the true arm)
+            (fa-movz 0 1)))) ; equal: result 1
+
     ; compile a whole function: lower the root, then return
     (defn lo-compile (prog root) (lo-app (lo-node prog root 1) (fa-ret)))
     ; compile a function OF n: the preamble banks argc (arriving in w0) into w1
@@ -148,7 +178,10 @@
         (if (eq (lo-tag prog i) 5) (lo-map-mul prog i)
         (if (eq (lo-tag prog i) 8) (lo-map-div prog i)
         (if (eq (lo-tag prog i) 6) (lo-map-cond prog i)
-            (list)))))))))
+        (if (eq (lo-tag prog i) 9) (lo-map-streq i)
+            (list))))))))))
+    ; STR_EQ owns all 12 loop instructions — the whole byte-compare block is one node
+    (defn lo-map-streq (i) (list i i i i i i i i i i i i))
     (defn lo-map-add (prog i)
         (if (lo-lit? prog (lo-c2 prog i))
             (lo-app (lo-map prog (lo-c1 prog i)) (list i))

--- a/form/form-stdlib/roadmap.fk
+++ b/form/form-stdlib/roadmap.fk
@@ -52,7 +52,7 @@
             (rm-step "ll-buffer"   "G1" "form-lower: stack/heap buffer model"
                      "a memory model (sp alloc + pointers), not just w0/w1 registers" "open")
             (rm-step "ll-streq"    "G1" "form-lower: lower string ops to byte loops"
-                     "(str_eq a b) -> byte-compare loop; form-asm-tr proves the primitive" "open")
+                     "(str_eq a b) -> byte-compare loop; form-asm-tr proves the primitive" "done")
             (rm-step "ll-readfile" "G1" "form-lower: lower host-io to syscalls"
                      "(read_file p) -> open/read/close svc; form-asm-syscall proves the primitive" "open")
             (rm-step "ll-callconv" "G1" "form-lower: general multi-arg calling convention"

--- a/form/form-stdlib/tests/form-lower-streq-band.fk
+++ b/form/form-stdlib/tests/form-lower-streq-band.fk
@@ -1,0 +1,55 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-lower.fk
+;
+; form-lower-streq-band — STRING LOWERING in the Form -> assembly compiler, the
+; ll-streq rung (roadmap.fk): (str_eq a b) lowers to a null-terminated byte-compare
+; LOOP in arm64, byte-for-byte the assembler's. This is the lever's string half —
+; once form-lower covers strings the whole tower turns native. The primitive
+; form-asm-tr/branch/headn already convict (ldrb, bcond, b-off four-way); the one
+; new encoder the rung names is fa-cmp-r — a register compare of two LOADED bytes
+; (cmp w8,w9), not a byte vs an immediate — also convicted here against the assembler.
+;
+; The tree is a single STR_EQ node (tag 9). Strings are POINTERS — a in x0, b in x1
+; (the C convention); the result is 1/0 in w0. lo-compile prog 0 lowers to:
+;   loop: ldrb w8,[x0] ; ldrb w9,[x1] ; cmp w8,w9 ; b.ne ne ;
+;         cmp w8,#0 ; b.eq eq ; add x0,x0,#1 ; add x1,x1,#1 ; b loop ;
+;   ne:   movz w0,#0 ; b end ; eq: movz w0,#1 ; end: ret
+; assembler ref (clang/as): 39400008 39400029 6b09011f 540000c1 7100011f 540000c0
+;                           91000400 91000421 17fffff8 52800000 14000002 52800020
+;                           d65f03c0
+;
+; Verdict 31 when string lowering is byte-accurate:
+;   1   the new register compare is exact — cmp w8,w9 = 1f 01 09 6b (the rung's
+;       one new primitive; str_eq compares two loaded bytes, not a byte vs immediate)
+;   2   the byte load + the loop's BACKWARD branch are exact — ldrb w8,[x0] and the
+;       -8 back-edge fold (the loop the byte-compare needs, folded to two's complement)
+;   4   the whole 52-byte str_eq image (13 instructions) ends in ret
+;   8   CONVICTION FULL — the compiled byte-compare loop byte-equals the assembler;
+;       the gate opens (clang may be dropped for str_eq) — fa-may-drop = 1
+;  16   COMPOSITIONAL — lo-node of the STR_EQ tree equals the hand-built loop block,
+;       byte-for-byte: the lowering IS the encoder sequence
+(do
+    (let prog (list
+        (list 9 0 0 0)))   ; 0 STR_EQ(a in x0, b in x1) = root
+
+    (let img (lo-compile prog 0))
+    (let ref (list 8 0 64 57    41 0 64 57    31 1 9 107    193 0 0 84
+                   31 1 0 113   192 0 0 84    0 4 0 145     33 4 0 145
+                   248 255 255 23  0 0 128 82  2 0 0 20     32 0 128 82
+                   192 3 95 214))
+    (let hand (lo-app (fa-image (list
+        (fa-ldrb 8 0 0) (fa-ldrb 9 1 0) (fa-cmp-r 8 9) (fa-bcond 1 6)
+        (fa-cmp 8 0) (fa-bcond 0 6) (fa-add-x-imm 0 0 1) (fa-add-x-imm 1 1 1)
+        (fa-b-off -8) (fa-movz 0 0) (fa-b-off 2) (fa-movz 0 1)))
+        (fa-ret)))
+
+    (let c0 (if (fa-conviction (fa-cmp-r 8 9) (list 31 1 9 107)) 1 0))
+    (let c1 (if (fa-conviction (fa-ldrb 8 0 0) (list 8 0 64 57))
+            (if (fa-conviction (fa-b-off -8) (list 248 255 255 23)) 2 0) 0))
+    (let c2 (if (eq (len img) 52)
+            (if (eq (nth img 48) 192)
+            (if (eq (nth img 51) 214) 4 0) 0) 0))
+    (let c3 (if (eq (fa-conviction img ref) 1)
+            (if (eq (fa-may-drop (fa-conviction img ref) 1) 1) 8 0) 0))
+    (let c4 (if (eq (fa-conviction img hand) 1) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -307,6 +307,7 @@ form-lower fks 31
 form-lower-cond fks 31
 form-lower-map fks 31
 form-lower-rec fks 31
+form-lower-streq fks 31
 form-macho fks 31
 form-elf fks 31
 form-elf-exec fks 63


### PR DESCRIPTION
## The ll-streq rung crosses four-way

The lever's string half (self-growing-machine.form, the one lever: grow form-lower over strings + host-io). `form-lower` now turns `(str_eq a b)` into a **null-terminated byte-compare loop in arm64**, byte-for-byte the assembler's — the first string op to lower native, the rung `roadmap.fk` names `ll-streq`.

### What lowers native now
- **`form-asm.fk`** — `fa-cmp-r`: register compare of two **loaded** bytes (`cmp w8,w9` = `subs wzr,wn,wm`, base `0x6B00001F`), the one new primitive the rung needs (`str_eq` compares two bytes, not a byte vs an immediate). Byte-exact against the assembler (`cmp w8,w9 == 6b09011f`). The byte load (`ldrb`), conditional branches (`bcond`), and the loop back-edge (`b-off`) were already convicted four-way by form-asm-tr / branch / headn.
- **`form-lower.fk`** — `STR_EQ` (tag 9) joins `lo-node`'s instruction-selection dispatch **as a data arm** (core-abstraction-first: the table grows, no bolted-on path). `lo-streq` emits the loop from the proven encoders; branch offsets are computed from the block layout in instructions, never labels — the `lo-cond2` discipline at loop scale. `lo-map` gains the mirroring `STR_EQ` source-map arm so the address→bytes→node map cannot drift from the lowering.
- **`tests/form-lower-streq-band.fk`** — verdict **31**, four-way incl. fkwu, **0 divergent**.

### Proof
```
✓  core.fk+form-asm.fk+form-lower.fk+form-lower-streq-band.fk  → 31
fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
1 ok, 0 divergent — kernels agree on every sample.
```

The band convicts: the new compare primitive (byte-exact), the byte load + the `-8` backward fold, the full 52-byte image (13 instructions) ending in `ret`, **CONVICTION FULL** (the compiled image byte-equals clang's — the gate opens, `fa-may-drop = 1`), and **COMPOSITIONAL** (`lo-node` of the STR_EQ tree equals the hand-built loop block).

Strings are pointers (`a` in x0, `b` in x1, the C convention), result 1/0 in w0.

### No regression
Sibling lower/asm bands — `form-lower`, `-cond`, `-rec`, `form-asm-tr`, `-branch`, `-headn`, `form-asm` — all still cross four-way, 0 divergent.

### Edges
- `fourth-arm-bands.txt`: `form-lower-streq fks 31` registered (newline-safe).
- `roadmap.fk`: `ll-streq` open → done.

### What of ll-streq lowers native vs what remains
`(str_eq a b)` over null-terminated string pointers now lowers to a native arm64 byte-compare loop, byte-identical to the assembler, four-way. The remaining string-lowering rungs stay open as their own rows: `str_len` / `str_concat` / `substring` / `str_find` (the rest of the string family) and length-bounded compare; the broader G1 lever steps `ll-buffer`, `ll-readfile` (host-io syscalls), and `ll-callconv` (multi-arg) remain open per `roadmap.fk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)