### PR TITLE
feat(form): the autoregressive causal mask crosses four-way — the generation-ready decoder block

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-19_causal_attention_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-19_causal_attention_four_way.json
@@ -1,0 +1,48 @@
+{
+  "date": "2026-06-19",
+  "brick": "causal-attention — the autoregressive mask (tb-attn-seq-causal) and the causal llama decoder block (lblk-block-causal), four-way",
+  "north_star_track": "device-native / model-as-recipe: the generation-ready decoder. The named next stone after the whole llama block ran FORWARD on the M4 GPU (brick 3s, #3355) was the causal mask — a decoder must not attend to future tokens. This adds it at the reusable engine altitude (transformer-block.fk) and on the real llama block, four-way; the generation loop steps the causal block.",
+  "what": "The whisper/llama blocks proven so far use NON-CAUSAL attention (every query sees every key) — correct for an encoder, wrong for autoregressive generation. Added tb-attn-seq-causal to transformer-block.fk: query at position i attends only to keys/values 0..i (a per-query key PREFIX via tb-take), composing tb-attend-one verbatim — no numeric change to the per-pair dot/softmax. Added lblk-block-causal to llama-block.fk (the real RMSNorm+RoPE+SwiGLU decoder block with the mask). Proved both four-way against an independent libm fp64 reference whose non-causal path bit-exactly reproduces llama-block-band's known pins (1115890, -1069281, 1648117).",
+  "mask_definition": "tb-attn-causal-i walks the queries with a 1-based count i; query k sees the first i=k+1 keys/values. The first query sees one key (itself); the last sees the whole sequence (the mask is a no-op there). softmax normalizes over the visible keys only.",
+  "the_proof_is_the_relationships": [
+    "first token sees ONLY itself: causal attn[0] == v0 EXACTLY (softmax of one score = 1) — bits 1,2 = (2000000, 3000000) = v0 — AND non-causal attn[0][0] (bit 16, 2806824) differs, so the mask actually restricts",
+    "mask is a NO-OP at the last position: causal attn[last] (bits 4,8) == non-causal attn[last] (bit 32) = 4193176 — no over-masking",
+    "same two laws on the REAL llama block: causal yc[last] (bits 64,128) == non-causal y[last] (-1069281/1648117) AND causal yc[0][0] (bit 256, 1893731) differs from non-causal 1115890 — the mask changed an earlier token"
+  ],
+  "composed_from_four_way_recipes": [
+    "tb-attend-one / tb-scores / tb-weighted-acc (transformer-block.fk, band 511) — reused verbatim",
+    "the full llama block lblk-attn-block / lblk-ffn-block (llama-block.fk, band 4095) — only the attention seq-walk swapped for the causal one"
+  ],
+  "recipes": [
+    "form/form-stdlib/transformer-block.fk (tb-take, tb-attn-causal-i, tb-attn-seq-causal)",
+    "form/form-stdlib/llama-block.fk (lblk-attn-sub-causal, lblk-attn-block-causal, lblk-block-causal)"
+  ],
+  "band": "form/form-stdlib/tests/causal-attention-band.fk",
+  "manifest_row": "causal-attention fks 511 (form/fourth-arm-bands.txt)",
+  "reference": "independent pure-libm fp64 (math.exp/sin/cos/sqrt). Generic attention fixture: scale 1, d=2, qs=ks=[[1,0],[0,1]], vs=[[2,3],[5,7]]. Llama block: the llama-block-band fixture (S=2, d=4, HD=4). The reference's NON-CAUSAL llama path reproduces llama-block-band's pins bit-exactly (1115890, -1069281, 1648117), validating it before reading the causal values.",
+  "claims_511": {
+    "1_causal_attn00": 2000000,
+    "2_causal_attn01": 3000000,
+    "4_causal_attn10": 4193176,
+    "8_causal_attn11": 5924234,
+    "16_noncausal_attn00": 2806824,
+    "32_noncausal_attn10": 4193176,
+    "64_causal_llama_y10": -1069281,
+    "128_causal_llama_y12": 1648117,
+    "256_causal_llama_y00": 1893731
+  },
+  "proof": {
+    "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/tests/causal-attention-band.fk",
+    "verdict": 511,
+    "kernels": "Go + Rust + TypeScript + fkwu",
+    "fourth_arm": "1 band(s) four-way (fkwu + pre-flattened tables)",
+    "divergent": 0
+  },
+  "regression": "llama-block-band still 4095 four-way, transformer-block-band still 511 four-way after the additive edits to the shared files.",
+  "named_next_stones": [
+    "emit lblk-block-causal to Metal (the causal jte-llama-block-fwd-msl) and run on the M4 GPU — the mask is a per-query key-prefix in the threadgroup walk, no new numerics",
+    "the generation loop: tokenizer + KV cache + greedy decode stepping the causal block over real llama3.2:3b GGUF weights (the load path q4k/q6k/f16 is already Form-native four-way)"
+  ],
+  "lesson": "A NEW-recipe brick (like 3p/3q/3r) but cheap: the mask composes tb-attend-one verbatim, so the only design cost was the strange-minimal characterization (prove causality by the RELATIONSHIPS between libm-pinned values — first token == v0 exactly, last token == non-causal) and validating the python reference against the known band pins. The four-way proof was seconds.",
+  "co_authored_by": "Claude Opus 4.8 (1M context)"
+}

--- a/form/form-stdlib/llama-block.fk
+++ b/form/form-stdlib/llama-block.fk
@@ -20,10 +20,11 @@
 ; residual walks of transformer-block.fk (tb-dot/tb-matvec/tb-attn-seq/tb-add-seq, 511). Nothing
 ; re-derived. Weights are arguments — recipe DATA all the way down; a layer stack is a SEQUENCE of
 ; lblk-block calls, mutable at runtime (the dynamic-recipe advantage). fp64 lane; the GPU emit
-; (fp32 mirror) and format lanes are the named follow-ups. Attention is non-causal here, matching
-; tb-block's whisper attention and the jte-blk-attn GPU walk it reuses; the causal mask is a named
-; orthogonal follow-up (a per-query key-prefix, no numeric change). Position = absolute token index.
-; Proven four-way against the libm fp64 reference by tests/llama-block-band.fk.
+; (fp32 mirror) and format lanes are the named follow-ups. lblk-block is non-causal (matching the
+; jte-llama-block-fwd-msl GPU walk it backs); lblk-block-causal applies the autoregressive mask
+; (tb-attn-seq-causal — a per-query key-prefix, no numeric change) for the real decoder that the
+; generation loop steps. Position = absolute token index. Proven four-way against the libm fp64
+; reference by tests/llama-block-band.fk; the causal mask by tests/causal-attention-band.fk.
 
 ; --- RMSNorm each token-vector of a sequence (gain g, no bias) ---
 (defn lblk-rms-seq (xs g eps)
@@ -67,3 +68,18 @@
 ; --- the whole llama block ---
 (defn lblk-block (xs g1 eps wq wk wv wo scale HD g2 wg wu wd)
   (lblk-ffn-block (lblk-attn-block xs g1 eps wq wk wv wo scale HD) g2 eps wg wu wd))
+
+; --- the causal llama block: the real autoregressive decoder. Identical to lblk-block but each
+;     token attends only to itself and the tokens before it (tb-attn-seq-causal). At the last token
+;     the prefix is the whole sequence, so the last position is bit-identical to lblk-block; earlier
+;     tokens differ because the non-causal block let them see the future. This is the block the
+;     generation loop steps: it produces one token's next-state without leaking later positions. ---
+(defn lblk-attn-sub-causal (n1 wq wk wv wo scale HD)
+  (lblk-proj-seq wo
+    (tb-attn-seq-causal (lblk-rope-seq (lblk-proj-seq wq n1) HD)
+                        (lblk-rope-seq (lblk-proj-seq wk n1) HD)
+                        (lblk-proj-seq wv n1) scale)))
+(defn lblk-attn-block-causal (xs g1 eps wq wk wv wo scale HD)
+  (tb-add-seq xs (lblk-attn-sub-causal (lblk-rms-seq xs g1 eps) wq wk wv wo scale HD)))
+(defn lblk-block-causal (xs g1 eps wq wk wv wo scale HD g2 wg wu wd)
+  (lblk-ffn-block (lblk-attn-block-causal xs g1 eps wq wk wv wo scale HD) g2 eps wg wu wd))

--- a/form/form-stdlib/tests/causal-attention-band.fk
+++ b/form/form-stdlib/tests/causal-attention-band.fk
@@ -1,0 +1,61 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk
+;
+; causal-attention-band — the autoregressive mask (tb-attn-seq-causal) and the causal llama decoder
+; block (lblk-block-causal), lifted to the four-kernel floor. The causal mask lets a query at
+; position i attend only to keys/values 0..i — what a decoder needs to generate one token at a time
+; without seeing the future. It composes tb-attend-one verbatim (a per-query key PREFIX, no numeric
+; change), so the proof is the RELATIONSHIPS between values, each a libm fp64 reference at 1e-6:
+;
+;   the mask's defining property — the FIRST token sees only itself:
+;     causal attn[0] == v0 EXACTLY (softmax of one score = 1) — and differs from non-causal attn[0]
+;     (which mixed in the future). So bits 1,2 (= v0) together with bit 16 (non-causal ≠ v0) say the
+;     mask actually restricts.
+;   the mask is a NO-OP at the last position — it sees the whole sequence:
+;     causal attn[last] == non-causal attn[last] (bits 4,8 == bit 32). No over-masking.
+;
+; The same two laws on the REAL llama block (RMSNorm + RoPE + SwiGLU, the llama-block-band fixture):
+;   causal yc[last] == non-causal y[last] (bits 64,128 == llama-block-band's -1069281/1648117) — the
+;     last token's whole downstream is bit-identical; and causal yc[0][0] (bit 256) DIFFERS from the
+;     non-causal 1115890 — the mask changed an earlier token. The first generation-ready decoder block.
+;
+; Verdict 511 when the mask lands four-way:
+;   1     cattn[0][0] → 2000000   (first token = v0 exactly: sees only itself)
+;   2     cattn[0][1] → 3000000
+;   4     cattn[1][0] → 4193176   (last token's prefix-softmax = whole-sequence softmax)
+;   8     cattn[1][1] → 5924234
+;   16    nattn[0][0] → 2806824   (non-causal token 0 mixed the future — ≠ causal 2000000)
+;   32    nattn[1][0] → 4193176   (non-causal last token == causal last: mask is a no-op at the end)
+;   64    yc[1][0]    → -1069281  (causal llama, last token == non-causal: mask no-op at the end)
+;   128   yc[1][2]    → 1648117
+;   256   yc[0][0]    → 1893731   (causal llama token 0 ≠ non-causal 1115890: the mask restricted it)
+(do
+    ; --- generic causal attention on a strange-minimal fixture (scale 1, d=2) ---
+    (let qs (list (list 1.0 0.0) (list 0.0 1.0)))
+    (let ks (list (list 1.0 0.0) (list 0.0 1.0)))
+    (let vs (list (list 2.0 3.0) (list 5.0 7.0)))
+    (let cattn (tb-attn-seq-causal qs ks vs 1.0))
+    (let nattn (tb-attn-seq qs ks vs 1.0))
+    ; --- the real llama decoder block, causal vs non-causal (llama-block-band fixture) ---
+    (let x  (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75)))
+    (let g1 (list 0.9 1.1 1.0 0.95))   (let g2 (list 1.05 0.95 1.0 0.9))
+    (let wq (list (list 0.5 -0.25 0.1 0.3) (list 0.2 0.4 -0.3 0.1) (list -0.1 0.2 0.5 -0.2) (list 0.3 0.0 -0.15 0.25)))
+    (let wk (list (list 0.2 0.4 -0.3 0.1) (list 0.3 -0.2 0.25 0.5) (list 0.1 0.15 -0.05 0.2) (list -0.25 0.3 0.4 -0.1)))
+    (let wv (list (list 0.3 -0.2 0.25 0.5) (list 0.6 0.1 -0.2 0.4) (list 0.05 -0.1 0.3 0.2) (list 0.15 0.35 -0.25 0.1)))
+    (let wo (list (list 0.6 0.1 -0.2 0.4) (list -0.2 0.4 0.3 0.1) (list 0.25 -0.15 0.5 0.05) (list 0.1 0.2 -0.3 0.45)))
+    (let wg (list (list 0.5 -0.3 0.2 0.1) (list 0.2 0.7 -0.4 0.3) (list -0.1 0.25 0.4 -0.2) (list 0.3 0.1 -0.15 0.5)))
+    (let wu (list (list 0.25 -0.15 0.3 0.05) (list 0.1 0.4 -0.2 0.15) (list 0.35 0.2 -0.1 0.25) (list -0.2 0.3 0.15 0.4)))
+    (let wd (list (list 0.4 -0.2 0.3 0.1) (list 0.15 0.5 -0.25 0.2) (list -0.3 0.1 0.45 -0.15) (list 0.2 -0.1 0.35 0.3)))
+    (let eps 0.00001)
+    (let HD 4)
+    (let scale (div 1.0 (tn-sqrt 4.0)))
+    (let yc (lblk-block-causal x g1 eps wq wk wv wo scale HD g2 wg wu wd))
+    (let c0 (if (eq (round (mul (nth (nth cattn 0) 0) 1000000.0)) 2000000) 1 0))
+    (let c1 (if (eq (round (mul (nth (nth cattn 0) 1) 1000000.0)) 3000000) 2 0))
+    (let c2 (if (eq (round (mul (nth (nth cattn 1) 0) 1000000.0)) 4193176) 4 0))
+    (let c3 (if (eq (round (mul (nth (nth cattn 1) 1) 1000000.0)) 5924234) 8 0))
+    (let c4 (if (eq (round (mul (nth (nth nattn 0) 0) 1000000.0)) 2806824) 16 0))
+    (let c5 (if (eq (round (mul (nth (nth nattn 1) 0) 1000000.0)) 4193176) 32 0))
+    (let c6 (if (eq (round (mul (nth (nth yc 1) 0) 1000000.0)) -1069281) 64 0))
+    (let c7 (if (eq (round (mul (nth (nth yc 1) 2) 1000000.0)) 1648117) 128 0))
+    (let c8 (if (eq (round (mul (nth (nth yc 0) 0) 1000000.0)) 1893731) 256 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 c8)))))))))

--- a/form/form-stdlib/transformer-block.fk
+++ b/form/form-stdlib/transformer-block.fk
@@ -48,6 +48,20 @@
   (if (eq (len qs) 0) (empty)
       (cons (tb-attend-one (head qs) ks vs scale) (tb-attn-seq (tail qs) ks vs scale))))
 
+; --- causal attention: the autoregressive mask. Query at position i sees only keys/values 0..i —
+;     a per-query key PREFIX. tb-take cuts the visibility window; the count starts at 1 so the first
+;     query sees one key (itself), the last sees the whole sequence (the mask is a no-op at the end).
+;     softmax normalizes over the visible keys only — no numeric change to the per-pair dot/softmax,
+;     so it composes tb-attend-one verbatim. This is what a decoder block needs to generate one token
+;     at a time without attending to the future. ---
+(defn tb-take (xs n)
+  (if (eq n 0) (empty) (cons (head xs) (tb-take (tail xs) (sub n 1)))))
+(defn tb-attn-causal-i (qs ks vs scale i)
+  (if (eq (len qs) 0) (empty)
+      (cons (tb-attend-one (head qs) (tb-take ks i) (tb-take vs i) scale)
+            (tb-attn-causal-i (tail qs) ks vs scale (add i 1)))))
+(defn tb-attn-seq-causal (qs ks vs scale) (tb-attn-causal-i qs ks vs scale 1))
+
 ; --- the two pre-LN residual sub-blocks, then the whole block ---
 (defn tb-attn-sub (lns wq bq wk bk wv bv wo bo scale)
   (tb-proj-seq wo bo

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -391,6 +391,7 @@ neural-lm-real fks 7
 llama-numerics fks 4095
 rope fks 4095
 llama-block fks 4095
+causal-attention fks 511
 geometric-learning fks 8388607
 transcendental-natives fks 16
 learning-arc fks 127


### PR DESCRIPTION
## The stone

The whole llama decoder block runs FORWARD on the M4 GPU (brick 3s, [#3355](https://github.com/seeker71/Coherence-Network/pull/3355)) — but with **non-causal** attention. Every query sees every key: correct for an encoder, wrong for autoregressive generation. The named next stone was the **causal mask**.

## What

- **`transformer-block.fk`** (reusable engine altitude): `tb-attn-seq-causal` — query at position *i* attends only to keys/values 0..i (a per-query key **prefix** via `tb-take`). Composes `tb-attend-one` **verbatim** — no numeric change to the per-pair dot/softmax.
- **`llama-block.fk`**: `lblk-block-causal` — the real RMSNorm + RoPE + SwiGLU llama decoder block with the mask. The block the generation loop steps.

## Proof — four-way, 0 divergent

`causal-attention fks 511`. The proof is the **relationships** between libm-pinned fp64 values, each at 1e-6:

- **First token sees ONLY itself**: causal `attn[0]` == v0 *exactly* (softmax of one score = 1) — and non-causal `attn[0]` differs. The mask restricts.
- **Mask is a NO-OP at the last position**: causal `attn[last]` == non-causal `attn[last]`. No over-masking.
- Both laws hold on the bare attention **and** the real llama block (causal `y[last]` == non-causal `-1069281/1648117`; causal `y[0][0]` = 1893731 ≠ non-causal 1115890).

The independent python libm reference reproduces `llama-block-band`'s known pins bit-exactly before reading the causal values. `llama-block-band` (4095) and `transformer-block-band` (511) still pass four-way after the additive edits.

Receipt: `docs/system_audit/commit_evidence_2026-06-19_causal_attention_four_way.json`.

## Next
Emit the causal block to Metal (causal `jte-llama-block-fwd-msl`), then the generation loop (tokenizer + KV cache + greedy decode) over real llama3.2:3b GGUF weights — the load path is already Form-native four-way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)