### PR TITLE
chore: enable Windows host startup flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Spec → Test → Implement → CI → Review → Merge
 
 - Provider limits, remaining quota, and routing behavior are claimed from machine evidence, not from assumptions or static docs.
 - For Cursor/Codex/OpenRouter/OpenAI usage-limit claims, include machine evidence from:
-  1. local fact report: `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/python scripts/cursor_fact_report.py`
+  1. local fact report from the active worktree: `cd api && python scripts/cursor_fact_report.py` (Windows PowerShell: `cd api; py -3 scripts/cursor_fact_report.py`)
   2. live usage/readiness API snapshots:
      - `curl -sS https://api.coherencycoin.com/api/automation/usage/readiness`
      - `curl -sS https://api.coherencycoin.com/api/automation/usage`
@@ -177,6 +177,18 @@ Spec → Test → Implement → CI → Review → Merge
 - **Future** — OpenClaw, Agent Zero, etc. when multi-agent framework is set up
 
 ## Commands
+
+Windows 11 PowerShell bootstrap:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\setup_windows_host.ps1
+git fetch origin main
+git worktree add "$env:USERPROFILE\.claude-worktrees\Coherence-Network\<thread-name>" -b "codex/<thread-name>" origin/main
+Set-Location "$env:USERPROFILE\.claude-worktrees\Coherence-Network\<thread-name>"
+make prompt-guide
+```
+
+Use `npm.cmd` from PowerShell. `npm.ps1` can be blocked by execution policy on this host.
 
 ```bash
 # First step for every prompt (new thread + follow-up)
@@ -406,6 +418,9 @@ Configure `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_IDS`, `TELEGRAM_ALLOWED_USER_IDS`
 
 ### Gotchas
 
+- Windows 11 host setup is `powershell -ExecutionPolicy Bypass -File .\scripts\setup_windows_host.ps1`.
+- In Windows PowerShell, use `py -3` for Python and `npm.cmd` for npm commands.
+- Repo `.sh` scripts run through Git Bash at `C:\Program Files\Git\bin\bash.exe`; the Makefile startup targets call it automatically.
 - `python3.12-venv` is not installed by default on the VM; the update script handles this.
 - `ruff` is not listed in `pyproject.toml` dev dependencies but is required for `make lint`. The update script installs it into the API venv.
 - `next lint` requires an ESLint config file that does not exist in the repo. The command prompts interactively and cannot be run non-interactively. Use `next build` for type-checking validation instead.

--- a/Makefile
+++ b/Makefile
@@ -1,64 +1,104 @@
 # Coherence Network — common targets
 
+ifeq ($(OS),Windows_NT)
+PYTHON ?= py -3
+GIT_BASH ?= C:/Program Files/Git/bin/bash.exe
+NPM ?= npm.cmd
+API_VENV_PYTHON ?= .venv/Scripts/python.exe
+API_VENV_PIP ?= .venv/Scripts/pip.exe
+API_VENV_PYTEST ?= .venv/Scripts/pytest.exe
+API_VENV_RUFF ?= .venv/Scripts/ruff.exe
+API_VENV_UVICORN ?= .venv/Scripts/uvicorn.exe
+else
+PYTHON ?= python3
+GIT_BASH ?= bash
+NPM ?= npm
+API_VENV_PYTHON ?= .venv/bin/python
+API_VENV_PIP ?= .venv/bin/pip
+API_VENV_PYTEST ?= .venv/bin/pytest
+API_VENV_RUFF ?= .venv/bin/ruff
+API_VENV_UVICORN ?= .venv/bin/uvicorn
+endif
+
 .PHONY: test test-quick run setup dev-setup lint seed web-dev api-dev build web-worktree-validate spec-quality pr-preflight start-guide prompt-guide start-gate prompt-gate install-pre-push-hook wellness circulation carrier-tissue-census carrier-vitality carrier-tending cell-voice-tissue json-lens-tending audit-evidence-tending audit-evidence-index-cache native-route-goal-tending
 
 test:
-	cd api && .venv/bin/pytest -v
+	cd api && $(API_VENV_PYTEST) -v
 
 test-quick:
-	cd api && .venv/bin/pytest -x -q
+	cd api && $(API_VENV_PYTEST) -x -q
 
 run:
-	cd api && uvicorn app.main:app --reload --port 8000
+	cd api && $(API_VENV_UVICORN) app.main:app --reload --port 8000
 
 setup:
-	cd api && python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"
+	cd api && $(PYTHON) -m venv .venv && $(API_VENV_PIP) install -e ".[dev]"
 
 dev-setup: setup
-	cd web && npm install
+	cd web && $(NPM) install
 
 lint:
-	cd api && .venv/bin/ruff check . 2>/dev/null || true
+ifeq ($(OS),Windows_NT)
+	cd api && $(API_VENV_RUFF) check . || exit 0
+else
+	cd api && $(API_VENV_RUFF) check . 2>/dev/null || true
+endif
 
 seed:
+ifeq ($(OS),Windows_NT)
+	api/.venv/Scripts/python.exe scripts/seed_db.py
+else
 	api/.venv/bin/python scripts/seed_db.py
+endif
 
 api-dev:
-	cd api && .venv/bin/uvicorn app.main:app --reload --port 8000
+	cd api && $(API_VENV_UVICORN) app.main:app --reload --port 8000
 
 web-dev:
-	cd web && npm run dev
+	cd web && $(NPM) run dev
 
 build:
-	cd web && npm run build
+	cd web && $(NPM) run build
 
 web-worktree-validate:
+ifeq ($(OS),Windows_NT)
+	@"$(GIT_BASH)" -lc "THREAD_RUNTIME_AUTO_HEAL=1 ./scripts/verify_worktree_local_web.sh"
+else
 	THREAD_RUNTIME_AUTO_HEAL=1 ./scripts/verify_worktree_local_web.sh
+endif
 
 spec-quality:
-	python3 scripts/validate_spec_quality.py --base origin/main --head HEAD
+	$(PYTHON) scripts/validate_spec_quality.py --base origin/main --head HEAD
 
 pr-preflight:
-	python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
+	$(PYTHON) scripts/worktree_pr_guard.py --mode local --base-ref origin/main
 
 install-pre-push-hook:
+ifeq ($(OS),Windows_NT)
+	@"$(GIT_BASH)" ./scripts/setup_pre_push_hook.sh
+else
 	./scripts/setup_pre_push_hook.sh
+endif
 
 start-guide:
-	@/usr/bin/python3 scripts/start_gate.py
+	@$(PYTHON) scripts/start_gate.py
 
 prompt-guide:
+ifeq ($(OS),Windows_NT)
+	@"$(GIT_BASH)" ./scripts/prompt_entry_gate.sh
+else
 	./scripts/prompt_entry_gate.sh
+endif
 
 start-gate: start-guide
 
 prompt-gate: prompt-guide
 
 wellness:
-	@python3 scripts/wellness_check.py
+	@$(PYTHON) scripts/wellness_check.py
 
 circulation:
-	@python3 scripts/sense_subscription_circulation.py
+	@$(PYTHON) scripts/sense_subscription_circulation.py
 
 carrier-tissue-census:
 	@cd form/form-kernel-rust && cargo build --release --quiet

--- a/docs/CODEX-THREAD-PROCESS.md
+++ b/docs/CODEX-THREAD-PROCESS.md
@@ -28,12 +28,25 @@ Non-negotiable:
 
 Minimum startup sequence:
 
+Windows PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\setup_windows_host.ps1
+git fetch origin main
+git worktree add "$env:USERPROFILE\.claude-worktrees\Coherence-Network\<thread-name>" -b "codex/<thread-name>" origin/main
+Set-Location "$env:USERPROFILE\.claude-worktrees\Coherence-Network\<thread-name>"
+git pull --ff-only origin main
+make prompt-guide
+```
+
+Git Bash / Linux / macOS:
+
 ```bash
 git fetch origin main
 git worktree add ~/.claude-worktrees/Coherence-Network/<thread-name> -b codex/<thread-name> origin/main
 cd ~/.claude-worktrees/Coherence-Network/<thread-name>
 git pull --ff-only origin main
-make prompt-gate
+make prompt-guide
 ```
 
 ### Phase 0: Start Gate (required before new task work)
@@ -41,7 +54,7 @@ make prompt-gate
 Run from the target worktree:
 
 ```bash
-make prompt-gate
+make prompt-guide
 ```
 
 Gate status:
@@ -50,7 +63,8 @@ Gate status:
 - PASS only when thread context is valid: linked worktree OR `codex/*` branch.
 
 Start command:
-- `make prompt-gate` is the required prompt-entry command. It is intentionally cheap: CLAUDE.md orientation, branch/worktree safety, and sibling continuity guidance.
+- `make prompt-guide` is the required prompt-entry command. It is intentionally cheap: CLAUDE.md orientation, branch/worktree safety, and sibling continuity guidance.
+- `make prompt-gate` remains a legacy alias.
 - `./scripts/prompt_entry_gate.sh --force-full` runs the heavier start-gate + rebase + local guard proof when a thread explicitly needs it before commit/push.
 - `make start-gate` is intentionally minimal and only validates branch/worktree safety.
 

--- a/docs/WORKTREE-QUICKSTART.md
+++ b/docs/WORKTREE-QUICKSTART.md
@@ -4,6 +4,30 @@ Date: 2026-02-17
 
 Purpose: remove repeated setup mistakes by making every Codex/Claude thread follow one exact worktree startup flow.
 
+## Windows 11 Host Bootstrap
+
+Run once from a PowerShell prompt in any Coherence Network checkout:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\setup_windows_host.ps1
+```
+
+What it prepares:
+
+- Git Bash as the shell for repo `.sh` scripts.
+- GNU Make from winget when `make` is missing.
+- `%USERPROFILE%\.local\bin\python3` shim so Git Bash avoids the broken Windows Store `python3` alias and uses `py -3`.
+- `~\.config\gh-seeker71` from the existing GitHub CLI login when `gh auth status` is already authenticated.
+- `api\.env` and `web\.env.local` copied from examples when they do not already exist.
+- PATH entries for GNU Make and `%USERPROFILE%\.local\bin`.
+
+PowerShell notes for this host:
+
+- Use `npm.cmd`, not `npm`, because `npm.ps1` can be blocked by execution policy.
+- Open a fresh PowerShell after bootstrap so the updated user PATH is inherited. In the current shell, use the printed absolute `make.exe` command if needed.
+- Git Bash is at `C:\Program Files\Git\bin\bash.exe`; the Makefile uses it automatically for startup targets on Windows.
+- Run `gh auth login` before unbypassed `make prompt-guide` and PR checks if the bootstrap warns that GitHub CLI is not authenticated.
+
 ## Rule 0
 
 - Never implement from the primary repo workspace.
@@ -11,24 +35,30 @@ Purpose: remove repeated setup mistakes by making every Codex/Claude thread foll
 
 ## Start New Thread (copy/paste)
 
-From primary workspace:
+Windows PowerShell:
+
+```powershell
+git fetch origin main
+git worktree add "$env:USERPROFILE\.claude-worktrees\Coherence-Network\<thread-name>" -b "codex/<thread-name>" origin/main
+Set-Location "$env:USERPROFILE\.claude-worktrees\Coherence-Network\<thread-name>"
+git pull --ff-only origin main
+make prompt-guide
+```
+
+Git Bash / Linux / macOS:
 
 ```bash
 git fetch origin main
 git worktree add ~/.claude-worktrees/Coherence-Network/<thread-name> -b codex/<thread-name> origin/main
-```
-
-Enter worktree:
-
-```bash
 cd ~/.claude-worktrees/Coherence-Network/<thread-name>
 git pull --ff-only origin main
+make prompt-guide
 ```
 
 ## Mandatory Preflight (before edits)
 
 ```bash
-make prompt-gate
+make prompt-guide
 ```
 
 Mandatory for every prompt (new or follow-up). This command is continuation-safe:
@@ -38,7 +68,8 @@ Mandatory for every prompt (new or follow-up). This command is continuation-safe
 - sibling continuity guard: treats sibling worktrees, including dirty, detached, patch-equivalent, and old unpushed-ahead branches, as guidance. It fails fast only for recent unpushed-ahead sibling history without an upstream.
 - autonomous worker sidecars under `.claude/worktrees/*` are excluded from sibling continuity risk so Claude workers can run in parallel without blocking Codex prompt entry.
 
-Full proof on demand: `./scripts/prompt_entry_gate.sh --force-full`.
+Legacy alias: `make prompt-gate`.
+Full proof on demand: `./scripts/prompt_entry_gate.sh --force-full` from Git Bash.
 Equivalent minimal branch/worktree check: `make start-gate`.
 
 ### If prompt-gate blocks on continuity risk
@@ -70,7 +101,7 @@ SQLite artifact rule:
 Temporary bypass (not recommended):
 
 ```bash
-PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-gate
+PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide
 ```
 
 ## Mandatory Local Guard (before commit/push)
@@ -89,8 +120,9 @@ git rebase origin/main
 ```
 
 ```bash
-# Optional: set deployed n8n version when automation flows depend on n8n
-# export N8N_VERSION=1.123.17
+# Optional: set deployed n8n version when automation flows depend on n8n.
+# Windows PowerShell: $env:N8N_VERSION = "1.123.17"
+# Git Bash/Linux/macOS: export N8N_VERSION=1.123.17
 python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
 ./scripts/verify_worktree_local_web.sh
 # optional explicit startup (for manual end-to-end contract check)
@@ -142,9 +174,12 @@ Interpretation:
 
 ## Recover Common Failures
 
-- `next: command not found`: run `cd web && npm ci --cache /tmp/npm-codex-cache`.
-- missing pytest in worktree: use repo venv path for validation:
-  - `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q`.
+- `make: The term 'make' is not recognized`: run `powershell -ExecutionPolicy Bypass -File .\scripts\setup_windows_host.ps1`, then open a new PowerShell.
+- `process_begin ... env bash ... failed` from GNU Make on Windows: rebase onto the Makefile startup target fix, or run `make prompt-guide` after this guide's Windows bootstrap.
+- `Python was not found; run without arguments to install from the Microsoft Store`: run `.\scripts\setup_windows_host.ps1`; Git Bash will use `%USERPROFILE%\.local\bin\python3` -> `py -3`.
+- `npm.ps1 cannot be loaded`: use `npm.cmd`, for example `cd web; npm.cmd ci`.
+- `next: command not found`: run `cd web; npm.cmd ci --cache "$env:TEMP\coherence-npm-cache"` in PowerShell, or `cd web && npm ci --cache /tmp/npm-codex-cache` in Git Bash.
+- missing pytest in worktree: create the API venv with `cd api; py -3 -m venv .venv; .\.venv\Scripts\python.exe -m pip install -e ".[dev]"`, then run `.\.venv\Scripts\pytest.exe -q`.
 - maintainability gate fail: run
   - `python3 api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression`
   and refactor before re-push.
@@ -162,8 +197,18 @@ THREAD_RUNTIME_API_BASE_PORT=18200 THREAD_RUNTIME_WEB_BASE_PORT=3120 ./scripts/v
 
 After merge and deploy validation:
 
+Windows PowerShell:
+
+```powershell
+Set-Location <primary-workspace>
+git worktree remove "$env:USERPROFILE\.claude-worktrees\Coherence-Network\<thread-name>"
+git branch -D "codex/<thread-name>"
+```
+
+Git Bash / Linux / macOS:
+
 ```bash
-cd /Users/ursmuff/source/Coherence-Network
+cd <primary-workspace>
 git worktree remove ~/.claude-worktrees/Coherence-Network/<thread-name>
 git branch -D codex/<thread-name> 2>/dev/null || true
 ```

--- a/docs/system_audit/commit_evidence_20260619_windows_host_start_guide.json
+++ b/docs/system_audit/commit_evidence_20260619_windows_host_start_guide.json
@@ -1,0 +1,93 @@
+{
+  "date": "2026-06-19",
+  "thread_branch": "codex/windows-host-start-guide",
+  "commit_scope": "Enable Windows 11 startup by adding a host bootstrap, making startup Makefile targets Windows-aware, and documenting PowerShell worktree flow.",
+  "files_owned": [
+    "AGENTS.md",
+    "Makefile",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "scripts/audit_bml_bmf_kernel_natives.py",
+    "scripts/check_ghx_auth.sh",
+    "scripts/ghx.sh",
+    "scripts/prompt_entry_gate.sh",
+    "scripts/setup_windows_host.ps1",
+    "scripts/worktree_pr_guard.py"
+  ],
+  "idea_ids": [
+    "coherence-network-windows-host-enablement"
+  ],
+  "spec_ids": [
+    "process-worktree-quickstart"
+  ],
+  "task_ids": [
+    "task-2026-06-19-windows-host-start-guide"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "openai-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "documentation",
+        "host-validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "openai-codex",
+    "version": "gpt-5-codex"
+  },
+  "evidence_refs": [
+    "powershell -ExecutionPolicy Bypass -File .\\scripts\\setup_windows_host.ps1 -> pass; installed/prepared host prerequisites, ghx profile, and env files",
+    "scripts/ghx.sh auth profile mapping -> fixed credentialed HTTPS remote parsing so ghx selects gh-seeker71 in tokenized Windows worktrees",
+    "& 'C:\\Program Files (x86)\\GnuWin32\\bin\\make.exe' start-guide -> pass",
+    "& 'C:\\Program Files (x86)\\GnuWin32\\bin\\make.exe' prompt-guide -> pass",
+    "py -3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main -> pass after fixing Windows python3 shim path, UTF-8 read in audit_bml_bmf_kernel_natives.py, and nested Python subprocess calls in worktree_pr_guard.py",
+    "py -3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict -> pass",
+    "make -n setup -> cd api && py -3 -m venv .venv && .venv/Scripts/pip.exe install -e \".[dev]\"",
+    "make -n web-dev -> cd web && npm.cmd run dev",
+    "make -n pr-preflight -> py -3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+  ],
+  "change_files": [
+    "AGENTS.md",
+    "Makefile",
+    "docs/CODEX-THREAD-PROCESS.md",
+    "docs/WORKTREE-QUICKSTART.md",
+    "scripts/audit_bml_bmf_kernel_natives.py",
+    "scripts/check_ghx_auth.sh",
+    "scripts/ghx.sh",
+    "scripts/prompt_entry_gate.sh",
+    "scripts/setup_windows_host.ps1",
+    "scripts/worktree_pr_guard.py"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "powershell -ExecutionPolicy Bypass -File .\\scripts\\setup_windows_host.ps1",
+      "& 'C:\\Program Files (x86)\\GnuWin32\\bin\\make.exe' prompt-guide",
+      "& 'C:\\Program Files (x86)\\GnuWin32\\bin\\make.exe' start-guide",
+      "& 'C:\\Program Files (x86)\\GnuWin32\\bin\\make.exe' -n setup",
+      "& 'C:\\Program Files (x86)\\GnuWin32\\bin\\make.exe' -n web-dev",
+      "& 'C:\\Program Files (x86)\\GnuWin32\\bin\\make.exe' -n pr-preflight",
+      "py -3 scripts\\validate_commit_evidence.py --file docs\\system_audit\\commit_evidence_20260619_windows_host_start_guide.json",
+      "py -3 scripts\\worktree_pr_guard.py --mode local --base-ref origin/main",
+      "py -3 scripts\\check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict",
+      "git diff --check"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "run_url": ""
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-required-process-only"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "blocked_reason": "Local validation passed; CI and deploy validation remain pending until commit, push, and PR."
+  }
+}

--- a/scripts/audit_bml_bmf_kernel_natives.py
+++ b/scripts/audit_bml_bmf_kernel_natives.py
@@ -44,7 +44,7 @@ FORBIDDEN_SCANNER_PATTERNS = [
 
 
 def native_names(path: Path) -> list[str]:
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     names: list[str] = []
     for pattern in REGISTER_PATTERNS:
         names.extend(pattern.findall(text))
@@ -52,7 +52,7 @@ def native_names(path: Path) -> list[str]:
 
 
 def forbidden_scanner_hits(path: Path) -> list[str]:
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     hits: list[str] = []
     for lineno, line in enumerate(text.splitlines(), start=1):
         for pattern in FORBIDDEN_SCANNER_PATTERNS:

--- a/scripts/check_ghx_auth.sh
+++ b/scripts/check_ghx_auth.sh
@@ -22,6 +22,11 @@ fi
 
 extract_owner() {
   local remote_url="$1"
+  if [[ "$remote_url" =~ ^https?://([^/@]+@)?github\.com/([^/]+)/[^/]+(\.git)?$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[2]}"
+    return 0
+  fi
+
   if [[ "$remote_url" =~ ^https?://github\.com/([^/]+)/[^/]+(\.git)?$ ]]; then
     printf '%s\n' "${BASH_REMATCH[1]}"
     return 0

--- a/scripts/ghx.sh
+++ b/scripts/ghx.sh
@@ -52,6 +52,11 @@ fi
 extract_owner() {
   local remote_url="$1"
 
+  if [[ "$remote_url" =~ ^https?://([^/@]+@)?github\.com/([^/]+)/[^/]+(\.git)?$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[2]}"
+    return 0
+  fi
+
   if [[ "$remote_url" =~ ^https?://github\.com/([^/]+)/[^/]+(\.git)?$ ]]; then
     printf '%s\n' "${BASH_REMATCH[1]}"
     return 0

--- a/scripts/prompt_entry_gate.sh
+++ b/scripts/prompt_entry_gate.sh
@@ -42,6 +42,23 @@ done
 
 cd "$REPO_ROOT"
 
+if [[ "${OS:-}" == "Windows_NT" || "${OSTYPE:-}" == msys* || "${OSTYPE:-}" == cygwin* ]]; then
+  export PATH="${HOME}/.local/bin:${PATH}"
+fi
+
+PYTHON3_CMD=(python3)
+if ! "${PYTHON3_CMD[@]}" --version >/dev/null 2>&1; then
+  if command -v py >/dev/null 2>&1 && py -3 --version >/dev/null 2>&1; then
+    PYTHON3_CMD=(py -3)
+  elif command -v python >/dev/null 2>&1 && python --version 2>&1 | grep -q '^Python 3'; then
+    PYTHON3_CMD=(python)
+  else
+    echo "prompt-entry-guide: Python 3 not found."
+    echo "On Windows, run: powershell -ExecutionPolicy Bypass -File .\\scripts\\setup_windows_host.ps1"
+    exit 1
+  fi
+fi
+
 ./scripts/ensure_coord_cli.sh --quiet || true
 
 print_claude_orientation() {
@@ -92,7 +109,7 @@ if [[ "${PROMPT_GATE_SKIP_CONTINUITY:-0}" != "1" ]]; then
   if [[ "${PROMPT_GATE_CONTINUITY_STRICT:-0}" == "1" ]]; then
     continuity_args=(--fail-on-risk)
   fi
-  if ! python3 scripts/worktree_continuity_guard.py "${continuity_args[@]}"; then
+  if ! "${PYTHON3_CMD[@]}" scripts/worktree_continuity_guard.py "${continuity_args[@]}"; then
     echo "prompt-entry-guide: sibling worktree continuity risk detected."
     echo "Sibling worktrees are guidance; recent unpushed-ahead siblings without an upstream can strand history."
     echo "Continue from that worktree, push it, or merge/cherry-pick its branch before starting new work."
@@ -108,7 +125,7 @@ if [[ "$force_full" == "1" ]]; then
   exec ./scripts/auto_heal_start_gate.sh --with-pr-gate --with-rebase
 fi
 
-if ! make start-guide; then
+if ! "${PYTHON3_CMD[@]}" scripts/start_gate.py; then
   exit 1
 fi
 

--- a/scripts/setup_windows_host.ps1
+++ b/scripts/setup_windows_host.ps1
@@ -1,0 +1,155 @@
+# Windows 11 host bootstrap for Coherence Network.
+# Run from the repository root in Windows PowerShell:
+#   powershell -ExecutionPolicy Bypass -File .\scripts\setup_windows_host.ps1
+
+[CmdletBinding()]
+param(
+    [switch]$SkipInstall,
+    [switch]$ForceEnv
+)
+
+$ErrorActionPreference = "Stop"
+
+function Add-UserPathEntry {
+    param(
+        [Parameter(Mandatory = $true)][string]$PathEntry,
+        [switch]$Prepend
+    )
+
+    $resolved = [System.IO.Path]::GetFullPath($PathEntry)
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $entries = @()
+    if ($userPath) {
+        $entries = $userPath -split ";" | Where-Object { $_ -ne "" }
+    }
+
+    $normalizedResolved = $resolved.TrimEnd("\")
+    $entriesWithoutPath = @($entries | Where-Object { $_.TrimEnd("\") -ine $normalizedResolved })
+    $newEntries = $entries
+    if ($Prepend) {
+        $newEntries = @($resolved) + $entriesWithoutPath
+    } elseif ($entriesWithoutPath.Count -eq $entries.Count) {
+        $newEntries = @($entries) + $resolved
+    }
+
+    $newPath = $newEntries -join ";"
+    if ($newPath -ne $userPath) {
+        [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+        Write-Host "updated user PATH entry: $resolved"
+    }
+
+    $processEntries = @($env:Path -split ";" | Where-Object { $_ -ne "" })
+    $processWithoutPath = @($processEntries | Where-Object { $_.TrimEnd("\") -ine $normalizedResolved })
+    if ($Prepend) {
+        $env:Path = (@($resolved) + $processWithoutPath) -join ";"
+    } elseif ($processWithoutPath.Count -eq $processEntries.Count) {
+        $env:Path = (@($processEntries) + $resolved) -join ";"
+    }
+}
+
+function Require-Command {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Hint
+    )
+
+    $cmd = Get-Command $Name -ErrorAction SilentlyContinue
+    if (-not $cmd) {
+        throw "$Name is required. $Hint"
+    }
+    return $cmd.Source
+}
+
+function Install-WingetPackage {
+    param(
+        [Parameter(Mandatory = $true)][string]$Id,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($SkipInstall) {
+        throw "$Name is missing and -SkipInstall was set."
+    }
+
+    Require-Command "winget" "Install App Installer from Microsoft Store or install $Name manually." | Out-Null
+    Write-Host "installing $Name with winget..."
+    winget install --exact --id $Id --accept-package-agreements --accept-source-agreements
+}
+
+if (-not (Test-Path ".git")) {
+    throw "Run this script from the Coherence Network repository root."
+}
+
+$gitBash = Join-Path ${env:ProgramFiles} "Git\bin\bash.exe"
+if (-not (Test-Path $gitBash)) {
+    Install-WingetPackage -Id "Git.Git" -Name "Git for Windows"
+}
+if (-not (Test-Path $gitBash)) {
+    throw "Git Bash was not found at $gitBash after installation."
+}
+
+$makeExe = "C:\Program Files (x86)\GnuWin32\bin\make.exe"
+if (-not (Get-Command "make" -ErrorAction SilentlyContinue) -and -not (Test-Path $makeExe)) {
+    Install-WingetPackage -Id "GnuWin32.Make" -Name "GNU Make"
+}
+if (Test-Path $makeExe) {
+    Add-UserPathEntry (Split-Path $makeExe -Parent)
+}
+
+Require-Command "git" "Install Git for Windows." | Out-Null
+Require-Command "py" "Install Python 3.12+ or enable the Python launcher." | Out-Null
+Require-Command "node" "Install Node.js LTS/current for the web app." | Out-Null
+Require-Command "npm.cmd" "Use npm.cmd from PowerShell because npm.ps1 may be blocked by execution policy." | Out-Null
+Require-Command "rg" "Install ripgrep, for example: winget install BurntSushi.ripgrep.MSVC." | Out-Null
+Require-Command "gh" "Install GitHub CLI, then run gh auth login." | Out-Null
+
+$localBin = Join-Path $HOME ".local\bin"
+New-Item -ItemType Directory -Force -Path $localBin | Out-Null
+Add-UserPathEntry $localBin -Prepend
+
+$pythonShim = Join-Path $localBin "python3"
+$pythonShimCmd = Join-Path $localBin "python3.cmd"
+[System.IO.File]::WriteAllText($pythonShim, "#!/usr/bin/env bash`nexec py -3 ""`$@""`n", [System.Text.UTF8Encoding]::new($false))
+[System.IO.File]::WriteAllText($pythonShimCmd, "@echo off`r`npy -3 %*`r`n", [System.Text.Encoding]::ASCII)
+& $gitBash -lc "chmod +x ~/.local/bin/python3"
+
+if ((-not (Test-Path "api\.env")) -or $ForceEnv) {
+    Copy-Item "api\.env.example" "api\.env" -Force:$ForceEnv
+    Write-Host "prepared api\.env"
+}
+if ((-not (Test-Path "web\.env.local")) -or $ForceEnv) {
+    Copy-Item "web\.env.example" "web\.env.local" -Force:$ForceEnv
+    Write-Host "prepared web\.env.local"
+}
+
+Write-Host ""
+Write-Host "host checks:"
+git --version
+& py -3 --version
+node --version
+npm.cmd --version
+rg --version | Select-Object -First 1
+gh --version | Select-Object -First 1
+if (Test-Path $makeExe) {
+    & $makeExe --version | Select-Object -First 1
+}
+
+$ghAuthOutput = gh auth status -h github.com 2>&1
+if ($LASTEXITCODE -eq 0) {
+    $defaultGhConfigDir = Join-Path $env:APPDATA "GitHub CLI"
+    $ghxProfileDir = Join-Path $HOME ".config\gh-seeker71"
+    if (Test-Path (Join-Path $defaultGhConfigDir "hosts.yml")) {
+        New-Item -ItemType Directory -Force -Path $ghxProfileDir | Out-Null
+        Copy-Item (Join-Path $defaultGhConfigDir "hosts.yml") (Join-Path $ghxProfileDir "hosts.yml") -Force
+        if (Test-Path (Join-Path $defaultGhConfigDir "config.yml")) {
+            Copy-Item (Join-Path $defaultGhConfigDir "config.yml") (Join-Path $ghxProfileDir "config.yml") -Force
+        }
+        Write-Host "prepared ghx GitHub profile: $ghxProfileDir"
+    }
+} else {
+    Write-Warning "GitHub CLI is installed but not authenticated. Run gh auth login before unbypassed make prompt-guide or PR checks."
+}
+
+Write-Host ""
+Write-Host "Windows host bootstrap complete."
+Write-Host "Open a new PowerShell window for the updated user PATH, or call make once with:"
+Write-Host "  & '$makeExe' prompt-guide"

--- a/scripts/worktree_pr_guard.py
+++ b/scripts/worktree_pr_guard.py
@@ -146,10 +146,21 @@ def _hint_for_step(name: str, command: str, output: str) -> str:
     return "Review command output tail, fix root cause, and re-run this guard before push."
 
 
+def _python_argv(*args: str) -> list[str]:
+    return [sys.executable, *args]
+
+
+def _python_command(*args: str) -> str:
+    argv = _python_argv(*args)
+    if os.name == "nt":
+        return subprocess.list2cmdline(argv)
+    return " ".join(shlex.quote(part) for part in argv)
+
+
 def _existing_script_command(*relative_candidates: str) -> str | None:
     for rel in relative_candidates:
         if (REPO_ROOT / rel).exists():
-            return f"python3 {rel}"
+            return _python_command(rel)
     return None
 
 
@@ -523,6 +534,14 @@ def _is_runtime_web_scoped_change(path: str) -> bool:
 
 def _run_commit_evidence_guard(base_ref: str) -> StepResult:
     start = time.monotonic()
+    evidence_range_command = _python_command(
+        "scripts/validate_commit_evidence.py",
+        "--base",
+        base_ref,
+        "--head",
+        "HEAD",
+        "--require-changed-evidence",
+    )
     changed, diff_error = _changed_paths_range(base_ref)
     raw_worktree_changed = _changed_paths_worktree()
     ignored_artifacts = sorted(path for path in raw_worktree_changed if _is_skippable_local_artifact(path))
@@ -530,7 +549,7 @@ def _run_commit_evidence_guard(base_ref: str) -> StepResult:
     if diff_error:
         return StepResult(
             name="commit-evidence-guard",
-            command=f"python3 scripts/validate_commit_evidence.py --base {base_ref} --head HEAD --require-changed-evidence",
+            command=evidence_range_command,
             ok=False,
             exit_code=1,
             duration_seconds=round(time.monotonic() - start, 2),
@@ -544,7 +563,7 @@ def _run_commit_evidence_guard(base_ref: str) -> StepResult:
             artifact_note = f" Ignored local artifacts: {', '.join(ignored_artifacts)}."
         return StepResult(
             name="commit-evidence-guard",
-            command=f"python3 scripts/validate_commit_evidence.py --base {base_ref} --head HEAD --require-changed-evidence",
+            command=evidence_range_command,
             ok=True,
             exit_code=0,
             duration_seconds=round(time.monotonic() - start, 2),
@@ -558,7 +577,7 @@ def _run_commit_evidence_guard(base_ref: str) -> StepResult:
     tails: list[str] = []
     if changed:
         cmd = [
-            "python3",
+            sys.executable,
             "scripts/validate_commit_evidence.py",
             "--base",
             base_ref,
@@ -578,7 +597,7 @@ def _run_commit_evidence_guard(base_ref: str) -> StepResult:
         if proc.returncode != 0:
             return StepResult(
                 name="commit-evidence-guard",
-                command=f"python3 scripts/validate_commit_evidence.py --base {base_ref} --head HEAD --require-changed-evidence",
+                command=evidence_range_command,
                 ok=False,
                 exit_code=proc.returncode,
                 duration_seconds=round(time.monotonic() - start, 2),
@@ -593,7 +612,7 @@ def _run_commit_evidence_guard(base_ref: str) -> StepResult:
         if not evidence_files:
             return StepResult(
                 name="commit-evidence-guard",
-                command=f"python3 scripts/validate_commit_evidence.py --base {base_ref} --head HEAD --require-changed-evidence",
+                command=evidence_range_command,
                 ok=False,
                 exit_code=1,
                 duration_seconds=round(time.monotonic() - start, 2),
@@ -603,7 +622,7 @@ def _run_commit_evidence_guard(base_ref: str) -> StepResult:
 
         declared: set[str] = set()
         for evidence_file in evidence_files:
-            cmd = ["python3", "scripts/validate_commit_evidence.py", "--file", evidence_file]
+            cmd = _python_argv("scripts/validate_commit_evidence.py", "--file", evidence_file)
             proc = subprocess.run(
                 cmd,
                 cwd=REPO_ROOT,
@@ -616,7 +635,7 @@ def _run_commit_evidence_guard(base_ref: str) -> StepResult:
             if proc.returncode != 0:
                 return StepResult(
                     name="commit-evidence-guard",
-                    command=f"python3 scripts/validate_commit_evidence.py --base {base_ref} --head HEAD --require-changed-evidence",
+                    command=evidence_range_command,
                     ok=False,
                     exit_code=proc.returncode,
                     duration_seconds=round(time.monotonic() - start, 2),
@@ -628,7 +647,7 @@ def _run_commit_evidence_guard(base_ref: str) -> StepResult:
             except Exception as exc:  # pragma: no cover - defensive guard
                 return StepResult(
                     name="commit-evidence-guard",
-                    command=f"python3 scripts/validate_commit_evidence.py --base {base_ref} --head HEAD --require-changed-evidence",
+                    command=evidence_range_command,
                     ok=False,
                     exit_code=1,
                     duration_seconds=round(time.monotonic() - start, 2),
@@ -649,7 +668,7 @@ def _run_commit_evidence_guard(base_ref: str) -> StepResult:
             tails.append(f"ERROR: worktree evidence coverage missing changed paths: {missing}")
             return StepResult(
                 name="commit-evidence-guard",
-                command=f"python3 scripts/validate_commit_evidence.py --base {base_ref} --head HEAD --require-changed-evidence",
+                command=evidence_range_command,
                 ok=False,
                 exit_code=1,
                 duration_seconds=round(time.monotonic() - start, 2),
@@ -661,7 +680,7 @@ def _run_commit_evidence_guard(base_ref: str) -> StepResult:
 
     return StepResult(
         name="commit-evidence-guard",
-        command=f"python3 scripts/validate_commit_evidence.py --base {base_ref} --head HEAD --require-changed-evidence",
+        command=evidence_range_command,
         ok=True,
         exit_code=0,
         duration_seconds=round(time.monotonic() - start, 2),
@@ -697,22 +716,27 @@ def _local_steps(
         [
             (
                 "spec-quality-guard",
-                f"python3 scripts/validate_spec_quality.py --base {base_ref} --head HEAD",
+                _python_command("scripts/validate_spec_quality.py", "--base", base_ref, "--head", "HEAD"),
             ),
             (
                 "runtime-drift-guard",
-                "python3 scripts/check_runtime_drift.py",
+                _python_command("scripts/check_runtime_drift.py"),
             ),
             (
                 "maintainability-regression-guard",
-                f"python3 api/scripts/run_maintainability_audit.py --output {shlex.quote(maintainability_output)} --fail-on-regression",
+                _python_command(
+                    "api/scripts/run_maintainability_audit.py",
+                    "--output",
+                    maintainability_output,
+                    "--fail-on-regression",
+                ),
             ),
         ]
     )
     if not _worktree_has_maintainability_scoped_changes(base_ref):
         steps = [s for s in steps if s[0] != "maintainability-regression-guard"]
     if require_gh_auth:
-        steps.insert(0, ("dev-auth-preflight", "python3 scripts/check_dev_auth.py --json"))
+        steps.insert(0, ("dev-auth-preflight", _python_command("scripts/check_dev_auth.py", "--json")))
     api_scoped = force_api_tests or _worktree_has_scoped_changes(base_ref, _is_api_test_scoped_change)
     web_scoped = force_web_build or _worktree_has_scoped_changes(base_ref, _is_web_build_scoped_change)
     runtime_scoped = force_runtime_web or _worktree_has_scoped_changes(base_ref, _is_runtime_web_scoped_change)
@@ -728,19 +752,37 @@ def _local_steps(
 def _check_run_hint(name: str) -> str:
     value = name.lower()
     mapping: list[tuple[str, str]] = [
-        ("validate commit evidence", "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence"),
-        ("spec quality", "python3 scripts/validate_spec_quality.py --base origin/main --head HEAD"),
-        ("workflow file references", "python3 scripts/validate_workflow_references.py"),
-        ("maintainability", "python3 api/scripts/run_maintainability_audit.py --output maintainability_audit_report.json --fail-on-regression"),
+        (
+            "validate commit evidence",
+            _python_command(
+                "scripts/validate_commit_evidence.py",
+                "--base",
+                "origin/main",
+                "--head",
+                "HEAD",
+                "--require-changed-evidence",
+            ),
+        ),
+        ("spec quality", _python_command("scripts/validate_spec_quality.py", "--base", "origin/main", "--head", "HEAD")),
+        ("workflow file references", _python_command("scripts/validate_workflow_references.py")),
+        (
+            "maintainability",
+            _python_command(
+                "api/scripts/run_maintainability_audit.py",
+                "--output",
+                "maintainability_audit_report.json",
+                "--fail-on-regression",
+            ),
+        ),
         ("run api tests", "cd api && pytest -q"),
         ("test", "cd api && pytest -q"),
         ("build web", "cd web && npm ci --allow-git=none && npm run build"),
-        ("thread gates", "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"),
+        ("thread gates", _python_command("scripts/worktree_pr_guard.py", "--mode", "local", "--base-ref", "origin/main")),
     ]
     for key, cmd in mapping:
         if key in value:
             return cmd
-    return "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main"
+    return _python_command("scripts/worktree_pr_guard.py", "--mode", "local", "--base-ref", "origin/main")
 
 
 def _parse_optional_status_contexts(raw: str) -> set[str]:


### PR DESCRIPTION
## Summary
- add Windows 11 bootstrap for Make/Git Bash/python3 shim/npm.cmd/env setup/ghx profile
- make Makefile startup and common dev targets Windows-aware
- fix Windows host guard issues: UTF-8 source reads, active Python subprocesses, credentialed HTTPS ghx owner parsing

## Verification
- sub-agent Parfit: PASS on setup, prompt guide, evidence validation, local PR guard, followthrough, diff check, and Windows diff review
- powershell -ExecutionPolicy Bypass -File .\scripts\setup_windows_host.ps1
- make prompt-guide
- make start-guide
- py -3 scripts\validate_commit_evidence.py --file docs\system_audit\commit_evidence_20260619_windows_host_start_guide.json
- py -3 scripts\worktree_pr_guard.py --mode local --base-ref origin/main
- py -3 scripts\check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict
- git diff --check