### PR TITLE
feat(form): replica-merge — reconcile offline edits back to prod (the merge-back rung)

### DIFF
--- a/docs/coherence-substrate/offline-replica.form
+++ b/docs/coherence-substrate/offline-replica.form
@@ -54,9 +54,11 @@
                        "SELECT k — both host-io.")
   (serve-all-native    "OPEN — lift every promoted native route onto storage-port-db (the ones"
                        "still calling pg_* directly), so the file carrier serves them offline.")
-  (merge-back          "OPEN — replica-merge: candidate set -> cell-sync diff vs prod ->"
-                       "cache-phase conflict -> storage-put db. The reconcile direction, on the"
-                       "proven cell-sync + cache-phase organs.")
+  (merge-back          "CROSSED — replica-merge: the candidate set reconciles back to prod, the"
+                       "seed baseline telling clean-apply from conflict (content-addressed, cache-"
+                       "phase input-hash trust). A clean edit applies; a key prod ALSO changed is"
+                       "NAMED a conflict, never clobbered; a clean run reports zero false conflicts."
+                       "Band replica-merge -> 15 four-way (0 divergent). The db storage-put leg is host-io.")
   (db-carrier-seed     "OPEN/host-io — the db leg of seed/apply rides the Rust-only pg_*"
                        "carrier; named 3-kernel host-io, the prod boundary."))
 

--- a/form/form-stdlib/replica.fk
+++ b/form/form-stdlib/replica.fk
@@ -41,4 +41,40 @@
                         (storage-value (storage-get local-c local-s (head keys)))) 1)
                 (cons (head keys) (replica-candidates base-c base-s local-c local-s (tail keys)))
                 (replica-candidates base-c base-s local-c local-s (tail keys)))))
+
+    ;; ---- MERGE-BACK: reconcile the offline edits into prod, on reconnect. -----
+    ;; Three values per candidate key — the seed BASELINE, the LOCAL edit, the
+    ;; current PROD — classify by content-addressed comparison (cache-phase's input-
+    ;; hash trust): clean-apply if prod still equals the baseline (untouched since
+    ;; seed), no-op if local never diverged (or converged with prod), CONFLICT if
+    ;; prod AND local both changed the baseline differently. No row is silently
+    ;; overwritten — a conflict is NAMED, not clobbered.
+    (defn replica-merge-class (baseline-val local-val prod-val)
+        (if (str_eq local-val baseline-val) 2          ; not edited offline -> no-op
+            (if (str_eq prod-val baseline-val) 0       ; prod untouched -> clean apply
+                (if (str_eq prod-val local-val) 2      ; converged independently -> no-op
+                    1))))                              ; both diverged -> conflict
+    ;; fold one candidate into the (prod-store, conflict-keys) accumulator.
+    (defn replica-merge-step (base-c base-s loc-c loc-s prod-c acc key)
+        (do
+            (let prod-s (head acc))
+            (let conflicts (head (tail acc)))
+            (let lv (storage-value (storage-get loc-c loc-s key)))
+            (let cls (replica-merge-class
+                        (storage-value (storage-get base-c base-s key)) lv
+                        (storage-value (storage-get prod-c prod-s key))))
+            (if (eq cls 0) (list (storage-put prod-c prod-s key lv) conflicts)
+                (if (eq cls 1) (list prod-s (cons key conflicts))
+                    (list prod-s conflicts)))))
+    (defn replica-merge-fold (base-c base-s loc-c loc-s prod-c acc keys)
+        (if (nil? keys) acc
+            (replica-merge-fold base-c base-s loc-c loc-s prod-c
+                (replica-merge-step base-c base-s loc-c loc-s prod-c acc (head keys))
+                (tail keys))))
+    ;; reconcile the local store's offline edits back into prod; the seed baseline
+    ;; tells clean-apply from conflict. Returns (prod-store' conflict-keys).
+    (defn replica-merge (base-c base-s loc-c loc-s prod-c prod-s keys)
+        (replica-merge-fold base-c base-s loc-c loc-s prod-c (list prod-s (empty)) keys))
+    (defn replica-merge-store (result) (head result))
+    (defn replica-merge-conflicts (result) (head (tail result)))
     0)

--- a/form/form-stdlib/tests/replica-merge-band.fk
+++ b/form/form-stdlib/tests/replica-merge-band.fk
@@ -1,0 +1,35 @@
+; preludes: form-stdlib/core.fk form-stdlib/storage-port.fk form-stdlib/replica.fk
+;
+; replica-merge-band — the offline replica's MERGE-BACK: reconcile offline edits into
+; prod on reconnect, the seed baseline distinguishing clean-apply from conflict (cache
+; -phase's input-hash trust, content-addressed). cell-sync is the kin transport (the
+; candidate set is its want-set); this proves the apply + conflict decision. Memory
+; carrier (prod = the db carrier, local = the file carrier in production).
+;
+; Verdict 15 when merge-back is correct:
+;   1   CLEAN-APPLY — prod still equals the baseline, so the offline edit lands in prod
+;   2   CONFLICT not clobbered — prod changed too, so the offline edit does NOT overwrite it
+;   4   CONFLICT named — the diverged key is reported in the conflict set, not silently dropped
+;   8   CLEAN run reports zero conflicts — a clean reconcile names no false conflict
+(do
+    (let mem (carrier-memory))
+    ;; seed baseline (the snapshot taken going offline)
+    (let base (storage-put mem (storage-put mem (storage-open mem 0) "alpha" "one") "beta" "two"))
+    ;; offline: alpha edited, beta untouched
+    (let local (storage-put mem base "alpha" "one-LOCAL"))
+    ;; auto-discover the dirty candidate set (storage-keys + replica-candidates)
+    (let cands (replica-candidates mem base mem local (storage-keys mem local)))   ; -> (alpha)
+
+    ;; scenario CLEAN — prod still == baseline
+    (let resA (replica-merge mem base mem local mem base cands))
+    ;; scenario CONFLICT — prod's alpha changed under us
+    (let prodB (storage-put mem base "alpha" "one-PROD"))
+    (let resB (replica-merge mem base mem local mem prodB cands))
+
+    (let c0 (if (str_eq (storage-value (storage-get mem (replica-merge-store resA) "alpha")) "one-LOCAL") 1 0))
+    (let c1 (if (str_eq (storage-value (storage-get mem (replica-merge-store resB) "alpha")) "one-PROD") 2 0))
+    (let c2 (if (eq (len (replica-merge-conflicts resB)) 1)
+            (if (str_eq (head (replica-merge-conflicts resB)) "alpha") 4 0) 0))
+    (let c3 (if (eq (len (replica-merge-conflicts resA)) 0) 8 0))
+
+    (add c0 (add c1 (add c2 c3))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -603,3 +603,4 @@ form-lower-callconv fkc 15
 transformer-kernel fks 511
 replica fks 15
 storage-keys fks 7
+replica-merge fks 15


### PR DESCRIPTION
The offline replica's merge-back: dirty candidates reconcile to prod, the seed baseline telling clean-apply from conflict (content-addressed, cache-phase trust). No row clobbered — conflicts are named. Band replica-merge → 15 four-way, 0 divergent. The seed→enumerate→change-detect→merge round-trip is now proven over storage-port. 🤖 Generated with [Claude Code](https://claude.com/claude-code)