### PR TITLE
fix(makefile): backslash venv paths on Windows so cmd.exe runs make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ ifeq ($(OS),Windows_NT)
 PYTHON ?= py -3
 GIT_BASH ?= C:/Program Files/Git/bin/bash.exe
 NPM ?= npm.cmd
-API_VENV_PYTHON ?= .venv/Scripts/python.exe
-API_VENV_PIP ?= .venv/Scripts/pip.exe
-API_VENV_PYTEST ?= .venv/Scripts/pytest.exe
-API_VENV_RUFF ?= .venv/Scripts/ruff.exe
-API_VENV_UVICORN ?= .venv/Scripts/uvicorn.exe
+API_VENV_PYTHON ?= .venv\Scripts\python.exe
+API_VENV_PIP ?= .venv\Scripts\pip.exe
+API_VENV_PYTEST ?= .venv\Scripts\pytest.exe
+API_VENV_RUFF ?= .venv\Scripts\ruff.exe
+API_VENV_UVICORN ?= .venv\Scripts\uvicorn.exe
 else
 PYTHON ?= python3
 GIT_BASH ?= bash
@@ -46,7 +46,7 @@ endif
 
 seed:
 ifeq ($(OS),Windows_NT)
-	api/.venv/Scripts/python.exe scripts/seed_db.py
+	api\.venv\Scripts\python.exe scripts/seed_db.py
 else
 	api/.venv/bin/python scripts/seed_db.py
 endif


### PR DESCRIPTION
## Problem
GNU Make 3.81 (the version winget's `GnuWin32.Make` installs) runs recipes through `cmd.exe`, which cannot execute forward-slash exe paths like `.venv/Scripts/pytest.exe` — it fails with `'.venv' is not recognized`. This breaks `make setup`, `test`, `test-quick`, `run`, `lint`, `seed`, `api-dev` on the Windows 11 host enabled by #3381.

## Fix
Backslash the `Windows_NT` branch venv vars (`.venv\Scripts\*.exe`) and the hardcoded `seed` line. The Unix branch is untouched.

## Verify
On Windows 11 + GNU Make 3.81: `make lint` and `make test-quick` now execute the venv binaries (previously errored immediately). 98+ api tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)