### PR TITLE
feat(runes): 24 Elder Futhark runes + symbol↔frequency-spectrum flow-match (four-way)

### DIFF
--- a/experiments/rune-galdr/README.md
+++ b/experiments/rune-galdr/README.md
@@ -1,0 +1,49 @@
+# Rune galdr — the symbol ↔ frequency-spectrum flow match
+
+Learn all 24 Elder Futhark runes, give each one's **galdr** (sung rune) a measurable
+**vibration**, and match a heard sound back to its rune — both directions.
+
+The **body is Form**, proven four-way (Go/Rust/TS/fkwu):
+
+- [`form-stdlib/nordic-runes.fk`](../../form/form-stdlib/nordic-runes.fk) — the 24 runes
+  as cells: glyph, name, phoneme, ætt (1–3), keyword, and a 6-band peak-normalized
+  spectral **shape** over [0–200, 200–500, 500–1k, 1k–2k, 2k–4k, 4k–8k] Hz.
+- [`form-stdlib/rune-frequency.fk`](../../form/form-stdlib/rune-frequency.fk) — the
+  flow match: `rf-match` (spectrum → rune), `rf-glyph`, `rf-aett`, `rf-confidence`, and
+  `rf-spectrum-at` (rune → spectrum). L1 over the contour, so loud/soft doesn't matter.
+- Bands: `tests/nordic-runes-band.fk`, `tests/rune-frequency-band.fk` → verdict 255,
+  registered in `fourth-arm-bands.txt` (`fks`). `bash scripts/fourth-arm-gate.sh
+  nordic-runes rune-frequency` → **PASS-4WAY**.
+
+The **carriers are thin** (physical I/O + sox DSP only — every decision is the Form recipe's):
+
+```bash
+# train each rune's vibration: synthesize its galdr, measure the 6-band signature,
+# emit Form rows (already baked into nordic-runes.fk):
+./train-rune-spectra.sh
+
+# live flow match — name the rune in a sound:
+./rune-galdr.sh --say "ssssss"          # → sowilo ᛋ   (synthesized round-trip)
+./rune-galdr.sh --wav clip.wav 0 10      # a recording clip (16k wav; sox can't read mp3)
+./rune-galdr.sh --listen 6               # the mic (needs a Microphone TCC grant)
+```
+
+## Honest floor
+
+- **Clean galdr matches well.** Sowilo (s), Isa (i), Raidho (r) round-trip correctly at
+  full confidence. The two nasals **nauthiz/mannaz share a contour and tie** — named, not
+  hidden (their phonemes are near-identical).
+- **A rune's "frequency" is the acoustic spectrum of its sung phoneme** (formant/fricative
+  energy per band) — *not* a single mystical Hz. The synthesized table is a reproducible
+  **reference**; the true vibrations come from real galdr matched against it.
+- **macOS `say` is a weak galdr source** — one voice, stop-consonant runes (k/g/p/t/b/d)
+  collapse toward their vowel. Stronger signatures want real sustained galdr samples.
+
+## Next step — voice/drum separation for live ritual recordings
+
+Matching a rune inside a real ritual recording fails today because the **frame drum
+(~80–100 Hz) dominates the low band**, so 10 s clips of the drum+voice mix resolve to
+low-energy runes regardless of what's sung. To hear the *sung* rune, the carrier must
+isolate the vocal formant range (bandpass ~180–3400 Hz) before extracting the contour,
+with training re-run through the same filter. That is the prototype for a **sonic sense
+organ** that hears tone and rune — the companion to the speech organ's lexical layer.

--- a/experiments/rune-galdr/rune-galdr.sh
+++ b/experiments/rune-galdr/rune-galdr.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# rune-galdr.sh — the live symbol<->frequency flow-match carrier.
+#
+# Hear a galdr (from the mic, a synthesized sound, or a clip of a recording), extract
+# its 6-band spectral SHAPE with sox, and ask the Form body (rune-frequency.fk over
+# nordic-runes.fk) which Elder Futhark rune it is. Carrier = physical I/O + DSP only;
+# the match decision is the four-way-proven Form recipe's.
+#
+#   rune-galdr.sh --say "ssssss"            # synthesize a sound, name its rune
+#   rune-galdr.sh --wav file.wav [START DUR] # name the rune in a recording clip
+#   rune-galdr.sh --listen [SECONDS]         # record the mic, name the rune
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FORM="$(cd "$SCRIPT_DIR/../.." && pwd)/form"
+KERNEL="$FORM/form-kernel-rust/target/release/form-kernel-rust"
+[[ -x "$KERNEL" ]] || { echo "FAIL no kernel — run: (cd $FORM && ./validate.sh form-stdlib/core.fk form-stdlib/nordic-runes.fk form-stdlib/rune-frequency.fk form-stdlib/tests/rune-frequency-band.fk)"; exit 1; }
+TMP=/tmp/rune-galdr.$$; mkdir -p "$TMP"; trap 'rm -rf "$TMP"' EXIT
+
+band() { sox "$1" -n highpass 80 sinc "$2"-"$3" stat 2>&1 | awk '/RMS +amplitude/{printf "%d",$3*10000+0.5}'; }
+# 6-band peak-normalized SHAPE (0..9) — identical recipe to train-rune-spectra.sh
+spectrum() {  # $1 wav -> "b0 b1 b2 b3 b4 b5"
+  local w="$1"
+  local r=( $(band "$w" 20 200) $(band "$w" 200 500) $(band "$w" 500 1000) \
+            $(band "$w" 1000 2000) $(band "$w" 2000 4000) $(band "$w" 4000 7900) )
+  local max=0 v; for v in "${r[@]}"; do [[ ${v:-0} -gt $max ]] && max=$v; done; [[ $max -eq 0 ]] && max=1
+  local q=(); for v in "${r[@]}"; do q+=( $(( (${v:-0}*9 + max/2) / max )) ); done
+  echo "${q[*]}"
+}
+identify() {  # $1 wav -> prints the matched rune via the Form body
+  local spec; spec="$(spectrum "$1")"
+  local drv="$TMP/q.fk"
+  cat > "$drv" <<FK
+(do (print (list "spectrum" (list $spec)
+            "rune" (rf-match (list $spec))
+            "glyph" (rf-glyph (list $spec))
+            "aett" (rf-aett (list $spec))
+            "confidence" (rf-confidence (list $spec)))))
+FK
+  ( cd "$FORM" && "$KERNEL" form-stdlib/nordic-runes.fk form-stdlib/rune-frequency.fk "$drv" 2>/dev/null | grep -E '^\[' | tail -1 )
+}
+
+case "${1:-}" in
+  --say)
+    say -v "${VOICE:-Daniel}" -r "${RATE:-110}" -o "$TMP/s.aiff" "${2:?need a sound}" 2>/dev/null
+    sox "$TMP/s.aiff" -c 1 -r 16000 "$TMP/s.wav" 2>/dev/null
+    identify "$TMP/s.wav" ;;
+  --wav)
+    src="${2:?need a wav/mp3}"; start="${3:-0}"; dur="${4:-8}"
+    sox "$src" -c 1 -r 16000 "$TMP/s.wav" trim "$start" "$dur" 2>/dev/null
+    identify "$TMP/s.wav" ;;
+  --listen)
+    secs="${2:-6}"; echo "[rune-galdr] listening ${secs}s — gall a rune now…"
+    rec -q -c 1 -r 16000 "$TMP/s.wav" trim 0 "$secs" >/dev/null 2>&1 || { echo "mic unavailable (grant Microphone)"; exit 2; }
+    identify "$TMP/s.wav" ;;
+  *) sed -n '8,11p' "$0" | sed 's/^# *//' ;;
+esac

--- a/experiments/rune-galdr/train-rune-spectra.sh
+++ b/experiments/rune-galdr/train-rune-spectra.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# train-rune-spectra.sh — the CARRIER that gives each Elder Futhark rune its galdr
+# "vibration": synthesize the rune's sustained sound, extract a 6-band spectral
+# signature with sox, and emit Form table rows for form-stdlib/nordic-runes.fk.
+#
+# This is physical I/O + DSP only (carrier-last). The MODEL — the rune table and the
+# symbol<->spectrum flow-match — lives in Form (nordic-runes.fk, rune-frequency.fk).
+# A rune's "frequency" here is the honest acoustic spectrum of its sung phoneme
+# (formant/fricative energy per band), NOT a mystical single-Hz attribution.
+#
+# Run:  train-rune-spectra.sh            # prints the spectral table + Form rows
+#       VOICE=Daniel RATE=110 train-rune-spectra.sh
+set -uo pipefail
+VOICE="${VOICE:-Daniel}"; RATE="${RATE:-110}"
+TMP=/tmp/rune-train; mkdir -p "$TMP"
+
+# 24 Elder Futhark runes: glyph | name | phoneme | aett(1-3) | keyword | sustained galdr sound
+RUNES=(
+"ᚠ|fehu|f|1|wealth|ffffffeh"
+"ᚢ|uruz|u|1|strength|ooooooo"
+"ᚦ|thurisaz|th|1|thorn|ththththh"
+"ᚨ|ansuz|a|1|breath-god|aaaaaaa"
+"ᚱ|raidho|r|1|journey|rrrrrrr"
+"ᚲ|kenaz|k|1|torch|kehkehkeh"
+"ᚷ|gebo|g|1|gift|gehgehgeh"
+"ᚹ|wunjo|w|1|joy|wuuuuuu"
+"ᚺ|hagalaz|h|2|hail|hahhahah"
+"ᚾ|nauthiz|n|2|need|nnnnnnn"
+"ᛁ|isa|i|2|ice|iiiiiii"
+"ᛃ|jera|y|2|harvest|yehyehyeh"
+"ᛇ|eihwaz|ei|2|yew|eyeyeyey"
+"ᛈ|perthro|p|2|fate-lot|pehpehpeh"
+"ᛉ|algiz|z|2|protection|zzzzzzz"
+"ᛋ|sowilo|s|2|sun|sssssss"
+"ᛏ|tiwaz|t|3|justice|tehtehteh"
+"ᛒ|berkano|b|3|birch-birth|behbehbeh"
+"ᛖ|ehwaz|e|3|horse|eeeeeee"
+"ᛗ|mannaz|m|3|human|mmmmmmm"
+"ᛚ|laguz|l|3|water|llllllll"
+"ᛜ|ingwaz|ng|3|seed|ngngngng"
+"ᛟ|othala|o|3|home-dna|oooohhh"
+"ᛞ|dagaz|d|3|day-dawn|dehdehdeh"
+)
+
+# raw band energy = RMS*10000 (finer), measured on a pre-emphasized signal so the
+# higher formant/fricative bands are not swamped by the voice fundamental.
+band_rms() { sox "$1" -n highpass 80 sinc "$2"-"$3" stat 2>&1 | awk '/RMS +amplitude/{printf "%d",$3*10000+0.5}'; }
+
+echo "; nordic-rune spectral signatures (peak-normalized SHAPE 0..9) — VOICE=$VOICE RATE=$RATE"
+printf "; %-9s %2s %2s %2s %2s %2s %2s\n" rune b0 b1 b2 b3 b4 b5 >&2
+for r in "${RUNES[@]}"; do
+  IFS='|' read -r glyph name ph aett kw snd <<<"$r"
+  say -v "$VOICE" -r "$RATE" -o "$TMP/r.aiff" "$snd" 2>/dev/null
+  sox "$TMP/r.aiff" -c 1 -r 16000 "$TMP/r.wav" 2>/dev/null
+  raw=( $(band_rms "$TMP/r.wav" 20 200) $(band_rms "$TMP/r.wav" 200 500) \
+        $(band_rms "$TMP/r.wav" 500 1000) $(band_rms "$TMP/r.wav" 1000 2000) \
+        $(band_rms "$TMP/r.wav" 2000 4000) $(band_rms "$TMP/r.wav" 4000 7900) )
+  # peak-normalize to SHAPE: each band -> round(9 * band / max)
+  max=0; for v in "${raw[@]}"; do [[ ${v:-0} -gt $max ]] && max=$v; done; [[ $max -eq 0 ]] && max=1
+  q=(); for v in "${raw[@]}"; do q+=( $(( (${v:-0}*9 + max/2) / max )) ); done
+  printf "; %-9s %2s %2s %2s %2s %2s %2s\n" "$name" "${q[@]}" >&2
+  echo "        (rune \"$glyph\" \"$name\" \"$ph\" $aett \"$kw\" (list ${q[*]}))"
+done
+rm -rf "$TMP"

--- a/form/form-stdlib/nordic-runes.fk
+++ b/form/form-stdlib/nordic-runes.fk
@@ -1,0 +1,51 @@
+; nordic-runes.fk — the 24 Elder Futhark runes as Form cells, each carrying its galdr
+; spectral signature (the "vibration"): a 6-band, peak-normalized SHAPE (0..9) over
+; [0–200, 200–500, 500–1k, 1k–2k, 2k–4k, 4k–8k] Hz.
+;
+; The signatures are TRAINED by the carrier experiments/rune-galdr/train-rune-spectra.sh
+; (synthesize each rune's sung sound, measure its band energies with sox). They are a
+; reproducible REFERENCE; the true galdr vibrations come from real recordings matched
+; against this table. A rune's "frequency" is the honest acoustic spectrum of its sung
+; phoneme — formant/fricative energy per band — never a single mystical Hz.
+;
+; The flow-match (spectrum <-> rune) lives in rune-frequency.fk. Proven by
+; form-stdlib/tests/nordic-runes-band.fk.
+
+(do
+    (defn rune (glyph name phoneme aett keyword spectrum) (list glyph name phoneme aett keyword spectrum))
+    (defn rune-glyph    (r) (nth r 0))
+    (defn rune-name     (r) (nth r 1))
+    (defn rune-phoneme  (r) (nth r 2))
+    (defn rune-aett     (r) (nth r 3))
+    (defn rune-keyword  (r) (nth r 4))
+    (defn rune-spectrum (r) (nth r 5))
+
+    (defn nordic-runes () (list
+; nordic-rune spectral signatures (peak-normalized SHAPE 0..9) — VOICE=Daniel RATE=110
+        (rune "ᚠ" "fehu" "f" 1 "wealth" (list 5 8 9 5 6 0))
+        (rune "ᚢ" "uruz" "u" 1 "strength" (list 3 9 4 2 2 0))
+        (rune "ᚦ" "thurisaz" "th" 1 "thorn" (list 4 9 2 2 5 1))
+        (rune "ᚨ" "ansuz" "a" 1 "breath-god" (list 3 9 3 2 5 0))
+        (rune "ᚱ" "raidho" "r" 1 "journey" (list 4 7 8 9 2 0))
+        (rune "ᚲ" "kenaz" "k" 1 "torch" (list 5 9 6 4 4 0))
+        (rune "ᚷ" "gebo" "g" 1 "gift" (list 4 9 4 3 4 1))
+        (rune "ᚹ" "wunjo" "w" 1 "joy" (list 4 9 4 2 2 0))
+        (rune "ᚺ" "hagalaz" "h" 2 "hail" (list 8 9 7 7 4 0))
+        (rune "ᚾ" "nauthiz" "n" 2 "need" (list 7 9 5 3 5 0))
+        (rune "ᛁ" "isa" "i" 2 "ice" (list 4 9 2 2 3 1))
+        (rune "ᛃ" "jera" "y" 2 "harvest" (list 5 9 4 2 5 0))
+        (rune "ᛇ" "eihwaz" "ei" 2 "yew" (list 4 9 3 3 4 0))
+        (rune "ᛈ" "perthro" "p" 2 "fate-lot" (list 6 9 6 4 4 0))
+        (rune "ᛉ" "algiz" "z" 2 "protection" (list 5 9 3 2 3 2))
+        (rune "ᛋ" "sowilo" "s" 2 "sun" (list 7 9 7 4 6 4))
+        (rune "ᛏ" "tiwaz" "t" 3 "justice" (list 5 9 6 4 4 1))
+        (rune "ᛒ" "berkano" "b" 3 "birch-birth" (list 5 9 6 4 3 0))
+        (rune "ᛖ" "ehwaz" "e" 3 "horse" (list 5 9 1 0 5 0))
+        (rune "ᛗ" "mannaz" "m" 3 "human" (list 7 9 5 3 5 0))
+        (rune "ᛚ" "laguz" "l" 3 "water" (list 4 9 8 3 3 1))
+        (rune "ᛜ" "ingwaz" "ng" 3 "seed" (list 5 9 3 2 5 0))
+        (rune "ᛟ" "othala" "o" 3 "home-dna" (list 3 9 1 1 1 0))
+        (rune "ᛞ" "dagaz" "d" 3 "day-dawn" (list 4 9 4 3 3 0))
+    ))
+    (defn rune-count () (len (nordic-runes)))
+    (defn rune-at (i) (nth (nordic-runes) i)))

--- a/form/form-stdlib/rune-frequency.fk
+++ b/form/form-stdlib/rune-frequency.fk
@@ -1,0 +1,50 @@
+; rune-frequency.fk — the symbol <-> frequency-spectrum FLOW MATCH (the body).
+;
+; Given a heard galdr's 6-band spectral SHAPE (0..9 per band), find the nearest
+; Elder Futhark rune by L1 distance over the band profile; and, given a rune index,
+; read its spectrum back. The carrier (experiments/rune-galdr/rune-galdr.sh) only
+; records + measures the bands with sox; every match decision is HERE.
+;
+; L1 over a peak-normalized shape is the honest metric: it compares the spectral
+; CONTOUR, not loudness, so the same rune sung louder/softer still matches. Nasal
+; siblings (nauthiz/mannaz) share a contour and will tie — named, not hidden.
+;
+; Composes nordic-runes.fk. Builtins + sub/add/lt only. Proven by
+; form-stdlib/tests/rune-frequency-band.fk.
+
+(do
+    (defn rf-abs (x) (if (lt x 0) (sub 0 x) x))
+
+    ; L1 distance between two equal-length band profiles
+    (defn rf-dist (a b)
+        (if (eq (len a) 0) 0
+            (add (rf-abs (sub (head a) (head b))) (rf-dist (tail a) (tail b)))))
+
+    ; nearest rune (the cell) to a query spectrum — min L1 over the table
+    (defn rf-best (query runes best bestd)
+        (if (eq (len runes) 0) best
+            (do
+                (let d (rf-dist query (rune-spectrum (head runes))))
+                (if (lt d bestd)
+                    (rf-best query (tail runes) (head runes) d)
+                    (rf-best query (tail runes) best bestd)))))
+    (defn rf-nearest (query)
+        (rf-best query
+                 (tail (nordic-runes))
+                 (head (nordic-runes))
+                 (rf-dist query (rune-spectrum (head (nordic-runes))))))
+
+    ; symbol <- frequency: a heard spectrum names its rune
+    (defn rf-match  (query) (rune-name  (rf-nearest query)))   ; -> "fehu"
+    (defn rf-glyph  (query) (rune-glyph (rf-nearest query)))   ; -> "ᚠ"
+    (defn rf-aett   (query) (rune-aett  (rf-nearest query)))   ; -> 1..3
+    ; how sure: L1 to the chosen rune (0 = exact; lower = surer)
+    (defn rf-distance (query) (rf-dist query (rune-spectrum (rf-nearest query))))
+    ; a 0..9 confidence: 9 when exact, falling as the contour drifts (cap at dist 18)
+    (defn rf-confidence (query)
+        (do
+            (let d (rf-distance query))
+            (if (ge d 18) 0 (sub 9 (div d 2)))))
+
+    ; frequency <- symbol: a rune index gives its trained spectrum
+    (defn rf-spectrum-at (i) (rune-spectrum (rune-at i))))

--- a/form/form-stdlib/tests/nordic-runes-band.fk
+++ b/form/form-stdlib/tests/nordic-runes-band.fk
@@ -1,0 +1,23 @@
+; preludes: form-stdlib/nordic-runes.fk
+;
+; nordic-runes-band — the 24 Elder Futhark cells, their ætt order and spectral shape, three-way.
+;
+; Verdict 255 when every claim lands:
+;   1   the full futhark is present        (rune-count = 24)
+;   2   first cell is Freyr's ætt           (rune-at 0 = fehu, ætt 1)
+;   4   ætt 1 runs through index 7          (rune-at 7 = wunjo, ætt 1)
+;   8   ætt 2 begins at index 8             (rune-at 8 = hagalaz, ætt 2)
+;   16  ætt 2 runs through index 15         (rune-at 15 = sowilo, ætt 2)
+;   32  ætt 3 begins at index 16            (rune-at 16 = tiwaz, ætt 3)
+;   64  ætt 3 runs through index 23         (rune-at 23 = dagaz, ætt 3)
+;   128 each cell carries a 6-band shape    (rune-spectrum has 6 bands)
+(do
+    (let c0 (if (eq (rune-count) 24) 1 0))
+    (let c1 (if (eq (rune-aett (rune-at 0)) 1) 2 0))
+    (let c2 (if (eq (rune-aett (rune-at 7)) 1) 4 0))
+    (let c3 (if (eq (rune-aett (rune-at 8)) 2) 8 0))
+    (let c4 (if (eq (rune-aett (rune-at 15)) 2) 16 0))
+    (let c5 (if (eq (rune-aett (rune-at 16)) 3) 32 0))
+    (let c6 (if (eq (rune-aett (rune-at 23)) 3) 64 0))
+    (let c7 (if (eq (len (rune-spectrum (rune-at 0))) 6) 128 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/form-stdlib/tests/rune-frequency-band.fk
+++ b/form/form-stdlib/tests/rune-frequency-band.fk
@@ -1,0 +1,23 @@
+; preludes: form-stdlib/nordic-runes.fk form-stdlib/rune-frequency.fk
+;
+; rune-frequency-band — the symbol <-> frequency-spectrum flow-match, three-way.
+;
+; Verdict 255 when every claim lands (numeric decisions only):
+;   1   |−5| = 5                            (rf-abs)
+;   2   identical contours → distance 0     (rf-dist self)
+;   4   opposite contours → distance 18     (rf-dist (9 9)(0 0))
+;   8   a rune's own spectrum matches exact  (rf-distance fehu = 0)
+;   16  exact match resolves the right ætt   (rf-aett fehu spectrum = 1)
+;   32  a different rune resolves too         (rf-aett sowilo spectrum = 2)
+;   64  exact match is full confidence        (rf-confidence fehu = 9)
+;   128 a drifted contour still finds fehu    (rf-aett perturbed fehu = 1)
+(do
+    (let c0 (if (eq (rf-abs (sub 0 5)) 5) 1 0))
+    (let c1 (if (eq (rf-dist (list 5 8 9 5 6 0) (list 5 8 9 5 6 0)) 0) 2 0))
+    (let c2 (if (eq (rf-dist (list 9 9) (list 0 0)) 18) 4 0))
+    (let c3 (if (eq (rf-distance (list 5 8 9 5 6 0)) 0) 8 0))
+    (let c4 (if (eq (rf-aett (list 5 8 9 5 6 0)) 1) 16 0))
+    (let c5 (if (eq (rf-aett (list 7 9 7 4 6 4)) 2) 32 0))
+    (let c6 (if (eq (rf-confidence (list 5 8 9 5 6 0)) 9) 64 0))
+    (let c7 (if (eq (rf-aett (list 5 8 8 5 6 1)) 1) 128 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -462,6 +462,8 @@ voice-traits fks 1023
 voiced fks 511
 speech-organ fks 255
 host-sense-organ fks 255
+nordic-runes fks 255
+rune-frequency fks 255
 wav-sense fks 63
 witness-theorem fks 31
 witness-to-co-regulate fks 127


### PR DESCRIPTION
## What

Learn all 24 Elder Futhark runes, give each **galdr** a measurable **vibration**, and match a heard sound back to its rune — both directions. The body is **Form**; audio synthesis + spectral extraction is the thin carrier.

## Form (PASS-4WAY — Go/Rust/TS/fkwu, verdict 255 each)

- **[`nordic-runes.fk`](form/form-stdlib/nordic-runes.fk)** — the 24 runes as cells: glyph, name, phoneme, ætt (1–3), keyword, and a 6-band peak-normalized galdr spectral **shape** over [0–200, 200–500, 500–1k, 1k–2k, 2k–4k, 4k–8k] Hz.
- **[`rune-frequency.fk`](form/form-stdlib/rune-frequency.fk)** — the flow match: `rf-match` (spectrum→rune), `rf-glyph`/`rf-aett`/`rf-confidence`, `rf-spectrum-at` (rune→spectrum). L1 over the contour (loud/soft-invariant).
- Bands `tests/nordic-runes-band.fk` + `tests/rune-frequency-band.fk`; registered `fks` in `fourth-arm-bands.txt`; `fourth-arm-gate.sh nordic-runes rune-frequency` → **PASS-4WAY**.

## Carriers (thin — I/O + sox DSP only; every decision is the recipe's)

- `experiments/rune-galdr/train-rune-spectra.sh` — synthesize each rune's galdr, measure its 6-band signature, emit the Form rows.
- `experiments/rune-galdr/rune-galdr.sh` — live: `--say` / `--wav` / `--listen` → names the rune via the Form body.

## Verified

Synthesized round-trip correct at full confidence: `'sss'→Sowilo ᛋ`, `'iii'→Isa ᛁ`, `'rrr'→Raidho ᚱ`.

## Honest floor

- A rune's "frequency" is the **acoustic spectrum of its sung phoneme** (formant/fricative energy), not a single mystical Hz. The synthesized table is a reproducible reference.
- Nasals **nauthiz/mannaz share a contour and tie** (named, not hidden); macOS `say` is a weak galdr source.
- **Next step (README):** voice/drum separation so the *sung* rune can be matched inside a live ritual recording (the drum's ~80–100 Hz fundamental currently dominates the contour). This is the prototype for a **sonic sense organ** — companion to the speech organ's lexical layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)