### PR TITLE
feat(form): corpus-train transformer crosses four-way at width 4 — dimension-generic proven

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 285 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 286 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/form/form-stdlib/tests/transformer-corpus-train-wide-band.fk
+++ b/form/form-stdlib/tests/transformer-corpus-train-wide-band.fk
@@ -1,0 +1,74 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-backprop.fk form-stdlib/transformer-corpus-train.fk
+;
+; transformer-corpus-train-wide-band — the SAME corpus-train recipe, WIDER.
+;
+; transformer-corpus-train-band proves the 2→2→2 floor; this proves the recipe
+; is DIMENSION-GENERIC at width 4. tbp-bk / tbp-stack-step / tct-train-blocks /
+; tct-corpus-loss are unchanged — every op (tb-matvec, tb-affine, tn-layernorm,
+; tbp-dx, tbp-outer) folds over list length, so at width 4 the matrices are 4×4
+; and the vectors are 4-wide; ZERO new logic, only a 4-dim fixture.
+;
+; The fixture is the carrier's real signal SHAPE: x = [task-length-norm, code-word,
+; has-path-token, question-mark], t = [Read-used, Edit-used, Bash-used, Write-used]
+; — the oracle's full tool-usage vector. Six examples train, two are held out. The
+; two-block residual stack folds tbp-stack-step over the corpus for 20 then 60
+; epochs. Loss ×1e6 rounded to integers, so all four kernels compare byte-for-byte.
+; Measured (Go, deterministic): train 13.964 → 2.122 → 1.034, held-out 4.808 → 0.431
+; — it learns the wider signal and carries it to UNSEEN turns.
+;
+; A wider stack boxes far more floats per epoch (4×4 matrices, six examples), so this
+; is also the real exercise of fkwu's grown-on-demand float pool at width.
+;
+; Verdict 31:
+;   1    the untrained wide stack carries real corpus loss (l0 > 0)
+;   2    training over the corpus lowers it (l20 < l0)
+;   4    and keeps lowering it past the first phase (l60 < l20)
+;   8    it GENERALIZES — held-out loss falls too (h60 < h0), not memorization
+;   16   substantial — training cut corpus loss to under a quarter (4·l60 < l0)
+(do
+    ; two 4×4 residual blocks — small structured init, the proven-shape pattern at width 4.
+    (let ba (tbp-bk
+        (list (list 0.30 -0.20 0.10 0.05) (list 0.10 0.40 -0.15 0.20)
+              (list -0.05 0.25 0.35 -0.10) (list 0.15 -0.30 0.20 0.30))
+        (list 0.0 0.0 0.0 0.0)
+        (list (list 0.50 0.20 -0.10 0.15) (list -0.30 0.60 0.25 -0.05)
+              (list 0.10 -0.20 0.45 0.30) (list 0.20 0.35 -0.25 0.40))
+        (list 0.0 0.0 0.0 0.0)))
+    (let bb (tbp-bk
+        (list (list 0.20 0.10 -0.05 0.15) (list -0.10 0.30 0.20 -0.15)
+              (list 0.25 -0.20 0.35 0.10) (list -0.05 0.15 -0.10 0.40))
+        (list 0.0 0.0 0.0 0.0)
+        (list (list 0.40 -0.20 0.15 -0.10) (list 0.30 0.50 -0.25 0.20)
+              (list -0.15 0.25 0.45 0.10) (list 0.20 -0.10 0.30 0.35))
+        (list 0.0 0.0 0.0 0.0)))
+    ; corpus: x = [task-len-norm, code-word, has-path, question-mark]  →  t = [Read Edit Bash Write]
+    (let train (list
+        (list (list 0.80 1.0 1.0 0.0) (list 1.0 1.0 0.0 0.0))
+        (list (list 0.30 0.0 0.0 1.0) (list 1.0 0.0 0.0 0.0))
+        (list (list 0.95 1.0 1.0 0.0) (list 1.0 1.0 1.0 1.0))
+        (list (list 0.50 1.0 0.0 0.0) (list 1.0 0.0 1.0 0.0))
+        (list (list 0.20 0.0 0.0 1.0) (list 0.0 0.0 0.0 0.0))
+        (list (list 0.70 1.0 1.0 1.0) (list 1.0 1.0 0.0 1.0))))
+    (let held (list
+        (list (list 0.60 1.0 1.0 0.0) (list 1.0 1.0 0.0 0.0))
+        (list (list 0.25 0.0 0.0 1.0) (list 1.0 0.0 0.0 0.0))))
+    (let eps 0.00001)
+    (let lr 0.03)
+
+    (let s0  (list ba bb))
+    (let s20 (tct-train-blocks ba bb train lr eps 20))
+    (let s60 (tct-train-blocks ba bb train lr eps 60))
+
+    (let l0  (round (mul (tct-corpus-loss s0  train eps) 1000000.0)))
+    (let l20 (round (mul (tct-corpus-loss s20 train eps) 1000000.0)))
+    (let l60 (round (mul (tct-corpus-loss s60 train eps) 1000000.0)))
+    (let h0  (round (mul (tct-corpus-loss s0  held eps) 1000000.0)))
+    (let h60 (round (mul (tct-corpus-loss s60 held eps) 1000000.0)))
+
+    (let c0 (if (gt l0 0) 1 0))
+    (let c1 (if (lt l20 l0) 2 0))
+    (let c2 (if (lt l60 l20) 4 0))
+    (let c3 (if (lt h60 h0) 8 0))
+    (let c4 (if (lt (add l60 (add l60 (add l60 l60))) l0) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -349,6 +349,7 @@ transformer-backprop-softmax-ln fks 31
 transformer-block-backward fks 31
 transformer-block-assembly fks 63
 transformer-corpus-train fks 31
+transformer-corpus-train-wide fks 31
 llama-numerics fks 4095
 rope fks 4095
 geometric-learning fks 8388607

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 285
+**Total files**: 286
 
 | File | Purpose |
 |---|---|
@@ -101,6 +101,7 @@
 | [form_cli_tiered.sh](form_cli_tiered.sh) | form_cli_tiered.sh — retire the REMOTE oracle on reasoning: local-first, tiered. |
 | [form_cli_train_predict.sh](form_cli_train_predict.sh) | form_cli_train_predict.sh — train a NATIVE tool predictor on the corpus, then |
 | [form_cli_transformer_train.sh](form_cli_transformer_train.sh) | form_cli_transformer_train.sh — train the Form-native transformer on the REAL |
+| [form_cli_transformer_train_wide.sh](form_cli_transformer_train_wide.sh) | form_cli_transformer_train_wide.sh — train the WIDER (4→4→4) Form-native |
 | [form_codesign_conviction_demo.sh](form_codesign_conviction_demo.sh) | form_codesign_conviction_demo.sh — byte-conviction for the Form code-signer. |
 | [form_coreutils_diff.sh](form_coreutils_diff.sh) | form_coreutils_diff.sh — differential test of the zero-clang Form coreutils against |
 | [form_debug_demo.sh](form_debug_demo.sh) | form_debug_demo.sh — LIVE DEBUGGING: the value trace joined with provenance. |

--- a/scripts/form_cli_transformer_train_wide.sh
+++ b/scripts/form_cli_transformer_train_wide.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# form_cli_transformer_train_wide.sh — train the WIDER (4→4→4) Form-native
+# transformer on the REAL captured oracle corpus.
+#
+# The LOGIC is Form: transformer-corpus-train.fk folds the proven two-block
+# residual SGD atom over a corpus — the SAME dimension-generic recipe the 2-dim
+# carrier uses, four-way proven (Go/Rust/TS/fkwu) at width 4 by
+# tests/transformer-corpus-train-wide-band.fk (verdict 31). This is a thin
+# host-IO carrier: it reads the body's 949-turn corpus of the trusted remote
+# oracle's (Claude's) turns and featurizes each into a 4-dim (x, t) row —
+#   x = [task-length-norm, code-word-present, has-path-or-file-token, question-mark]
+#   t = [Read-used, Edit-used, Bash-used, Write-used]   (the oracle's REAL tool vector)
+# — splits train/held (every 5th held), emits a Form program that trains the
+# wider native transformer through the proven recipe, and reports train +
+# held-out loss falling on real data.
+#
+# Width 2 is the proven floor; this proves the recipe is dimension-generic — at
+# width 4 the matrices are 4×4 and only the fixture changes, no new logic.
+# Usage: form_cli_transformer_train_wide.sh [corpus] [epochs] [cap]
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STD="$ROOT/form/form-stdlib"; GO="$ROOT/form/form-kernel-go/bin-go"
+CORPUS="${1:-${FORM_CLI_CORPUS:-$HOME/.coherence-network/form-cli-corpus/corpus.jsonl}}"
+EPOCHS="${2:-60}"; CAP="${3:-200}"
+[[ -x "$GO" ]] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) 2>/dev/null
+[[ -f "$CORPUS" ]] || { echo "no corpus at $CORPUS"; exit 1; }
+
+echo "── train the WIDE (4→4→4) Form-native transformer on the real oracle corpus (logic is four-way Form) ──"
+
+# featurize the corpus into 4-dim Form (x t) rows; split train/held; emit the program body
+body="$(python3 - "$CORPUS" "$CAP" <<'PY'
+import json,sys,re
+path,cap=sys.argv[1],int(sys.argv[2])
+KW  =re.compile(r"\b(file|code|fix|bug|function|test|error|class|import|build|deploy|kernel)\b", re.I)
+PATH=re.compile(r"(/|\.\w{1,4}\b|\b\w+\.(py|ts|tsx|go|rs|fk|md|sh|json)\b)")
+def feat(t):
+    task=str(t.get("task",""))
+    xlen=min(len(task)/300.0,1.0)
+    xkw =1.0 if KW.search(task) else 0.0
+    xpath=1.0 if PATH.search(task) else 0.0
+    xq  =1.0 if "?" in task else 0.0
+    tools=set(st.get("tool") for st in t.get("steps",[]) if isinstance(st,dict))
+    return (round(xlen,4), xkw, xpath, xq,
+            1.0 if "Read" in tools else 0.0, 1.0 if "Edit" in tools else 0.0,
+            1.0 if "Bash" in tools else 0.0, 1.0 if "Write" in tools else 0.0)
+rows=[]
+for l in open(path):
+    try: r=json.loads(l)
+    except: continue
+    if not r.get("steps"): continue
+    rows.append(feat(r))
+train=[r for i,r in enumerate(rows) if i%5!=0][:cap]
+held =[r for i,r in enumerate(rows) if i%5==0][:max(1,cap//4)]
+def flist(rs):
+    return "(list "+" ".join(
+        "(list (list %s %s %s %s) (list %s %s %s %s))"%r for r in rs)+")"
+print("(let train %s)"%flist(train))
+print("(let held %s)"%flist(held))
+sys.stderr.write("featurized: %d train, %d held (real corpus turns, 4-dim x/t)\n"%(len(train),len(held)))
+PY
+)"
+[[ -n "$body" ]] || { echo "featurization produced no rows"; exit 1; }
+
+prog="$(mktemp)"
+{ cat "$STD/transformer-numerics.fk" "$STD/transformer-block.fk" "$STD/transformer-backprop.fk" "$STD/transformer-corpus-train.fk"
+  echo "(do"
+  # untrained 4×4 block inits — the proven-shape init from the wide band.
+  echo "  (let ba (tbp-bk (list (list 0.30 -0.20 0.10 0.05) (list 0.10 0.40 -0.15 0.20) (list -0.05 0.25 0.35 -0.10) (list 0.15 -0.30 0.20 0.30)) (list 0.0 0.0 0.0 0.0) (list (list 0.50 0.20 -0.10 0.15) (list -0.30 0.60 0.25 -0.05) (list 0.10 -0.20 0.45 0.30) (list 0.20 0.35 -0.25 0.40)) (list 0.0 0.0 0.0 0.0)))"
+  echo "  (let bb (tbp-bk (list (list 0.20 0.10 -0.05 0.15) (list -0.10 0.30 0.20 -0.15) (list 0.25 -0.20 0.35 0.10) (list -0.05 0.15 -0.10 0.40)) (list 0.0 0.0 0.0 0.0) (list (list 0.40 -0.20 0.15 -0.10) (list 0.30 0.50 -0.25 0.20) (list -0.15 0.25 0.45 0.10) (list 0.20 -0.10 0.30 0.35)) (list 0.0 0.0 0.0 0.0)))"
+  echo "  $body"
+  echo "  (let eps 0.00001) (let lr 0.03)"
+  echo "  (let s0 (list ba bb))"
+  echo "  (let sN (tct-train-blocks ba bb train lr eps $EPOCHS))"
+  echo "  (print (round (mul (tct-corpus-loss s0 train eps) 1000000.0)))"
+  echo "  (print (round (mul (tct-corpus-loss sN train eps) 1000000.0)))"
+  echo "  (print (round (mul (tct-corpus-loss s0 held eps) 1000000.0)))"
+  echo "  (print (round (mul (tct-corpus-loss sN held eps) 1000000.0)))"
+  echo "  (print (len train)) (print (len held)) 0)"
+} > "$prog"
+out="$("$GO" "$prog" 2>/dev/null | grep -E '^-?[0-9]+$')"; rm -f "$prog"
+tr0=$(sed -n '1p' <<<"$out"); trN=$(sed -n '2p' <<<"$out")
+hd0=$(sed -n '3p' <<<"$out"); hdN=$(sed -n '4p' <<<"$out")
+ntr=$(sed -n '5p' <<<"$out"); nhd=$(sed -n '6p' <<<"$out")
+f6(){ printf "%d.%06d" "$(( ${1:-0}/1000000 ))" "$(( ${1:-0}<0 ? -${1:-0}%1000000 : ${1:-0}%1000000 ))"; }
+
+echo
+printf "  corpus            %s train turns, %s held-out (real Claude turns, 4-dim tool vector)\n" "$ntr" "$nhd"
+printf "  shape             4→4→4 two-block residual stack (x=[len,code,path,?]  t=[Read,Edit,Bash,Write])\n"
+printf "  epochs            %s   (SGD lr=0.03)\n" "$EPOCHS"
+printf "  train loss        %s  →  %s\n" "$(f6 "$tr0")" "$(f6 "$trN")"
+printf "  held-out loss     %s  →  %s\n" "$(f6 "$hd0")" "$(f6 "$hdN")"
+if [[ "${trN:-1}" -lt "${tr0:-0}" && "${hdN:-1}" -lt "${hd0:-0}" ]]; then
+  echo "  → the WIDE Form-native transformer learned the oracle's full tool-usage vector and generalized to held-out turns."
+fi


### PR DESCRIPTION
Widens the proven 2→2→2 corpus-train transformer to a richer 4→4→4 model on the real captured oracle corpus, four-way proven.

## What

`transformer-corpus-train.fk`'s SGD fold (`tbp-stack-step` over a corpus) is **dimension-generic** — every op (`tb-matvec`, `tb-affine`, `tn-layernorm`, `tbp-dx`, `tbp-outer`) iterates over list length, so widening to width 4 is fixture + capacity, **zero new logic**. This commit proves that carry.

- **`form/form-stdlib/tests/transformer-corpus-train-wide-band.fk`** — a 4-dim fixture over the SAME recipe.
  - `x = [task-len-norm, code-word, has-path, question-mark]`, `t = [Read, Edit, Bash, Write]` (the oracle's full tool-usage vector)
  - six examples train, two held out; two-block residual stack, 20 then 60 epochs
  - measured loss (Go, deterministic, ×1e6 int so all four kernels compare byte-for-byte):
    - **train: 13.964 → 2.122 → 1.034**
    - **held-out: 4.808 → 0.431** (generalizes)
  - **Verdict 31** — c0 `l0>0`, c1 `l20<l0`, c2 `l60<l20`, c3 `h60<h0` (generalizes, not memorization), c4 `4·l60<l0` (substantial)

- **`scripts/form_cli_transformer_train_wide.sh`** — sibling carrier. Featurizes the real 949-turn Claude corpus into 4-dim (x,t) rows, trains the wider transformer through the four-way recipe on the Go kernel. On real data (200 train / 50 held, 60 epochs): **train loss 523.5 → 163.2, held-out 134.7 → 42.7** — both fall, held-out falling proves generalization. (High magnitude is honest: Bash dominates real turns, so the model learns a strong Bash prior against varied real targets.)

- **`form/fourth-arm-bands.txt`** — registers `transformer-corpus-train-wide fks 31`.

## Proof

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk \
  form-stdlib/transformer-block.fk form-stdlib/transformer-backprop.fk \
  form-stdlib/transformer-corpus-train.fk form-stdlib/tests/transformer-corpus-train-wide-band.fk
```
→ `✓ ... → 31` · `fourth arm: 1 band(s) four-way` · `1 ok, 0 divergent` (Go/Rust/TS/fkwu agree byte-for-byte). The wider stack boxes far more floats per epoch — the real exercise of fkwu's grown-on-demand float pool at width.

## Honest framing

Width 2 is the proven floor; this proves the recipe carries to width 4 with only the fixture changing. The 2-dim band stays as the floor proof; this is its sibling, not its replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)