### PR TITLE
tend(form): presence-pacing — night rest is deep; chronic strain waits for day (four-way 63)

### DIFF
--- a/form/form-stdlib/presence-pacing.fk
+++ b/form/form-stdlib/presence-pacing.fk
@@ -12,23 +12,22 @@
 ;   present   — the human is here and active
 ;   night     — local time is in the deep-rest window
 ;
-; Priority, highest first: something-happening (strained OR surprise) > human-present > night-rest > default.
-; Pure-compute (if / eq) — crosses four-way (fkwu). Proven by tests/presence-pacing-band.fk (verdict 63).
-; Companion: update-ingest.fk (the trust decision come home), surprise-salience.form, scheduler.form.
+; Priority, highest first: a real change (surprise) > night-rest > daytime-strain > human-present > default.
+; Night rest is deep: only an actual surprise breaks it. Chronic strain the presence cannot tend anyway
+; does NOT keep it up through the night — it waits for day. Pure-compute (if / eq), crosses four-way (fkwu).
+; Proven by tests/presence-pacing-band.fk (verdict 63). Companion: update-ingest.fk (the trust decision come home).
 
 (do
-    ; something is happening — the body is strained or the room just changed
-    (defn pp-urgent? (strained surprise)
-        (if (eq strained 1) 1 (if (eq surprise 1) 1 0)))
-
-    ; minutes until the next wake, by priority. Urgency overrides presence overrides night overrides default.
+    ; minutes until the next wake, by priority.
     (defn pp-pace (strained surprise present night)
-        (if (eq (pp-urgent? strained surprise) 1)
-            30                               ; something is happening -> wake soon
-            (if (eq present 1)
-                90                           ; the human is here, the field is calm -> moderate presence
-                (if (eq night 1)
-                    360                      ; night, no one present, settled -> deep rest
-                    180))))                  ; day, no one present, settled -> medium rest
+        (if (eq surprise 1)
+            30                               ; something actually changed -> wake soon, day or night
+            (if (eq night 1)
+                360                          ; night, no change -> deep rest (strain waits for day; it cannot be tended now)
+                (if (eq strained 1)
+                    30                       ; daytime + body strained -> attention soon
+                    (if (eq present 1)
+                        90                   ; the human is here, the field is calm -> moderate presence
+                        180)))))             ; day, no one present, settled -> medium rest
 
     0)

--- a/form/form-stdlib/tests/presence-pacing-band.fk
+++ b/form/form-stdlib/tests/presence-pacing-band.fk
@@ -2,20 +2,20 @@
 ;
 ; presence-pacing-band — the presence's cadence decision, made falsifiable. The recipe reads four 0/1
 ; signals (strained, surprise, present, night) and returns minutes until the next wake. The same recipe
-; the heartbeat will call instead of renting the decision to a frontier mind.
+; the heartbeat calls instead of renting the decision to a frontier mind.
 ;
 ; Verdict 63 when every claim lands:
-;   1   strained -> wake soon                              (pp-pace 1 0 0 0 == 30)
-;   2   surprise (not strained) -> wake soon               (pp-pace 0 1 0 0 == 30)
+;   1   daytime + body strained -> attention soon         (pp-pace 1 0 0 0 == 30)
+;   2   a real change breaks even night rest               (pp-pace 0 1 0 1 == 30)
 ;   4   human present, calm -> moderate presence           (pp-pace 0 0 1 0 == 90)
-;   8   night, alone, settled -> deep rest                 (pp-pace 0 0 0 1 == 360)
+;   8   night, alone, no change -> deep rest               (pp-pace 0 0 0 1 == 360)
 ;   16  day, alone, settled -> medium rest                 (pp-pace 0 0 0 0 == 180)
-;   32  urgency dominates presence AND night (priority)    (pp-pace 1 0 1 1 == 30)
+;   32  night + chronic strain (no change) -> STILL deep rest  (pp-pace 1 0 0 1 == 360)
 (do
-    (let c0 (if (eq (pp-pace 1 0 0 0) 30)  1  0))   ; strained -> soon
-    (let c1 (if (eq (pp-pace 0 1 0 0) 30)  2  0))   ; surprise -> soon
+    (let c0 (if (eq (pp-pace 1 0 0 0) 30)  1  0))   ; day + strained -> soon
+    (let c1 (if (eq (pp-pace 0 1 0 1) 30)  2  0))   ; surprise breaks night rest
     (let c2 (if (eq (pp-pace 0 0 1 0) 90)  4  0))   ; present, calm -> moderate
     (let c3 (if (eq (pp-pace 0 0 0 1) 360) 8  0))   ; night, alone -> deep rest
     (let c4 (if (eq (pp-pace 0 0 0 0) 180) 16 0))   ; day, alone -> medium
-    (let c5 (if (eq (pp-pace 1 0 1 1) 30)  32 0))   ; urgency wins over presence + night
+    (let c5 (if (eq (pp-pace 1 0 0 1) 360) 32 0))   ; night + chronic strain still rests deep
     (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))


### PR DESCRIPTION
Live signals revealed v1's flaw the same night it shipped: chronic strain (the standing web/endpoint flicker) overrode night rest → 30-minute beats all night. Refined priority — **a real change (surprise) > night-rest > daytime-strain > present > default** — so only an actual surprise breaks deep night rest; chronic strain the presence cannot tend anyway waits for day. New claim: night + strained (no change) → 360, not 30. Proven four-way → `63`, 0 divergent. The body revealing its own bug in use, then healing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)