### PR TITLE
attune(form): map the diffusion-Q native frontier in dependency order (GAP-Q7a/b/c)

### DIFF
--- a/docs/coherence-substrate/diffusion-q-learning.form
+++ b/docs/coherence-substrate/diffusion-q-learning.form
@@ -155,6 +155,27 @@
   #   (forbidden: native is what a proven recipe BECOMES, not a parallel hand-lowering).
   # GAP-Q7 [INFER]: lower the gl/mtb cons-list + boxed-fp64 runtime onto the Form→asm native lane so a
   #   diffusion-Q band runs as no-clang native machine code, matching its walked verdict byte-for-byte.
+  #   A second audit (2026-06-21) mapped the sub-frontiers in dependency order — none is a one-breath step:
+  #   (Q7a) FLOAT EXPRESSIONS beyond single-arg. lo-fnode lowers a one-float-arg function to arm64 bytes
+  #         (form-lower-float → 15); the "two non-ARG subtrees" case returns (list) — the named frontier.
+  #         The clean register-mirror of the integer lo-tree (caller-saved FP temps d16+, fa-fmov, no frame)
+  #         is blocked by the conviction gate: form-lower's fa-conviction is WHOLE-FUNCTION byte-identity to
+  #         the clang oracle, and the two-subtree register allocation is not clang-verified — matching clang's
+  #         allocation is the oracle-as-MASTER ceiling (register allocation has many valid lowerings, unlike
+  #         a single instruction's one-true encoding). Resolve by giving form-lower a SEMANTIC-parity claim
+  #         (lowered-walks-to-same-answer, as jit-lower has) for register allocation, keeping byte-identity
+  #         only for per-instruction encodings — then the FP register-stack lands honestly.
+  #   (Q7b) LIST-TRAVERSAL native — the real diffusion-Q blocker, ABSENT entirely. gl-step/mtb walk cons
+  #         cells (nth/head/tail, tags 18-23); the native lane has no cons value model. Needs the value-model
+  #         BRIDGE: native code reading the walker's node-table heap (a heap-pointer convention) OR a flat
+  #         native list encoding. This is the deep stone — a runtime, not an op.
+  #   (Q7c) NATIVE EXECUTION within the four-way floor. Today the emitted dylib's bytes are four-way (Form),
+  #         but EXECUTION (dlopen+dlsym+call) is a host Go test (jit_dylib_test.go) — not sovereign. A fkwu
+  #         dylib_call native would let a band run its own emitted dylib inside validate.sh — native execution
+  #         proven with no Go, no clang. Absent today.
+  #   Roadmap placement: the body's named native roadmap (one-acceleration-engine.form M0-M2) targets the
+  #   SCALAR-FLOAT self-JIT (M0). Q7a is a piece of M0's sovereign byte path; Q7b/Q7c are BEYOND it. So
+  #   diffusion-Q native is genuinely several stones past the current native frontier — recorded, not faked.
 
 # ─────────────────────────────────────────────────────────────────────
 # How to run / how to query


### PR DESCRIPTION
Continuing *"make it all 4th-kernel native, no clang/go/python."* I investigated whether any clean one-breath step lands the diffusion-Q body on the no-clang native lane. **None does** — and the honest value is mapping exactly why, in dependency order (GAP-Q7a/b/c):

- **Q7a — float expressions beyond single-arg.** `lo-fnode`'s "two non-ARG subtrees" case is the named frontier. The clean register-mirror of the integer `lo-tree` (FP temps `d16+`, `fa-fmov`, no frame) is blocked by `form-lower`'s `fa-conviction` being **whole-function byte-identity to the clang oracle** — matching clang's register allocation is the **oracle-as-master ceiling** (allocation has many valid lowerings; only a single instruction's encoding has one true answer). The honest resolve: a semantic-parity claim for allocation, byte-identity only per-instruction.
- **Q7b — list-traversal native** (the real diffusion-Q blocker, **absent**). `gl-step`/`mtb` walk cons cells; the native lane has no cons value model. Needs the value-model bridge.
- **Q7c — native execution within the four-way floor.** The emitted dylib's *bytes* are four-way (Form), but *execution* is a host Go test — not sovereign. A `fkwu` `dylib_call` native would run it inside `validate.sh`, no Go/clang.

The body's named native roadmap (`one-acceleration-engine` M0-M2) targets the **scalar-float** self-JIT; Q7a is part of M0's sovereign byte path, **Q7b/Q7c are beyond it.** So diffusion-Q native is several stones past the current frontier — recorded, not faked, and never a hand-written asm fast-path beside the recipe (forbidden: native is what a proven recipe *becomes*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)