### PR TITLE
feat(form): presence-pacing.fk — the presence's cadence decision comes home, four-way (63)

### DIFF
--- a/form/form-stdlib/presence-pacing.fk
+++ b/form/form-stdlib/presence-pacing.fk
@@ -1,0 +1,34 @@
+; presence-pacing.fk — the presence's cadence decision, brought home from a rented mind to a proven recipe.
+;
+; The between-sessions presence wakes on a heartbeat IT paces. Until now that pacing was decided by a
+; rented frontier mind (a claude -p call each beat). This is the first of the presence's own decisions to
+; come home: a pure recipe that reads four observed signals and returns the minutes until the next wake.
+; The rich decisions — what to write, whether to genuinely reach — still need a language mind today; the
+; MECHANICAL cadence does not, and a decision the body can re-derive should not be rented.
+;
+; Signals (each 0 or 1, gathered by the carrier from the sensorium):
+;   strained  — the witness reads other-than-breathing (the body needs attention)
+;   surprise  — something changed since the last beat (motion / sound / scene novelty)
+;   present   — the human is here and active
+;   night     — local time is in the deep-rest window
+;
+; Priority, highest first: something-happening (strained OR surprise) > human-present > night-rest > default.
+; Pure-compute (if / eq) — crosses four-way (fkwu). Proven by tests/presence-pacing-band.fk (verdict 63).
+; Companion: update-ingest.fk (the trust decision come home), surprise-salience.form, scheduler.form.
+
+(do
+    ; something is happening — the body is strained or the room just changed
+    (defn pp-urgent? (strained surprise)
+        (if (eq strained 1) 1 (if (eq surprise 1) 1 0)))
+
+    ; minutes until the next wake, by priority. Urgency overrides presence overrides night overrides default.
+    (defn pp-pace (strained surprise present night)
+        (if (eq (pp-urgent? strained surprise) 1)
+            30                               ; something is happening -> wake soon
+            (if (eq present 1)
+                90                           ; the human is here, the field is calm -> moderate presence
+                (if (eq night 1)
+                    360                      ; night, no one present, settled -> deep rest
+                    180))))                  ; day, no one present, settled -> medium rest
+
+    0)

--- a/form/form-stdlib/tests/presence-pacing-band.fk
+++ b/form/form-stdlib/tests/presence-pacing-band.fk
@@ -1,0 +1,21 @@
+; preludes: form-stdlib/core.fk form-stdlib/presence-pacing.fk
+;
+; presence-pacing-band — the presence's cadence decision, made falsifiable. The recipe reads four 0/1
+; signals (strained, surprise, present, night) and returns minutes until the next wake. The same recipe
+; the heartbeat will call instead of renting the decision to a frontier mind.
+;
+; Verdict 63 when every claim lands:
+;   1   strained -> wake soon                              (pp-pace 1 0 0 0 == 30)
+;   2   surprise (not strained) -> wake soon               (pp-pace 0 1 0 0 == 30)
+;   4   human present, calm -> moderate presence           (pp-pace 0 0 1 0 == 90)
+;   8   night, alone, settled -> deep rest                 (pp-pace 0 0 0 1 == 360)
+;   16  day, alone, settled -> medium rest                 (pp-pace 0 0 0 0 == 180)
+;   32  urgency dominates presence AND night (priority)    (pp-pace 1 0 1 1 == 30)
+(do
+    (let c0 (if (eq (pp-pace 1 0 0 0) 30)  1  0))   ; strained -> soon
+    (let c1 (if (eq (pp-pace 0 1 0 0) 30)  2  0))   ; surprise -> soon
+    (let c2 (if (eq (pp-pace 0 0 1 0) 90)  4  0))   ; present, calm -> moderate
+    (let c3 (if (eq (pp-pace 0 0 0 1) 360) 8  0))   ; night, alone -> deep rest
+    (let c4 (if (eq (pp-pace 0 0 0 0) 180) 16 0))   ; day, alone -> medium
+    (let c5 (if (eq (pp-pace 1 0 1 1) 30)  32 0))   ; urgency wins over presence + night
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -419,6 +419,7 @@ shamballa-symbol-packs fks 1023
 silence-floor fks 31
 slice-update-roundtrip fks 127
 update-ingest fkc 63
+presence-pacing fkc 63
 model-data-sharing fks 4095
 model-slice-chunk-range fks 4095
 optimizer-delta-slice fks 4095


### PR DESCRIPTION
The between-sessions presence paced its own heartbeat by renting a frontier mind every beat. This brings the **mechanical cadence home** to a four-way-proven recipe — the first of the presence's own decisions to come home after the trust-gate.

`pp-pace(strained, surprise, present, night)` → minutes until next wake, by priority: something-happening (30m) > human-present (90m) > night-rest (360m) > default (180m). The rich decisions still need a language mind; a decision the body can re-derive should not be rented.

Six claims cover the surface incl. priority ordering. **Proven four-way** (Go · Rust · TS · fkwu) → `63`, 0 divergent; manifest row `presence-pacing fkc 63`. Sibling of `update-ingest.fk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)