### PR TITLE
feat(form): storage-keys — enumerate a store through the port (offline-replica rung 2)

### DIFF
--- a/docs/coherence-substrate/offline-replica.form
+++ b/docs/coherence-substrate/offline-replica.form
@@ -47,9 +47,11 @@
   (replica-seed-detect "CROSSED — replica.fk: seed a key-set through the port + content-"
                        "addressed change detection (dirty? + candidate set). Band replica -> 15"
                        "four-way (0 divergent).")
-  (enumerate           "OPEN — storage-keys: enumerate a store's keys (the file carrier has"
-                       "the keydir; the db carrier a SELECT). Both seed and merge auto-discover"
-                       "the key-set from it instead of being handed one. A 5th carrier op.")
+  (enumerate           "CROSSED — storage-keys: a 5th carrier op (a new field, never a new call"
+                       "site) enumerates a store's live keys; seed and merge auto-discover the"
+                       "key-set instead of being handed one. memory four-way (band storage-keys ->"
+                       "7); file via record_keys over the keydir (tombstones excluded); db via"
+                       "SELECT k — both host-io.")
   (serve-all-native    "OPEN — lift every promoted native route onto storage-port-db (the ones"
                        "still calling pg_* directly), so the file carrier serves them offline.")
   (merge-back          "OPEN — replica-merge: candidate set -> cell-sync diff vs prod ->"

--- a/form/form-stdlib/cell-log-store.fk
+++ b/form/form-stdlib/cell-log-store.fk
@@ -134,6 +134,16 @@
     (defn cls-found? (result) (if (eq (len result) 1) 1 0))
     (defn cls-value (result) (head result))
 
+    ;; ---- keys: the LIVE keys (every keydir key whose entry is not a tombstone) --
+    ;; record_keys lists the keydir; a deleted key still has a "T" entry, so skip it.
+    (defn cls-keys-loop (kd ks acc)
+        (if (nil? ks) acc
+            (if (cls-tomb? (record_get kd (head ks)))
+                (cls-keys-loop kd (tail ks) acc)
+                (cls-keys-loop kd (tail ks) (cons (head ks) acc)))))
+    (defn cls-keys (st)
+        (do (let kd (cls-keydir st)) (cls-keys-loop kd (record_keys kd) (empty))))
+
     ;; ---- delete: tombstone record in the active segment -------------------
     (defn cls-delete (st key)
         (do

--- a/form/form-stdlib/storage-port-db.fk
+++ b/form/form-stdlib/storage-port-db.fk
@@ -64,7 +64,17 @@
                           (str_concat (db-quote key) ""))) "1")
             1 0))
 
+    ;; ---- keys: SELECT k → the rows, one key per line, walked into a list --
+    ;; pg_query returns rows newline-separated; str_line_at pulls line i, "" past
+    ;; the end (keys are the PRIMARY KEY, never empty, so "" is the honest stop).
+    (defn db-keys-lines (s i acc)
+        (do (let line (str_line_at s i))
+            (if (str_eq line "") acc
+                (db-keys-lines s (add i 1) (cons line acc)))))
+    (defn db-keys (conn)
+        (db-keys-lines (pg_query conn "SELECT k FROM port_kv") 0 (empty)))
+
     (defn carrier-db ()
-        (mk-carrier "postgres" db-init db-put db-get db-has))
+        (mk-carrier "postgres" db-init db-put db-get db-has db-keys))
 
     0)

--- a/form/form-stdlib/storage-port-file.fk
+++ b/form/form-stdlib/storage-port-file.fk
@@ -30,7 +30,10 @@
     (defn file-has (store key)
         (if (eq (cls-found? (cls-get store key)) 1) 1 0))
 
+    ;; keys: the live keys from the log's keydir (tombstones excluded).
+    (defn file-keys (store) (cls-keys store))
+
     (defn carrier-file ()
-        (mk-carrier "file" file-init file-put file-get file-has))
+        (mk-carrier "file" file-init file-put file-get file-has file-keys))
 
     0)

--- a/form/form-stdlib/storage-port.fk
+++ b/form/form-stdlib/storage-port.fk
@@ -34,12 +34,13 @@
     ;; (name, init-fn, put-fn, get-fn, has-fn) — four function VALUES. The whole
     ;; port is these four; a new backend is a new record, never a new call site.
     ;; init-fn takes a CONFIG (path/dir/dsn; memory ignores it) → an open store.
-    (defn mk-carrier (name init put get has) (list "carrier" name init put get has))
+    (defn mk-carrier (name init put get has keys) (list "carrier" name init put get has keys))
     (defn carrier-name (c) (nth c 1))
     (defn carrier-init (c) (nth c 2))
     (defn carrier-put  (c) (nth c 3))
     (defn carrier-get  (c) (nth c 4))
     (defn carrier-has  (c) (nth c 5))
+    (defn carrier-keys (c) (nth c 6))
 
     ;; ---- the PORT interface (carrier-agnostic) ----------------------------
     ;; The entire surface a caller sees. Each pulls the operation (a function
@@ -53,6 +54,14 @@
         (do (let f (carrier-get carrier)) (f store key)))
     (defn storage-has? (carrier store key)
         (do (let f (carrier-has carrier)) (f store key)))
+    ;; storage-keys: enumerate a store's live keys — the op seed + merge need to
+    ;; auto-discover the cell-set (replica-seed / replica-candidates ride this).
+    ;; The carrier pulls its keys-fn just like the other four; no backend named.
+    (defn storage-keys (carrier store)
+        (do (let f (carrier-keys carrier)) (f store)))
+    ;; generic string-list membership, shared (the keys-dedup + candidate walks use it).
+    (defn sp-contains? (xs x)
+        (if (nil? xs) 0 (if (str_eq (head xs) x) 1 (sp-contains? (tail xs) x))))
 
     ;; optional helpers (shared across carriers — the body's 0-or-1 idiom)
     (defn storage-found? (result) (if (eq (len result) 1) 1 0))
@@ -98,8 +107,16 @@
                 (mem-scan (tail store) key))))
     (defn mem-get (store key) (mem-scan store key))
     (defn mem-has (store key) (if (eq (len (mem-scan store key)) 1) 1 0))
+    ;; mem-keys: the unique keys in the assoc-list (newest-first dedup, so an
+    ;; overwritten key appears once — matching last-write-wins on get).
+    (defn mem-keys-loop (store acc)
+        (if (nil? store) acc
+            (if (eq (sp-contains? acc (mem-pair-key (head store))) 1)
+                (mem-keys-loop (tail store) acc)
+                (mem-keys-loop (tail store) (cons (mem-pair-key (head store)) acc)))))
+    (defn mem-keys (store) (mem-keys-loop store (empty)))
 
     (defn carrier-memory ()
-        (mk-carrier "memory" mem-init mem-put mem-get mem-has))
+        (mk-carrier "memory" mem-init mem-put mem-get mem-has mem-keys))
 
     0)

--- a/form/form-stdlib/tests/storage-keys-band.fk
+++ b/form/form-stdlib/tests/storage-keys-band.fk
@@ -1,0 +1,24 @@
+; preludes: form-stdlib/core.fk form-stdlib/storage-port.fk
+;
+; storage-keys-band — enumerate a store's live keys through the port, proven over
+; the memory carrier (the file carrier rides record_keys, the db carrier a SELECT —
+; both host-io). storage-keys is the op the offline replica's seed + merge ride to
+; auto-discover the cell-set; a new carrier op is a new carrier field, never a new
+; call site (the substitutability discipline).
+;
+; Verdict 7 when enumerate is correct:
+;   1   DEDUP — alpha put twice + beta once enumerates to exactly 2 keys (last-write-wins)
+;   2   alpha is present in the enumerated key-set
+;   4   beta is present in the enumerated key-set
+(do
+    (let mem (carrier-memory))
+    (let s (storage-put mem
+              (storage-put mem
+                (storage-put mem (storage-open mem 0) "alpha" "one")
+                "beta" "two")
+              "alpha" "one-REVISED"))
+    (let ks (storage-keys mem s))
+    (let c0 (if (eq (len ks) 2) 1 0))
+    (let c1 (if (eq (sp-contains? ks "alpha") 1) 2 0))
+    (let c2 (if (eq (sp-contains? ks "beta") 1) 4 0))
+    (add c0 (add c1 c2)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -602,3 +602,4 @@ moe-router fks 127
 form-lower-callconv fkc 15
 transformer-kernel fks 511
 replica fks 15
+storage-keys fks 7


### PR DESCRIPTION
The enumerate op seed + merge need, added as a 5th storage-port carrier field (new op = new field, never a new call site). All three carriers: memory (four-way), file (record_keys over keydir), db (SELECT, host-io). Band storage-keys → 7 four-way, 0 divergent; storage-port-band stays 11111. Replica enumerate rung crosses. 🤖 Generated with [Claude Code](https://claude.com/claude-code)