### PR TITLE
feat(form): replica-serve — serve-swap policy in Form (prod online, local offline)

### DIFF
--- a/docs/coherence-substrate/offline-replica.form
+++ b/docs/coherence-substrate/offline-replica.form
@@ -52,8 +52,12 @@
                        "key-set instead of being handed one. memory four-way (band storage-keys ->"
                        "7); file via record_keys over the keydir (tombstones excluded); db via"
                        "SELECT k — both host-io.")
-  (serve-all-native    "OPEN — lift every promoted native route onto storage-port-db (the ones"
-                       "still calling pg_* directly), so the file carrier serves them offline.")
+  (serve-all-native    "RECIPE-COMPLETE — the native route bodies already read through the port,"
+                       "carrier-agnostic and four-way (ideas-graph-projection -> 11111, graph-node-"
+                       "port -> 11111 name no backend; no stdlib recipe calls pg_* directly). The"
+                       "serve POLICY is now Form too: replica-serve -> 7 reads from prod online,"
+                       "local offline, by mode. The only remaining serve work is host-io: the kernel"
+                       "route dispatch opening the file carrier when offline (the toggle, not logic).")
   (merge-back          "CROSSED — replica-merge: the candidate set reconciles back to prod, the"
                        "seed baseline telling clean-apply from conflict (content-addressed, cache-"
                        "phase input-hash trust). A clean edit applies; a key prod ALSO changed is"

--- a/form/form-stdlib/replica.fk
+++ b/form/form-stdlib/replica.fk
@@ -77,4 +77,17 @@
         (replica-merge-fold base-c base-s loc-c loc-s prod-c (list prod-s (empty)) keys))
     (defn replica-merge-store (result) (head result))
     (defn replica-merge-conflicts (result) (head (tail result)))
+
+    ;; ---- SERVE: which backend answers a read, by online-mode. ----------------
+    ;; The native route bodies already read through storage-port (carrier-agnostic —
+    ;; ideas-graph-projection / graph-node-port name no backend), so serving offline
+    ;; is purely WHICH carrier the route is handed. This is that policy, in Form:
+    ;; online -> the prod (db) carrier+store, offline -> the local (file) carrier+store.
+    ;; The route dispatch opens the chosen carrier (host-io); the choice is Form.
+    (defn replica-serve-carrier (online? online-c offline-c) (if (eq online? 1) online-c offline-c))
+    (defn replica-serve-store   (online? online-s offline-s) (if (eq online? 1) online-s offline-s))
+    ;; serve a read: pick the backend by mode, then the carrier-agnostic storage-get.
+    (defn replica-serve (online? on-c on-s off-c off-s key)
+        (storage-get (replica-serve-carrier online? on-c off-c)
+                     (replica-serve-store   online? on-s off-s) key))
     0)

--- a/form/form-stdlib/tests/replica-serve-band.fk
+++ b/form/form-stdlib/tests/replica-serve-band.fk
@@ -1,0 +1,26 @@
+; preludes: form-stdlib/core.fk form-stdlib/storage-port.fk form-stdlib/replica.fk
+;
+; replica-serve-band — the offline replica's SERVE policy: a read is answered from
+; prod when online, from the local store when offline, through the carrier-agnostic
+; port. The native route bodies (ideas-graph-projection fks 11111, graph-node-port
+; fks 11111) are ALREADY carrier-agnostic and four-way, so serving offline is purely
+; which carrier the route is handed — this proves that choice. The route dispatch
+; opens the chosen carrier (host-io); the policy is Form.
+;
+; Verdict 7 when the serve-swap is correct:
+;   1   ONLINE serves prod — the read returns the prod store's value
+;   2   OFFLINE serves local — the read returns the local store's value
+;   4   the SAME key reads differently by mode (the swap actually selects the backend)
+(do
+    (let mem (carrier-memory))
+    (let prod  (storage-put mem (storage-open mem 0) "idea:alpha" "PROD"))
+    (let local (storage-put mem (storage-open mem 0) "idea:alpha" "LOCAL"))
+
+    (let online  (replica-serve 1 mem prod mem local "idea:alpha"))
+    (let offline (replica-serve 0 mem prod mem local "idea:alpha"))
+
+    (let c0 (if (str_eq (storage-value online)  "PROD")  1 0))
+    (let c1 (if (str_eq (storage-value offline) "LOCAL") 2 0))
+    (let c2 (if (eq (str_eq (storage-value online) (storage-value offline)) 0) 4 0))
+
+    (add c0 (add c1 c2)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -604,3 +604,4 @@ transformer-kernel fks 511
 replica fks 15
 storage-keys fks 7
 replica-merge fks 15
+replica-serve fks 7


### PR DESCRIPTION
The serve direction of the offline replica. Native route bodies are already carrier-agnostic + four-way (ideas-graph-projection 11111, graph-node-port 11111); replica-serve makes the backend choice Form (prod online / local offline) → band 7 four-way, 0 divergent. serve-all-native is recipe-complete; only the host-io route-dispatch carrier toggle remains. 🤖 Generated with [Claude Code](https://claude.com/claude-code)