### PR TITLE
feat(form): multi-arg calling convention lowers native — ll-callconv, G1 lever complete

### DIFF
--- a/form/form-stdlib/form-lower.fk
+++ b/form/form-stdlib/form-lower.fk
@@ -178,6 +178,21 @@
             (fa-svc 128)        ; svc #0x80 : close(x0=fd)
             (fa-mov 0 4))))     ; x0 = nread (return value)
 
+    ; CALLCONV (the general multi-arg calling convention): place N args in w0..w7 in
+    ; order, over a stack frame, then bl the target. lo-marshal is GENERAL — it moves a
+    ; list of source registers into w0, w1, w2, ... by recursion, so any arity (up to the
+    ; 8 argument registers) lowers without per-arity code. The frame is ll-buffer's own
+    ; alloc/free (sub/add sp), so the calling convention composes the memory model the
+    ; lever already proved — one engine, not a parallel path.
+    (defn lo-marshal (srcs i)
+        (if (eq (len srcs) 0) (list)
+            (lo-app (fa-mov i (head srcs)) (lo-marshal (tail srcs) (add i 1)))))
+    (defn lo-callconv (srcs off n)
+        (lo-app (fa-sub-x-imm 31 31 n)        ; ll-alloc(n): open the call frame
+        (lo-app (lo-marshal srcs 0)           ; args -> w0..w<len-1> (the convention)
+        (lo-app (fa-bl off)                   ; bl target
+                (fa-add-x-imm 31 31 n)))))     ; ll-free(n): close the frame
+
     ; compile a whole function: lower the root, then return
     (defn lo-compile (prog root) (lo-app (lo-node prog root 1) (fa-ret)))
     ; compile a function OF n: the preamble banks argc (arriving in w0) into w1

--- a/form/form-stdlib/tests/form-lower-callconv-band.fk
+++ b/form/form-stdlib/tests/form-lower-callconv-band.fk
@@ -1,0 +1,37 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-lower.fk
+;
+; form-lower-callconv-band — the GENERAL multi-arg calling convention in the
+; Form -> assembly compiler, the ll-callconv rung (roadmap.fk): a call places its
+; args in w0..w7 in order over a stack frame, then bl the target. This is the LAST
+; G1 lever piece — with ll-buffer (memory), ll-streq (strings) and ll-readfile
+; (host-io), form-lower now covers the full surface, so G3 (any recipe -> native)
+; and G7 (self-host) open. lo-marshal is general (recursion over the arg list, any
+; arity up to the 8 argument registers); the frame is ll-buffer's own alloc/free
+; (sub/add sp), so the convention composes the memory model the lever already proved.
+;
+; lo-callconv (19 20 21) 0 16 lowers to:
+;   sub sp,sp,#16 ; mov w0,w19 ; mov w1,w20 ; mov w2,w21 ; bl #0 ; add sp,sp,#16
+;
+; Verdict 15 when the convention is byte-accurate:
+;   1   GENERAL arity — lo-marshal of 2 srcs is 2 movs (8 bytes), of 3 srcs is 3
+;       movs (12 bytes): the marshalling scales with the arg list, never hardcoded
+;   2   the frame is ll-buffer's alloc/free — opens with sub sp,sp,#16 and closes
+;       with add sp,sp,#16 (the memory model carries the call frame)
+;   4   the call + arg placement are exact — bl #0 and mov w0,w19 byte-for-byte
+;   8   COMPOSITIONAL — lo-callconv equals the hand-built frame/marshal/bl block
+(do
+    (let m2 (lo-marshal (list 19 20) 0))
+    (let m3 (lo-marshal (list 19 20 21) 0))
+    (let img (lo-callconv (list 19 20 21) 0 16))
+    (let hand (lo-app (fa-sub-x-imm 31 31 16)
+              (lo-app (fa-image (list (fa-mov 0 19) (fa-mov 1 20) (fa-mov 2 21)))
+              (lo-app (fa-bl 0) (fa-add-x-imm 31 31 16)))))
+
+    (let c0 (if (eq (len m2) 8) (if (eq (len m3) 12) 1 0) 0))
+    (let c1 (if (eq (nth img 0) 255) (if (eq (nth img 3) 209)
+            (if (eq (nth img 20) 255) (if (eq (nth img 23) 145) 2 0) 0) 0) 0))
+    (let c2 (if (fa-conviction (fa-bl 0) (list 0 0 0 148))
+            (if (fa-conviction (fa-mov 0 19) (list 224 3 19 42)) 4 0) 0))
+    (let c3 (if (eq (fa-conviction img hand) 1) 8 0))
+
+    (add c0 (add c1 (add c2 c3))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -599,3 +599,4 @@ arch-type fks 31
 arch-search fks 31
 arch-joint fks 31
 moe-router fks 127
+form-lower-callconv fkc 15


### PR DESCRIPTION
The last G1 lever piece: form-lower lowers the general N-arg calling convention (lo-marshal places args in w0..w7, frame = ll-buffer's alloc/free, then bl). Band form-lower-callconv → 15 four-way, 0 divergent. G1 now covers memory + strings + host-io + multi-arg calls — G3 (any recipe → native) and G7 (self-host) open from here. 🤖 Generated with [Claude Code](https://claude.com/claude-code)