### PR TITLE
feat(form): write_file lowers to native arm64 syscalls — host-io write half

### DIFF
--- a/docs/coherence-substrate/offline-replica.form
+++ b/docs/coherence-substrate/offline-replica.form
@@ -63,8 +63,17 @@
                        "phase input-hash trust). A clean edit applies; a key prod ALSO changed is"
                        "NAMED a conflict, never clobbered; a clean run reports zero false conflicts."
                        "Band replica-merge -> 15 four-way (0 divergent). The db storage-put leg is host-io.")
-  (db-carrier-seed     "OPEN/host-io — the db leg of seed/apply rides the Rust-only pg_*"
-                       "carrier; named 3-kernel host-io, the prod boundary."))
+  (local-host-io       "NATIVE-LOWERABLE — the offline substrate's own host-io (the cell-log"
+                       "read AND append) lowers to native arm64 syscalls via the lever:"
+                       "form-lower-readfile -> 15 (open/read/close) and form-lower-writefile -> 15"
+                       "(open-append/write/close), both four-way. So the local store compiles to"
+                       "native machine code, not interpreted-kernel host_io natives. fkwu the"
+                       "WALKER does not carry I/O (a correct standing wall — its job is agreement,"
+                       "not side-effects); 'native' here means the form-lower lever, the G7 path.")
+  (db-prod-boundary    "EXTERNAL/host-io — the pg_* leg of seed-from-prod / apply-to-prod is the"
+                       "Postgres wire protocol to an external server, only needed ONLINE (offline"
+                       "the file carrier serves everything). Rust-only; the genuine external edge,"
+                       "not an fkwu gap — naming it honest, not a wall to climb in the walker."))
 
 ; The north star rides the completed G1 lever (form-lower covers memory/strings/host-io/
 ; calls four-way) and the proven storage organs above. No step invents a new primitive —

--- a/form/form-stdlib/form-lower.fk
+++ b/form/form-stdlib/form-lower.fk
@@ -47,7 +47,8 @@
         (if (eq (lo-tag prog i) 6) (lo-cond prog i argr)
         (if (eq (lo-tag prog i) 9) (lo-streq)
         (if (eq (lo-tag prog i) 10) (lo-readfile)
-            (list)))))))))))
+        (if (eq (lo-tag prog i) 11) (lo-writefile)
+            (list))))))))))))
     ; ADD: (x, LIT i) -> lower(x); add w0,w0,#i · (ARG, x) -> lower(x); add w0,w<argr>,w0 ·
     ; else (two subtrees) -> lo-tree. The (ARG, x) fast path needs c1=ARG; without that
     ; guard the general case would silently add w<argr> in place of the left subtree.
@@ -177,6 +178,23 @@
             (fa-movz-x 16 6)    ; x16 = SYS_close
             (fa-svc 128)        ; svc #0x80 : close(x0=fd)
             (fa-mov 0 4))))     ; x0 = nread (return value)
+
+    ; WRITE_FILE (tag 11): host-io WRITE lowers to the open(append)/write/close syscall
+    ; sequence — the write half of the lever, mirroring lo-readfile (macOS BSD: open=5
+    ; with O_WRONLY|O_APPEND flags in x1, write=4, close=6, svc #0x80). With lo-readfile
+    ; this makes the local store's host-io (cell-log read AND append) native-lowerable.
+    (defn lo-writefile ()
+        (lo-cat (list
+            (fa-movz-x 16 5)    ; x16 = SYS_open  (x0=path, x1=flags O_WRONLY|O_APPEND)
+            (fa-svc 128)        ; svc #0x80 : open -> fd in x0
+            (fa-mov 3 0)        ; bank fd -> x3
+            (fa-movz-x 16 4)    ; x16 = SYS_write (x0=fd, x1=buf, x2=count)
+            (fa-svc 128)        ; svc #0x80 : write -> nwritten in x0
+            (fa-mov 4 0)        ; bank nwritten -> x4
+            (fa-mov 0 3)        ; x0 = fd
+            (fa-movz-x 16 6)    ; x16 = SYS_close
+            (fa-svc 128)        ; svc #0x80 : close(x0=fd)
+            (fa-mov 0 4))))     ; x0 = nwritten (return value)
 
     ; CALLCONV (the general multi-arg calling convention): place N args in w0..w7 in
     ; order, over a stack frame, then bl the target. lo-marshal is GENERAL — it moves a

--- a/form/form-stdlib/tests/form-lower-writefile-band.fk
+++ b/form/form-stdlib/tests/form-lower-writefile-band.fk
@@ -1,0 +1,42 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-lower.fk
+;
+; form-lower-writefile-band — the WRITE half of host-io lowering, the lever's last
+; host-io piece. (write_file p) lowers to the open(append)/write/close syscall
+; sequence in arm64 (macOS BSD: open=5, write=4, close=6, svc #0x80), byte-for-byte
+; the assembler's. With form-lower-readfile (the read half), the local store's host-io
+; — the cell-log's read AND append — is now native-lowerable; the offline substrate's
+; durable store compiles to native machine code, no interpreted-kernel host_io natives.
+;
+; The tree is a single WRITE_FILE node (tag 11). lo-compile prog 0 lowers to:
+;   movz x16,#5 ; svc #0x80     ; open(x0=path, x1=O_WRONLY|O_APPEND) -> fd in x0
+;   mov w3,w0                   ; bank fd
+;   movz x16,#4 ; svc #0x80     ; write(x0=fd, x1=buf, x2=count) -> nwritten in x0
+;   mov w4,w0                   ; bank nwritten
+;   mov w0,w3 ; movz x16,#6 ; svc #0x80   ; close(x0=fd)
+;   mov w0,w4 ; ret             ; return nwritten
+;
+; Verdict 15 when the write lowering is byte-accurate:
+;   1   the syscall instruction + open-number load are exact (svc #0x80, movz x16,#5)
+;   2   the WRITE + close syscall-number loads are exact (movz x16,#4 / movz x16,#6)
+;   4   the whole 44-byte image (10 instructions + ret) ends in ret
+;   8   COMPOSITIONAL — lo-node of the WRITE_FILE tree equals the hand-built
+;       open/write/close block byte-for-byte: the lowering IS the syscall sequence
+(do
+    (let prog (list (list 11 0 0 0)))   ; 0 WRITE_FILE(path in x0) = root
+    (let img (lo-compile prog 0))
+    (let hand (lo-app (fa-image (list
+        (fa-movz-x 16 5) (fa-svc 128) (fa-mov 3 0)
+        (fa-movz-x 16 4) (fa-svc 128) (fa-mov 4 0)
+        (fa-mov 0 3) (fa-movz-x 16 6) (fa-svc 128) (fa-mov 0 4)))
+        (fa-ret)))
+
+    (let c0 (if (fa-conviction (fa-svc 128) (list 1 16 0 212))
+            (if (fa-conviction (fa-movz-x 16 5) (list 176 0 128 210)) 1 0) 0))
+    (let c1 (if (fa-conviction (fa-movz-x 16 4) (list 144 0 128 210))
+            (if (fa-conviction (fa-movz-x 16 6) (list 208 0 128 210)) 2 0) 0))
+    (let c2 (if (eq (len img) 44)
+            (if (eq (nth img 40) 192)
+            (if (eq (nth img 43) 214) 4 0) 0) 0))
+    (let c3 (if (eq (fa-conviction img hand) 1) 8 0))
+
+    (add c0 (add c1 (add c2 c3))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -605,3 +605,4 @@ replica fks 15
 storage-keys fks 7
 replica-merge fks 15
 replica-serve fks 7
+form-lower-writefile fkc 15


### PR DESCRIPTION
The lever's last host-io piece: form-lower lowers WRITE_FILE (tag 11) to the canonical open-append/write/close svc sequence, byte-for-byte the assembler's. Band form-lower-writefile → 15 four-way, 0 divergent. With readfile, the offline substrate's local store (cell-log read + append) now lowers native. Honest framing: fkwu-the-walker correctly doesn't carry I/O; 'native' host-io = the form-lower lever. The pg prod boundary is the external online-only edge. 🤖 Generated with [Claude Code](https://claude.com/claude-code)