### PR TITLE
feat(form): RoPE crosses four-way — rotary position embedding as a standalone Form recipe

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-18_rope_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-18_rope_four_way.json
@@ -1,0 +1,31 @@
+{
+  "title": "RoPE — rotary position embedding crosses to the four-kernel floor as a standalone Form recipe",
+  "date": "2026-06-18",
+  "advances": "Closes the LAST llama-specific numeric on the real-llama-block-on-GPU path. llama-numerics.fk (PR #3308, brick 3p) lifted RMSNorm/SwiGLU/SiLU four-way and named RoPE as the next stone, believing it needed a sin/cos primitive floor that 'transformer-numerics carries exp/tanh/sqrt but not sin/cos.' Read-the-body corrected that: the sin/cos floor already lives in trig.fk (fsin/fcos as Taylor recipes, fpow = exp(e*ln b)), already four-way (manifest 'trig fks 127' + 'trig-atan fks 1111111'). RoPE itself lived ONLY inside transformer-kernel.fk's tk-emit-llama as emitted C (cosf/sinf/powf, three-way, projecting to a freestanding C unit) — there was no standalone proven Form recipe for the rotation. This run authors rope.fk and lifts it to the four-kernel floor, composing trig.fk's already-four-way fcos/fsin/fpow rather than re-deriving any transcendental (core-abstraction-first).",
+  "device": "Apple M4 Max (40-core GPU), arm64 Darwin 26.3.1 — proof is host-independent (pure fp64 arithmetic band)",
+  "recipe_new": {
+    "file": "form/form-stdlib/rope.fk",
+    "defns": [
+      "rope-base () = 10000.0  -- the llama rope_theta",
+      "rope-freq (hd HD) = fpow(base, -hd/HD)  -- per-pair frequency, base^(-hd/HD)",
+      "rope-angle (pos hd HD) = pos * rope-freq(hd, HD)  -- rotation angle at position pos",
+      "rope-rot-pair (q0 q1 a) = [q0*cos(a) - q1*sin(a), q0*sin(a) + q1*cos(a)]  -- a planar rotation of one pair",
+      "rope-walk (xs i pos HD) = pairwise walk; hd = i mod HD, steps by 2",
+      "rope (xs pos HD) = rope-walk(xs, 0, pos, HD)  -- rotate a whole even-length vector"
+    ]
+  },
+  "band_new": {
+    "stem": "rope",
+    "verdict": 4095,
+    "what": "RoPE against the libm fp64 reference (cos/sin/pow), every value reduced to an integer at 1e-6. Fixture: x = [1.0, 0.0, 1.0, 1.0], HD = 4 (one head). Pair 0 sits at hd=0 (freq base^0 = 1, so theta = pos exactly: q0=1,q1=0 rotates to (cos pos, sin pos)); pair 1 sits at hd=2 (freq base^-0.5 = 0.01, a slow rotation). Three positions: 0 (identity), 1, 2.",
+    "claims": "1-8: pos=0 identity [1000000, 0, 1000000, 1000000] (pos 0 => theta=0 => cos=1,sin=0 => x unchanged). 16-128: pos=1 [540302, 841471, 989950, 1009950] (the fast pair = (cos 1, sin 1); the slow pair rotates by theta=0.01). 256-2048: pos=2 [-416147, 909297, 979801, 1019799] (the fast pair = (cos 2, sin 2), rotated past pi/2; the slow pair by theta=0.02). => 4095.",
+    "preludes": "form-stdlib/core.fk form-stdlib/trig.fk (already four-way: trig 127, trig-atan 1111111) form-stdlib/rope.fk (new)"
+  },
+  "reference": "libm fp64 via python math (cos/sin/pow). For each adjacent pair (x[i],x[i+1]) at head-dim offset hd=i mod HD: f=10000^(-hd/HD); val=pos*f; q[i]=x[i]*cos(val)-x[i+1]*sin(val); q[i+1]=x[i]*sin(val)+x[i+1]*cos(val). This is exactly the rotation tk-emit-llama emits as C. Every reference value matched the recipe's Form output bit-for-bit at 1e-6 rounding — trig.fk's Taylor sin/cos and exp/ln-based pow land within 0.5e-6 of libm on every claim.",
+  "proof": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/rope.fk form-stdlib/tests/rope-band.fk  ->  '-> 4095', 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)', '1 ok, 0 divergent'.",
+  "verdict": "FOUR-WAY (rope 4095), 0 divergent — Go, Rust, TypeScript, and the emitted fkwu walker all reproduce the RoPE rotation bit-for-bit at 1e-6 against the libm reference. Pure fp64 arithmetic + list recursion (head/tail/cons/empty) + integer mod for the head-dim offset — the same op family trig 127 / llama-numerics 4095 cross on; no unsupported op, no divergence.",
+  "manifest": "registered in form/fourth-arm-bands.txt as 'rope fks 4095', placed in the transformer family directly after 'llama-numerics fks 4095'.",
+  "reading": "With RoPE four-way, EVERY llama-specific numeric is now a proven Form recipe rather than emitted-C-only: RMSNorm + SwiGLU + SiLU (llama-numerics 4095) and now the rotary embedding. Combined with the whisper-shaped block math four-way + on the M4 GPU (transformer-numerics 4095, transformer-block 511, brick 3m), the full backward pass four-way (transformer-backprop / attention-backward / ffn / softmax-ln, all four-way), and the load-path dequant math four-way (Q4_K 4095, Q6_K 4095, f16-decode 4095), the numeric floor under a REAL llama3.2:3b block on the M4 GPU is now complete in Form. Named next stones: emit the llama block (RMSNorm + RoPE + SwiGLU MSL kernel) to Metal next to the whisper block (brick 3m), and run it over real GGUF weights (the load path is already Form-native).",
+  "reproduce": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/rope.fk form-stdlib/tests/rope-band.fk  (four-way 4095, 0 divergent). Run the band individually: rapid back-to-back validate.sh calls share a temp dir and can report a spurious divergence; a single invocation isolates it.",
+  "read_the_body_note": "Confirmed the gap by grep before authoring (default-to-body): RoPE appeared only inside transformer-kernel.fk's tk-emit-llama as emitted C (cosf/sinf), never a standalone four-way recipe. The llama-numerics receipt believed the sin/cos floor was missing; reading the body found trig.fk already carries fsin/fcos/fpow four-way (trig 127, trig-atan 1111111) — so RoPE composed onto an existing proven floor with NO new transcendental and NO kernel native. Design (the rotation shape + the libm reference + strange-minimal fixtures spanning identity / fast pair / slow pair across three positions) was the cost; the four-way proof was seconds — the autonomous-walk lesson held a SIXTH time."
+}

--- a/form/form-stdlib/rope.fk
+++ b/form/form-stdlib/rope.fk
@@ -1,0 +1,40 @@
+; rope.fk — Rotary Position Embedding (RoPE) as a FORM RECIPE, not emitted C.
+;
+; A real llama3.2:3b block rotates the query/key vectors by position before attention:
+; each adjacent pair (x[i], x[i+1]) is rotated by angle θ = pos · base^(−hd/HD), where
+; hd = i mod HD is the position within the head and base = 10000. This is the LAST
+; position-dependent numeric in the llama block — the whisper block (transformer-numerics,
+; 4095) has no RoPE; llama-numerics.fk added RMSNorm/SwiGLU/SiLU; this closes RoPE.
+;
+; Until now RoPE lived ONLY inside transformer-kernel.fk's tk-emit-llama as emitted C
+; (cosf/sinf/powf, three-way, projecting to a C unit). This lifts it to a standalone
+; proven Form recipe — the rotation floor under running a real llama block on the GPU.
+;
+; Core-abstraction-first: compose trig.fk's already-four-way fcos/fsin/fpow (sin/cos as
+; Taylor recipes, fpow = exp(e·ln b)) rather than re-deriving any transcendental. All fp64;
+; the recipe DEFINES the reduction order so every kernel computes the same bits. Conformance
+; pinned to libm cos/sin/pow at 1e-6 in the band.
+
+; --- base θ frequency: base^(−hd/HD), base = 10000 (the llama rope_theta) ---
+(defn rope-base () 10000.0)
+(defn rope-freq (hd HD) (fpow (rope-base) (div (mul -1.0 hd) (mul HD 1.0))))
+; per-pair rotation angle at position pos for head-dim offset hd
+(defn rope-angle (pos hd HD) (mul (mul pos 1.0) (rope-freq hd HD)))
+
+; --- rotate one (q0,q1) pair by angle a → the rotated pair as a 2-list ---
+;   q0' = q0·cos a − q1·sin a ;  q1' = q0·sin a + q1·cos a   (a planar rotation)
+(defn rope-rot-pair (q0 q1 a)
+  (cons (sub (mul q0 (fcos a)) (mul q1 (fsin a)))
+        (cons (add (mul q0 (fsin a)) (mul q1 (fcos a))) (empty))))
+
+; --- walk a vector pairwise, rotating each pair by its position+head-dim angle ---
+; i = absolute dim index (so hd = i mod HD); steps by 2. xs must have even length.
+(defn rope-walk (xs i pos HD)
+  (if (eq (len xs) 0) (empty)
+      (do (let q0 (head xs))
+          (let q1 (head (tail xs)))
+          (let r (rope-rot-pair q0 q1 (rope-angle pos (mod i HD) HD)))
+          (cons (head r)
+                (cons (head (tail r))
+                      (rope-walk (tail (tail xs)) (add i 2) pos HD))))))
+(defn rope (xs pos HD) (rope-walk xs 0 pos HD))

--- a/form/form-stdlib/tests/rope-band.fk
+++ b/form/form-stdlib/tests/rope-band.fk
@@ -1,0 +1,44 @@
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/rope.fk
+;
+; rope-band — Rotary Position Embedding as a Form recipe, lifted to the four-kernel floor.
+; RoPE rotates each adjacent pair (x[i],x[i+1]) by θ = pos·base^(−hd/HD), base=10000. It is
+; the last position-dependent numeric separating a real llama block from the whisper block.
+; Composes trig.fk's already-four-way fcos/fsin/fpow; every claim is a libm fp64 reference
+; value (cos/sin/pow) reduced to an integer at 1e-6 so last-bit display never moves the proof.
+;
+; Fixture: x = [1.0, 0.0, 1.0, 1.0], HD = 4 (one head). Pair 0 sits at hd=0 (freq base^0 = 1,
+; so θ = pos exactly — q0=1,q1=0 rotates to (cos pos, sin pos)); pair 1 sits at hd=2 (freq
+; base^−0.5 = 0.01, a slow rotation). Three positions: 0 (identity), 1, 2.
+;
+; Verdict 4095 when every value lands (×1e6):
+;   1     pos=0 [0] → 1000000   (identity: pos 0 ⇒ θ=0 ⇒ cos=1,sin=0 ⇒ x unchanged)
+;   2     pos=0 [1] → 0
+;   4     pos=0 [2] → 1000000
+;   8     pos=0 [3] → 1000000
+;   16    pos=1 [0] → 540302    (= cos 1, the fast-pair real part)
+;   32    pos=1 [1] → 841471    (= sin 1, the fast-pair imag part)
+;   64    pos=1 [2] → 989950    (slow pair, θ=0.01)
+;   128   pos=1 [3] → 1009950
+;   256   pos=2 [0] → -416147   (= cos 2, the fast pair has rotated past π/2)
+;   512   pos=2 [1] → 909297    (= sin 2)
+;   1024  pos=2 [2] → 979801    (slow pair, θ=0.02)
+;   2048  pos=2 [3] → 1019799
+(do
+    (let x (list 1.0 0.0 1.0 1.0))
+    (let r0 (rope x 0 4))
+    (let r1 (rope x 1 4))
+    (let r2 (rope x 2 4))
+    (let c0  (if (eq (round (mul (nth r0 0) 1000000.0)) 1000000) 1 0))
+    (let c1  (if (eq (round (mul (nth r0 1) 1000000.0)) 0) 2 0))
+    (let c2  (if (eq (round (mul (nth r0 2) 1000000.0)) 1000000) 4 0))
+    (let c3  (if (eq (round (mul (nth r0 3) 1000000.0)) 1000000) 8 0))
+    (let c4  (if (eq (round (mul (nth r1 0) 1000000.0)) 540302) 16 0))
+    (let c5  (if (eq (round (mul (nth r1 1) 1000000.0)) 841471) 32 0))
+    (let c6  (if (eq (round (mul (nth r1 2) 1000000.0)) 989950) 64 0))
+    (let c7  (if (eq (round (mul (nth r1 3) 1000000.0)) 1009950) 128 0))
+    (let c8  (if (eq (round (mul (nth r2 0) 1000000.0)) -416147) 256 0))
+    (let c9  (if (eq (round (mul (nth r2 1) 1000000.0)) 909297) 512 0))
+    (let c10 (if (eq (round (mul (nth r2 2) 1000000.0)) 979801) 1024 0))
+    (let c11 (if (eq (round (mul (nth r2 3) 1000000.0)) 1019799) 2048 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7
+    (add c8 (add c9 (add c10 c11))))))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -348,6 +348,7 @@ transformer-backprop-softmax-ln fks 31
 transformer-block-backward fks 31
 transformer-block-assembly fks 63
 llama-numerics fks 4095
+rope fks 4095
 geometric-learning fks 8388607
 transcendental-natives fks 16
 learning-arc fks 127


### PR DESCRIPTION
## What

Lifts **RoPE (rotary position embedding)** from emitted-C-only to a standalone four-way-proven Form recipe — the **last llama-specific numeric** on the real-llama-block-on-GPU path.

`llama-numerics.fk` (#3308, brick 3p) lifted RMSNorm/SwiGLU/SiLU four-way and named RoPE as the next stone, believing it needed a sin/cos floor that "transformer-numerics carries exp/tanh/sqrt but not sin/cos." **Read-the-body corrected that:** `trig.fk` already carries `fsin`/`fcos`/`fpow` four-way (`trig fks 127`, `trig-atan fks 1111111`). RoPE itself lived only inside `tk-emit-llama` as emitted C (`cosf`/`sinf`/`powf`, three-way). This composes trig's already-four-way primitives — **no new transcendental, no kernel native** (core-abstraction-first).

## Recipe — `form/form-stdlib/rope.fk`

Each adjacent pair `(x[i], x[i+1])` rotates by `θ = pos · 10000^(−hd/HD)`, `hd = i mod HD`:
`q[i] = x[i]·cos θ − x[i+1]·sin θ`, `q[i+1] = x[i]·sin θ + x[i+1]·cos θ`.

## Proof — `rope` four-way **4095**, 0 divergent

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/trig.fk \
  form-stdlib/rope.fk form-stdlib/tests/rope-band.fk
  →  → 4095
  fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
  1 ok, 0 divergent
```

Fixture `x=[1,0,1,1]`, `HD=4`, positions 0/1/2 — identity at pos 0; the fast pair (hd=0, freq 1) rotating to `(cos pos, sin pos)`; the slow pair (hd=2, freq `base^-0.5 = 0.01`). Every value bit-for-bit vs libm `cos`/`sin`/`pow` at 1e-6. Registered as `rope fks 4095`.

## Why it matters

With RoPE four-way, **every llama-specific numeric is now a proven Form recipe** (RMSNorm + SwiGLU + SiLU + rotary embedding). Combined with the whisper block on the M4 GPU (3m), the full backward pass four-way, and the load-path dequant four-way (Q4_K/Q6_K/f16), the numeric floor under a real llama3.2:3b block on the M4 GPU is complete in Form. Next: emit the llama block to Metal next to the whisper block; run it over real GGUF weights.

Receipt: `docs/system_audit/commit_evidence_2026-06-18_rope_four_way.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)