### PR TITLE
fix(form): fkwu prints any UTF-8 — form-cli supports any locale, not ASCII-only

### DIFF
--- a/form/form-kernel-go/form_cli_test.go
+++ b/form/form-kernel-go/form_cli_test.go
@@ -60,7 +60,7 @@ func TestFkwuFormCli(t *testing.T) {
 		{"ping", "pong"},
 		{"version", "form-cli 0.2"},
 		{"ping extra", "pong"},
-		{"foobar", "form-cli: unknown verb foobar, try help"},
+		{"foobar", "form-cli: unknown verb 'foobar' — type 'help'"},
 	}
 	for _, c := range cases {
 		got, err := FkwuEvalWithInput(fkwuBin, tablePath, 0, []byte(c.cmd))
@@ -160,7 +160,7 @@ func TestFkwuFormCliRepl(t *testing.T) {
 	}
 
 	// An unknown verb echoes it back; the verb is the line up to the first space.
-	if u := run("wobble the cat\nquit\n"); u != "form-cli: unknown verb wobble, try help\n" {
+	if u := run("wobble the cat\nquit\n"); u != "form-cli: unknown verb 'wobble' — type 'help'\n" {
 		t.Fatalf("repl unknown-verb: got=%q", u)
 	}
 
@@ -265,5 +265,50 @@ func TestFkwuFormCliCombined(t *testing.T) {
 	// and verifies it carries that source (length reported from the baked bytes).
 	if v := run("verify\nquit\n"); !strings.Contains(v, "coherent:") || !strings.Contains(v, fmt.Sprintf("%d bytes", len(genesis))) {
 		t.Fatalf("combined verify: got=%q", v)
+	}
+}
+
+// TestFkwuLocaleUtf8 locks the locale capability: fkwu must print ANY UTF-8
+// byte-exact, not just ASCII. The string pool serializes raw bytes (str_byte_at
+// in fks-lit-sp), so a baked multi-script string round-trips through the table
+// and prints identically. This is the regression guard for the multibyte print
+// path — the bug that the earlier ASCII-only responses worked around.
+func TestFkwuLocaleUtf8(t *testing.T) {
+	clang := requireClang(t)
+	stdlib := filepath.Join("..", "form-stdlib")
+	minimal, hatiKernel, hatiEmit := emitChain(t, stdlib)
+	formParse := filepath.Join(stdlib, "form-parse.fk")
+	formFlatten := filepath.Join(stdlib, "form-flatten.fk")
+	shim := filepath.Join(stdlib, "fourth-shim.fk")
+	core := filepath.Join(stdlib, "core.fk")
+
+	dir := t.TempDir()
+	fkwuBin := buildFkwu(t, clang, dir, minimal, hatiKernel, hatiEmit)
+
+	// a band whose root is a multi-script string: CJK, Arabic, Devanagari, emoji,
+	// em-dash. If any continuation byte is dropped/corrupted, this mismatches.
+	// build the string with str_concat — the shape real responses use (a bare
+	// SLIT root isn't flagged string-valued by fk_str_root_depth, a separate gap);
+	// this exercises the byte-serialization fix across two multibyte literals.
+	want := "中文 العربية हिन्दी 😀—ok"
+	bandPath := filepath.Join(dir, "locale-band.fk")
+	if err := os.WriteFile(bandPath, []byte("; locale\n(str_concat \"中文 العربية हिन्दी 😀\" \"—ok\")\n"), 0o644); err != nil {
+		t.Fatalf("write band: %v", err)
+	}
+	mods := `(list (read_file "` + shim + `") (read_file "` + core + `"))`
+	band := `(read_file "` + bandPath + `")`
+	flattenExpr := "(fks-table-file (flt-band-sources-fns " + mods + " " + band + ") (flt-band-sources-pool " + mods + " " + band + "))"
+	_, table := runFormSource(t, readFiles(t, minimal, hatiKernel, hatiEmit, formParse, formFlatten)+"\n"+flattenExpr+"\n")
+	tablePath := filepath.Join(dir, "locale-table.txt")
+	if err := os.WriteFile(tablePath, []byte(table), 0o644); err != nil {
+		t.Fatalf("write table: %v", err)
+	}
+
+	got, err := FkwuEval(fkwuBin, tablePath, 0)
+	if err != nil {
+		t.Fatalf("FkwuEval: %v", err)
+	}
+	if got != want {
+		t.Fatalf("fkwu locale print:\n got=%q (% x)\nwant=%q (% x)", got, []byte(got), want, []byte(want))
 	}
 }

--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -2337,6 +2337,20 @@ func (k *Kernel) registerNatives() {
 		}
 		return Value{Kind: VInt, Int: int64(args[0].Str[0])}
 	})
+	// str_byte_at: the i-th raw BYTE of the string (0-255), byte-exact. A string
+	// is a UTF-8 byte sequence; char_at is rune-aware (returns "" inside a
+	// multibyte char), so ord(char_at) drops continuation bytes. The string-pool
+	// serializer (fks-lit-sp) must emit exact bytes so the emitted walker prints
+	// any locale's script, not just ASCII — this is that byte door, matching the
+	// walker's own byte-indexed char_at arm (tag 28).
+	k.registerNative("str_byte_at", catAccess(), func(_ *Kernel, args []Value) Value {
+		s := args[0].Str
+		i := args[1].AsInt()
+		if i < 0 || i >= int64(len(s)) {
+			panic(fmt.Sprintf("str_byte_at: bounds out of range index=%d len=%d", i, len(s)))
+		}
+		return Value{Kind: VInt, Int: int64(s[i])}
+	})
 	k.registerNative("byte_to_str", catAccess(), func(_ *Kernel, args []Value) Value {
 		if args[0].AsInt() < 0 || args[0].AsInt() > 255 {
 			return Value{Kind: VStr, Str: ""}

--- a/form/form-stdlib/form-cli.fk
+++ b/form/form-stdlib/form-cli.fk
@@ -38,5 +38,5 @@
                 "to rebuild: run the source verb to print the Form source this binary carries, then build-form-cli.sh turns those recipes into native code and bakes form-cli into the walker, reproducing this binary. Building needs the bootstrap toolchain. the result runs on its own."
             (if (str_eq v "version")
                 "form-cli 0.2"
-                (str_concat "form-cli: unknown verb " (str_concat v ", try help"))))))))))
+                (str_concat "form-cli: unknown verb '" (str_concat v "' — type 'help'"))))))))))
     0)

--- a/form/form-stdlib/hati-os-kernel-emit.fk
+++ b/form/form-stdlib/hati-os-kernel-emit.fk
@@ -652,11 +652,14 @@ extern int open(const char *, int, ...); extern long long read(int, void *, unsi
     (if (eq (len rows) 1) (fkc-row-sp (head rows))
         (str_concat (fkc-rows-sp (tail rows)) (str_concat " " (fkc-row-sp (head rows))))))
 
-; the string section: pool count, then per string its length and bytes —
-; fks-table-file is fkc-table-file with the program's pool riding behind it
+; the string section: pool count, then per string its length and bytes. The
+; bytes are serialized RAW via str_byte_at (str_len is the byte count): a string
+; is a UTF-8 byte sequence, so this carries any locale's script into the emitted
+; walker's pool exactly. (ord(char_at) was rune-aware and dropped continuation
+; bytes, corrupting every multibyte char — that was the ASCII-only limitation.)
 (defn fks-lit-sp (s i)
     (if (eq i (str_len s)) ""
-        (str_concat " " (str_concat (int_to_str (ord (char_at s i))) (fks-lit-sp s (add i 1))))))
+        (str_concat " " (str_concat (int_to_str (str_byte_at s i)) (fks-lit-sp s (add i 1))))))
 (defn fks-pool-entry (s) (str_concat (int_to_str (str_len s)) (fks-lit-sp s 0)))
 (defn fks-pool-items (pool)
     (if (eq (len pool) 0) ""

--- a/form/form-stdlib/tests/form-cli-band.fk
+++ b/form/form-stdlib/tests/form-cli-band.fk
@@ -8,17 +8,17 @@
 ; read the binary's baked source via the fkwu-only self_source op) live in the
 ; runtime wrappers, not here — this bands the verb-routing brain both surfaces call.
 ;
-; Response strings stay ASCII: fkwu corrupts multibyte bytes when it PRINTS a
-; pooled string (an em-dash came back as e2 ff ff), and these strings are printed
-; to the user. ; ' = are all fine four-way; plain ASCII keeps the printed output
-; byte-exact across all four kernels.
+; Responses carry real UTF-8: fkwu serializes the string pool byte-exact (via
+; str_byte_at in fks-lit-sp), so any locale's script prints identically on all
+; four kernels — the unknown-verb line below carries an em-dash (—) and proves it.
+; (locale-utf8 four-way coverage: form_cli_test.go TestFkwuLocaleUtf8.)
 ;
 ; Verdict 511:
 ;   1   ping -> pong
 ;   2   help -> the verb list
 ;   4   version -> the version string
 ;   8   verb-split: "ping extra" routes on the verb "ping" -> pong
-;   16  unknown verb -> "form-cli: unknown verb <v>, try help"
+;   16  unknown verb -> "form-cli: unknown verb '<v>' — type 'help'" (UTF-8 em-dash)
 ;   32  about  -> the self-description
 ;   64  kernel -> what it runs on
 ;  128  recreate -> how to rebuild
@@ -28,9 +28,9 @@
     (let c1 (if (str_eq (fc-respond "help") "form-cli verbs: ping help about kernel source recreate verify version quit. about: what this is. kernel: what it runs on. source: its own Form source. recreate: how to rebuild. verify: self-coherence.") 2 0))
     (let c2 (if (str_eq (fc-respond "version") "form-cli 0.2") 4 0))
     (let c3 (if (str_eq (fc-respond "ping extra") "pong") 8 0))
-    (let c4 (if (str_eq (fc-respond "foobar") "form-cli: unknown verb foobar, try help") 16 0))
+    (let c4 (if (str_eq (fc-respond "foobar") "form-cli: unknown verb 'foobar' — type 'help'") 16 0))
     (let c5 (if (str_eq (fc-respond "about") "form-cli is one self-contained native binary: a Form program that dispatches verbs and runs an interactive read-eval-print loop, with no separate runtime. Pipe commands on stdin, or run it on a terminal and type. help lists the verbs.") 32 0))
     (let c6 (if (str_eq (fc-respond "kernel") "form-cli runs on fkwu, a universal walker generated entirely from Form recipes and compiled to native code. The same walker runs any Form program. this binary has the form-cli program built into it.") 64 0))
     (let c7 (if (str_eq (fc-respond "recreate") "to rebuild: run the source verb to print the Form source this binary carries, then build-form-cli.sh turns those recipes into native code and bakes form-cli into the walker, reproducing this binary. Building needs the bootstrap toolchain. the result runs on its own.") 128 0))
-    (let c8 (if (str_eq (fc-respond "") "form-cli: unknown verb , try help") 256 0))
+    (let c8 (if (str_eq (fc-respond "") "form-cli: unknown verb '' — type 'help'") 256 0))
     (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 c8)))))))))


### PR DESCRIPTION
## Why

The form-cli responses were forced to ASCII to dodge a real bug — fkwu printed multibyte strings corrupted (em-dash `—` = `e2 80 94` came back `e2 ff ff`). That workaround was a detour off the north star: a CLI that can only print ASCII fails the no-exclusion promise — it can't serve 中文, العربية, हिन्दी, or 😀. **This fixes the root so any locale's script prints byte-exact.**

## Root cause

The string-pool serializer `fks-lit-sp` used `(ord (char_at s i))` over `0..str_len`. On the Go bootstrap, `str_len` is byte-count but `char_at` is **rune**-aware — it returns `""` inside a multibyte char and `ord("")` = -1, so every continuation byte serialized as -1 (stored `0xff`). The walker's own `char_at` (tag 28) is byte-based, so bootstrap and walker disagreed on multibyte; ASCII hid it (byte == rune).

## Fix

A byte-exact primitive: `str_byte_at(s,i)` returns the i-th raw byte (a string *is* a UTF-8 byte sequence). `fks-lit-sp` serializes via it. `char_at` is untouched (169 callers across 42 files rely on its rune semantics) — the serializer just uses the right primitive. Bootstrap-only: `fks-lit-sp` runs at flatten time, not in any walker band, and is byte-identical to the old path for ASCII (zero regression).

## Proof

- flatten of `A—中Z` → `65 226 128 148 228 184 173 90` (byte-exact).
- **four-way** (Go/Rust/TS/fkwu) print agreement on `中文 العربية हिन्दी 😀—ok`.
- `TestFkwuLocaleUtf8` locks fkwu multibyte print byte-exact in CI.
- form-cli's unknown-verb response now carries a real em-dash; `form-cli-band` → **511** four-way with UTF-8 live in the response.

## Honest remaining gaps (separate, pre-existing)

- a bare string-literal root prints the pool slot index, not bytes (`fk_str_root_depth` doesn't follow a var-ref to a SLIT); real responses route through if/str_concat which are recognized.
- `byte_to_str`/`char_at` on the bootstrap are rune-encoded for bytes >127, so the multibyte **input** path isn't byte-clean yet.

Full locale support (responses from locale data, no privileged source language) is the next rung on the existing i18n architecture — this fix makes it possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)