### PR TITLE
feat(form): the KV-cached causal LLAMA block crosses four-way — lblk-generate-causal proven BIT-IDENTICAL to the full causal recompute

### DIFF
--- a/docs/coherence-substrate/kv-llama-block.form
+++ b/docs/coherence-substrate/kv-llama-block.form
@@ -1,0 +1,54 @@
+; kv-llama-block.form — the KV-cached causal LLAMA block: the inner step of the autoregressive
+; generation loop, the cache applied to the WHOLE real decoder block (not just bare attention).
+;
+; THE PLACE IN THE LOOP:
+;   A decoder generates one token at a time: run the block over the prefix, read the logits, pick the
+;   next token (greedy-decode.form), append, repeat. kv-cache.fk realized the ATTENTION half over
+;   already-projected q/k/v (#3382). But a real decode step does the whole block per token: RMSNorm,
+;   project q/k/v, RoPE q and k by position, APPEND the projected+RoPE'd k/v to the cache, attend the
+;   query over the grown prefix, then Wo/residual/RMSNorm2/SwiGLU/residual. This file is that step for
+;   the real llama decoder block — only the NEW token is projected each step; earlier positions' k/v are
+;   reused from the cache. O(n)/token, not O(n^2) recompute of the block over [x0..xt].
+;
+; THE SHAPE  (runnable: form-stdlib/kv-llama-block.fk · proven: tests/kv-llama-block-band.fk -> 255)
+;
+;   lblk-dec-run (xs p cks cvs ...weights...) -> the output sequence
+;     the autoregressive walk: front to back, threading the growing cache (cks/cvs = positions 0..p-1).
+;     At each token: RMSNorm1 once, project+RoPE q/k and project v, APPEND k/v to the cache (kv-append),
+;     hand the GROWN cache to the per-step output and thread it forward as the next step's prior cache.
+;   lblk-dec-out (x q gks gvs ...) -> one token's block output
+;     attend the query over the grown cache (tb-attend-one verbatim), then the per-token tail:
+;     h = x + Wo*a ; y = h + Wdown*SwiGLU(Wgate*RMSNorm2(h), Wup*RMSNorm2(h)).
+;   lblk-generate-causal (xs ...weights...) -> the whole output, from an empty cache
+;     == lblk-block-causal (llama-block.fk, #3365) bit-for-bit. The decoder name for the cached path.
+;
+; WHY THE CACHE IS EXACT (proven by EQUALITY, not a 1e-6 reference):
+;   A cached k_i/v_i is RoPE(Wk*RMSNorm1(x_i), i) / Wv*RMSNorm1(x_i) — it depends ONLY on position i's
+;   input and the fixed weights, never on later tokens. So the grown cache at step p is exactly the
+;   prefix [k_0..k_p] = tb-take(ks, p+1) that tb-attn-seq-causal's mask cuts at query p. kv-append == the
+;   take of the prefix, so tb-attend-one gets IDENTICAL arguments and the tail is per-token; therefore
+;   lblk-generate-causal == lblk-block-causal element-for-element. The band proves this at S=2 AND S=3
+;   (the inductive step — the cache threads correctly past the boundary), grounded against
+;   causal-attention-band's already-four-way libm pins (token-0 1893731, last-token -1069281/1648117).
+;
+; THE AUTOREGRESSIVE INVARIANT (why a KV cache is reusable across generation steps):
+;   appending a future token never changes an earlier token's output — gen3[token i] == gen2[token i],
+;   libm-pinned (bits 64,128). A frozen k_i/v_i is the structural reason a cache built at step t is still
+;   valid at step t+1; this invariant is what the whole generation loop leans on.
+;
+; HOW IT COMPOSES THE TOOLKIT:
+;   tb-attend-one (transformer-block.fk) verbatim — no numeric change; kv-append (kv-cache.fk) for the
+;   cache grow; llama-block.fk's own ln-rmsnorm / tb-matvec / rope / lblk-ffn (SwiGLU) for the block. The
+;   cache is the efficient realization of the same four-way-proven causal llama block, at the reusable
+;   decoder-engine altitude (like tb-attn-seq-causal and kv-generate before it) — any causal block
+;   generates through the same cache; this instance is the real llama block.
+;
+; HONEST LANE / NEXT:
+;   fp64 lane. The GPU emit — the cached attention as a key-prefix in the threadgroup walk, mirroring
+;   jte-llama-block-fwd-causal-msl (#3376) with an fp32 CPU-mirror bit-exact gate — is the named follow-up.
+;   Then the full loop: tokenizer + lblk-generate-causal + gd-token (greedy-decode.form) over real
+;   llama3.2:3b GGUF weights on the M4 GPU (the load path q4k/q6k/f16 is already Form-native four-way).
+;   Multi-layer decode stacks lblk-generate-causal across blocks, each with its own cache.
+;
+; Kin: kv-cache.form, greedy-decode.form, llama-block.fk, transformer-block.form
+; teaching: lc-cognitive-sovereignty

--- a/docs/system_audit/commit_evidence_2026-06-20_kv_llama_block_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-20_kv_llama_block_four_way.json
@@ -1,0 +1,37 @@
+{
+  "date": "2026-06-20",
+  "brick": "kv-llama-block (3x)",
+  "title": "the KV-cached causal LLAMA block crosses four-way — lblk-generate-causal proven BIT-IDENTICAL to the full causal llama block, the inner step of the autoregressive generation loop",
+  "north_star_track": "real local llama inference on the M4 GPU — the generation loop (named next stone after #3382, the bare-attention KV cache)",
+  "what": "Lifted the KV cache from the bare-attention altitude (kv-generate, #3382) to the WHOLE real llama decoder block. The generation loop steps one token at a time: kv-cache.fk proved the cache over already-projected q/k/v; a real decode step must do more — for each new token RMSNorm, project q/k/v, RoPE q and k by the token's absolute position, APPEND the projected+RoPE'd k/v to the running cache, attend the query over the grown prefix, then run the Wo/residual/RMSNorm2/SwiGLU/residual tail. Only the NEW token is projected each step; earlier positions' keys/values are reused from the cache (O(n)/token, not O(n^2) recompute of the block over [x0..xt]). The load-bearing proof is that the cache is EXACT: a cached k_i/v_i is RoPE(Wk*RMSNorm1(x_i), i) / Wv*RMSNorm1(x_i) — it depends ONLY on position i's input and the fixed weights, never on later tokens. So the grown cache at step p is exactly [k_0..k_p] = tb-take(ks, p+1) — the very prefix tb-attn-seq-causal's mask cuts at query p. tb-attend-one gets IDENTICAL arguments and the block tail is per-token, so lblk-generate-causal == lblk-block-causal (#3365, four-way) bit-for-bit. Composes tb-attend-one and llama-block's own RMSNorm/proj/RoPE/SwiGLU verbatim — no numeric change. Lives at the reusable decoder-engine altitude (like tb-attn-seq-causal and kv-generate before it).",
+  "files": {
+    "recipe": "form/form-stdlib/kv-llama-block.fk",
+    "band": "form/form-stdlib/tests/kv-llama-block-band.fk",
+    "manifest_row": "kv-llama-block fks 255"
+  },
+  "proof": {
+    "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/kv-cache.fk form-stdlib/kv-llama-block.fk form-stdlib/tests/kv-llama-block-band.fk",
+    "verdict": 255,
+    "fourth_arm": "1 band four-way (fkwu + pre-flattened tables)",
+    "divergent": 0,
+    "kernels": "Go, Rust, TypeScript, fkwu — agree on every sample",
+    "wall_clock_seconds": 29
+  },
+  "fixture": "the llama-block-band / causal-attention-band fixture: S=2 (and S=3) tokens, d=4, HD=4 single head, FFN hidden 4, scale = 1/sqrt(4), every weight non-trivial. Grounded against causal-attention-band's already-four-way libm fp64 pins (#3365).",
+  "claims": {
+    "1": "gen2[0][0] -> 1893731   cache reproduces causal token 0 (libm-pinned, mask-restricted) with no recompute of earlier tokens",
+    "2": "gen2[1][0] -> -1069281  cache reproduces causal last token (libm-pinned)",
+    "4": "gen2[1][2] -> 1648117",
+    "8": "gen2 == yc2   (S=2: the KV-cached decode EXACTLY equals the full causal llama block lblk-block-causal, element-for-element — the heart)",
+    "16": "gen3 == yc3  (S=3: the cache threads correctly past the boundary — the inductive step, grounded by equivalence to the already-four-way lblk-block-causal)",
+    "32": "gen2[0][0] (1893731) != non-causal block token 0 (1115890)   the cache respects causality — not a no-op",
+    "64": "gen3[0][0] -> 1893731   token 0 unchanged by appending future tokens — the autoregressive INVARIANT",
+    "128": "gen3[1][0] -> -1069281  token 1 unchanged by appending token 2 — the AR invariant mid-sequence (why a KV cache is reusable across generation steps)"
+  },
+  "lesson": "Read-the-body held again: the per-step KV-cached decode of the real llama block was the named next stone in #3382's own receipt — the cache lived at the bare-attention altitude but had never been composed with the real RMSNorm/RoPE/SwiGLU block. Provable by EXACT equality (not a 1e-6 reference) because a cached k_i/v_i is frozen at position i, so the grown cache hands tb-attend-one bit-identical arguments to what the causal mask cuts. The strongest part is the autoregressive INVARIANT — appending a future token never changes an earlier token's output (gen3[token i] == gen2[token i]) — which is exactly why the cache is reusable across generation steps. Design (recognizing the per-token block tail decomposes cleanly, the strange-minimal S=2/S=3 fixtures, the invariant claim) was the cost; the four-way proof was seconds. NEW-recipe composition brick (like 3r) at the reusable decoder altitude, not llama-specific.",
+  "named_next_stones": [
+    "emit the KV-cached causal llama block to Metal: the cached attention as a key-prefix in the threadgroup walk, mirroring jte-llama-block-fwd-causal-msl (#3376), with an fp32 CPU-mirror bit-exact gate (the 3m/3s/3u GPU lane)",
+    "the full generation loop: tokenizer (text-tokenize.fk) + lblk-generate-causal (this brick) + greedy-decode (gd-token, #3402) over real llama3.2:3b GGUF weights on the M4 GPU — the load path q4k/q6k/f16 dequant is already Form-native four-way",
+    "multi-layer decode: stack lblk-generate-causal across the model's blocks, each with its own KV cache, threading the residual stream"
+  ]
+}

--- a/form/form-stdlib/kv-llama-block.fk
+++ b/form/form-stdlib/kv-llama-block.fk
@@ -1,0 +1,68 @@
+; kv-llama-block.fk — the KV-cached causal llama decoder block: the inner step of the autoregressive
+; generation loop, proven BIT-IDENTICAL to the full causal llama block (lblk-block-causal, four-way #3365).
+;
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/kv-cache.fk
+;
+; The named next stone after #3382 (the bare-attention KV cache, kv-generate) and #3376 (the causal
+; llama block on the M4 GPU): the generation loop steps the WHOLE block one token at a time. kv-cache.fk
+; proved the cache at the bare-attention altitude — q/k/v already projected. A real decoder step does
+; more: for each new token it must RMSNorm, project q/k/v, RoPE q and k by the token's position, APPEND
+; the projected+RoPE'd k/v to the running cache, attend the query over the grown prefix, then run the
+; Wo/residual/RMSNorm2/SwiGLU/residual tail. Only the NEW token is projected each step — the earlier
+; positions' keys/values are reused from the cache (O(n) work per token, not O(n²) recompute of the
+; whole block over [x0..xt]).
+;
+; The load-bearing claim is that the cache is EXACT, composing kv-cache + llama-block, not approximating.
+; A cached k_i/v_i is RoPE(Wk·RMSNorm1(x_i), i) / Wv·RMSNorm1(x_i) — it depends ONLY on position i's
+; input and the fixed weights, never on later tokens. So the grown cache the front-to-back walk holds at
+; step p is exactly [k_0..k_p] = (tb-take ks (add p 1)) — the very prefix tb-attn-seq-causal's mask cuts
+; at query p (transformer-block.fk). kv-append == tb-take of the prefix, so tb-attend-one gets IDENTICAL
+; arguments, and the block tail (Wo/residual/RMSNorm2/SwiGLU/residual) is per-token. Therefore
+; lblk-generate-causal == lblk-block-causal (llama-block.fk) bit-for-bit. The decode step is the efficient
+; realization of the same four-way-proven causal llama block, composing tb-attend-one and llama-block's
+; own RMSNorm/proj/RoPE/SwiGLU verbatim — no numeric change.
+;
+; The defining autoregressive INVARIANT this makes provable: appending a future token never changes an
+; earlier token's output (a cached k_i/v_i is frozen at position i). That invariant is exactly why a KV
+; cache can be reused across generation steps — proven here as gen3[token i] == gen2[token i].
+;
+; This lives at the reusable decoder-engine altitude (like tb-attn-seq-causal and kv-generate before it):
+; any causal block generates through the same cache; this instance is the real llama block (RMSNorm +
+; RoPE + SwiGLU). Position = absolute token index. fp64 lane; the GPU emit (the cached attention as a
+; key-prefix in the threadgroup walk, mirroring jte-llama-block-fwd-causal-msl, #3376) is the named
+; follow-up. Proven four-way against lblk-block-causal (#3365) and causal-attention-band's libm pins by
+; tests/kv-llama-block-band.fk.
+; teaching: lc-cognitive-sovereignty
+
+; --- the block TAIL, per token: h = x + Wo·a ; y = h + Wdown·SwiGLU(Wgate·RMSNorm2(h), Wup·RMSNorm2(h)).
+;     Identical to lblk-block-causal's attn-residual + ffn-block, taken one token at a time. ---
+(defn lblk-dec-tail (h g2 eps wg wu wd)
+  (tb-vec-add h (lblk-ffn wg wu wd (ln-rmsnorm h g2 eps))))
+(defn lblk-dec-out (x q gks gvs scale wo g2 eps wg wu wd)
+  (lblk-dec-tail (tb-vec-add x (tb-matvec wo (tb-attend-one q gks gvs scale))) g2 eps wg wu wd))
+
+; --- one decode step over an already-grown cache (gks/gvs hold positions 0..p): emit this token's block
+;     output, then thread the grown cache forward as the next step's prior cache (the genuine cache, not
+;     a re-take from the full sequence — the grown cache is computed ONCE per step in lblk-dec-n1). ---
+(defn lblk-dec-grow (x q gks gvs xs p g1 eps wq wk wv wo scale HD g2 wg wu wd)
+  (cons (lblk-dec-out x q gks gvs scale wo g2 eps wg wu wd)
+        (lblk-dec-run xs p gks gvs g1 eps wq wk wv wo scale HD g2 wg wu wd)))
+
+; --- per token: RMSNorm1 once (n1), then project+RoPE q/k and project v, APPEND k/v to the cache, and
+;     hand the grown cache to lblk-dec-grow. Position p is the token's absolute index. ---
+(defn lblk-dec-n1 (x n1 xs p cks cvs g1 eps wq wk wv wo scale HD g2 wg wu wd)
+  (lblk-dec-grow x (rope (tb-matvec wq n1) p HD)
+                 (kv-append cks (rope (tb-matvec wk n1) p HD))
+                 (kv-append cvs (tb-matvec wv n1))
+                 xs (add p 1) g1 eps wq wk wv wo scale HD g2 wg wu wd))
+
+; --- the autoregressive walk: front to back, threading the growing cache (cks/cvs = positions 0..p-1) ---
+(defn lblk-dec-run (xs p cks cvs g1 eps wq wk wv wo scale HD g2 wg wu wd)
+  (if (eq (len xs) 0) (empty)
+      (lblk-dec-n1 (head xs) (ln-rmsnorm (head xs) g1 eps) (tail xs) p cks cvs
+                   g1 eps wq wk wv wo scale HD g2 wg wu wd)))
+
+; --- generate the whole output sequence incrementally from an empty cache. Equals
+;     (lblk-block-causal xs ...) bit-for-bit — the equivalence the band proves. ---
+(defn lblk-generate-causal (xs g1 eps wq wk wv wo scale HD g2 wg wu wd)
+  (lblk-dec-run xs 0 (empty) (empty) g1 eps wq wk wv wo scale HD g2 wg wu wd))

--- a/form/form-stdlib/tests/kv-llama-block-band.fk
+++ b/form/form-stdlib/tests/kv-llama-block-band.fk
@@ -1,0 +1,61 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/kv-cache.fk form-stdlib/kv-llama-block.fk
+;
+; kv-llama-block-band — the KV-cached causal llama decoder block (lblk-generate-causal) lifted to the
+; four-kernel floor. This is the inner step of the autoregressive generation loop: each token is RMSNorm'd,
+; q/k/v projected, q/k RoPE'd by position, k/v APPENDED to the cache, the query attends over the grown
+; prefix, then the Wo/residual/RMSNorm2/SwiGLU/residual tail runs — only the NEW token projected each step.
+; The proof is that the cache is EXACT — lblk-generate-causal is BIT-IDENTICAL to the full causal llama
+; block (lblk-block-causal, four-way #3365) — because a cached k_i/v_i depends only on position i, never
+; the future, so the grown cache at step p equals exactly the prefix the causal mask cuts. The proof is the
+; RELATIONSHIPS, each grounded against causal-attention-band's already-four-way libm fp64 pins:
+;
+;   the cache reproduces causal-attention-band's libm-pinned llama values — token-0 y[0][0]=1893731 (the
+;     mask-restricted value, DIFFERING from non-causal 1115890), last-token y[1][0]=-1069281, y[1][2]=
+;     1648117 — with NO recompute of earlier tokens' attention.
+;   the EQUIVALENCE LAW (the heart): lblk-generate-causal == lblk-block-causal element-for-element, at S=2
+;     AND S=3 — the S=3 fixture proves the recursion threads the cache correctly past the boundary (the
+;     inductive step), grounded by equivalence to the already-four-way lblk-block-causal.
+;   the cache respects CAUSALITY (not a no-op): token 0's cached output ≠ the non-causal block's token 0.
+;   the autoregressive INVARIANT (why a KV cache is reusable across generation steps): appending a future
+;     token never changes an earlier token's output — gen3[token i] == gen2[token i], libm-pinned.
+;
+; Verdict 255 when the KV-cached causal llama block lands four-way:
+;   1     gen2[0][0] → 1893731   (cache reproduces causal token 0, libm-pinned, mask-restricted)
+;   2     gen2[1][0] → -1069281  (cache reproduces causal last token, libm-pinned — no recompute)
+;   4     gen2[1][2] → 1648117
+;   8     gen2 == yc2  (S=2: the KV-cached decode EXACTLY equals the full causal llama block, bit-for-bit)
+;   16    gen3 == yc3  (S=3: the cache threads correctly past the boundary — the inductive step)
+;   32    gen2[0][0] ≠ ncy[0][0] (1115890)  (the cache respects causality — not a no-op)
+;   64    gen3[0][0] → 1893731   (token 0 unchanged by appending future tokens — the AR invariant)
+;   128   gen3[1][0] → -1069281  (token 1 unchanged by appending token 2 — the AR invariant, mid-sequence)
+(do
+    ; --- the llama-block-band / causal-attention-band fixture (S=2 tokens, d=4, HD=4, scale=1/√4) ---
+    (let x  (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75)))
+    (let g1 (list 0.9 1.1 1.0 0.95))   (let g2 (list 1.05 0.95 1.0 0.9))
+    (let wq (list (list 0.5 -0.25 0.1 0.3) (list 0.2 0.4 -0.3 0.1) (list -0.1 0.2 0.5 -0.2) (list 0.3 0.0 -0.15 0.25)))
+    (let wk (list (list 0.2 0.4 -0.3 0.1) (list 0.3 -0.2 0.25 0.5) (list 0.1 0.15 -0.05 0.2) (list -0.25 0.3 0.4 -0.1)))
+    (let wv (list (list 0.3 -0.2 0.25 0.5) (list 0.6 0.1 -0.2 0.4) (list 0.05 -0.1 0.3 0.2) (list 0.15 0.35 -0.25 0.1)))
+    (let wo (list (list 0.6 0.1 -0.2 0.4) (list -0.2 0.4 0.3 0.1) (list 0.25 -0.15 0.5 0.05) (list 0.1 0.2 -0.3 0.45)))
+    (let wg (list (list 0.5 -0.3 0.2 0.1) (list 0.2 0.7 -0.4 0.3) (list -0.1 0.25 0.4 -0.2) (list 0.3 0.1 -0.15 0.5)))
+    (let wu (list (list 0.25 -0.15 0.3 0.05) (list 0.1 0.4 -0.2 0.15) (list 0.35 0.2 -0.1 0.25) (list -0.2 0.3 0.15 0.4)))
+    (let wd (list (list 0.4 -0.2 0.3 0.1) (list 0.15 0.5 -0.25 0.2) (list -0.3 0.1 0.45 -0.15) (list 0.2 -0.1 0.35 0.3)))
+    (let eps 0.00001)
+    (let HD 4)
+    (let scale (div 1.0 (tn-sqrt 4.0)))
+    (let gen2 (lblk-generate-causal x g1 eps wq wk wv wo scale HD g2 wg wu wd))
+    (let yc2  (lblk-block-causal     x g1 eps wq wk wv wo scale HD g2 wg wu wd))
+    (let ncy  (lblk-block            x g1 eps wq wk wv wo scale HD g2 wg wu wd))
+    ; --- a 3-token fixture: proves the cache threads correctly for S>2 (the inductive step) AND the AR
+    ;     invariant (earlier tokens unchanged when a future token is appended). Same weights. ---
+    (let x3 (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75) (list 0.5 1.0 -0.5 0.25)))
+    (let gen3 (lblk-generate-causal x3 g1 eps wq wk wv wo scale HD g2 wg wu wd))
+    (let yc3  (lblk-block-causal     x3 g1 eps wq wk wv wo scale HD g2 wg wu wd))
+    (let c0 (if (eq (round (mul (nth (nth gen2 0) 0) 1000000.0)) 1893731) 1 0))
+    (let c1 (if (eq (round (mul (nth (nth gen2 1) 0) 1000000.0)) -1069281) 2 0))
+    (let c2 (if (eq (round (mul (nth (nth gen2 1) 2) 1000000.0)) 1648117) 4 0))
+    (let c3 (if (eq (kv-lol-eq gen2 yc2) 1) 8 0))
+    (let c4 (if (eq (kv-lol-eq gen3 yc3) 1) 16 0))
+    (let c5 (if (eq (round (mul (nth (nth ncy 0) 0) 1000000.0)) 1115890) 32 0))
+    (let c6 (if (eq (round (mul (nth (nth gen3 0) 0) 1000000.0)) 1893731) 64 0))
+    (let c7 (if (eq (round (mul (nth (nth gen3 1) 0) 1000000.0)) -1069281) 128 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -694,6 +694,7 @@ http-client-socket-response fks 8191
 nanite-mem-parse fks 15
 kv-cache fks 255
 greedy-decode fks 255
+kv-llama-block fks 255
 
 # ── gap-close lane (2026-06-19): bands the survey found crossing fkwu, each
 # GATED four-way by scripts/fourth-arm-gate.sh (validate.sh: 0 divergent AND


### PR DESCRIPTION
## The brick

The inner step of the autoregressive generation loop, lifted from the bare-attention KV cache (#3382) to the **whole real llama decoder block**.

`kv-cache.fk` proved the cache over already-projected q/k/v. A real decode step does the whole block per token: **RMSNorm → project q/k/v → RoPE q/k by position → APPEND the projected+RoPE'd k/v to the running cache → attend the query over the grown prefix → Wo/residual/RMSNorm2/SwiGLU/residual.** Only the NEW token is projected each step; earlier positions' k/v are reused from the cache — **O(n)/token, not O(n²)** recompute of the block over `[x0..xt]`.

## Why the cache is EXACT (proven by equality, not a 1e-6 reference)

A cached `k_i/v_i = RoPE(Wk·RMSNorm1(x_i), i) / Wv·RMSNorm1(x_i)` depends only on position `i`'s input and the fixed weights — never the future. So the grown cache at step `p` is exactly the prefix `[k_0..k_p] = tb-take(ks, p+1)` that `tb-attn-seq-causal`'s mask cuts at query `p`. `tb-attend-one` gets identical arguments and the tail is per-token, so **`lblk-generate-causal == lblk-block-causal` (#3365, four-way) bit-for-bit.** Composes `tb-attend-one` + `kv-append` + llama-block's own RMSNorm/RoPE/SwiGLU verbatim — no numeric change, at the reusable decoder-engine altitude.

## Proof — four-way, 0 divergent

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk \
  form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk \
  form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/kv-cache.fk \
  form-stdlib/kv-llama-block.fk form-stdlib/tests/kv-llama-block-band.fk
  → 255
  fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
  1 ok, 0 divergent — kernels agree on every sample.
```

Grounded against `causal-attention-band`'s already-four-way libm pins. The heart: `gen == lblk-block-causal` at **S=2 AND S=3** (the inductive step — the cache threads correctly past the boundary). Plus the **autoregressive invariant**: appending a future token never changes an earlier token's output (`gen3[i] == gen2[i]`) — the structural reason a KV cache is reusable across generation steps.

## Tissue (edges in the same commit)
- recipe `form/form-stdlib/kv-llama-block.fk`, band `tests/kv-llama-block-band.fk`
- manifest row `kv-llama-block fks 255`
- receipt `docs/system_audit/commit_evidence_2026-06-20_kv_llama_block_four_way.json`
- substrate companion `docs/coherence-substrate/kv-llama-block.form`

## Named next stones
- emit this block to Metal (cached attention as a key-prefix in the threadgroup walk, mirroring `jte-llama-block-fwd-causal-msl` #3376) with an fp32 CPU-mirror bit-exact gate — the GPU lane
- the full generation loop: tokenizer + `lblk-generate-causal` + `gd-token` (#3402) over real llama3.2:3b GGUF on the M4 GPU (load path already Form-native four-way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)