### PR TITLE
feat(form): harvest the float-pool fix — seven more bands cross four-way

### DIFF
--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -592,3 +592,10 @@ form-os-channel fks 111111
 tool-channel-grammar fks 255
 bml-capability-ledger fks 255
 form-lower-readfile fkc 15
+learning-style-space fks 4095
+arch-capacity fks 31
+arch-gen fks 31
+arch-type fks 31
+arch-search fks 31
+arch-joint fks 31
+moe-router fks 127


### PR DESCRIPTION
The fkwu float-pool growth (this session's `fk_fv` grows-on-demand fix) unblocked **seven bands** that were 3-kernel-only purely because their float-heavy loops boxed more than the old fixed 65536 slots. Each re-verified isolated, matching its expected verdict, 0 divergent:

```
learning-style-space fks 4095   (was a fkwu segfault pre-fix)
arch-capacity        fks 31
arch-gen             fks 31
arch-type            fks 31
arch-search          fks 31
arch-joint           fks 31
moe-router           fks 127
```

**No recipe changes** — these already computed the right answer on every kernel; the fix removed the float wall that made fkwu disagree. The transformer/arch/moe float stack is now four-way.

Two float-heavy bands stay 3-kernel-only for OTHER reasons (honestly named, not the float pool): `whisper-block0` (fkwu Segmentation fault — a separate capacity wall) and `transformer-kernel` (a value divergence, fkwu 255 vs 511 — a distinct bug). Both left unregistered, tracked for a focused pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)