### PR TITLE
fix(windows): durable UTF-8 host bootstrap + CLI capture encoding + venv-path script

### DIFF
--- a/api/tests/test_flow_cli.py
+++ b/api/tests/test_flow_cli.py
@@ -322,6 +322,10 @@ def _run_cli(api_base: str, *args: str) -> subprocess.CompletedProcess:
             cwd=str(REPO_ROOT),
             capture_output=True,
             text=True,
+            # Decode the CLI's UTF-8 stdout as UTF-8 regardless of the host
+            # locale; on Windows text=True defaults to cp1252 and mangles
+            # non-ASCII (e.g. the em-dash in `coh help`).
+            encoding="utf-8",
             timeout=20,
             check=False,
             env=env,

--- a/scripts/clear_queue_and_start_flow.sh
+++ b/scripts/clear_queue_and_start_flow.sh
@@ -23,7 +23,13 @@ fi
 
 echo "Resetting project manager and creating spec task for first backlog item ..."
 cd "$API_DIR"
-.venv/bin/python scripts/project_manager.py --once -v --reset
+# Resolve the venv python for either layout (Windows .venv/Scripts, POSIX .venv/bin).
+if [ -x ".venv/Scripts/python.exe" ]; then
+  VENV_PY=".venv/Scripts/python.exe"
+else
+  VENV_PY=".venv/bin/python"
+fi
+"$VENV_PY" scripts/project_manager.py --once -v --reset
 
 echo "Done. Run the agent runner to execute the spec task (then PM again for impl, etc.):"
-echo "  cd api && .venv/bin/python scripts/agent_runner.py --once -v"
+echo "  cd api && $VENV_PY scripts/agent_runner.py --once -v"

--- a/scripts/setup_windows_host.ps1
+++ b/scripts/setup_windows_host.ps1
@@ -121,6 +121,14 @@ if ((-not (Test-Path "web\.env.local")) -or $ForceEnv) {
     Write-Host "prepared web\.env.local"
 }
 
+# Force Python UTF-8 mode for every process on this host. Much of the codebase
+# reads UTF-8 files with bare open()/read_text() (no encoding=); without UTF-8
+# mode, Windows' cp1252 default raises UnicodeDecodeError on non-ASCII bytes and
+# the test suite fails. PYTHONUTF8=1 is CPython's sanctioned remedy.
+[Environment]::SetEnvironmentVariable("PYTHONUTF8", "1", "User")
+$env:PYTHONUTF8 = "1"
+Write-Host "set PYTHONUTF8=1 (user env)"
+
 Write-Host ""
 Write-Host "host checks:"
 git --version


### PR DESCRIPTION
Closes the remaining in-lane Windows host gaps (api suite: 400 passing on Windows).

- **setup_windows_host.ps1**: persist `PYTHONUTF8=1` (User env). The codebase has 100+ bare `open()`/`read_text()` reads of UTF-8 files; without UTF-8 mode, Windows cp1252 raises `UnicodeDecodeError` (e.g. reading `local_runner.py`) and the suite fails. CPython's sanctioned remedy, set once at host bootstrap. CI already sets it as job env. Shell-agnostic — replaces a cmd-only Makefile approach that broke under Git Bash's sh.
- **test_flow_cli.py**: decode the CLI subprocess stdout as UTF-8 explicitly so the em-dash help test passes regardless of UTF-8 mode (verified with `PYTHONUTF8=0`).
- **clear_queue_and_start_flow.sh**: resolve the venv python for either layout (`.venv/Scripts` on Windows, `.venv/bin` on POSIX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)