### PR TITLE
feat(form): host value-null carrier — json-emitter + json-promoted-types cross four-way

### DIFF
--- a/form/form-stdlib/fourth-shim.fk
+++ b/form/form-stdlib/fourth-shim.fk
@@ -153,4 +153,19 @@
     ; (cat, kids), with the attribution parameters held in the frame, read by
     ; nothing. A grammar's parse produces the same recipe tree on all four arms.
     (defn intern_node_at (cat kids file line col) (intern_node cat kids))
+    ; ── null + dict mirrors — the host value-null model on the fourth arm ──
+    ; The three reference kernels carry a VNull value and native _dict_*/value_kind.
+    ; fkwu has no host-null in its value ABI, so null is carried STRUCTURALLY: a
+    ; reserved blueprint node (VALUE-NONE) is the absent/None value, and node_eq
+    ; (a four-way structural primitive) tests for it — never nil?/len, which
+    ; collapse int/string/empty in fkwu's scalar region. _dict_get on a miss
+    ; answers VALUE-NONE; value_kind answers "null" for it and "value" otherwise,
+    ; which is exactly what json-node-null-value? (str_eq ... "null") reads. The
+    ; dict is the "__dict__"-marked cons-list the kernels and fkwu's _get share.
+    (defn value-none () (bp "VALUE-NONE"))
+    (defn value_kind (v) (if (node_eq v (value-none)) "null" "value"))
+    (defn _dict_new () (cons "__dict__" (empty)))
+    (defn _dict-scan (xs k) (if (nil? xs) (value-none) (if (str_eq (head xs) k) (head (tail xs)) (_dict-scan (tail (tail xs)) k))))
+    (defn _dict_get (d k) (_dict-scan (tail d) k))
+    (defn _dict_has (d k) (if (node_eq (_dict_get d k) (value-none)) 0 1))
     0)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -72,6 +72,18 @@
 #     Adding the two unary serializer rows beside tag 43 unblocked them:
 #     trivial-typed-leaf 1111111, json-codec-bml 8191, json-meaning-ingestion 1000,
 #     whisper-block0 1023.
+#   host value-null         — the reference kernels carry a VNull value and native
+#     value_kind / _dict_*; fkwu has no host-null in its value ABI. Carried
+#     STRUCTURALLY on the fourth arm: a reserved blueprint node (VALUE-NONE) is the
+#     absent/None value and node_eq (a four-way structural primitive) tests for it,
+#     never nil?/len which collapse int/string/empty in fkwu's scalar region. The
+#     shim mirrors _dict_new/_dict_get/_dict_has + value_kind over the "__dict__"
+#     cons-list (the shape fkwu's _get already shares); value_kind answers "null"
+#     for VALUE-NONE and "value" otherwise — exactly what json-node-null-value?
+#     (str_eq ... "null") reads. json-emitter (31) and json-promoted-types (115)
+#     cross. RESIDUAL: value_kind cannot yet split int from string (both x<<1) —
+#     the named next rung is a boxed-string region (like the float region) that
+#     lifts int_to_str(node_value(string)) passthrough and general value_kind.
 #
 # Current floor (2026-06-14 content-address + sibling-node floor): the admitted
 # manifest carries content-address, durable substrate-core, and the doc-xpath,
@@ -79,8 +91,8 @@
 # record-blueprint rows among its focused four-way rows, and
 # android-mesh-learning now carries
 # active mic/camera/GPU sample rows at focused verdict 32767. The latest
-# completed full `cd form && ./validate.sh` on this branch reads 364
-# four-way bands and 740 total passing workloads with 0 residual divergent
+# completed full `cd form && ./validate.sh` on this branch reads 372
+# four-way bands and 745 total passing workloads with 0 residual divergent
 # bands; refresh the full aggregate on a quiet host after focused release
 # rather than spending repeated validation cycles under shared-runner
 # contention. Literal bp registry aliases now fold through make_nodeid for the
@@ -630,3 +642,5 @@ json-codec-bml fks 8191
 whisper-block0 fks 1023
 json-meaning-ingestion fks 1000
 form-cli fks 31
+json-emitter fks 31
+json-promoted-types fks 115


### PR DESCRIPTION
## What

Carry a host **null** value on the fourth kernel (fkwu) so the JSON codec's null handling crosses four-way — the robust, generic null model the codec and a future BML class serializer lean on.

## Root cause

The reference kernels carry a `VNull` value and native `value_kind`/`_dict_*`. fkwu has no host-null in its value ABI, so `json-node-null-value?` = `(str_eq (value_kind v) "null")` lit-0'd on the fourth arm — a missing/`None` field rendered as the string `"null"` instead of JSON `null`.

## Fix — null as structure, not reflection

Null is carried **structurally**: a reserved blueprint node `VALUE-NONE` is the absent value, and `node_eq` (a four-way structural primitive) tests for it. The shim mirrors `_dict_new`/`_dict_get`/`_dict_has` + `value_kind` over the `"__dict__"` cons-list fkwu's `_get` already shares: a `_dict_get` miss answers `VALUE-NONE`; `value_kind` answers `"null"` for it and `"value"` otherwise — exactly what `json-node-null-value?` reads.

This is the elegant fix the adversarial pass *missed*: it tried `nil?`/empty-list (which collapses in fkwu's scalar region) and gave up; a node sentinel + structural equality sidesteps the int/string collapse entirely. Pure Form, zero new C, in `fourth-shim.fk` (fkwu-flatten-only — **empty blast radius**, no prior registered band reaches `value_kind`/`_dict_*`).

## Proof — four-way (Go / Rust / TS / fkwu, 0 divergent)

| band | verdict | proves |
|------|---------|--------|
| `json-emitter` | 31 | full serialization: strings/escapes/ints/floats/bools/**null**/arrays/nested |
| `json-promoted-types` | 115 | the typed value model — dispatch on `node_type` (3=bool, 7=float), arrays, text |

Full `cd form && ./validate.sh`: **745 ok, 0 divergent; 372 bands four-way.**

## Residual (named, not hidden)

`value_kind` cannot yet split **int from string** (both are `x<<1` in fkwu's value ABI). The next rung is a boxed-string region (mirroring the existing float region) that lifts `int_to_str(node_value(string))` passthrough and a general `value_kind` — fully designed and audited (25 sites), implementing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)