### PR TITLE
attune(fourth-arm): read band header from the file that exists — recursive-let-clobber crosses four-way

### DIFF
--- a/form/scripts/fourth-arm.sh
+++ b/form/scripts/fourth-arm.sh
@@ -88,6 +88,11 @@ fourth_band_stem() {
 # fallback when no prelude is declared).
 fourth_band_srcs() {
     local stem="$1" band="form-stdlib/tests/$stem-band.fk" mods
+    # A manifest stem maps to tests/<stem>-band.fk OR the plain tests/<stem>.fk —
+    # fourth_band_stem strips -band when reading, so both are the same band.
+    # Read the preludes header from whichever file exists, else a stem registered
+    # under the plain name silently builds an empty table and runs three-kernel only.
+    [[ -f "$band" ]] || band="form-stdlib/tests/$stem.fk"
     # Drop ONLY the exact core.fk prelude (the shim mirrors it). Anchor the match
     # to a path boundary so sibling-named modules — substrate-core.fk, bmf-core.fk
     # — keep their place in the source list instead of vanishing as substrings.


### PR DESCRIPTION
## What

`fourth_band_srcs` in `form/scripts/fourth-arm.sh` hardcoded the band path as `form-stdlib/tests/<stem>-band.fk`. The manifest registers `recursive-let-clobber fks 1`, but the file on disk is `form-stdlib/tests/recursive-let-clobber.fk` (plain name, no `-band` suffix). The missing `-band.fk` made the preludes grep read nothing → `fourth_prep_srcs` hit its `[[ -f ]] || return 0` guard → empty table → **the band ran three-kernel only despite sitting in the manifest.** The fourth-arm verdict (`1`) was a claim the runtime never honored.

Same naming bug previously diagnosed for the json bands.

## Fix

`fourth_band_stem` already strips `-band` when reading, so `tests/<stem>-band.fk` and `tests/<stem>.fk` are the same band. Mirror that on the source side with a one-line fallback that reads the preludes header from whichever file exists. The fallback fires **only** when `-band.fk` is absent, so every existing band resolves exactly as before — the change can only add coverage, never alter it.

## Proof

- Scoped run: `✓ core.fk+recursive-let-clobber.fk → 1`, `fourth arm: 1 band(s) four-way`. fkwu emits `1` matching go/rust/ts — the correct verdict (a clobbering arm would answer `3`).
- Audited every manifest stem: `recursive-let-clobber` was the **only** naming victim; no still-missing stems.
- It crosses **clean** four-way — a pure naming victim, not a hidden native-only gap, so there is **no divergence** to root-cause (per the divergence rule).
- Full suite: **744 ok, 0 divergent**; **fourth arm 369 band(s) four-way** (was 368).

🤖 Generated with [Claude Code](https://claude.com/claude-code)