### PR TITLE
tend(web): one source of truth for Hati-OS downloads — kill the stale v0.1.0 summary link

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -45,7 +45,7 @@
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 247 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 58 | API models — Pydantic + ORM shapes |
 | [api/tests/INDEX.md](api/tests/INDEX.md) | 274 | API tests — flow-centric |
-| [web/lib/INDEX.md](web/lib/INDEX.md) | 35 | Web library — shared client/server helpers |
+| [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
 | [scripts/INDEX.md](scripts/INDEX.md) | 311 | Scripts — operational tools, generators, syncers |

--- a/docs/vision-kb/INDEX.md
+++ b/docs/vision-kb/INDEX.md
@@ -1,7 +1,7 @@
 # The Living Collective — Knowledge Base
 
 > AI-maintained markdown wiki. Read this file first. Drill into linked files for detail.
-> **Last maintained**: 2026-06-18 | **Concepts**: 191 | **Status**: 5 expanding, 128 seed, 55 deepening, 1 living, 2 gas | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
+> **Last maintained**: 2026-06-18 | **Concepts**: 192 | **Status**: 5 expanding, 129 seed, 55 deepening, 1 living, 2 gas | **Transmissions held**: 15 (12 integrated, 3 witnessed-without-absorption)
 
 ## How to use this KB
 

--- a/web/app/downloads/hati-os/[os]/[arch]/[name]/route.ts
+++ b/web/app/downloads/hati-os/[os]/[arch]/[name]/route.ts
@@ -1,18 +1,12 @@
+// Redirects /downloads/hati-os/<os>/<arch>/<name> to the matching asset in the
+// published GitHub release. Tag + allowlist come from the single source of
+// truth in web/lib/hati-os-release.ts so this route can never serve a stale
+// release tag or surface an asset the page does not know about.
 import { NextResponse, type NextRequest } from "next/server";
-
-const RELEASE_TAG = "hati-os-v0.2.0-20260614";
-const RELEASE_BASE = `https://github.com/seeker71/Coherence-Network/releases/download/${RELEASE_TAG}`;
-
-const ASSETS: Record<string, string> = {
-  "macos/arm64/hati-os-macos-arm64.tar.zst": "hati-os-macos-arm64.tar.zst",
-  "macos/arm64/hati-os-macos-arm64.tar.zst.sha256": "hati-os-macos-arm64.tar.zst.sha256",
-  "android/arm64/hati-os-android-arm64.tar.zst": "hati-os-android-arm64.tar.zst",
-  "android/arm64/hati-os-android-arm64.tar.zst.sha256": "hati-os-android-arm64.tar.zst.sha256",
-  "android/arm64/coherence-sense-hati-mesh-debug.apk": "coherence-sense-hati-mesh-debug.apk",
-  "android/arm64/coherence-sense-hati-mesh-debug.apk.sha256": "coherence-sense-hati-mesh-debug.apk.sha256",
-  "android/arm64/coherence-sense-hati-mesh-release.apk": "coherence-sense-hati-mesh-release.apk",
-  "android/arm64/coherence-sense-hati-mesh-release.apk.sha256": "coherence-sense-hati-mesh-release.apk.sha256",
-};
+import {
+  HATI_OS_PROXY_ASSETS,
+  HATI_OS_RELEASE_BASE,
+} from "@/lib/hati-os-release";
 
 type Params = {
   os: string;
@@ -26,7 +20,7 @@ export async function GET(
 ) {
   const resolved = await params;
   const key = `${resolved.os}/${resolved.arch}/${resolved.name}`;
-  const asset = ASSETS[key];
+  const asset = HATI_OS_PROXY_ASSETS[key];
   if (!asset) {
     return NextResponse.json(
       { error: "unknown Hati-OS asset", key },
@@ -34,5 +28,5 @@ export async function GET(
     );
   }
 
-  return NextResponse.redirect(`${RELEASE_BASE}/${asset}`, 307);
+  return NextResponse.redirect(`${HATI_OS_RELEASE_BASE}/${asset}`, 307);
 }

--- a/web/app/downloads/hati-os/hati-os-public-assets-summary.json/route.ts
+++ b/web/app/downloads/hati-os/hati-os-public-assets-summary.json/route.ts
@@ -1,11 +1,12 @@
+// Redirects to the release receipt JSON for the published Hati-OS assets.
+// Tag comes from web/lib/hati-os-release.ts so the summary always describes the
+// same release the download links serve.
 import { NextResponse, type NextRequest } from "next/server";
-
-const RELEASE_TAG = "hati-os-v0.1.0-20260613";
-const RELEASE_BASE = `https://github.com/seeker71/Coherence-Network/releases/download/${RELEASE_TAG}`;
+import { HATI_OS_RELEASE_BASE } from "@/lib/hati-os-release";
 
 export function GET(_request: NextRequest) {
   return NextResponse.redirect(
-    `${RELEASE_BASE}/hati-os-public-assets-summary.json`,
+    `${HATI_OS_RELEASE_BASE}/hati-os-public-assets-summary.json`,
     307,
   );
 }

--- a/web/app/hati-os/page.tsx
+++ b/web/app/hati-os/page.tsx
@@ -1,26 +1,16 @@
-const downloads = [
-  {
-    target: "macOS arm64",
-    artifact: "Native CLI tarball",
-    href: "/downloads/hati-os/macos/arm64/hati-os-macos-arm64.tar.zst",
-    checksum: "/downloads/hati-os/macos/arm64/hati-os-macos-arm64.tar.zst.sha256",
-    proof: "Form-emitted C compiled to Mach-O arm64 and executed locally for fib, sum, and ack parity.",
-  },
-  {
-    target: "Android arm64",
-    artifact: "Native kernel package",
-    href: "/downloads/hati-os/android/arm64/hati-os-android-arm64.tar.zst",
-    checksum: "/downloads/hati-os/android/arm64/hati-os-android-arm64.tar.zst.sha256",
-    proof: "Android ARM64 ELF executable and C-ABI shared library cross-compiled with local file and symbol proof.",
-  },
-  {
-    target: "Android app",
-    artifact: "Hati mesh sensing-organ release APK",
-    href: "/downloads/hati-os/android/arm64/coherence-sense-hati-mesh-release.apk",
-    checksum: "/downloads/hati-os/android/arm64/coherence-sense-hati-mesh-release.apk.sha256",
-    proof: "Release APK is signed with the Hati mesh app key, verified by apksigner, announces to hati.mesh, and checks signed update metadata.",
-  },
-];
+import {
+  HATI_OS_ASSETS,
+  HATI_OS_RELEASE_TAG,
+  hatiOsHref,
+} from "@/lib/hati-os-release";
+
+const downloads = HATI_OS_ASSETS.filter((a) => a.surfaced).map((a) => ({
+  target: a.target,
+  artifact: a.artifact,
+  href: hatiOsHref(a),
+  checksum: `${hatiOsHref(a)}.sha256`,
+  proof: a.proof,
+}));
 
 export default function HatiOsPage() {
   return (
@@ -36,6 +26,12 @@ export default function HatiOsPage() {
           <p className="max-w-3xl text-base leading-7 text-stone-700">
             Public native packages for the Form fourth-kernel surface. Each
             download has a checksum and release receipt beside it.
+          </p>
+          <p className="text-sm text-stone-500">
+            Release{" "}
+            <code className="rounded bg-stone-100 px-1.5 py-0.5 text-stone-700">
+              {HATI_OS_RELEASE_TAG}
+            </code>
           </p>
         </div>
 

--- a/web/lib/INDEX.md
+++ b/web/lib/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 35
+**Total files**: 36
 
 | File | Purpose |
 |---|---|
@@ -18,6 +18,7 @@
 | [egress.ts](egress.ts) | _no top-of-file purpose_ |
 | [entry-paths.ts](entry-paths.ts) | _no top-of-file purpose_ |
 | [fetch.ts](fetch.ts) | _no top-of-file purpose_ |
+| [hati-os-release.ts](hati-os-release.ts) | Single source of truth for the published Hati-OS native release. |
 | [home-presence-traces.ts](home-presence-traces.ts) | _no top-of-file purpose_ |
 | [html-entities.ts](html-entities.ts) | Many imported asset descriptions arrive carrying WordPress HTML |
 | [humanize.ts](humanize.ts) | _no top-of-file purpose_ |

--- a/web/lib/hati-os-release.ts
+++ b/web/lib/hati-os-release.ts
@@ -1,0 +1,79 @@
+// Single source of truth for the published Hati-OS native release.
+// The /hati-os page renders the surfaced rows; the download proxy route builds
+// its allowlist from the same list; the summary route redirects to the same
+// tag. One cell, three readers — they cannot drift to different releases.
+
+export const HATI_OS_RELEASE_TAG = "hati-os-v0.2.0-20260614";
+export const HATI_OS_RELEASE_BASE = `https://github.com/seeker71/Coherence-Network/releases/download/${HATI_OS_RELEASE_TAG}`;
+
+export type HatiOsAsset = {
+  /** Display name of the target, e.g. "macOS arm64". */
+  target: string;
+  /** Proxy-path OS segment, e.g. "macos". */
+  os: string;
+  /** Proxy-path arch segment, e.g. "arm64". */
+  arch: string;
+  /** Asset filename in the GitHub release. */
+  name: string;
+  /** Short artifact label shown on the page. */
+  artifact: string;
+  /** The proof lane behind the artifact, shown on the page. */
+  proof: string;
+  /** Whether the row is shown on the /hati-os page (debug builds stay downloadable but unsurfaced). */
+  surfaced: boolean;
+};
+
+export const HATI_OS_ASSETS: HatiOsAsset[] = [
+  {
+    target: "macOS arm64",
+    os: "macos",
+    arch: "arm64",
+    name: "hati-os-macos-arm64.tar.zst",
+    artifact: "Native CLI tarball",
+    proof: "Form-emitted C compiled to Mach-O arm64 and executed locally for fib, sum, and ack parity.",
+    surfaced: true,
+  },
+  {
+    target: "Android arm64",
+    os: "android",
+    arch: "arm64",
+    name: "hati-os-android-arm64.tar.zst",
+    artifact: "Native kernel package",
+    proof: "Android ARM64 ELF executable and C-ABI shared library cross-compiled with local file and symbol proof.",
+    surfaced: true,
+  },
+  {
+    target: "Android app",
+    os: "android",
+    arch: "arm64",
+    name: "coherence-sense-hati-mesh-release.apk",
+    artifact: "Hati mesh sensing-organ release APK",
+    proof: "Release APK is signed with the Hati mesh app key, verified by apksigner, announces to hati.mesh, and checks signed update metadata.",
+    surfaced: true,
+  },
+  {
+    target: "Android app (debug)",
+    os: "android",
+    arch: "arm64",
+    name: "coherence-sense-hati-mesh-debug.apk",
+    artifact: "Hati mesh sensing-organ debug APK",
+    proof: "Debug-key build for sideload testing; same mesh announce path as the release APK.",
+    surfaced: false,
+  },
+];
+
+/** Local proxy path for an asset, e.g. /downloads/hati-os/macos/arm64/<name>. */
+export function hatiOsHref(asset: HatiOsAsset): string {
+  return `/downloads/hati-os/${asset.os}/${asset.arch}/${asset.name}`;
+}
+
+/** Allowlist of proxy keys → release filenames, including each asset's .sha256. */
+export const HATI_OS_PROXY_ASSETS: Record<string, string> = Object.fromEntries(
+  HATI_OS_ASSETS.flatMap((a) => {
+    const key = `${a.os}/${a.arch}/${a.name}`;
+    return [
+      [key, a.name],
+      [`${key}.sha256`, `${a.name}.sha256`],
+    ];
+  }),
+);


### PR DESCRIPTION
## What

The `/hati-os` download surface kept "what's in the release" in **three hardcoded copies that had already drifted**:

- the download proxy route served release **v0.2.0**, while
- the "Release summary JSON" link still redirected to the older **v0.1.0** receipt, and
- the page's download list + the route's allowlist were separate hand-maintained copies.

This collapses all three onto **one cell** — [`web/lib/hati-os-release.ts`](web/lib/hati-os-release.ts) — holding the release tag, base URL, and asset list. The page renders the surfaced rows; the proxy route derives its allowlist (each asset + `.sha256`); the summary route redirects to the same tag. They can no longer point at different releases, and bumping a release is now a one-line change. The page also surfaces the release tag so a visitor sees which build they're getting.

## Why now

Asked why the homepage's download link still pointed at an unmaintained, drifting table. Root cause was three copies with no source of truth.

## Windows — named, not papered

There is **no Windows download** in this or any published release. `.github/workflows/windows-host.yml` proves the four-way Form floor + a standalone `form-cli.exe` on `windows-latest`, but it's a **proof lane with no upload step** — the binary is never packaged or published. That coverage gap is now explicit. Publishing a Windows artifact (add a package+upload step to the already-green Windows workflow) is a separate, outward-facing follow-up.

## Verify
- `tsc --noEmit` clean
- post-merge: `/hati-os` renders + shows release tag; `/downloads/hati-os/hati-os-public-assets-summary.json` now 307s to **v0.2.0** (was v0.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)