### PR TITLE
tend(worker): give the worker last words — death recorder + detached supervisor

### DIFF
--- a/api/scripts/local_runner.py
+++ b/api/scripts/local_runner.py
@@ -222,6 +222,67 @@ def _stable_node_id() -> str:
 _NODE_ID = _stable_node_id()
 
 
+# --- Death recorder: a worker that vanishes should leave its last words ---
+# The worker has been disappearing with no traceback — killed by SIGTERM at
+# session teardown or by the OS under memory pressure. Python swallows those
+# silently. These handlers write one structured line naming the cause so the
+# next eye on the logs knows WHY the body went away. SIGKILL / OOM-kill can't
+# be caught here (the process is gone before any handler runs); the external
+# worker_supervisor records those from the outside.
+_PROCESS_START = time.time()
+_DEATH_LOG = _LOG_DIR / "worker_death.log"
+_DEATH_RECORDED = [False]
+
+
+def _record_death(cause: str) -> None:
+    if _DEATH_RECORDED[0]:
+        return
+    _DEATH_RECORDED[0] = True
+    uptime = time.time() - _PROCESS_START
+    line = (
+        f"{datetime.now(timezone.utc).isoformat()} WORKER EXIT "
+        f"cause={cause} pid={os.getpid()} node={_NODE_NAME} uptime={uptime:.0f}s"
+    )
+    try:
+        with open(_DEATH_LOG, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except Exception:
+        pass
+    try:
+        log.warning(line)
+    except Exception:
+        pass
+
+
+def _install_death_recorder() -> None:
+    import atexit
+    import signal as _signal
+
+    atexit.register(lambda: _record_death("atexit"))
+
+    def _handler(signum, _frame):
+        try:
+            name = _signal.Signals(signum).name
+        except Exception:
+            name = str(signum)
+        _record_death(f"signal:{name}")
+        # Restore default disposition and re-raise so the exit status still
+        # reflects the signal (the supervisor reads that to confirm the cause).
+        try:
+            _signal.signal(signum, _signal.SIG_DFL)
+            os.kill(os.getpid(), signum)
+        except Exception:
+            os._exit(128 + (signum if isinstance(signum, int) else 15))
+
+    for _name in ("SIGTERM", "SIGINT", "SIGBREAK"):
+        _sig = getattr(_signal, _name, None)
+        if _sig is not None:
+            try:
+                _signal.signal(_sig, _handler)
+            except (ValueError, OSError):
+                pass
+
+
 def _completed_process_text(value: object) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="ignore")
@@ -7031,6 +7092,7 @@ def _check_for_updates_and_restart() -> bool:
 
 
 def main():
+    _install_death_recorder()
     parser = argparse.ArgumentParser(description="Task runner — data-driven provider selection")
     parser.add_argument("--task", help="Run a specific task ID")
     parser.add_argument("--provider", help="Force a specific provider (overrides Thompson Sampling)")

--- a/api/scripts/worker_supervisor.py
+++ b/api/scripts/worker_supervisor.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Worker supervisor: own the local_runner worker's life and death, and record both.
+
+The worker has been vanishing with no last words — killed by SIGTERM at session
+teardown or by the OS under memory pressure, neither of which Python can
+self-report once it's gone. This supervisor launches the worker as a child,
+waits on it, and writes a structured record the moment it exits: exit code,
+decoded signal, uptime, and the tail of its output. Then it restarts the worker
+with crash-loop backoff. Run the supervisor detached so it outlives the session
+that started it — that detachment is what stops the worker disappearing every
+time a monitoring session ends.
+
+Usage:
+  python api/scripts/worker_supervisor.py --interval 15 --no-self-update
+"""
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_API_DIR = _SCRIPT_DIR.parent
+_REPO_DIR = _API_DIR.parent
+_LOG_DIR = _API_DIR / "logs"
+_LOG_DIR.mkdir(exist_ok=True)
+_SUP_LOG = _LOG_DIR / "worker_supervisor.log"
+_CHILD_LOG = _LOG_DIR / "worker_service.log"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _log(msg: str) -> None:
+    line = f"{_now()} SUPERVISOR {msg}"
+    try:
+        with open(_SUP_LOG, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+    except Exception:
+        pass
+    print(line, flush=True)
+
+
+def _decode_exit(rc) -> str:
+    """Name the worker's cause of death from its return code.
+
+    POSIX Popen reports a signal kill as a negative return code; a wrapper that
+    already translated it lands as 128+N. Windows reports large unsigned codes
+    for terminated processes — surface those as hex so they're recognisable.
+    """
+    if rc is None:
+        return "launch-failed"
+    if rc == 0:
+        return "exit_code=0 (clean)"
+    if rc < 0:
+        try:
+            name = signal.Signals(-rc).name
+        except Exception:
+            name = str(-rc)
+        return f"signal:{name}({-rc})"
+    if 128 < rc < 192:
+        try:
+            name = signal.Signals(rc - 128).name
+        except Exception:
+            name = str(rc - 128)
+        return f"exit_code={rc} (signal:{name})"
+    if rc > 0xFF:
+        return f"exit_code={rc} (0x{rc & 0xFFFFFFFF:08X})"
+    return f"exit_code={rc}"
+
+
+def _tail(path: Path, n: int = 25) -> str:
+    try:
+        with open(path, "rb") as fh:
+            data = fh.read()[-65536:]
+        lines = data.decode("utf-8", "replace").splitlines()[-n:]
+        return "\n    ".join(lines) if lines else "<empty>"
+    except Exception as exc:
+        return f"<tail unavailable: {exc}>"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Supervise the local_runner worker, recording every death")
+    ap.add_argument("--interval", type=int, default=15, help="Worker poll interval (seconds)")
+    ap.add_argument("--no-self-update", action="store_true", help="Pass through to the worker")
+    ap.add_argument("--python", default=sys.executable, help="Python interpreter for the worker")
+    ap.add_argument("--max-restarts", type=int, default=0, help="0 = unlimited")
+    ap.add_argument("--backoff", type=float, default=5.0, help="Base restart delay (seconds)")
+    ap.add_argument("--max-backoff", type=float, default=120.0, help="Cap on crash-loop backoff")
+    args = ap.parse_args()
+
+    runner = str(_SCRIPT_DIR / "local_runner.py")
+    cmd = [args.python, "-u", runner, "--loop", "--interval", str(args.interval)]
+    if args.no_self_update:
+        cmd.append("--no-self-update")
+
+    env = dict(os.environ)
+    env.setdefault("PYTHONUTF8", "1")
+
+    stop = {"flag": False}
+
+    def _on_term(signum, _frame):
+        stop["flag"] = True
+        _log(f"received signal {signum} — stopping after current child")
+
+    for _name in ("SIGTERM", "SIGINT", "SIGBREAK"):
+        _sig = getattr(signal, _name, None)
+        if _sig is not None:
+            try:
+                signal.signal(_sig, _on_term)
+            except (ValueError, OSError):
+                pass
+
+    _log(f"start pid={os.getpid()} cwd={_REPO_DIR} supervising: {' '.join(cmd)}")
+
+    restarts = 0
+    backoff = args.backoff
+
+    while not stop["flag"]:
+        started = time.time()
+        rc = None
+        try:
+            with open(_CHILD_LOG, "a", encoding="utf-8") as out:
+                out.write(f"\n{_now()} === supervisor launching worker ===\n")
+                out.flush()
+                proc = subprocess.Popen(
+                    cmd, cwd=str(_REPO_DIR), env=env,
+                    stdout=out, stderr=subprocess.STDOUT,
+                )
+                _log(f"worker started pid={proc.pid}")
+                rc = proc.wait()
+        except Exception as exc:
+            _log(f"FAILED to launch worker: {exc}")
+
+        uptime = time.time() - started
+        _log(f"worker DIED {_decode_exit(rc)} uptime={uptime:.0f}s restarts_so_far={restarts}")
+        _log(f"worker last words (tail of {_CHILD_LOG.name}):\n    {_tail(_CHILD_LOG)}")
+
+        if stop["flag"]:
+            break
+
+        restarts += 1
+        if args.max_restarts and restarts > args.max_restarts:
+            _log(f"max-restarts={args.max_restarts} reached — supervisor exiting")
+            break
+
+        # Crash-loop backoff: a worker that dies fast probably can't recover in
+        # one breath, so wait longer; one that ran a while resets to the base.
+        backoff = min(backoff * 2, args.max_backoff) if uptime < 30 else args.backoff
+        _log(f"restarting in {backoff:.0f}s")
+        slept = 0.0
+        while slept < backoff and not stop["flag"]:
+            time.sleep(1)
+            slept += 1.0
+
+    _log("supervisor exiting")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The-Seeker's `local_runner` worker keeps disappearing with **no traceback** — the log just stops clean mid-stream. That signature is an external kill: SIGTERM at monitor-session teardown, or an OS/OOM kill (RAM has been running 91–94%). The runner only caught `KeyboardInterrupt`, so the body vanished with no last words and the next eye on the logs was blind to *why*.

Root structural cause: the worker was launched as a bare `&` background child of each 30-min monitor session's shell, so it could only live as long as the session that birthed it.

## What

Two layers so the death is always recorded, and so the worker survives the session:

- **`local_runner.py` death recorder** — SIGTERM/SIGINT/SIGBREAK + `atexit` handlers write one structured line (`cause`, `pid`, `node`, `uptime`) to `api/logs/worker_death.log` and the runner log, then re-raise the signal so exit status stays honest. Catches the silent signal deaths Python otherwise swallows.
- **`worker_supervisor.py` (new)** — owns the worker as a child, waits on it, and on exit records the decoded cause (signal / exit-code / Windows hex), uptime, and a tail of the worker's last output to `api/logs/worker_supervisor.log`, then restarts with crash-loop backoff. Run **detached**, it outlives the session that started it — which is what stops the worker dying every time a monitor run ends. SIGKILL/OOM can't self-report from inside; the supervisor records them from outside.

## Verify
- `python -m py_compile` clean on both files.
- `worker_supervisor.py --help` renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)