### PR TITLE
tend(web): restore hati.earth homepage, move downloads to /hati-os link

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -43,14 +43,15 @@ export function middleware(req: NextRequest) {
   // instead. Runs before any page code, so no error-boundary interference.
   const { pathname } = req.nextUrl;
 
-  // Host-based landing pages: hati.earth, sense.hati.earth, and suci.hati.earth resolve to
-  // this same web service; serve their download/landing pages by rewriting the
-  // root to /sense and /suci. (Assets — _next, api, files — are excluded by the
-  // matcher below, so they keep loading normally under the subdomain.)
+  // Host-based landing pages: sense.hati.earth and suci.hati.earth resolve to
+  // this same web service; serve their landing pages by rewriting the root to
+  // /sense and /suci. (Assets — _next, api, files — are excluded by the matcher
+  // below, so they keep loading normally under the subdomain.)
+  //
+  // hati.earth itself serves the normal Coherence homepage — its native-asset
+  // download table is no longer the root, it lives at /hati-os as its own
+  // download link, kept reachable without hijacking the home door.
   const host = (req.headers.get("host") || "").toLowerCase();
-  if ((host === "hati.earth" || host.startsWith("hati.")) && pathname === "/") {
-    return NextResponse.rewrite(new URL("/hati-os", req.url));
-  }
   if (host.startsWith("sense.") && !pathname.startsWith("/sense")) {
     return NextResponse.rewrite(new URL("/sense", req.url));
   }


### PR DESCRIPTION
## What

`hati.earth/` had been rewritten in middleware to `/hati-os` — a bare native-asset download table that is no longer maintained. So the home door showed download links instead of the actual homepage.

This removes the `hati.earth → /hati-os` root rewrite in `web/middleware.ts`, restoring the original Coherence homepage at `hati.earth/`. The download table stays reachable at its own `/hati-os` link (a download link), no longer hijacking the home door.

## Why this is the restoration

The rewrite was introduced in `cc4138c28` ("Add Hati OS public assets and mesh organ surface"). Before that commit, `hati.earth` had no special routing and served the normal homepage. Reverting the rewrite restores exactly the pre-replacement behavior.

`sense.hati.earth` and `suci.hati.earth` landing-page rewrites are untouched.

## Proof

- Control flow is a pure deletion of one conditional: a `hati.earth` request now falls through the `sense.`/`suci.` checks (no match) to normal locale handling → `NextResponse.next()` → homepage renders.
- `/hati-os` route is unchanged and remains a valid direct download link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)