### PR TITLE
fix(windows): robust python3 in validate.sh + preflight venv path

### DIFF
--- a/form/validate.sh
+++ b/form/validate.sh
@@ -25,8 +25,17 @@ export npm_config_update_notifier=false
 # Keep the kernel-resident bp lookup table in sync with the registry before the
 # staleness check decides whether to rebuild. Writes only on change, so a no-op
 # run leaves mtimes (and the rebuild decision) untouched.
-if command -v python3 >/dev/null 2>&1 && [[ -f ../scripts/gen_bp_table.py ]]; then
-    python3 ../scripts/gen_bp_table.py >/dev/null || true
+# Resolve a working Python 3: prefer `py -3` on Windows (a bare `python3` there
+# resolves to the App-Execution-Alias stub that prints "Python was not found"),
+# and verify the interpreter actually runs before using it.
+BP_PY=""
+if command -v py >/dev/null 2>&1 && py -3 --version >/dev/null 2>&1; then
+    BP_PY="py -3"
+elif command -v python3 >/dev/null 2>&1 && python3 --version >/dev/null 2>&1; then
+    BP_PY="python3"
+fi
+if [[ -n "$BP_PY" && -f ../scripts/gen_bp_table.py ]]; then
+    $BP_PY ../scripts/gen_bp_table.py >/dev/null 2>&1 || true
 fi
 
 GO_DIR="form-kernel-go"

--- a/scripts/kernel_front_door_local_preflight.sh
+++ b/scripts/kernel_front_door_local_preflight.sh
@@ -41,7 +41,7 @@ need lsof
 
 select_python() {
   local candidate
-  for candidate in "${API_DIR}/.venv/bin/python" "${API_DIR}/.venv/bin/python3" "$(command -v python3 || true)"; do
+  for candidate in "${API_DIR}/.venv/bin/python" "${API_DIR}/.venv/Scripts/python.exe" "${API_DIR}/.venv/bin/python3" "$(command -v python3 || true)"; do
     if [[ -n "${candidate}" && -x "${candidate}" ]]; then
       if "${candidate}" -c "import fastapi, uvicorn" >/dev/null 2>&1; then
         echo "${candidate}"


### PR DESCRIPTION
Two Windows-portability fixes in the build/validate path (three-way validate.sh confirmed green on Windows):
- **form/validate.sh**: bare `python3` hits the Windows App-Execution-Alias stub (prints 'Python was not found', skips bp-table regen). Now prefers `py -3` and verifies the interpreter runs.
- **kernel_front_door_local_preflight.sh**: adds `.venv/Scripts/python.exe` so the preflight finds the venv on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)