### PR TITLE
feat(form-native-view-history): twin + Windows recipe-gen fix; record lifter-gap blocker

### DIFF
--- a/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_view_history_order_demo.py
+++ b/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_view_history_order_demo.py
@@ -1,0 +1,71 @@
+# endpoint_view_history_order_demo.py — the body of
+# translation_cache_service.list_history's ordering, captured as pure Python
+# and compiled to a Form recipe.
+#
+# Contract: order a concept's language views canonical-first, then newest-first.
+# Inputs are two parallel lists in the views' original (DB) order:
+#   ranks[i] — 0 if view i is the canonical view, 1 otherwise
+#   keys[i]  — view i's updated_at as a comparable integer (e.g. epoch micros)
+# Output: the original indices reordered so that the canonical view comes first,
+# then superseded views by descending key (newest first). The original index is
+# the final tiebreak, so the order is TOTAL and deterministic — there is no
+# hash-seed-dependent comparison, which is the bug class this recipe removes
+# (a hash-dependent order cannot be byte-identical four-way, so it cannot pass
+# the witness gate).
+#
+# Implemented as insertion sort over an index list (no index-store, no pop —
+# each insert builds a fresh list via the append-accumulator idiom the kernel
+# value-walk carries), keeping the recipe inside the compiled Python subset.
+
+
+# Comparator: 1 if row a should come before row b, else 0. Written with flat
+# `if` statements (no `else`, no compound boolean) so it stays inside the
+# python-bmf compiler's currently-supported lift subset. Total order:
+# rank ascending, then key descending, then original index ascending.
+def view_before(ra, rb, ka, kb, ia, ib):
+    b = 0
+    if ra < rb:
+        b = 1
+    if ra == rb:
+        if ka > kb:
+            b = 1
+    if ra == rb:
+        if ka == kb:
+            if ia < ib:
+                b = 1
+    return b
+
+
+def view_history_order(ranks, keys):
+    n = len(ranks)
+    order = []
+    i = 0
+    while i < n:
+        # Insert i into `order` at the first position whose row is worse than i.
+        newlist = []
+        inserted = 0
+        j = 0
+        m = len(order)
+        while j < m:
+            oj = order[j]
+            if inserted == 0:
+                if view_before(ranks[i], ranks[oj], keys[i], keys[oj], i, oj) == 1:
+                    newlist.append(i)
+                    inserted = 1
+            newlist.append(oj)
+            j = j + 1
+        if inserted == 0:
+            newlist.append(i)
+        order = newlist
+        i = i + 1
+    return order
+
+
+# Frozen sample: three views in DB order — a superseded view (ts 300), the
+# canonical view (ts 100), and another superseded view (ts 200). Canonical
+# first despite its older timestamp (the exact inversion that broke the Python
+# sort), then superseded newest-first: [1, 0, 2].
+ranks = [1, 0, 1]
+keys = [300, 100, 200]
+
+view_history_order(ranks, keys)

--- a/form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-compile
+++ b/form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-compile
@@ -29,6 +29,13 @@ in_py_abs="$(cd "$(dirname "$in_py")" && pwd)/$(basename "$in_py")"
 out_fk_dir="$(cd "$(dirname "$out_fk")" && pwd)"
 out_fk_abs="$out_fk_dir/$(basename "$out_fk")"
 
+# On Windows/MSYS the native kernel binaries resolve Windows-form paths, not the
+# MSYS `/c/...` form bash produces. Mixed form (`C:/...`) is accepted by BOTH bash
+# redirects and the native kernels, so normalize every path handed to a kernel.
+to_native() { if command -v cygpath >/dev/null 2>&1; then cygpath -m "$1"; else printf '%s' "$1"; fi; }
+in_py_abs="$(to_native "$in_py_abs")"
+out_fk_abs="$(to_native "$out_fk_abs")"
+
 # Locate the form/ directory.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FORM_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
@@ -65,6 +72,7 @@ PRELUDES=(
 
 # Working directory for compiled artifacts.
 work_dir="$(mktemp -d "${TMPDIR:-/tmp}/kernel-bmf-compile.XXXXXX")"
+work_dir="$(to_native "$work_dir")"
 cleanup() { rm -rf "$work_dir"; }
 trap cleanup EXIT
 

--- a/specs/form-native-view-history-store.md
+++ b/specs/form-native-view-history-store.md
@@ -54,9 +54,11 @@ exist.
 4. - [ ] The kernel carrier that served the ordering is observable (the `runtime` string), exactly as the vitality route exposes it; missing kernel remains a hard failure (no silent Python fallback).
 
 ## Files to Create/Modify
-- `form/form-kernel-ts/seedbank/python-adapter/examples/view_history_order.fk` — new ordering recipe (the determinism core).
-- `form/form-stdlib/tests/view-history-order-band.fk` — new four-way band for the ordering recipe.
-- `api/app/services/translation_cache_service.py` — `list_history` becomes a thin shell over the Form runtime; the Python comparator is removed.
+- `form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_view_history_order_demo.py` — the Python twin (source of truth the compiler lowers). **Landed** and verified as plain Python.
+- `form/form-kernel-ts/seedbank/python-adapter/scripts/kernel-bmf-compile` — `cygpath -m` path normalization so recipe generation runs on Windows/MSYS. **Landed** (unblocks generation on this host).
+- `form/form-kernel-ts/seedbank/python-adapter/examples/view_history_order.fk` — generated ordering recipe. **Blocked** — see the lifter gap in Known Gaps.
+- `form/form-stdlib/tests/view-history-order-band.fk` — new four-way band for the ordering recipe (after the recipe generates cleanly).
+- `api/app/services/translation_cache_service.py` — `list_history` becomes a thin shell over the Form runtime; the Python comparator is removed (only once the recipe exists and crosses four-way).
 
 ## Acceptance Criteria
 - `cd api && python -m pytest tests/test_flow_multilingual.py -q` passes, including `test_history_preserves_superseded_views`, deterministically across `PYTHONHASHSEED` 0–8 (the prior failing seed was 0).
@@ -92,10 +94,13 @@ python3 scripts/validate_spec_quality.py --file specs/form-native-view-history-s
 ## Risks and Assumptions
 - **Marshalling shape**: `serve_via_kernel` must return a list/permutation, not only a scalar like `_breath_balance`. Assumption: the kernel's `list`/`head`/`tail` primitives support this; the band validates the returned shape before Python is wired, and `list_history` applies the returned index order to the SQLAlchemy rows it already holds (so only the comparison, not the row data, crosses the kernel boundary).
 - **Round-trip cost**: one kernel call per history read. Assumption: the route-preload/inline carrier keeps this within the budget the vitality route already pays; if a hot path needs it, the ordered result is memoized per `(entity, lang, row-set hash)`.
-- **Four-way tooling on this host**: the Windows dev host has the Rust kernel built and can serve the recipe via the subprocess carrier, so Python-level behavior is verifiable locally; full four-way `validate.sh` (incl. fkwu's clang-emitted carrier) may need CI/Linux. The four-way band is the gate of record, run in CI.
+- **Four-way tooling on this host**: the Windows dev host now builds both kernels and (after the `kernel-bmf-compile` cygpath fix) runs the generation pipeline locally; full four-way `validate.sh` (incl. fkwu's clang-emitted carrier) still needs CI/Linux and remains the gate of record.
+- **Compiler-gap dependency (confirmed blocker)**: the python-bmf lifter cannot yet lower a multi-branch comparison (the rank → key-desc → index ladder), in either nested-`else` or flat-`if` form — it emits invalid Form (`unsupported kind/rule [else]` → parse error). Phase 1's recipe therefore cannot be generated until that lift arm exists. A degenerate "compose a single key in Python, sort one key in Form" encoding is explicitly rejected: it pushes the tie-break decision back into Python, defeating the point.
 - **Tie semantics**: ordering must be total and deterministic even when `updated_at` ties across rows; the recipe breaks ties by `status` rank first, then a stable secondary key (e.g. `id`), so no hash-dependent comparison remains.
 
 ## Known Gaps and Follow-up Tasks
+- **PHASE 1 PRECONDITION (the blocker) — close the python-bmf lifter gap**: add a lift arm for multi-branch `if` / comparison ladders to `form/form-stdlib/python-bmf-lift.fk` (+ matching eval arm in `python-bmf-eval.fk`), proven by a small band, so `endpoint_view_history_order_demo.py` compiles to a valid recipe. Until this lands, `list_history` keeps its deterministic Python comparator (already merged) and is NOT rewired.
+- **Landed this slice**: the verified Python twin (`endpoint_view_history_order_demo.py`) and the `kernel-bmf-compile` cygpath fix (Windows recipe generation now runs). The generated `.fk`, the four-way band, and the `list_history` rewire are all gated on the lifter gap above.
 - **Phase 2 — view-store over the storage port**: `view-store.fk` (`vs-list-history`/`vs-canonical`) reading Form cells via `storage-get`/`storage-put`, with `upsert_view` projecting rows into the carrier and a read-parity band; retire the SQLAlchemy read for this family once parity holds.
 - **Generalize** to `canonical_views`/`all_canonical_views` and then to other entity families.
 - **The crux** — `intern_node` → storage-port bridge (`substrate-core.fk`) per `services-on-form-plan.md` Step 1 — remains the highest-leverage follow-up this slice de-risks but does not deliver.


### PR DESCRIPTION
## Phase 1 progress toward Form-native view-history ordering

Follows `specs/form-native-view-history-store.md`. Lands the verifiable pieces and records the real blocker honestly — does **not** rewire `list_history` (the deterministic Python comparator already merged stays the live fix).

### Landed
- **`kernel-bmf-compile` Windows fix**: the py→fk generator passed MSYS-form paths (`/c/...`) to the native kernels, which need Windows form. Added `cygpath -m` normalization. Verified: the generation pipeline now runs on this Windows host (it previously couldn't at all).
- **`endpoint_view_history_order_demo.py`**: the Python twin for canonical-first / newest-next ordering, verified correct as plain Python.

### Recorded blocker (in the spec)
The python-bmf lifter cannot yet lower a multi-branch comparison ladder (rank → key-desc → index), in either nested-`else` or flat-`if` form — it emits invalid Form (`unsupported kind/rule [else]` → parse error). This is the bounded compiler gap `services-on-form-plan` step 3 names. The recipe, its four-way band, and the `list_history` rewire are gated on adding that lift arm.

A degenerate "compose one key in Python, sort one key in Form" encoding is explicitly rejected (pushes the tie-break back into Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
