### PR TITLE
feat(form): const-recipe — numbers as JIT-resolvable recipes (+ restore shell manifest rows)

### DIFF
--- a/form/form-stdlib/const-recipe.fk
+++ b/form/form-stdlib/const-recipe.fk
@@ -1,0 +1,61 @@
+; const-recipe.fk — numbers as const-recipe resolvers, not literals.
+;
+; THESIS (the user's): we don't need to store every number as a literal. We can
+; build ANY integer from a tiny core basis — here {zero, one} under {add, mul} —
+; as a RECIPE (structure), and let a JIT/fold resolve the recipe back into the
+; const on demand. The only place a numeric literal ever appears is the basis
+; itself (0 and 1, in cr-resolve's two base cases); every other number — 255,
+; 1300, 31415 — is carried as shape, never as a stored literal.
+;
+; WHY IT SELF-FLATTENS ON fkwu. The recipe is the uniform fncall(TAG, kids)
+; encoding the shell uses: TAG is the first child (a string), kids are the rest.
+; The resolver reads the TAG from that first child (node_value), NEVER from the
+; node's blueprint — so it does not matter that `(bp "fncall")` resolves to a
+; real NodeID on a sibling kernel but to a tag-45 string on fkwu. Tag-first
+; reading is blueprint-agnostic, so the same recipe folds identically on every
+; kernel AND on the self-hosted fkwu flatten.
+;
+; SHARING IS THE COMPACTION. intern_node is content-addressed, so cr-zero(),
+; cr-one(), cr-two() return the SAME interned node every call. Building a million
+; numbers reuses one zero, one one, one two — the basis is shared, not copied.
+; A single number costs ~log2(n) structural nodes; a corpus of numbers costs the
+; shared basis plus the distinct shapes, instead of one fat literal each.
+
+(do
+    ;; ---- encoding: fncall(TAG, kids), tag-first (blueprint-agnostic) ----
+    (defn cr-node (tag kids)
+        (intern_node (bp "fncall") (cons (intern_trivial_string tag) kids)))
+    (defn cr-tag (n) (node_value (head (node_children n))))
+    (defn cr-kid (n i) (nth (tail (node_children n)) i))
+
+    ;; ---- the core basis and the two operators ----
+    (defn cr-zero () (cr-node "zero" (empty)))
+    (defn cr-one  () (cr-node "one"  (empty)))
+    (defn cr-add (a b) (cr-node "add" (cons a (cons b (empty)))))
+    (defn cr-mul (a b) (cr-node "mul" (cons a (cons b (empty)))))
+    (defn cr-two () (cr-add (cr-one) (cr-one)))
+    (defn cr-bit (b) (if (eq b 0) (cr-zero) (cr-one)))
+
+    ;; ---- cr-build n -> the recipe AST (Horner over binary digits) ----
+    ;; n = (n/2)*2 + (n%2); bottoms out at the basis {zero, one}. No literal > 1
+    ;; ever enters the recipe — TWO is itself add(one, one).
+    (defn cr-build (n)
+        (if (eq n 0) (cr-zero)
+            (if (eq n 1) (cr-one)
+                (cr-add (cr-mul (cr-build (div n 2)) (cr-two)) (cr-bit (mod n 2))))))
+
+    ;; ---- cr-resolve node -> n : the JIT/fold. ONLY site of literals 0 and 1 ----
+    (defn cr-resolve (node)
+        (do (let t (cr-tag node))
+            (if (str_eq t "zero") 0
+                (if (str_eq t "one") 1
+                    (if (str_eq t "add")
+                        (add (cr-resolve (cr-kid node 0)) (cr-resolve (cr-kid node 1)))
+                        (mul (cr-resolve (cr-kid node 0)) (cr-resolve (cr-kid node 1))))))))
+
+    ;; ---- cr-size node -> structural node count (the cost a literal would avoid) ----
+    (defn cr-size (node)
+        (do (let t (cr-tag node))
+            (if (or (str_eq t "zero") (str_eq t "one")) 1
+                (add 1 (add (cr-size (cr-kid node 0)) (cr-size (cr-kid node 1)))))))
+    0)

--- a/form/form-stdlib/tests/const-recipe-band.fk
+++ b/form/form-stdlib/tests/const-recipe-band.fk
@@ -1,0 +1,24 @@
+; const-recipe-band.fk — proof that numbers self-build from the core basis {0,1}.
+;
+; verdict = 511, but ONLY if every number below round-trips (build -> resolve == n)
+; AND the basis is content-addressed (shared node identity), AND 511 itself is
+; reconstructed from structure by the resolver. 1300 is MS-PAIR's instance number
+; and 31415 a NodeID-ish constant — both carried as shape, never as a literal.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/const-recipe.fk
+
+(do
+    (defn chk (n) (if (eq (cr-resolve (cr-build n)) n) 1 0))
+    (let r0    (chk 0))
+    (let r1    (chk 1))
+    (let r2    (chk 2))
+    (let r7    (chk 7))
+    (let r255  (chk 255))
+    (let r1300 (chk 1300))
+    (let r31415 (chk 31415))
+    ;; the basis is shared (intern_node is content-addressed): identical recipes
+    ;; for zero / two are the SAME node, so a corpus reuses one basis.
+    (let shared (if (node_eq (cr-zero) (cr-zero))
+                    (if (node_eq (cr-two) (cr-two)) 1 0) 0))
+    (let allok (mul r0 (mul r1 (mul r2 (mul r7 (mul r255 (mul r1300 (mul r31415 shared))))))))
+    (if (eq allok 1) (cr-resolve (cr-build 511)) 0))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -785,3 +785,7 @@ q-actor-critic-fixpoint fks 255
 diffusion-q-autoresearch fks 63
 form-lower-sim fks 15
 form-lower-fp-stack fks 31
+shell-parse fks 31
+shell-exec fks 63
+shell-cell fks 15
+const-recipe fks 511


### PR DESCRIPTION
## What

**const-recipe** — represent numbers as JIT-resolvable recipes over a tiny core basis, instead of literals (the user's idea, prototyped). Build ANY integer from `{zero, one}` under `{add, mul}` as STRUCTURE, and a fold (`cr-resolve`) resolves it back into the const on demand — the same JIT lane we already have for affine recipes, pushed down to the const layer.

- `const-recipe.fk` — `cr-build n` (Horner over binary digits) / `cr-resolve` (the fold) / `cr-size`. The recipe is the uniform `fncall(TAG, kids)`; the resolver reads the TAG **tag-first** (`node_value` of child 0), never the blueprint, so it is blueprint-agnostic and folds identically on every kernel.
- The only numeric literals are the basis itself (`0`/`1` in `cr-resolve`); `255`, `1300`, `31415` are carried as shape. Content-addressed sharing is the compaction: `cr-zero`/`cr-one`/`cr-two` intern to one node each, so a corpus reuses one basis.
- band `const-recipe = 511`: every round-trip reconstructs, the basis is shared, and 511 is rebuilt from structure. Proven **Rust-direct** and on the **emitted fkwu binary** (Go/Rust-flattened table → fkwu → 511).

## Also

Restores the `shell-parse` / `shell-exec` / `shell-cell` manifest rows from #3431 — a concurrent manifest rework dropped them (the band files were untouched; only the registrations were lost). This re-registers them alongside `const-recipe`.

## Verification

`const-recipe-band` crosses on Rust + the emitted fkwu (sibling-flatten → fkwu run, the fourth-arm bar). The fourth-arm gate pre-flattens via the Go kernel and runs on fkwu, so this is CI-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
