### PR TITLE
feat(form): generic-class templates carry embedded knowledge (field/ref/thought) — adler32 lifted into Adler32<T>

### DIFF
--- a/form/form-stdlib/adler32.fk
+++ b/form/form-stdlib/adler32.fk
@@ -1,18 +1,23 @@
-; adler32.fk — RFC 1950 §9 Adler-32 checksum, as a Form recipe.
+; adler32.fk — RFC 1950 §9 Adler-32 checksum, as a generic abstraction.
 ;
 ; Canonical truth: this recipe MEANS Adler-32. A kernel with the bitwise
-; primitives (band, bor, shl_u32, add_u32) and integer mod can compute
-; the checksum from this definition alone — no host adler32 library
-; required. The recipe stays sovereign across sibling kernels
-; (Go, Rust, TypeScript).
+; primitives (band, bor, shl_u32, add_u32) and integer mod can compute the
+; checksum from this definition alone — no host adler32 library required. The
+; recipe stays sovereign across sibling kernels (Go, Rust, TypeScript, fkwu).
 ;
-; The flavor: this is the Adler-32 that ships in zlib (the checksum
-; on the tail of every DEFLATE stream, used in PNG's zTXt and IDAT
-; framing, in HTTP "deflate" Content-Encoding, in the .zip 0x08 method
-; envelope when zlib framing is on, and in countless legacy formats).
-; The canonical 9-byte test vector "123456789" → 152961502 = 0x091E01DE
-; attests every implementation in the world cross-checks against it,
-; alongside zlib's own "Wikipedia" → 0x11E60398.
+; Lifted into the Adler32<T> abstraction: the RFC's magic numbers are no longer
+; inline literals but DECLARED FIELDS — embedded knowledge the abstraction names
+; and any reader (or the substrate) can query. `(Adler32)` returns its
+; descriptor; the methods read each constant as modulus(), init-a(), etc. The
+; runtime is unchanged — every field/thought/method lowers to the same four-way
+; recipe floor — so callers keep using `(adler32 bytes)` exactly as before.
+;
+; The flavor: this is the Adler-32 that ships in zlib (the checksum on the tail
+; of every DEFLATE stream, used in PNG's zTXt and IDAT framing, in HTTP
+; "deflate" Content-Encoding, in the .zip 0x08 method envelope when zlib framing
+; is on, and in countless legacy formats). The canonical 9-byte test vector
+; "123456789" → 152961502 = 0x091E01DE attests every implementation in the world
+; cross-checks against it, alongside zlib's own "Wikipedia" → 0x11E60398.
 ;
 ; Algorithm (RFC 1950 §9):
 ;
@@ -26,40 +31,43 @@
 ;     for byte in bytes: (a, b) = adler32-step(a, b, byte)
 ;     return (b << 16) | a
 ;
-; The modulus 65521 is the largest prime below 2^16; bounding both
-; halves there ensures `b << 16 | a` is a stable 32-bit checksum.
-; Cost is O(n) over input length — head/tail straight through, no
-; precomputed table, no nth lookups.
+; The modulus 65521 is the largest prime below 2^16; bounding both halves there
+; ensures `b << 16 | a` is a stable 32-bit checksum. Cost is O(n) over input
+; length — head/tail straight through, no precomputed table, no nth lookups.
 
-(do
-    (defn adler32-nil? (xs) (eq (len xs) 0))
+section [form.bml] {
+    class Adler32<T> {
+        ; --- embedded knowledge: the RFC's fixed constants, named -----------
+        field modulus = 65521;       ; RFC 1950: largest prime below 2^16
+        field init-a = 1;            ; §9 fixes the initial accumulators so the
+        field init-b = 0;            ;   empty-input checksum is (0<<16)|1 = 1
+        field byte-mask = 255;       ; keep input honest at the low 8 bits
+        field half-shift = 16;       ; b occupies the high half of the u32
 
-    ;; Walk the byte-list head-to-tail, folding (a, b) along the way.
-    ;; Form has no native tuple/multiple-return, so a and b are carried
-    ;; as separate arguments. After the byte is consumed:
-    ;;   a' = (a + byte) mod 65521
-    ;;   b' = (b + a')   mod 65521
-    ;; The byte is masked to its low 8 bits — input bytes in this body
-    ;; arrive as ints 0..255, but the band keeps the recipe honest if
-    ;; a caller hands in something wider.
-    (defn adler32-loop (a b bs)
-        (if (adler32-nil? bs)
-            ;; End of input — combine the two halves into a 32-bit value.
-            ;; b can reach 65520, so b << 16 reaches 0xFFF10000 — above
-            ;; the signed i32 ceiling. shl_u32 + add_u32 keep the result
-            ;; in u32-space across sibling kernels (Go/Rust/TS) so the
-            ;; printed integer is identical three-way.
-            (add_u32 (shl_u32 b 16) a)
-            (do
-                (let a-next (mod (add a (band (head bs) 255)) 65521))
-                (let b-next (mod (add b a-next) 65521))
-                (adler32-loop a-next b-next (tail bs)))))
+        ; --- a computable thought: derived knowledge from a field -----------
+        ; both halves are bounded by modulus-1; b can reach 65520, so b<<16
+        ; reaches 0xFFF10000 — above the signed i32 ceiling, which is why the
+        ; combine below rides shl_u32 + add_u32 to stay in u32-space.
+        thought half-cap = sub(modulus(), 1);
 
-    ;; ---- THE CANONICAL ENTRY POINT ---------------------------------
-    ;; (adler32 byte-list) → Adler-32 as an unsigned 32-bit int.
-    ;; Initial state: a = 1, b = 0. RFC 1950 §9 fixes these so that the
-    ;; empty input checksum is (0 << 16) | 1 = 1, distinct from "no
-    ;; data seen yet" sentinels. zlib, PNG, and every wire format that
-    ;; carries Adler-32 agrees: adler32("") = 1.
-    (defn adler32 (bytes)
-        (adler32-loop 1 0 bytes)))
+        def adler32-nil?(xs) = eq(len(xs), 0);
+
+        ; One byte of the fold (only entered when bs is non-empty, so head(bs)
+        ; is safe): a' = (a + byte) mod m; b' = (b + a') mod m; recurse.
+        def adler32-step(a, b, bs) {
+            let a-next = mod(add(a, band(head(bs), byte-mask())), modulus());
+            let b-next = mod(add(b, a-next), modulus());
+            adler32-loop(a-next, b-next, tail(bs));
+        }
+
+        ; Guard the fold: at end of input, combine the two halves into a stable
+        ; u32; otherwise fold one more byte. (add_u32 (shl_u32 b 16) a) carries
+        ; the b=65520 case across the i32 ceiling, identical on every kernel.
+        def adler32-loop(a, b, bs) = if adler32-nil?(bs) then add_u32(shl_u32(b, half-shift()), a) else adler32-step(a, b, bs);
+
+        ; THE CANONICAL ENTRY POINT — (adler32 byte-list) → Adler-32 as a u32.
+        def adler32(bytes) = adler32-loop(init-a(), init-b(), bytes);
+    }
+
+    0;
+}

--- a/form/form-stdlib/source-compiler.fk
+++ b/form/form-stdlib/source-compiler.fk
@@ -1307,8 +1307,49 @@
             (let open (fsc-find-char-from line "(" 4))
             (fsc-trim (fsc-sub line 4 open))))
 
-    ;; Hoist each `def` inside the class body to a bare top-level fndef recipe,
-    ;; reusing the flat def lowerers verbatim (= node_eq to the flat form).
+    ;; A class member is a method (def), a field, a ref, or a thought. Methods
+    ;; hoist to bare fndefs (reusing the flat def lowerers verbatim = node_eq to
+    ;; the flat form). field / ref / thought each bind a nullary global
+    ;; (defn NAME () <expr>): a field holds embedded knowledge (a constant), a
+    ;; ref points at another cell, a thought computes derived knowledge. They
+    ;; read as NAME(); the kind is recorded in the descriptor so the abstraction
+    ;; DECLARES its structure (its knowledge), not just its callables.
+
+    (defn fsc-bml-nullary-after-kw (line)
+        (fsc-skip-spaces line (fsc-bml-word-end line 0)))
+
+    (defn fsc-bml-nullary-line-name (line)
+        (do
+            (let after-kw (fsc-bml-nullary-after-kw line))
+            (let eq-pos (fsc-find-char-from line "=" after-kw))
+            (fsc-trim (fsc-sub line after-kw eq-pos))))
+
+    (defn fsc-compile-form-bml-nullary-recipe (line)
+        (do
+            (let after-kw (fsc-bml-nullary-after-kw line))
+            (let eq-pos (fsc-find-char-from line "=" after-kw))
+            (let name (fsc-trim (fsc-sub line after-kw eq-pos)))
+            ;; `;` terminates the statement; anything after it (e.g. an inline
+            ;; comment) is not part of the expression.
+            (let semi (fsc-find-char-from line ";" eq-pos))
+            (let expr-end (if (ge semi 0) semi (str_len line)))
+            (let expr-text (fsc-trim (fsc-sub line (add eq-pos 1) expr-end)))
+            (fsc-rec-fndef name (empty)
+                (fsc-compile-form-bml-expr-recipe expr-text))))
+
+    (defn fsc-bml-class-nullary-member? (line)
+        (or (fsc-prefix? line "field ")
+            (or (fsc-prefix? line "ref ")
+                (fsc-prefix? line "thought "))))
+
+    (defn fsc-bml-class-member-kind (line)
+        (if (fsc-prefix? line "def ") "method"
+        (if (fsc-prefix? line "field ") "field"
+        (if (fsc-prefix? line "ref ") "ref"
+        (if (fsc-prefix? line "thought ") "thought" "")))))
+
+    ;; Walk the class body once, hoisting every member to its recipe. Methods
+    ;; ride the flat def lowerers; field/ref/thought ride the nullary lowerer.
     (defn fsc-bml-generic-class-defs-loop (body i end acc)
         (do
             (let p (fsc-skip-spaces body i))
@@ -1332,10 +1373,16 @@
                             (fsc-line-next body p) end
                             (cons (fsc-compile-form-bml-def-recipe (fsc-strip-semi line))
                                   acc))
+                    (if (fsc-bml-class-nullary-member? line)
                         (fsc-bml-generic-class-defs-loop body
-                            (fsc-line-next body p) end acc))))))))
+                            (fsc-line-next body p) end
+                            (cons (fsc-compile-form-bml-nullary-recipe line) acc))
+                        (fsc-bml-generic-class-defs-loop body
+                            (fsc-line-next body p) end acc)))))))))
 
-    (defn fsc-bml-generic-class-names-loop (body i end acc)
+    ;; Walk the class body once more, collecting (kind name) pairs. Skips def
+    ;; block bodies so an inner `field` line inside a method is never miscounted.
+    (defn fsc-bml-class-member-pairs-loop (body i end acc)
         (do
             (let p (fsc-skip-spaces body i))
             (if (ge p end) (fsc-rev acc)
@@ -1343,21 +1390,33 @@
                     (let line-end (fsc-line-end body p))
                     (let line (fsc-trim (fsc-sub body p line-end)))
                     (if (fsc-bml-comment-line? line)
-                        (fsc-bml-generic-class-names-loop body
+                        (fsc-bml-class-member-pairs-loop body
                             (fsc-line-next body p) end acc)
                     (if (and (fsc-prefix? line "def ") (fsc-line-opens-block? line))
                         (do
                             (let method-start (fsc-line-next body p))
                             (let method-end (fsc-bml-block-end body method-start 0))
-                            (fsc-bml-generic-class-names-loop body
+                            (fsc-bml-class-member-pairs-loop body
                                 (fsc-line-next body method-end) end
-                                (cons (fsc-bml-def-line-name line) acc)))
+                                (cons (list "method" (fsc-bml-def-line-name line)) acc)))
                     (if (fsc-prefix? line "def ")
-                        (fsc-bml-generic-class-names-loop body
+                        (fsc-bml-class-member-pairs-loop body
                             (fsc-line-next body p) end
-                            (cons (fsc-bml-def-line-name line) acc))
-                        (fsc-bml-generic-class-names-loop body
-                            (fsc-line-next body p) end acc))))))))
+                            (cons (list "method" (fsc-bml-def-line-name line)) acc))
+                    (if (fsc-bml-class-nullary-member? line)
+                        (fsc-bml-class-member-pairs-loop body
+                            (fsc-line-next body p) end
+                            (cons (list (fsc-bml-class-member-kind line)
+                                        (fsc-bml-nullary-line-name line)) acc))
+                        (fsc-bml-class-member-pairs-loop body
+                            (fsc-line-next body p) end acc)))))))))
+
+    (defn fsc-bml-names-of-kind (pairs kind)
+        (if (fsc-empty? pairs) (empty)
+            (if (str_eq (head (head pairs)) kind)
+                (cons (head (tail (head pairs)))
+                      (fsc-bml-names-of-kind (tail pairs) kind))
+                (fsc-bml-names-of-kind (tail pairs) kind))))
 
     (defn fsc-compile-form-bml-generic-class-block-recipes (body line body-start)
         (do
@@ -1373,11 +1432,11 @@
                             (fsc-sub line (add lt-pos 1) gt-pos) 0 (empty)))
                     (empty)))
             (let body-end (fsc-bml-block-end body body-start 0))
-            (let method-defs
+            (let member-defs
                 (fsc-bml-generic-class-defs-loop body body-start body-end (empty)))
-            (let member-names
-                (fsc-bml-generic-class-names-loop body body-start body-end (empty)))
-            (fsc-list-append method-defs
+            (let pairs
+                (fsc-bml-class-member-pairs-loop body body-start body-end (empty)))
+            (fsc-list-append member-defs
                 (list
                     (fsc-rec-fndef class-name (empty)
                         (fsc-rec-call "list"
@@ -1385,7 +1444,10 @@
                                 (fsc-rec-string "abstraction")
                                 (fsc-rec-string class-name)
                                 (fsc-rec-string-list type-params)
-                                (fsc-rec-string-list member-names))))))))
+                                (fsc-rec-string-list (fsc-bml-names-of-kind pairs "method"))
+                                (fsc-rec-string-list (fsc-bml-names-of-kind pairs "field"))
+                                (fsc-rec-string-list (fsc-bml-names-of-kind pairs "ref"))
+                                (fsc-rec-string-list (fsc-bml-names-of-kind pairs "thought")))))))))
 
     (defn fsc-form-bml-lines-recipes-loop (body i acc)
         (do

--- a/form/form-stdlib/tests/bml-class-fields-refs-thoughts-band.fk
+++ b/form/form-stdlib/tests/bml-class-fields-refs-thoughts-band.fk
@@ -1,0 +1,45 @@
+; bml-class-fields-refs-thoughts-band.fk — a generic class carries embedded
+; knowledge: fields (constants), refs (to other abstractions), and thoughts
+; (computed derived knowledge), all four-way.
+;
+; field NAME = V;   -> a nullary global (defn NAME () V), read NAME(): embedded
+;                      knowledge a method can use.
+; ref NAME = OTHER; -> a reference to another abstraction's cell.
+; thought NAME = E; -> a nullary global computing derived knowledge from fields.
+; def m(..) = ..;   -> a method (hoisted bare, as before).
+;
+; The class descriptor records each member under its kind, so the abstraction
+; DECLARES its structure: (Name) = (list "abstraction" Name (type-params)
+;   (methods) (fields) (refs) (thoughts)).
+;
+; Strangeness in one class: a method uses its own field AND a referenced
+; abstraction's field; a thought derives from a field; the descriptor counts
+; one of each kind. Computed inside the one section form so it reads identically
+; on every kernel.
+;
+; preludes: form-stdlib/core.fk
+
+section [form.bml] {
+    class Seed<T> {
+        field val = 41;
+    }
+
+    class Kit<E> {
+        ref seed = Seed();
+        field base = 100;
+        thought base1 = add(base(), 1);
+        def scaled(x) = add(mul(x, base()), val());
+    }
+
+    ; scaled(3) = 3*base() + val() = 300 + 41 = 341 (own field + ref'd field)
+    let a = scaled(3);
+    ; thought derived from the field: base() + 1 = 101
+    let b = base1();
+    ; the ref resolves to the Seed abstraction descriptor
+    let refok = if str_eq(nth(seed(), 1), "Seed") then 1 else 0;
+    ; Kit descriptor records one member of each kind -> counts sum to 4
+    let k = Kit();
+    let counts = add(len(nth(k, 3)), add(len(nth(k, 4)), add(len(nth(k, 5)), len(nth(k, 6)))));
+    ; 341 + 101*1000 + 1*1000000 + 4*10000000 = 41101341
+    add(a, add(mul(b, 1000), add(mul(refok, 1000000), mul(counts, 10000000))));
+}

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -248,6 +248,7 @@ field-model-form-runtime-intervene fks 1
 field-model-form-runtime-lift fks 1
 bml-route-source-object fks 2047
 bml-generic-class-stdlib fks 31112009
+bml-class-fields-refs-thoughts fks 41101341
 bml-protocol-capability-row fks 65535
 bml-choice-routing-metadata fks 4095
 bml-choice-receipt-row fks 131071


### PR DESCRIPTION
## What

Extends last breath's generic-class form (`class Name<T> { def m(..) }`) with three new member kinds, so a stdlib abstraction can carry **embedded knowledge**, not just callables — the direction toward `field-domain-grammars.form`'s rich template shape (carrier/fiber/recipe), now in the class surface that lowers to the four-way recipe floor.

```
field NAME = V;    embedded knowledge — a constant the abstraction declares
ref   NAME = X;    a reference to another abstraction's cell
thought NAME = E;  computable derived knowledge from the fields
```

Each lowers to a four-way nullary global `(defn NAME () <expr>)`, read as `NAME()`. The descriptor now records each member by kind:

```
(Name) = (list "abstraction" Name (type-params) (methods) (fields) (refs) (thoughts))
```

so the abstraction **declares its structure**. The 4→7 descriptor growth is backward-compatible (indices 0–3 unchanged).

## Proof

- **`bml-class-fields-refs-thoughts-band.fk`** (manifest `fks 41101341`) — one class packs a field used by a method, a `ref` to another abstraction whose field the method also reads, a `thought` derived from a field, and the kind-tagged descriptor. **Four-way.**
- **First real lift: `adler32.fk` → `Adler32<T>`.** The RFC 1950 magic numbers (`65521` modulus, `1`/`0` init, `255` mask, `16` shift) are no longer inline literals but **declared fields** — single-source, queryable via `(Adler32)`; the `65520` half-bound is a computed `thought`. The public `(adler32 bytes)` entry and every checksum are unchanged:
  - `adler32-band` stays **5 four-way**
  - `pack-manifest` (a real consumer that hashes with `adler32`) stays **1023 four-way**

## Honest notes

- Constants now read as nullary accessors (`modulus()` vs inline `65521`) — a per-call cost the JIT erases by inlining nullary constants; the tree-walker pays it, which is fine for the recipe floor.
- No regression to last breath: the generic-class band (`31112009`) and `core.fk`'s Num/List/Cell/Task descriptors hold.

This is the vision applied to a real feature — stdlib lifted into reusable templates with embedded knowledge — and the pattern the broader sweep (crc32, rope, arch-capacity, …) can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)