### PR TITLE
fix(fkwu): restore fkc-flat's 2 dropped closing parens — #3354 silently killed the fourth arm

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-19_fkwu_emit_paren_heal.json
+++ b/docs/system_audit/commit_evidence_2026-06-19_fkwu_emit_paren_heal.json
@@ -1,0 +1,20 @@
+{
+  "title": "Heal: restore the 2 dropped closing parens in fkc-flat — #3354 left hati-os-kernel-emit.fk unparseable, silently killing the fourth arm on main",
+  "date": "2026-06-19",
+  "thread_branch": "claude/ecstatic-hofstadter-cd3234",
+  "severity": "high — the fourth kernel (fkwu) could not be emitted at all on main, so EVERY 'four-way' band silently ran 3-kernel-only. fourth-arm.sh degrades honestly on an emit failure (no red suite), which is correct for a missing clang but masked a real parse-error regression. Every four-way claim merged after #3354 was actually 3-kernel until this heal.",
+  "root_cause": "PR #3354 (Form-native HTTP/TLS over fkwu wire primitives) added two new arms to the fkc-flat node-flattener cascade in form-stdlib/hati-os-kernel-emit.fk — `(if (eq (fk-tag n) 118) (fkc-tri2 118 ...)` and the same for tag 119 — but did NOT add the two matching closing parens to the cascade's trailing close run. Net +2 unclosed '(' → the Go/Rust/TS parser reached EOF with fkc-flat's `(if` still open, so the whole emit module failed to parse, so fkc-emit-universal never produced C, so the fkwu binary never built.",
+  "bisect": "form-kernel-go/bin-go parses form-stdlib/hati-os-kernel-emit.fk cleanly at fcc59852d (#3369) and its parent, and FAILS at a7cae78f7 (#3354) with `unclosed ( opened at line 37 col 5 in (if ...)`. The band that preludes it (hati-os-kernel-emit-band) crashes at HEAD. Confirmed origin/main == the broken blob (git diff empty).",
+  "fix": "Added the 2 missing ')' to fkc-flat's trailing close run (the line ending `(fkc-bin2 ... n))))...`). Paren delta returns to 0; no semantic change — the two added tag arms (118/119) now close correctly, exactly as their sibling arms (105/108) do.",
+  "files_owned": ["form/form-stdlib/hati-os-kernel-emit.fk"],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "form/form-kernel-go/bin-go form-stdlib/hati-os-kernel-emit.fk   # parses, no error",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/tests/form-asm-float-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-lower.fk form-stdlib/tests/form-lower-float-band.fk"
+    ],
+    "summary": "hati-os-kernel-emit.fk parses again. The fkwu binary BUILDS again ('building fourth kernel (fkwu)...' with no 'did not land'). form-asm-float -> 2047 with 'fourth arm: 1 band four-way', form-lower-float -> 15 with 'fourth arm: 1 band four-way' — the emitted fourth kernel runs the manifest tables and agrees byte-for-byte. The fourth arm is alive again."
+  },
+  "follow_up": "fourth-arm.sh degrades silently on ANY emit failure. It should distinguish an honest degrade (no clang / no manifest) from a CHAIN PARSE ERROR (a real regression that must go RED), so a future unclosed-paren in the emit chain fails the suite instead of silently dropping every four-way claim to 3-kernel. Flagged as a separate guard task."
+}

--- a/form/form-stdlib/hati-os-kernel-emit.fk
+++ b/form/form-stdlib/hati-os-kernel-emit.fk
@@ -133,7 +133,7 @@
     (if (eq (fk-tag n) 115) (fkc-un2 115 (fkc-flat (fk-body n) acc))
     (if (or (eq (fk-tag n) 81) (or (eq (fk-tag n) 82) (or (eq (fk-tag n) 83) (or (eq (fk-tag n) 85) (or (eq (fk-tag n) 87) (or (eq (fk-tag n) 88) (or (eq (fk-tag n) 89) (eq (fk-tag n) 90))))))))
         (fkc-un2 (fk-tag n) (fkc-flat (fk-body n) acc))
-        (fkc-bin2 (fk-tag n) (fkc-flat (ms-child (fk-body n) 0) acc) n))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+        (fkc-bin2 (fk-tag n) (fkc-flat (ms-child (fk-body n) 0) acc) n))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
 
 (defn fkc-call2 (fidx acc1) (cons (list 12 fidx (sub (len acc1) 1) 0) acc1))
 


### PR DESCRIPTION
## Critical: the fourth arm has been silently dead on main since #3354

**PR #3354** (Form-native HTTP/TLS over fkwu wire primitives) added two arms (tags **118/119**) to the `fkc-flat` node-flattener cascade in `hati-os-kernel-emit.fk` but **dropped the two matching closing parens**. The file became unparseable (net +2 unclosed `(`), so `fkc-emit-universal` never produced C, so the **fkwu binary never built**.

`fourth-arm.sh` degrades honestly on an emit failure (so the suite never goes red just because the fourth arm couldn't build) — which is correct for a missing `clang`, but it **masked a real parse-error regression**. Result: every "four-way" band merged after #3354 has actually been running **3-kernel-only**, with the fourth (fkwu) leg silently absent.

## Bisect

`form-kernel-go/bin-go` parses `hati-os-kernel-emit.fk` cleanly at `fcc59852d` (#3369) and its parent, and **fails at `a7cae78f7` (#3354)** with `unclosed ( opened at line 37 col 5 in (if ...)`. `origin/main` == the broken blob. The band that preludes it (`hati-os-kernel-emit-band`) crashes at HEAD.

## Fix

The 2 missing `)` on `fkc-flat`'s trailing close run. No semantic change — tags 118/119 now close exactly as their sibling arms (105/108) do; paren delta returns to 0.

## Proof

- `hati-os-kernel-emit.fk` parses again.
- The **fkwu binary builds again** (`building fourth kernel (fkwu)...` with no "did not land").
- `form-asm-float → 2047` and `form-lower-float → 15` both report `fourth arm: 1 band four-way` — the emitted fourth kernel runs the manifest tables and agrees **byte-for-byte**. The fourth arm is alive again.

## Follow-up (flagged, not in this PR)

`fourth-arm.sh` should fail **RED** on a chain **parse error** (a real regression), distinct from an honest degrade (no clang / no manifest) — so an unclosed paren in the emit chain can never again silently drop every four-way claim to 3-kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)