### PR TITLE
feat(form): core.fk as generic abstractions (Num/List/Cell/Task) + a plain generic-class form in the form.bml dialect

### DIFF
--- a/form/form-stdlib/core.fk
+++ b/form/form-stdlib/core.fk
@@ -1,86 +1,100 @@
-; core.fk - Form core definitions, authored in the BML maintenance dialect.
+; core.fk - Form core stdlib, authored as generic abstractions in the BML
+; maintenance dialect.
+;
+; The stdlib travels as four generic classes — Num<T>, List<T>, Cell<T>,
+; Task<T> — plus two cross-cutting top-level defs. A plain generic class is an
+; organizing abstraction: each method hoists to a BARE top-level fndef (built by
+; the same def lowerer a flat `def` rides, so the runtime recipe is unchanged
+; and four-way), and the class name binds to a nullary descriptor `(Name)` so
+; the abstraction stays a queryable value. The type parameter is a contract that
+; erases. Callers use the bare names exactly as before.
 ;
 ; Kernel execution receives lowered Form objects. Source sections are compiled
 ; by form-stdlib/source-compiler.fk before kernels walk source or binary form.
 
 section [form.bml] {
-    // predicates
-    def nil?(xs) = eq(len(xs), 0);
-    def even?(n) = eq(mod(n, 2), 0);
-    def odd?(n) = eq(mod(n, 2), 1);
-    def zero?(n) = eq(n, 0);
-    def positive?(n) = gt(n, 0);
-    def negative?(n) = lt(n, 0);
+    // the identity arrow — used across every abstraction (Task threads it as a
+    // resolved continuation), so it rests above the classes.
     def identity(x) = x;
 
-    // math closures
-    def plus(a, b) = add(a, b);
-    def minus(a, b) = sub(a, b);
-    def times(a, b) = mul(a, b);
-    def divide(a, b) = div(a, b);
-
-    // numeric helpers
-    def abs(n) = if negative?(n) then sub(0, n) else n;
-    def min2(a, b) = if lt(a, b) then a else b;
-    def max2(a, b) = if gt(a, b) then a else b;
-
-    // list traversal
-    def map(f, xs) = if nil?(xs) then empty else cons(f(head(xs)), map(f, tail(xs)));
-    def filter(pred, xs) = if nil?(xs) then empty else if pred(head(xs)) then cons(head(xs), filter(pred, tail(xs))) else filter(pred, tail(xs));
-    def foldl(f, init, xs) = if nil?(xs) then init else foldl(f, f(init, head(xs)), tail(xs));
-    def foldr(f, init, xs) = if nil?(xs) then init else f(head(xs), foldr(f, init, tail(xs)));
-
-    // list constructors / shape transforms
-    def range(start, end) = if ge(start, end) then empty else cons(start, range(add(start, 1), end));
-    def append(xs, ys) = if nil?(xs) then ys else cons(head(xs), append(tail(xs), ys));
-    def take(n, xs) = if or(le(n, 0), nil?(xs)) then empty else cons(head(xs), take(sub(n, 1), tail(xs)));
-    def drop(n, xs) = if le(n, 0) then xs else if nil?(xs) then empty else drop(sub(n, 1), tail(xs));
-    def nth(xs, n) = if eq(n, 0) then head(xs) else nth(tail(xs), sub(n, 1));
-    def cons-flip(acc, x) = cons(x, acc);
-    def reverse(xs) = foldl(cons-flip, empty, xs);
-
-    // reversible cells
-    def cell(kind, value, origin, inverse) = list("cell", kind, value, origin, inverse);
-    def cell?(c) = and(gt(len(c), 0), str_eq(head(c), "cell"));
-    def cell-kind(c) = head(tail(c));
-    def cell-value(c) = head(tail(tail(c)));
-    def cell-origin(c) = head(tail(tail(tail(c))));
-    def cell-inverse(c) = head(tail(tail(tail(tail(c)))));
-    def cell-undo(c) {
-        let inverse = cell-inverse(c);
-        inverse(c);
+    // Num<T> — numeric predicates, closures, and helpers over a number.
+    class Num<T> {
+        def even?(n) = eq(mod(n, 2), 0);
+        def odd?(n) = eq(mod(n, 2), 1);
+        def zero?(n) = eq(n, 0);
+        def positive?(n) = gt(n, 0);
+        def negative?(n) = lt(n, 0);
+        def plus(a, b) = add(a, b);
+        def minus(a, b) = sub(a, b);
+        def times(a, b) = mul(a, b);
+        def divide(a, b) = div(a, b);
+        def abs(n) = if negative?(n) then sub(0, n) else n;
+        def min2(a, b) = if lt(a, b) then a else b;
+        def max2(a, b) = if gt(a, b) then a else b;
     }
-    def cell-do(c) = cell-value(c);
 
-    // task cells
-    def task-undo(t) = cell-origin(t);
-    def task-cell(state, value, cont, origin, inverse) = cell("task", list(state, value, cont), origin, inverse);
-    def task?(t) = and(cell?(t), str_eq(cell-kind(t), "task"));
-    def task-state(t) = nth(cell-value(t), 0);
-    def task-value(t) = nth(cell-value(t), 1);
-    def task-cont(t) = nth(cell-value(t), 2);
-    def task-pending(origin, cont) = task-cell("pending", empty, cont, origin, task-undo);
-    def task-resolved(value) = task-cell("resolved", value, identity, empty, task-undo);
-    def task-failed(failure) = task-cell("failed", failure, identity, empty, task-undo);
-    def task-resolve(t, value) = task-cell("resolved", value, task-cont(t), cell-origin(t), cell-inverse(t));
-    def task-reject(t, failure) = task-cell("failed", failure, task-cont(t), cell-origin(t), cell-inverse(t));
-    def task-await(t) = if str_eq(task-state(t), "resolved") then task-value(t) else t;
-    def task-step(t) {
-        let cont = task-cont(t);
-        if str_eq(task-state(t), "resolved") then cont(task-value(t)) else t;
+    // List<T> — traversal, shape transforms, and aggregation over a list. The
+    // aggregators lean on Num (plus/times/min2/max2), so List rests below Num.
+    class List<T> {
+        def nil?(xs) = eq(len(xs), 0);
+        def map(f, xs) = if nil?(xs) then empty else cons(f(head(xs)), map(f, tail(xs)));
+        def filter(pred, xs) = if nil?(xs) then empty else if pred(head(xs)) then cons(head(xs), filter(pred, tail(xs))) else filter(pred, tail(xs));
+        def foldl(f, init, xs) = if nil?(xs) then init else foldl(f, f(init, head(xs)), tail(xs));
+        def foldr(f, init, xs) = if nil?(xs) then init else f(head(xs), foldr(f, init, tail(xs)));
+        def range(start, end) = if ge(start, end) then empty else cons(start, range(add(start, 1), end));
+        def append(xs, ys) = if nil?(xs) then ys else cons(head(xs), append(tail(xs), ys));
+        def take(n, xs) = if or(le(n, 0), nil?(xs)) then empty else cons(head(xs), take(sub(n, 1), tail(xs)));
+        def drop(n, xs) = if le(n, 0) then xs else if nil?(xs) then empty else drop(sub(n, 1), tail(xs));
+        def nth(xs, n) = if eq(n, 0) then head(xs) else nth(tail(xs), sub(n, 1));
+        def cons-flip(acc, x) = cons(x, acc);
+        def reverse(xs) = foldl(cons-flip, empty, xs);
+        def sum(xs) = foldl(plus, 0, xs);
+        def product(xs) = foldl(times, 1, xs);
+        def maximum(xs) = foldl(max2, head(xs), tail(xs));
+        def minimum(xs) = foldl(min2, head(xs), tail(xs));
+        def any?(pred, xs) = if nil?(xs) then false else if pred(head(xs)) then true else any?(pred, tail(xs));
+        def all?(pred, xs) = if nil?(xs) then true else if pred(head(xs)) then all?(pred, tail(xs)) else false;
     }
-    def task-ready?(t) = str_eq(task-state(t), "resolved");
-    def task-failed?(t) = str_eq(task-state(t), "failed");
 
-    // aggregators
-    def sum(xs) = foldl(plus, 0, xs);
-    def product(xs) = foldl(times, 1, xs);
-    def maximum(xs) = foldl(max2, head(xs), tail(xs));
-    def minimum(xs) = foldl(min2, head(xs), tail(xs));
+    // Cell<T> — a reversible cell: kind, value, origin, and an inverse that
+    // undoes it. The substrate's smallest unit of reversible state.
+    class Cell<T> {
+        def cell(kind, value, origin, inverse) = list("cell", kind, value, origin, inverse);
+        def cell?(c) = and(gt(len(c), 0), str_eq(head(c), "cell"));
+        def cell-kind(c) = head(tail(c));
+        def cell-value(c) = head(tail(tail(c)));
+        def cell-origin(c) = head(tail(tail(tail(c))));
+        def cell-inverse(c) = head(tail(tail(tail(tail(c)))));
+        def cell-undo(c) {
+            let inverse = cell-inverse(c);
+            inverse(c);
+        }
+        def cell-do(c) = cell-value(c);
+    }
 
-    // universal / existential
-    def any?(pred, xs) = if nil?(xs) then false else if pred(head(xs)) then true else any?(pred, tail(xs));
-    def all?(pred, xs) = if nil?(xs) then true else if pred(head(xs)) then all?(pred, tail(xs)) else false;
+    // Task<T> — an async cell over Cell: a (state, value, continuation) triple
+    // that resolves, rejects, awaits, and steps. Rests below Cell (it is one)
+    // and below List (it reads its triple with nth).
+    class Task<T> {
+        def task-undo(t) = cell-origin(t);
+        def task-cell(state, value, cont, origin, inverse) = cell("task", list(state, value, cont), origin, inverse);
+        def task?(t) = and(cell?(t), str_eq(cell-kind(t), "task"));
+        def task-state(t) = nth(cell-value(t), 0);
+        def task-value(t) = nth(cell-value(t), 1);
+        def task-cont(t) = nth(cell-value(t), 2);
+        def task-pending(origin, cont) = task-cell("pending", empty, cont, origin, task-undo);
+        def task-resolved(value) = task-cell("resolved", value, identity, empty, task-undo);
+        def task-failed(failure) = task-cell("failed", failure, identity, empty, task-undo);
+        def task-resolve(t, value) = task-cell("resolved", value, task-cont(t), cell-origin(t), cell-inverse(t));
+        def task-reject(t, failure) = task-cell("failed", failure, task-cont(t), cell-origin(t), cell-inverse(t));
+        def task-await(t) = if str_eq(task-state(t), "resolved") then task-value(t) else t;
+        def task-step(t) {
+            let cont = task-cont(t);
+            if str_eq(task-state(t), "resolved") then cont(task-value(t)) else t;
+        }
+        def task-ready?(t) = str_eq(task-state(t), "resolved");
+        def task-failed?(t) = str_eq(task-state(t), "failed");
+    }
 
     // assertion — pred holds or the kernel halts. Form has no halt-with-
     // message native; head(empty) panics in every kernel, which surfaces

--- a/form/form-stdlib/source-compiler.fk
+++ b/form/form-stdlib/source-compiler.fk
@@ -1273,6 +1273,120 @@
                 (list (fsc-compile-form-bml-let-recipe value))
                 (list (fsc-compile-form-bml-expr-recipe value)))))))))
 
+    ;; --- plain generic stdlib class ----------------------------------
+    ;;
+    ;; A plain generic class `class Name<T,...> { def m(params) = expr; ... }`
+    ;; (no `: Template` extension) is an organizing abstraction over stdlib
+    ;; recipes. Its methods hoist to BARE top-level fndefs — built by the SAME
+    ;; def lowerers a flat `def` rides, so the executable recipe is node-for-
+    ;; node identical to writing those defs at the section top level. Callers
+    ;; keep using the bare names; the type parameter is a contract that erases.
+    ;; The class name also binds to a structural abstraction descriptor —
+    ;; a nullary global `(defn Name () (list "abstraction" Name (type-params)
+    ;; (member-names)))`, read as `(Name)`. A top-level `let` would leak its
+    ;; binding to global scope on three kernels but stay `do`-scoped on fkwu
+    ;; (the correct reading), so the descriptor rides a `defn` like every other
+    ;; core binding — global and portable across all four arms.
+
+    (defn fsc-bml-word-end (s i)
+        (if (ge i (str_len s)) i
+            (if (fsc-word-char? (char_at s i))
+                (fsc-bml-word-end s (add i 1))
+                i)))
+
+    ;; A language class extends a template — `class Name : Template<..> { ..`.
+    ;; A plain generic class has no `:` before its opening brace.
+    (defn fsc-bml-class-header-has-colon? (line)
+        (do
+            (let colon (fsc-find-char-from line ":" 6))
+            (let brace (fsc-find-char-from line "{" 6))
+            (and (ge colon 0) (and (ge brace 0) (lt colon brace)))))
+
+    (defn fsc-bml-def-line-name (line)
+        (do
+            (let open (fsc-find-char-from line "(" 4))
+            (fsc-trim (fsc-sub line 4 open))))
+
+    ;; Hoist each `def` inside the class body to a bare top-level fndef recipe,
+    ;; reusing the flat def lowerers verbatim (= node_eq to the flat form).
+    (defn fsc-bml-generic-class-defs-loop (body i end acc)
+        (do
+            (let p (fsc-skip-spaces body i))
+            (if (ge p end) (fsc-rev acc)
+                (do
+                    (let line-end (fsc-line-end body p))
+                    (let line (fsc-trim (fsc-sub body p line-end)))
+                    (if (fsc-bml-comment-line? line)
+                        (fsc-bml-generic-class-defs-loop body
+                            (fsc-line-next body p) end acc)
+                    (if (and (fsc-prefix? line "def ") (fsc-line-opens-block? line))
+                        (do
+                            (let method-start (fsc-line-next body p))
+                            (let method-end (fsc-bml-block-end body method-start 0))
+                            (fsc-bml-generic-class-defs-loop body
+                                (fsc-line-next body method-end) end
+                                (cons (fsc-compile-form-bml-def-block-recipe body line method-start)
+                                      acc)))
+                    (if (fsc-prefix? line "def ")
+                        (fsc-bml-generic-class-defs-loop body
+                            (fsc-line-next body p) end
+                            (cons (fsc-compile-form-bml-def-recipe (fsc-strip-semi line))
+                                  acc))
+                        (fsc-bml-generic-class-defs-loop body
+                            (fsc-line-next body p) end acc))))))))
+
+    (defn fsc-bml-generic-class-names-loop (body i end acc)
+        (do
+            (let p (fsc-skip-spaces body i))
+            (if (ge p end) (fsc-rev acc)
+                (do
+                    (let line-end (fsc-line-end body p))
+                    (let line (fsc-trim (fsc-sub body p line-end)))
+                    (if (fsc-bml-comment-line? line)
+                        (fsc-bml-generic-class-names-loop body
+                            (fsc-line-next body p) end acc)
+                    (if (and (fsc-prefix? line "def ") (fsc-line-opens-block? line))
+                        (do
+                            (let method-start (fsc-line-next body p))
+                            (let method-end (fsc-bml-block-end body method-start 0))
+                            (fsc-bml-generic-class-names-loop body
+                                (fsc-line-next body method-end) end
+                                (cons (fsc-bml-def-line-name line) acc)))
+                    (if (fsc-prefix? line "def ")
+                        (fsc-bml-generic-class-names-loop body
+                            (fsc-line-next body p) end
+                            (cons (fsc-bml-def-line-name line) acc))
+                        (fsc-bml-generic-class-names-loop body
+                            (fsc-line-next body p) end acc))))))))
+
+    (defn fsc-compile-form-bml-generic-class-block-recipes (body line body-start)
+        (do
+            (let name-end (fsc-bml-word-end line 6))
+            (let class-name (fsc-trim (fsc-sub line 6 name-end)))
+            (let lt-pos (fsc-find-char-from line "<" name-end))
+            (let brace (fsc-find-char-from line "{" name-end))
+            (let type-params
+                (if (and (ge lt-pos 0) (lt lt-pos brace))
+                    (do
+                        (let gt-pos (fsc-find-char-from line ">" lt-pos))
+                        (fsc-bml-name-list-strings-loop
+                            (fsc-sub line (add lt-pos 1) gt-pos) 0 (empty)))
+                    (empty)))
+            (let body-end (fsc-bml-block-end body body-start 0))
+            (let method-defs
+                (fsc-bml-generic-class-defs-loop body body-start body-end (empty)))
+            (let member-names
+                (fsc-bml-generic-class-names-loop body body-start body-end (empty)))
+            (fsc-list-append method-defs
+                (list
+                    (fsc-rec-fndef class-name (empty)
+                        (fsc-rec-call "list"
+                            (list
+                                (fsc-rec-string "abstraction")
+                                (fsc-rec-string class-name)
+                                (fsc-rec-string-list type-params)
+                                (fsc-rec-string-list member-names))))))))
+
     (defn fsc-form-bml-lines-recipes-loop (body i acc)
         (do
             (let p (fsc-skip-spaces body i))
@@ -1293,7 +1407,9 @@
                         (let body-start (fsc-line-next body p))
                         (let body-end (fsc-bml-block-end body body-start 0))
                         (let class-recipes
-                            (fsc-compile-form-bml-language-class-block-recipes body line body-start))
+                            (if (fsc-bml-class-header-has-colon? line)
+                                (fsc-compile-form-bml-language-class-block-recipes body line body-start)
+                                (fsc-compile-form-bml-generic-class-block-recipes body line body-start)))
                         (fsc-form-bml-lines-recipes-loop body
                             (fsc-line-next body body-end)
                             (fsc-rec-append-rev class-recipes acc)))

--- a/form/form-stdlib/tests/bml-generic-class-stdlib-band.fk
+++ b/form/form-stdlib/tests/bml-generic-class-stdlib-band.fk
@@ -1,0 +1,41 @@
+; bml-generic-class-stdlib-band.fk — a plain generic stdlib class hoists its
+; methods to BARE top-level fndefs that execute identically to flat defs, on
+; all four kernels.
+;
+; `class Name<T> { def m(..) = ..; }` with no `: Template` extension is an
+; organizing abstraction: the methods keep bare names (callers unchanged), the
+; type parameter erases, and the class name binds to a nullary global
+; abstraction descriptor `(Name)` = (list "abstraction" Name (type-params)
+; (member-names)). The descriptor rides a `defn`, not a top-level `let`, so it
+; stays global and portable across all four arms.
+;
+; The strangeness packs the boundary into one class: a recursive higher-order
+; method (recursion + function argument + if/then/else + cons/head/tail/nil?),
+; a block-bodied method with a local let, and the erased <T> — every hoisted
+; path a real stdlib (core.fk) walks. The witness is computed inside the one
+; section form so it reads identically on every kernel.
+;
+; preludes: form-stdlib/core.fk
+
+section [form.bml] {
+    class ListKit<T> {
+        def gc-inc(x) = add(x, 1);
+        def gc-map(f, xs) = if nil?(xs) then empty else cons(f(head(xs)), gc-map(f, tail(xs)));
+        def gc-bump(xs) {
+            let ys = gc-map(gc-inc, xs);
+            ys;
+        }
+    }
+
+    ; gc-bump (1 2 3) -> (2 3 4); sum -> 9
+    let a = sum(gc-bump(list(1, 2, 3)));
+    ; gc-map gc-inc over (2 3 4) -> (3 4 5); sum -> 12
+    let b = sum(gc-map(gc-inc, gc-bump(list(1, 2, 3))));
+    ; descriptor: (ListKit) = ("abstraction" "ListKit" ("T") ("gc-inc" "gc-map" "gc-bump"))
+    let desc = ListKit();
+    let d-name = if str_eq(nth(desc, 1), "ListKit") then 1 else 0;
+    let d-tparams = len(nth(desc, 2));
+    let d-members = len(nth(desc, 3));
+    ; 9 + 12*1000 + 1*100000 + 1*1000000 + 3*10000000 = 31112009
+    add(a, add(mul(b, 1000), add(mul(d-name, 100000), add(mul(d-tparams, 1000000), mul(d-members, 10000000)))));
+}

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -247,6 +247,7 @@ field-model-form-runtime-conflict fks 1
 field-model-form-runtime-intervene fks 1
 field-model-form-runtime-lift fks 1
 bml-route-source-object fks 2047
+bml-generic-class-stdlib fks 31112009
 bml-protocol-capability-row fks 65535
 bml-choice-routing-metadata fks 4095
 bml-choice-receipt-row fks 131071


### PR DESCRIPTION
## What

Re-authors the universal stdlib prelude `core.fk` as **generic abstractions** — `Num<T>`, `List<T>`, `Cell<T>`, `Task<T>` — and teaches the `form.bml` dialect a **plain generic-class form** (`class Name<T> { def m(..) }`, no `: Template` extension) that lowers each method to a bare top-level `fndef` plus a portable abstraction descriptor.

This is the first real stdlib written in the high-level class/generic surface the BML-native compiler consumes (the [Bootstrap Boundary / SelfHostingPlan](kernels/BMF_BML_COMPILER_PICTURE.md) north star). The runtime stays the proven four-way recipe floor; the *source* becomes an abstraction.

## Why it's safe (the byte-identity gate)

The new class methods hoist through the **same def lowerers** a flat `def` rides, so every function's recipe is unchanged. Verified by lowering old (flat) and new (class) `core.fk` and diffing the emitted recipes:

- **All 55 functions lower node-for-node identical** — zero differ, zero missing.
- The only additions are the four nullary abstraction descriptors `(Num)`/`(List)`/`(Cell)`/`(Task)`.
- The fourth arm (fkwu) reads core vocabulary from `fourth-shim.fk`, not `core.fk`, so this re-authoring is invisible to it; the three lowering kernels reproduce identical behavior.

## Proof

- New band `bml-generic-class-stdlib-band.fk` (manifest `fks 31112009`) packs recursion + higher-order + block-`let` + erased `<T>` + the descriptor read into one class — **four-way green**.
- Diverse core-heavy bands confirmed four-way with the new prelude: `adam-step-cell` (4095, Cell), `android-mesh-learning` (131071, 14-prelude chain), `bml-concrete-source-lowerer-execution` (34, language-class path unchanged).

## Notable

- The four-way gate caught a **pre-existing** fkwu scoping divergence (a `section`'s `defn`s aren't visible to a *separate* trailing top-level form under fkwu — the other three share a global env). Unrelated to this change; sidestepped by riding `defn` (not top-level `let`) for the descriptor and computing the band witness in one form. Worth a follow-up to reconcile fkwu top-level scope.
- The change is purely additive to the dialect: the language-class path is gated by a colon-before-brace check, and no colon-less `class` exists in any form.bml section today.

Two commits: the lowerer mechanism, then `core.fk` using it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)