### PR TITLE
feat(form): native form-cli on fkwu — dispatch four-way + headless runtime entry

### DIFF
--- a/form/form-stdlib/form-cli-main.fk
+++ b/form/form-stdlib/form-cli-main.fk
@@ -1,0 +1,27 @@
+; form-cli-main.fk — the native form-cli runtime entry on the emitted walker (fkwu).
+;
+; The HEADLESS front door: the command arrives staged in fk_src (fkwu's argv[3], or
+; the persistent fkwu-server's per-request buffer — see form-kernel-go/fkwu_bridge.go).
+; fc-read walks it byte-by-byte via input_byte (walker tag 17), and the dispatch
+; (fc-respond, four-way proven by tests/form-cli-band.fk) returns the response
+; string, which fkwu prints natively through fk_pv_root/fk_psv.
+;
+; This entry is fkwu-native: input_byte is the staged-input op the emitted walker
+; carries (tag 17); it is not registered in the three host walkers, so this runs on
+; the emitted kernel — the native form-cli exe — not on Go/Rust/TS. The dispatch it
+; calls (form-cli.fk) is the four-way-proven shared brain. Interactive TTY (a
+; read-line loop + isatty prompt) wraps this same dispatch once those host-io ops
+; land in the emitter (host-io family).
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-cli.fk
+
+(do
+    ; read the command from fk_src: input_byte i -> the i-th byte, stop at NUL/newline.
+    (defn fc-read (i acc)
+        (do (let b (input_byte i))
+            (if (eq b 0) acc
+                (if (eq b 10) acc
+                    (fc-read (add i 1) (str_concat acc (byte_to_str b)))))))
+    (defn fc-command () (fc-read 0 ""))
+
+    (fc-respond (fc-command)))

--- a/form/form-stdlib/form-cli.fk
+++ b/form/form-stdlib/form-cli.fk
@@ -1,0 +1,43 @@
+; form-cli.fk — the native form-cli FRONT DOOR, running on the emitted walker (fkwu).
+;
+; The form-cli LOGIC already lives as Form recipes (form-cli-predict/gaps/score/
+; review-gap/router/loop, several four-way). What was missing is the front door: a
+; native dispatcher that reads the command from the staged input (fk_src, via the
+; input_byte op = walker tag 17), routes on the verb, and returns the response
+; STRING — which fkwu prints natively through fk_pv_root/fk_psv. One native engine
+; on the emitted kernel, not 23 bespoke Python/shell carriers.
+;
+; Surfaces: HEADLESS works today (the command arrives staged in fk_src — `fkwu
+; <table> 0 <cmdfile>`). INTERACTIVE TTY (a read-line loop + isatty prompt) is the
+; one remaining kernel-emitter add-on (host-io family); the dispatch below is the
+; shared core both surfaces call.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    ; read the command from fk_src: input_byte i -> the i-th byte, stop at NUL/newline.
+    (defn fc-read (i acc)
+        (do (let b (input_byte i))
+            (if (eq b 0) acc
+                (if (eq b 10) acc
+                    (fc-read (add i 1) (str_concat acc (byte_to_str b)))))))
+    (defn fc-command () (fc-read 0 ""))
+
+    ; the verb is the command up to the first space (or the whole line).
+    (defn fc-verb (cmd)
+        (do (let sp (str_find cmd " " 0))
+            (if (lt sp 0) cmd (substring cmd 0 sp))))
+
+    ; dispatch: the self-contained verbs prove the native door end-to-end; the
+    ; data verbs (predict/gaps/score) route to their existing recipes next, and
+    ; the host-io verbs (ask/rag/ingest) follow as POST + dir-scan land.
+    (defn fc-respond (cmd)
+        (do (let v (fc-verb cmd))
+            (if (str_eq v "ping") "pong"
+                (if (str_eq v "help")
+                    "form-cli (native/fkwu): ping | help | version | <verb> ..."
+                    (if (str_eq v "version")
+                        "form-cli native 0.1 — running on the emitted walker (fkwu)"
+                        (str_concat "form-cli: unknown verb " v))))))
+
+    (fc-respond (fc-command)))

--- a/form/form-stdlib/form-cli.fk
+++ b/form/form-stdlib/form-cli.fk
@@ -1,43 +1,33 @@
-; form-cli.fk — the native form-cli FRONT DOOR, running on the emitted walker (fkwu).
+; form-cli.fk — the native form-cli DISPATCH library (the verb-routing brain).
 ;
 ; The form-cli LOGIC already lives as Form recipes (form-cli-predict/gaps/score/
-; review-gap/router/loop, several four-way). What was missing is the front door: a
-; native dispatcher that reads the command from the staged input (fk_src, via the
-; input_byte op = walker tag 17), routes on the verb, and returns the response
-; STRING — which fkwu prints natively through fk_pv_root/fk_psv. One native engine
-; on the emitted kernel, not 23 bespoke Python/shell carriers.
+; review-gap/router/loop, several four-way). This is the missing dispatcher: given a
+; command string it splits the verb and routes to a response. It is deterministic
+; (str_find/substring/str_eq/str_concat) and crosses four-way (Go/Rust/TS/fkwu) by
+; tests/form-cli-band.fk — the brain BOTH surfaces call.
 ;
-; Surfaces: HEADLESS works today (the command arrives staged in fk_src — `fkwu
-; <table> 0 <cmdfile>`). INTERACTIVE TTY (a read-line loop + isatty prompt) is the
-; one remaining kernel-emitter add-on (host-io family); the dispatch below is the
-; shared core both surfaces call.
+; The two input surfaces wrap this dispatch (see form-cli-main.fk, the fkwu runtime
+; entry): HEADLESS reads the command staged in fk_src (input_byte = walker tag 17);
+; INTERACTIVE TTY adds a read-line loop + isatty prompt (the remaining host-io
+; emitter add-on). One native engine on the emitted kernel, not 23 bespoke carriers.
 ;
 ; preludes: form-stdlib/core.fk
 
 (do
-    ; read the command from fk_src: input_byte i -> the i-th byte, stop at NUL/newline.
-    (defn fc-read (i acc)
-        (do (let b (input_byte i))
-            (if (eq b 0) acc
-                (if (eq b 10) acc
-                    (fc-read (add i 1) (str_concat acc (byte_to_str b)))))))
-    (defn fc-command () (fc-read 0 ""))
-
     ; the verb is the command up to the first space (or the whole line).
     (defn fc-verb (cmd)
         (do (let sp (str_find cmd " " 0))
             (if (lt sp 0) cmd (substring cmd 0 sp))))
 
-    ; dispatch: the self-contained verbs prove the native door end-to-end; the
-    ; data verbs (predict/gaps/score) route to their existing recipes next, and
-    ; the host-io verbs (ask/rag/ingest) follow as POST + dir-scan land.
+    ; dispatch: self-contained verbs prove the native door end-to-end; the data
+    ; verbs (predict/gaps/score) route to their existing recipes next, and the
+    ; host-io verbs (ask/rag/ingest) follow as POST + dir-scan land.
     (defn fc-respond (cmd)
         (do (let v (fc-verb cmd))
             (if (str_eq v "ping") "pong"
                 (if (str_eq v "help")
                     "form-cli (native/fkwu): ping | help | version | <verb> ..."
                     (if (str_eq v "version")
-                        "form-cli native 0.1 — running on the emitted walker (fkwu)"
+                        "form-cli native 0.1 - running on the emitted walker (fkwu)"
                         (str_concat "form-cli: unknown verb " v))))))
-
-    (fc-respond (fc-command)))
+    0)

--- a/form/form-stdlib/form-flatten.fk
+++ b/form/form-stdlib/form-flatten.fk
@@ -56,6 +56,7 @@
           (list "str_len" 1 25) (list "str_eq" 2 26) (list "str_concat" 2 27)
           (list "substring" 3 29) (list "str_find" 3 30)
           (list "str_to_int" 1 31) (list "int_to_str" 1 32) (list "byte_to_str" 1 33)
+          (list "input_byte" 1 17)
           (list "intern_trivial_int" 1 43)
           (list "intern_trivial_bool" 1 112) (list "intern_trivial_float" 1 113)
           (list "make_nodeid" 4 91)

--- a/form/form-stdlib/tests/form-cli-band.fk
+++ b/form/form-stdlib/tests/form-cli-band.fk
@@ -1,0 +1,24 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-cli.fk
+;
+; form-cli-band — the native form-cli DISPATCH crosses four-way.
+;
+; The dispatch (fc-respond: verb-split via str_find/substring, route via str_eq,
+; build the response via str_concat) is deterministic, so it proves four-way here
+; with command strings passed as data. The only host-IO part — fc-command reading
+; the command from fk_src (input_byte) — is wired at the runtime entry (the fkwu
+; staged-input path, fk_src), not banded; this proves the verb-routing brain that
+; both the headless and TTY surfaces call.
+;
+; Verdict 31:
+;   1   ping -> pong
+;   2   help -> the usage line
+;   4   version -> the version line
+;   8   verb-split: "ping extra" routes on the verb "ping" -> pong
+;   16  unknown verb -> "form-cli: unknown verb <v>"
+(do
+    (let c0 (if (str_eq (fc-respond "ping") "pong") 1 0))
+    (let c1 (if (str_eq (fc-respond "help") "form-cli (native/fkwu): ping | help | version | <verb> ...") 2 0))
+    (let c2 (if (str_eq (fc-respond "version") "form-cli native 0.1 - running on the emitted walker (fkwu)") 4 0))
+    (let c3 (if (str_eq (fc-respond "ping extra") "pong") 8 0))
+    (let c4 (if (str_eq (fc-respond "foobar") "form-cli: unknown verb foobar") 16 0))
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -628,3 +628,4 @@ trivial-typed-leaf fks 1111111
 json-codec-bml fks 8191
 whisper-block0 fks 1023
 json-meaning-ingestion fks 1000
+form-cli fks 31


### PR DESCRIPTION
First spine of collapsing the 23 bespoke `form_cli*` Python/shell carriers into one native engine **running on the emitted walker (fkwu)**.

## What lands
- **`form-cli.fk`** — the dispatch library (verb-split + route + response). Deterministic; crosses **four-way (Go/Rust/TS/fkwu, 0 divergent)** via `tests/form-cli-band.fk` (verdict 31: ping→pong, help, version, verb-split, unknown). The shared verb-routing brain both surfaces call.
- **`form-flatten.fk`** — exposes `input_byte` (= walker tag 17, the staged `fk_src` read) to the high-level recipe layer, so a recipe can read its command on fkwu.
- **`form-cli-main.fk`** — the fkwu runtime entry (HEADLESS): reads the command from `fk_src` via `input_byte`, runs the dispatch, returns the response string fkwu prints through `fk_pv_root`/`fk_psv`.

## Honest proof boundary
The **dispatch is four-way proven**. The `fk_src` read is fkwu host-IO (tag 17, the same staged-input path `form-kernel-go/fkwu_bridge.go` drives) — exercised at runtime, **not banded** (host-IO is non-deterministic, so it can't be a deterministic four-way band). Interactive **TTY** (read-line loop + isatty prompt) wraps this same dispatch once those two host-IO ops land in the emitter (host-io family).

This is the native door; the data verbs (predict/gaps/score → existing recipes) and host-IO verbs (ask/rag/ingest → POST + dir-scan) route through it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)