### PR TITLE
feat(form): the whole llama decoder block crosses four-way — RMSNorm + RoPE + SwiGLU composed

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-18_llama_block_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-18_llama_block_four_way.json
@@ -1,0 +1,44 @@
+{
+  "date": "2026-06-18",
+  "brick": "llama-block.fk — one real llama-shaped decoder block as proven Form, four-way",
+  "north_star_track": "device-native / model-as-recipe: the fp64 ALGORITHM floor under running a real llama block on the M4 GPU, next to the whisper block already on the GPU (brick 3m)",
+  "what": "Composed the already-four-way llama numerics (RMSNorm, RoPE, SwiGLU/SiLU) with the transformer-block dot/matvec/attention/residual walks into ONE real llama-shaped decoder block, and proved it four-way against an independent libm fp64 reference. This is the recipe tk-emit-llama only ever emitted as C (three-way); it had never been a standalone proven Form recipe. It is the missing fp64 floor the llama GPU kernel will mirror, exactly as transformer-block.fk's tb-block (511) backs the whisper GPU kernel (jte-block-fwd-msl, 3m).",
+  "block": "n1 = RMSNorm1(x); h = x + Wo·attn(RoPE(Wq·n1), RoPE(Wk·n1), Wv·n1, scale); n2 = RMSNorm2(h); y = h + Wdown·SwiGLU(Wgate·n2, Wup·n2). Bias-free projections (llama), position = absolute token index, scale = 1/sqrt(dq).",
+  "composed_from_four_way_recipes": [
+    "ln-rmsnorm, ln-swiglu, ln-silu (llama-numerics.fk, band 4095)",
+    "rope (rope.fk, band 4095) over trig.fk fsin/fcos/fpow",
+    "tb-dot / tb-matvec / tb-attn-seq / tb-add-seq / tb-scores (transformer-block.fk, band 511)"
+  ],
+  "recipe": "form/form-stdlib/llama-block.fk",
+  "band": "form/form-stdlib/tests/llama-block-band.fk",
+  "manifest_row": "llama-block fks 4095 (form/fourth-arm-bands.txt)",
+  "reference": "independent pure-libm fp64 (math.exp/sin/cos/sqrt) — RMSNorm1 -> q/k/v proj (bias-free) -> RoPE(q),RoPE(k) by token position -> softmax(q·kT·scale)-weighted v -> residual -> RMSNorm2 -> Wdown·(silu(Wgate·n2)·(Wup·n2)) -> residual. S=2 tokens, d=4, dq=dv=4, HD=4 (single head), FFN hidden 4. Every weight non-trivial. Each claim a libm value rounded at 1e-6.",
+  "claims_4095": {
+    "1_alpha00": 394953,
+    "2_alpha0_sum": 1000000,
+    "4_h00": 962606,
+    "8_h12": 1806845,
+    "16_y00": 1115890,
+    "32_y01": -492135,
+    "64_y03": 1846721,
+    "128_y10": -1069281,
+    "256_y12": 1648117,
+    "512_y13": -1118617,
+    "1024_scale": 500000,
+    "2048_qr10": 185718
+  },
+  "proof": {
+    "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/tests/llama-block-band.fk",
+    "verdict": 4095,
+    "kernels": "Go + Rust + TypeScript + fkwu",
+    "fourth_arm": "1 band(s) four-way (fkwu + pre-flattened tables)",
+    "divergent": 0
+  },
+  "non_causal_note": "Attention is non-causal here, matching tb-block's whisper attention and the jte-blk-attn GPU walk this block's GPU emit will reuse. The causal decoder mask is a named orthogonal follow-up (a per-query key-prefix, no numeric change).",
+  "named_next_stones": [
+    "emit lblk-block to Metal (jte-llama-block-fwd-msl) next to the whisper block and run on the M4 GPU with an fp32 CPU-mirror parity gate, as brick 3m did for the whisper block",
+    "run the llama block forward over REAL llama3.2:3b GGUF weights (the load path q4k/q6k/f16 dequant is already Form-native, four-way)",
+    "add the causal mask (decoder attention)"
+  ],
+  "lesson": "Read-the-body found the exact gap: the llama numerics (RMSNorm/RoPE/SwiGLU) were already four-way standalone (3p/3q) but NEVER composed into a block; tk-emit-llama only emitted the whole llama as C. Core-abstraction-first composition of proven recipes; design (the block shape + the libm reference + fixtures) was the cost, the four-way proof was seconds."
+}

--- a/form/form-stdlib/llama-block.fk
+++ b/form/form-stdlib/llama-block.fk
@@ -1,0 +1,69 @@
+; llama-block.fk — one real llama-shaped decoder block as proven Form, the fp64 ALGORITHM
+; floor under running a llama block on the M4 GPU (next to the whisper block, brick 3m).
+;
+; The whisper-shaped block transformer-block.fk's tb-block (LayerNorm + gelu, proven FOUR-WAY 511)
+; runs on the GPU as one Metal kernel (jte-block-fwd-msl). A REAL llama3.2:3b block differs in
+; exactly the numerics already lifted to four-way standalone recipes — RMSNorm (llama-numerics.fk,
+; not LayerNorm), SwiGLU (llama-numerics.fk, not gelu), and RoPE on q/k (rope.fk, position-dependent
+; rotation the whisper block has none of). Until now those four-way numerics were never COMPOSED into
+; a block; tk-emit-llama (transformer-kernel.fk) only emitted the whole llama as C (three-way). This
+; file composes them into the block — the missing proven recipe the GPU emit will mirror, exactly as
+; tb-block backs the whisper GPU kernel.
+;
+;   n1 = RMSNorm1(x)                                          (gain g1, no bias — the llama norm)
+;   h  = x + Wo·attn( RoPE(Wq·n1), RoPE(Wk·n1), Wv·n1, scale ) (bias-free proj, RoPE q/k, residual)
+;   n2 = RMSNorm2(h)
+;   y  = h + Wdown·SwiGLU( Wgate·n2, Wup·n2 )                  (silu(gate)·up FFN, residual)
+;
+; Core-abstraction-first: every numeric is an ALREADY-FOUR-WAY recipe — ln-rmsnorm/ln-swiglu
+; (llama-numerics, 4095), rope (rope.fk, 4095, over trig's fsin/fcos/fpow), and the dot/matvec/attn/
+; residual walks of transformer-block.fk (tb-dot/tb-matvec/tb-attn-seq/tb-add-seq, 511). Nothing
+; re-derived. Weights are arguments — recipe DATA all the way down; a layer stack is a SEQUENCE of
+; lblk-block calls, mutable at runtime (the dynamic-recipe advantage). fp64 lane; the GPU emit
+; (fp32 mirror) and format lanes are the named follow-ups. Attention is non-causal here, matching
+; tb-block's whisper attention and the jte-blk-attn GPU walk it reuses; the causal mask is a named
+; orthogonal follow-up (a per-query key-prefix, no numeric change). Position = absolute token index.
+; Proven four-way against the libm fp64 reference by tests/llama-block-band.fk.
+
+; --- RMSNorm each token-vector of a sequence (gain g, no bias) ---
+(defn lblk-rms-seq (xs g eps)
+  (if (eq (len xs) 0) (empty)
+      (cons (ln-rmsnorm (head xs) g eps) (lblk-rms-seq (tail xs) g eps))))
+
+; --- project each token by W, NO bias (llama projections are bias-free) ---
+(defn lblk-proj-seq (w xs)
+  (if (eq (len xs) 0) (empty)
+      (cons (tb-matvec w (head xs)) (lblk-proj-seq w (tail xs)))))
+
+; --- RoPE each token's vector by its absolute position (token index), head-dim HD ---
+(defn lblk-rope-seq-i (xs i HD)
+  (if (eq (len xs) 0) (empty)
+      (cons (rope (head xs) i HD) (lblk-rope-seq-i (tail xs) (add i 1) HD))))
+(defn lblk-rope-seq (xs HD) (lblk-rope-seq-i xs 0 HD))
+
+; --- SwiGLU FFN per token: down · [silu(gate_i)·up_i] ---
+(defn lblk-swiglu-map (gs us)
+  (if (eq (len gs) 0) (empty)
+      (cons (ln-swiglu (head gs) (head us)) (lblk-swiglu-map (tail gs) (tail us)))))
+(defn lblk-ffn (wg wu wd n)
+  (tb-matvec wd (lblk-swiglu-map (tb-matvec wg n) (tb-matvec wu n))))
+(defn lblk-ffn-seq (wg wu wd xs)
+  (if (eq (len xs) 0) (empty)
+      (cons (lblk-ffn wg wu wd (head xs)) (lblk-ffn-seq wg wu wd (tail xs)))))
+
+; --- attention sub-block: RMSNorm → q/k/v proj → RoPE(q),RoPE(k) → attn → Wo proj → +residual ---
+(defn lblk-attn-sub (n1 wq wk wv wo scale HD)
+  (lblk-proj-seq wo
+    (tb-attn-seq (lblk-rope-seq (lblk-proj-seq wq n1) HD)
+                 (lblk-rope-seq (lblk-proj-seq wk n1) HD)
+                 (lblk-proj-seq wv n1) scale)))
+(defn lblk-attn-block (xs g1 eps wq wk wv wo scale HD)
+  (tb-add-seq xs (lblk-attn-sub (lblk-rms-seq xs g1 eps) wq wk wv wo scale HD)))
+
+; --- FFN sub-block ---
+(defn lblk-ffn-block (xs g2 eps wg wu wd)
+  (tb-add-seq xs (lblk-ffn-seq wg wu wd (lblk-rms-seq xs g2 eps))))
+
+; --- the whole llama block ---
+(defn lblk-block (xs g1 eps wq wk wv wo scale HD g2 wg wu wd)
+  (lblk-ffn-block (lblk-attn-block xs g1 eps wq wk wv wo scale HD) g2 eps wg wu wd))

--- a/form/form-stdlib/tests/llama-block-band.fk
+++ b/form/form-stdlib/tests/llama-block-band.fk
@@ -1,0 +1,60 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk
+;
+; llama-block-band — one real llama-shaped decoder block (RMSNorm + RoPE + softmax attention +
+; SwiGLU FFN + two residuals) against the libm fp64 reference, lifted to the four-kernel floor.
+; The reference: pure-libm fp64 (exp/sin/cos/sqrt) — RMSNorm1 → q/k/v proj (bias-free) →
+; RoPE(q),RoPE(k) by token position → softmax(q·kᵀ·scale)-weighted v → residual → RMSNorm2 →
+; Wdown·(silu(Wgate·n2)·(Wup·n2)) → residual. S=2 tokens, d=4, dq=dv=4, HD=4 (single head),
+; FFN hidden 4, scale = 1/√4. Every weight non-trivial. Each claim is a libm value at 1e-6.
+;
+; This composes ONLY already-four-way recipes (ln-rmsnorm/ln-swiglu 4095, rope 4095 over trig's
+; fsin/fcos/fpow, tb-* walks 511) into the block tk-emit-llama only ever emitted as C — the fp64
+; algorithm floor the GPU emit will mirror (as tb-block 511 backs the whisper GPU kernel, 3m).
+;
+; Verdict 4095 when the whole llama block lands:
+;   1     α[0][0]   → 394953   (the attention actually mixes — neither 0 nor 1)
+;   2     α[0] sum  → 1         (a distribution over keys, exactly)
+;   4     h[0][0]   → 962606    (post-attention residual, position 0)
+;   8     h[1][2]   → 1806845   (post-attention residual, position 1)
+;   16    y[0][0]   → 1115890   (block output)
+;   32    y[0][1]   → -492135
+;   64    y[0][3]   → 1846721
+;   128   y[1][0]   → -1069281
+;   256   y[1][2]   → 1648117
+;   512   y[1][3]   → -1118617
+;   1024  scale     → 500000    (1/tn-sqrt(4) — the body's own √, no host constant smuggled in)
+;   2048  qr[1][0]  → 185718    (RoPE actually rotated token 1's query — position-dependence proven)
+(do
+    (let x  (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75)))
+    (let g1 (list 0.9 1.1 1.0 0.95))   (let g2 (list 1.05 0.95 1.0 0.9))
+    (let wq (list (list 0.5 -0.25 0.1 0.3) (list 0.2 0.4 -0.3 0.1) (list -0.1 0.2 0.5 -0.2) (list 0.3 0.0 -0.15 0.25)))
+    (let wk (list (list 0.2 0.4 -0.3 0.1) (list 0.3 -0.2 0.25 0.5) (list 0.1 0.15 -0.05 0.2) (list -0.25 0.3 0.4 -0.1)))
+    (let wv (list (list 0.3 -0.2 0.25 0.5) (list 0.6 0.1 -0.2 0.4) (list 0.05 -0.1 0.3 0.2) (list 0.15 0.35 -0.25 0.1)))
+    (let wo (list (list 0.6 0.1 -0.2 0.4) (list -0.2 0.4 0.3 0.1) (list 0.25 -0.15 0.5 0.05) (list 0.1 0.2 -0.3 0.45)))
+    (let wg (list (list 0.5 -0.3 0.2 0.1) (list 0.2 0.7 -0.4 0.3) (list -0.1 0.25 0.4 -0.2) (list 0.3 0.1 -0.15 0.5)))
+    (let wu (list (list 0.25 -0.15 0.3 0.05) (list 0.1 0.4 -0.2 0.15) (list 0.35 0.2 -0.1 0.25) (list -0.2 0.3 0.15 0.4)))
+    (let wd (list (list 0.4 -0.2 0.3 0.1) (list 0.15 0.5 -0.25 0.2) (list -0.3 0.1 0.45 -0.15) (list 0.2 -0.1 0.35 0.3)))
+    (let eps 0.00001)
+    (let HD 4)
+    (let scale (div 1.0 (tn-sqrt 4.0)))
+    (let n1 (lblk-rms-seq x g1 eps))
+    (let qr (lblk-rope-seq (lblk-proj-seq wq n1) HD))
+    (let kr (lblk-rope-seq (lblk-proj-seq wk n1) HD))
+    (let vv (lblk-proj-seq wv n1))
+    (let alpha0 (tn-softmax (tb-scores (head qr) kr scale)))
+    (let h (lblk-attn-block x g1 eps wq wk wv wo scale HD))
+    (let y (lblk-block x g1 eps wq wk wv wo scale HD g2 wg wu wd))
+    (let c0  (if (eq (round (mul (nth alpha0 0) 1000000.0)) 394953) 1 0))
+    (let c1  (if (eq (round (mul (tn-sum alpha0) 1000000.0)) 1000000) 2 0))
+    (let c2  (if (eq (round (mul (nth (nth h 0) 0) 1000000.0)) 962606) 4 0))
+    (let c3  (if (eq (round (mul (nth (nth h 1) 2) 1000000.0)) 1806845) 8 0))
+    (let c4  (if (eq (round (mul (nth (nth y 0) 0) 1000000.0)) 1115890) 16 0))
+    (let c5  (if (eq (round (mul (nth (nth y 0) 1) 1000000.0)) -492135) 32 0))
+    (let c6  (if (eq (round (mul (nth (nth y 0) 3) 1000000.0)) 1846721) 64 0))
+    (let c7  (if (eq (round (mul (nth (nth y 1) 0) 1000000.0)) -1069281) 128 0))
+    (let c8  (if (eq (round (mul (nth (nth y 1) 2) 1000000.0)) 1648117) 256 0))
+    (let c9  (if (eq (round (mul (nth (nth y 1) 3) 1000000.0)) -1118617) 512 0))
+    (let c10 (if (eq (round (mul scale 1000000.0)) 500000) 1024 0))
+    (let c11 (if (eq (round (mul (nth (head (tail qr)) 0) 1000000.0)) 185718) 2048 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7
+    (add c8 (add c9 (add c10 c11))))))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -367,6 +367,7 @@ transformer-corpus-train-wide fks 31
 corpus-license-gate fks 31
 llama-numerics fks 4095
 rope fks 4095
+llama-block fks 4095
 geometric-learning fks 8388607
 transcendental-natives fks 16
 learning-arc fks 127


### PR DESCRIPTION
Composes the already-four-way llama numerics (RMSNorm/RoPE/SwiGLU — bricks 3p/3q) with transformer-block's dot/matvec/attention/residual walks into **one real llama-shaped decoder block**, proven **four-way (4095, 0 divergent)** against an independent libm fp64 reference.

```
n1 = RMSNorm1(x)
h  = x + Wo·attn(RoPE(Wq·n1), RoPE(Wk·n1), Wv·n1, scale)   (bias-free, residual)
n2 = RMSNorm2(h)
y  = h + Wdown·SwiGLU(Wgate·n2, Wup·n2)                    (residual)
```

This is the recipe `tk-emit-llama` only ever emitted as C (three-way) — never a standalone proven Form recipe. It's the missing fp64 **algorithm floor** the llama GPU kernel will mirror, exactly as `tb-block` (511) backs the whisper GPU kernel (`jte-block-fwd-msl`, brick 3m). Composed entirely from proven recipes (core-abstraction-first); attention non-causal to match the `jte-blk-attn` GPU walk it will reuse (causal mask a named follow-up).

**Proof** (scoped four-way validate): verdict **4095**, `fourth arm: 1 band(s) four-way`, **0 divergent**.

- Recipe: `form/form-stdlib/llama-block.fk`
- Band: `form/form-stdlib/tests/llama-block-band.fk` (12 strange-minimal claims, libm-pinned at 1e-6)
- Manifest: `llama-block fks 4095`
- Receipt: `docs/system_audit/commit_evidence_2026-06-18_llama_block_four_way.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)