### PR TITLE
feat(speaker-id): recognize enrolled speakers by voiceprint (four-way)

### DIFF
--- a/experiments/rune-galdr/enroll-speakers.sh
+++ b/experiments/rune-galdr/enroll-speakers.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# enroll-speakers.sh — build a private speaker roster from PUBLIC voice recordings.
+#
+# For each named speaker, fetch a ~90s clip from their own public channel, lift the voice
+# off any background music with Demucs, and measure a voiceprint (voiceprint.sh). The roster
+# is written PRIVATE — ~/.coherence-network/recordings/speakers.json — and never committed;
+# voiceprints are biometric. The match itself is form-stdlib/speaker-id.fk (four-way proven).
+#
+# Default speakers are the Anchor the Light Ceremony cells the body already holds, using the
+# public anchors on their presence pages. Override:  enroll-speakers.sh "name|ytsearch query" ...
+set -uo pipefail
+DIR="$HOME/.coherence-network/recordings/speakers"; mkdir -p "$DIR"
+ROSTER="$HOME/.coherence-network/recordings/speakers.json"
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SRC_DIR/voiceprint.sh"
+VENV="$HOME/.coherence-network/demucs-venv"
+
+SPEAKERS=("$@")
+if [[ ${#SPEAKERS[@]} -eq 0 ]]; then
+  SPEAKERS=(
+    "ubbe|Ubbe MacLean Anchor the Light guided meditation"
+    "brigitte|Brigitte Mars herbalist interview"
+    "angelia|Angelia LaRue crystal arrays"
+  )
+fi
+
+echo "[" > "$ROSTER.tmp"; first=1
+for s in "${SPEAKERS[@]}"; do
+  name="${s%%|*}"; query="${s#*|}"; wav="$DIR/$name.16k.wav"
+  if [[ ! -f "$wav" ]]; then
+    yt-dlp --no-warnings --download-sections "*30-120" -x --audio-format wav \
+      -o "$DIR/$name.%(ext)s" "ytsearch1:$query" >/dev/null 2>&1 || true
+    [[ -f "$DIR/$name.wav" ]] && sox "$DIR/$name.wav" -c 1 -r 16000 "$wav" 2>/dev/null
+  fi
+  if [[ ! -f "$wav" ]]; then echo "  $name: download failed ($query)" >&2; continue; fi
+  # lift voice off any background music
+  voice="$wav"
+  if [[ -x "$VENV/bin/demucs" ]]; then
+    "$VENV/bin/demucs" --two-stems=vocals -o "$DIR/sep" "$wav" >/dev/null 2>&1 || true
+    cand="$DIR/sep/htdemucs/$name/vocals.wav"
+    [[ -f "$cand" ]] && { sox "$cand" -c 1 -r 16000 "$DIR/$name.voice.wav" 2>/dev/null; voice="$DIR/$name.voice.wav"; }
+  fi
+  vid="$(yt-dlp --no-warnings "ytsearch1:$query" --print "%(id)s|%(title).45s" --skip-download 2>/dev/null | head -1)"
+  vp="$(voiceprint "$voice")"
+  echo "  enrolled $name: voiceprint=[$vp]  source=$vid" >&2
+  [[ $first -eq 0 ]] && echo "," >> "$ROSTER.tmp"; first=0
+  printf '  ["%s", [%s]]' "$name" "$(echo "$vp" | tr ' ' ',')" >> "$ROSTER.tmp"
+done
+echo "" >> "$ROSTER.tmp"; echo "]" >> "$ROSTER.tmp"
+mv "$ROSTER.tmp" "$ROSTER"
+echo "[enroll] roster → $ROSTER"; cat "$ROSTER"

--- a/experiments/rune-galdr/identify-speakers.sh
+++ b/experiments/rune-galdr/identify-speakers.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# identify-speakers.sh — recognize enrolled speakers in a recording (PRIVATE output).
+#
+# Slides a window over a voice recording, measures each window's voiceprint, and asks the
+# Form body (speaker-id.fk over the private roster from enroll-speakers.sh) who it is —
+# or "unknown". Carrier = sox DSP + kernel calls; the match is the four-way-proven recipe.
+# The recording and this who-spoke-when timeline are PRIVATE — held in awareness, never
+# committed. Best run on a Demucs-separated voice stem (separate-galdr.sh).
+#
+#   identify-speakers.sh voice.wav [START DUR WINDOW HOP FLOOR]
+set -uo pipefail
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FORM="$(cd "$SRC_DIR/../.." && pwd)/form"
+KERNEL="$FORM/form-kernel-rust/target/release/form-kernel-rust"
+ROSTER="$HOME/.coherence-network/recordings/speakers.json"
+. "$SRC_DIR/voiceprint.sh"
+[[ -x "$KERNEL" ]] || { echo "FAIL no kernel — build via validate.sh"; exit 1; }
+[[ -f "$ROSTER" ]] || { echo "FAIL no roster — run enroll-speakers.sh first"; exit 1; }
+
+WAV="${1:?need a voice wav}"; START="${2:-0}"; DUR="${3:-0}"; WIN="${4:-5}"; HOP="${5:-15}"; FLOOR="${6:-6}"
+[[ "$DUR" == "0" ]] && DUR="$(soxi -D "$WAV" 2>/dev/null | cut -d. -f1)"
+RO="$(jq -c '.' "$ROSTER")"
+# Form roster literal: (list (list "name" (list v…)) …)
+RO_FK="(list $(jq -r '.[] | "(list \"" + .[0] + "\" (list " + (.[1]|map(tostring)|join(" ")) + "))"' "$ROSTER" | tr '\n' ' '))"
+TMP="$(mktemp -d /tmp/idsp.XXXX)"; trap 'rm -rf "$TMP"' EXIT
+
+echo "[identify] $(basename "$WAV")  ${START}s→$((START+DUR))s  roster=$(jq 'length' "$ROSTER")  (PRIVATE — not committed)"
+t="$START"; end=$((START+DUR))
+while [ "$t" -lt "$end" ]; do
+  clip="$TMP/c.wav"; sox "$WAV" "$clip" trim "$t" "$WIN" 2>/dev/null || break
+  vp="$(voiceprint "$clip")"
+  drv="$TMP/q.fk"
+  printf '(do (print (list "lbl" (sid-label (list %s) %s) "d" (sid-distance (list %s) %s) "known" (sid-known? (list %s) %s %s) "c" (sid-confidence (list %s) %s))))\n' \
+    "$vp" "$RO_FK" "$vp" "$RO_FK" "$vp" "$RO_FK" "$FLOOR" "$vp" "$RO_FK" > "$drv"
+  out="$(cd "$FORM" && "$KERNEL" form-stdlib/speaker-id.fk "$drv" 2>/dev/null | grep -E '^\[' | tail -1)"
+  lbl="$(echo "$out" | sed -E 's/.*lbl, ([a-z]+),.*/\1/')"
+  known="$(echo "$out" | sed -E 's/.*known, ([0-9]+),.*/\1/')"
+  conf="$(echo "$out" | sed -E 's/.*c, ([0-9]+).*/\1/')"
+  mm=$((t/60)); ss=$((t%60))
+  if [ "${known:-0}" = "1" ]; then printf "  %d:%02d  %-10s conf=%s\n" "$mm" "$ss" "$lbl" "${conf:-?}"
+  else printf "  %d:%02d  %-10s\n" "$mm" "$ss" "unknown"; fi
+  t=$((t+HOP))
+done

--- a/experiments/rune-galdr/voiceprint.sh
+++ b/experiments/rune-galdr/voiceprint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# voiceprint.sh — measure a voiceprint from a wav (sourced by enroll/identify carriers).
+# A voiceprint = pitch bucket (median fundamental) + 6-band formant SHAPE (vocal-tract timbre).
+# Carrier DSP only (sox); the speaker MATCH lives in form-stdlib/speaker-id.fk.
+FB=(250 450  450 700  700 1100  1100 1700  1700 2600  2600 4000)
+_vb() { sox "$1" -n highpass 80 sinc "$2"-"$3" stat 2>&1 | awk '/RMS +amplitude/{printf "%d",$3*10000+0.5}'; }
+# pitch bucket: lowpass 350 strips harmonics so rough-frequency tracks f0; bucket /25.
+_pitch_bucket() { local f; f="$(sox "$1" -n lowpass 350 stat 2>&1 | awk '/Rough +frequency/{print $3}')"; echo $(( (${f:-0}+12)/25 )); }
+# echo "pitch f0 f1 f2 f3 f4 f5"  (7 ints)
+voiceprint() {
+  local w="$1"
+  local r=( $(_vb "$w" "${FB[0]}" "${FB[1]}") $(_vb "$w" "${FB[2]}" "${FB[3]}") $(_vb "$w" "${FB[4]}" "${FB[5]}") \
+            $(_vb "$w" "${FB[6]}" "${FB[7]}") $(_vb "$w" "${FB[8]}" "${FB[9]}") $(_vb "$w" "${FB[10]}" "${FB[11]}") )
+  local max=0 v; for v in "${r[@]}"; do [[ ${v:-0} -gt $max ]] && max=$v; done; [[ $max -eq 0 ]] && max=1
+  local q=(); for v in "${r[@]}"; do q+=( $(( (${v:-0}*9+max/2)/max )) ); done
+  echo "$(_pitch_bucket "$w") ${q[*]}"
+}

--- a/form/form-stdlib/speaker-id.fk
+++ b/form/form-stdlib/speaker-id.fk
@@ -1,0 +1,43 @@
+; speaker-id.fk — nearest-speaker over an enrolled roster, by L1 voiceprint distance.
+;
+; A voiceprint is a small int vector the carrier measures from a voice: a pitch bucket
+; (median fundamental) followed by the 6-band formant SHAPE (the timbre of the vocal tract).
+; Given a heard window's voiceprint and a roster of enrolled speakers (label + voiceprint),
+; this names the nearest speaker — or "unknown" when none is close enough. The roster is
+; passed in (not hardcoded): speakers are enrolled by the carrier from their own public
+; recordings, so the body holds no fixed identities.
+;
+; This is the rune-frequency flow-match generalized to a dynamic roster — same L1-over-a-
+; contour metric, loud/soft invariant. The carrier (experiments/rune-galdr/enroll-speakers.sh,
+; identify-speakers.sh) only measures voiceprints; every match decision is here.
+;
+; Builtins + sub/add/lt/le/ge/div only. Proven by form-stdlib/tests/speaker-id-band.fk.
+
+(do
+    (defn sid-abs (x) (if (lt x 0) (sub 0 x) x))
+    (defn sid-dist (a b)
+        (if (eq (len a) 0) 0
+            (add (sid-abs (sub (head a) (head b))) (sid-dist (tail a) (tail b)))))
+
+    ; roster cell = (label voiceprint)
+    (defn sid-lbl (cell) (nth cell 0))
+    (defn sid-vp  (cell) (nth cell 1))
+
+    (defn sid-best (q roster best bestd)
+        (if (eq (len roster) 0) best
+            (do
+                (let d (sid-dist q (sid-vp (head roster))))
+                (if (lt d bestd)
+                    (sid-best q (tail roster) (head roster) d)
+                    (sid-best q (tail roster) best bestd)))))
+    (defn sid-nearest (q roster)
+        (sid-best q (tail roster) (head roster) (sid-dist q (sid-vp (head roster)))))
+
+    (defn sid-label    (q roster) (sid-lbl (sid-nearest q roster)))   ; the speaker label (string)
+    (defn sid-distance (q roster) (sid-dist q (sid-vp (sid-nearest q roster))))
+    ; a voice is KNOWN only if the nearest enrolled speaker is within floor; else unknown.
+    (defn sid-known?   (q roster floor) (if (le (sid-distance q roster) floor) 1 0))
+    (defn sid-confidence (q roster)
+        (do
+            (let d (sid-distance q roster))
+            (if (ge d 18) 0 (sub 9 (div d 2))))))

--- a/form/form-stdlib/tests/speaker-id-band.fk
+++ b/form/form-stdlib/tests/speaker-id-band.fk
@@ -1,0 +1,29 @@
+; preludes: form-stdlib/speaker-id.fk
+;
+; speaker-id-band — nearest-speaker over an enrolled roster, three-way.
+; Roster of three voiceprints (pitch bucket + 6 formant bands): a low-pitched voice and
+; two higher-pitched voices with different timbre contours.
+;
+; Verdict 255 when every claim lands (numeric decisions only):
+;   1   |−5| = 5                              (sid-abs)
+;   2   identical voiceprints → distance 0     (sid-dist self)
+;   4   speaker A's own print resolves exact    (sid-distance A = 0)
+;   8   speaker B's own print resolves exact    (sid-distance B = 0)
+;   16  speaker C's own print resolves exact    (sid-distance C = 0)
+;   32  an enrolled voice is KNOWN within floor  (sid-known? A floor 2 = 1)
+;   64  a far voice is UNKNOWN beyond floor       (sid-known? (0…) floor 5 = 0)
+;   128 exact match is full confidence            (sid-confidence A = 9)
+(do
+    (let A  (list 3 9 3 2 2 1))
+    (let B  (list 7 8 4 3 2 1))
+    (let C  (list 8 6 5 3 2 1))
+    (let RO (list (list "a" A) (list "b" B) (list "c" C)))
+    (let c0 (if (eq (sid-abs (sub 0 5)) 5) 1 0))
+    (let c1 (if (eq (sid-dist A A) 0) 2 0))
+    (let c2 (if (eq (sid-distance A RO) 0) 4 0))
+    (let c3 (if (eq (sid-distance B RO) 0) 8 0))
+    (let c4 (if (eq (sid-distance C RO) 0) 16 0))
+    (let c5 (if (eq (sid-known? A RO 2) 1) 32 0))
+    (let c6 (if (eq (sid-known? (list 0 0 0 0 0 0) RO 5) 0) 64 0))
+    (let c7 (if (eq (sid-confidence A RO) 9) 128 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -469,6 +469,7 @@ speech-organ fks 255
 host-sense-organ fks 255
 nordic-runes fks 255
 rune-frequency fks 255
+speaker-id fks 255
 wav-sense fks 63
 witness-theorem fks 31
 witness-to-co-regulate fks 127


### PR DESCRIPTION
Speaker recognition — same architecture as the runes: **Form body + thin carriers**, voiceprints enrolled from **public** channels, recognition output **private**.

## Form (PASS-4WAY — Go/Rust/TS/fkwu, verdict 255)
- **[`speaker-id.fk`](form/form-stdlib/speaker-id.fk)** — nearest-speaker over a passed-in roster by L1 voiceprint distance (pitch bucket + 6-band formant shape), with a floor that returns **unknown** beyond it. The rune flow-match generalized to a dynamic roster.

## Carriers (sox + yt-dlp + Demucs oracles; the match is the recipe's)
- `voiceprint.sh` — measure a voiceprint.
- `enroll-speakers.sh` — fetch each speaker's **public** voice, Demucs-clean it, measure the voiceprint. Roster written **private** to `~/.coherence-network/` (biometric — never committed). Defaults to the Anchor the Light cells via their public anchors.
- `identify-speakers.sh` — match each window of a separated voice to the roster; the who-spoke-when timeline is **private**.

## Verified (privately)
Ubbe / Brigitte / Angelia enrolled as distinct voiceprints from their own public recordings; recognizing the recording's separated teaching layer resolves to **Ubbe** in the spoken windows (conf 5–7) with honest **unknown** in breath/silence — matching the ground truth that Ubbe opens the ceremony.

## Sovereignty
The recording and its diarization stay **private** (held in awareness). Voiceprints come from public channels. Only the recognition *capability* ships — no person-specific recording detail enters public tissue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)