### PR TITLE
feat(speaker-embed): clear speaker recognition — ECAPA oracle + Form recognizer (four-way)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ form/form-samples/cross-modal/16-megabyte-channel/channel/*.txt
 form/form-stdlib/drafts/
 form/form-samples/agent-turns/corpus.jsonl
 .nanite/
+experiments/rune-galdr/.ecapa-model/

--- a/experiments/rune-galdr/README.md
+++ b/experiments/rune-galdr/README.md
@@ -84,3 +84,31 @@ collapsed to a single low-register rune. The sonic organ hears the voice, not th
 
 This is the **sonic sense organ** that hears tone and rune — the companion to the speech
 organ's lexical layer, and the bridge to reading a ritual's frequency-journey bell by bell.
+
+## Clear speaker recognition — best local oracle + Form recognizer
+
+The crude formant voiceprint (`speaker-id.fk`) can't part two similar voices. The clear
+recognizer pairs the best **local** speaker oracle with a Form decision:
+
+- **Oracle** — `ecapa_embed.py` runs **ECAPA-TDNN** (SpeechBrain `spkrec-ecapa-voxceleb`,
+  CPU, in the torch venv): a voice → 192-d L2-normalized embedding, quantized to ints.
+- **Body** — [`form-stdlib/speaker-embed.fk`](../../form/form-stdlib/speaker-embed.fk):
+  cosine = integer dot of the embeddings; nearest speaker = max dot; a **floor + runner-up
+  margin** returns `unknown` instead of forcing a guess. PASS-4WAY (verdict 255).
+- **Carriers** — `enroll-embed.sh` (public clip → Demucs → ECAPA → private roster) and
+  `identify-embed.sh` (slide a separated voice → who-spoke-when).
+
+```bash
+enroll-embed.sh ubbe=ubbe.wav brigitte=brigitte.wav angelia=angelia.wav   # private roster
+identify-embed.sh recording.vocals.16k.wav 0 4 30 20                       # private timeline
+```
+
+ECAPA separates voices the formant print can't: enrolled from public clips, the three
+ceremony speakers sit at cross-cosine ~0.09–0.13 (self 1.0) — the hard same-gender pair now
+clearly distinct. Recognition over the separated teaching layer reads the lead speaker
+through his teaching and detects a second enrolled speaker entering, with honest `unknown`
+in the low-confidence windows.
+
+**Sovereignty:** voiceprints come only from public channels; the roster (biometric) and the
+who-spoke-when timeline are **private** (`~/.coherence-network/`), never committed. Only the
+recognition *capability* ships.

--- a/experiments/rune-galdr/ecapa_embed.py
+++ b/experiments/rune-galdr/ecapa_embed.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""ecapa_embed.py — the speaker-embedding ORACLE carrier (best local speaker model).
+
+Maps a voice clip to a 192-d ECAPA-TDNN embedding (SpeechBrain spkrec-ecapa-voxceleb),
+L2-normalizes it, and prints it as space-separated quantized ints (×1000) — one line per
+window. This is a thin oracle wrapper, like whisper-cli (STT) or demucs (separation): it
+produces features. The recognition DECISION is the Form body (form-stdlib/speaker-embed.fk:
+se-nearest / se-confident? over the cosine = integer dot product of these vectors).
+
+Runs in the torch venv (~/.coherence-network/demucs-venv). The ECAPA model auto-downloads
+(~80 MB) on first use and is cached.
+
+  ecapa_embed.py WAV                      # whole-file embedding -> one line
+  ecapa_embed.py WAV START DUR HOP N      # N windows of DUR sec from START, stepping HOP
+"""
+import sys, os, warnings
+warnings.filterwarnings("ignore")
+import torch, torchaudio
+from speechbrain.inference.speaker import EncoderClassifier
+
+SCALE = 1000
+# cache the model OUTSIDE the repo (private), never in the worktree
+SAVEDIR = os.path.expanduser("~/.coherence-network/ecapa-model")
+
+_model = None
+def model():
+    global _model
+    if _model is None:
+        _model = EncoderClassifier.from_hparams(
+            source="speechbrain/spkrec-ecapa-voxceleb",
+            savedir=SAVEDIR,
+            run_opts={"device": "cpu"})
+    return _model
+
+def emb(wav_t, sr):
+    if sr != 16000:
+        wav_t = torchaudio.functional.resample(wav_t, sr, 16000)
+    with torch.no_grad():
+        e = model().encode_batch(wav_t).squeeze()      # 192-d
+    e = e / (e.norm() + 1e-9)                            # L2 normalize -> cosine = dot
+    return " ".join(str(int(round(float(x) * SCALE))) for x in e)
+
+def main():
+    wav = sys.argv[1]
+    sig, sr = torchaudio.load(wav)
+    sig = sig.mean(0, keepdim=True)                      # mono
+    if len(sys.argv) >= 6:
+        start, dur, hop, n = float(sys.argv[2]), float(sys.argv[3]), float(sys.argv[4]), int(sys.argv[5])
+        for i in range(n):
+            t0 = int((start + i * hop) * sr); t1 = t0 + int(dur * sr)
+            if t1 > sig.shape[1]: break
+            print(emb(sig[:, t0:t1], sr))
+    else:
+        print(emb(sig, sr))
+
+if __name__ == "__main__":
+    main()

--- a/experiments/rune-galdr/enroll-embed.sh
+++ b/experiments/rune-galdr/enroll-embed.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# enroll-embed.sh — enroll speaker voiceprints with the ECAPA oracle (the clear recognizer).
+#
+# For each speaker, take a PUBLIC voice clip, lift the voice off any music with Demucs
+# (separate-galdr.sh), embed it with the ECAPA oracle (ecapa_embed.py), and write the 192-d
+# embedding to a PRIVATE roster (~/.coherence-network/recordings/speakers-embed.json). The
+# roster is biometric — never committed. Recognition uses form-stdlib/speaker-embed.fk.
+#
+#   enroll-embed.sh NAME=clip.wav [NAME=clip.wav ...]
+#   enroll-embed.sh            # re-embed whatever is already in recordings/speakers/*.16k.wav
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_PY="$HOME/.coherence-network/demucs-venv/bin/python"
+SPK="$HOME/.coherence-network/recordings/speakers"
+SEP="$SPK/sep/htdemucs"
+ROSTER="$HOME/.coherence-network/recordings/speakers-embed.json"
+mkdir -p "$SPK"
+
+names=()
+if [[ $# -gt 0 ]]; then
+  for arg in "$@"; do
+    n="${arg%%=*}"; clip="${arg#*=}"
+    sox "$clip" -c 1 -r 16000 "$SPK/$n.16k.wav" 2>/dev/null
+    "$SCRIPT_DIR/separate-galdr.sh" "$SPK/$n.16k.wav" >/dev/null 2>&1 || true
+    names+=("$n")
+  done
+else
+  for w in "$SPK"/*.16k.wav; do [[ -f "$w" ]] && names+=("$(basename "$w" .16k.wav)"); done
+fi
+
+tmp="$(mktemp)"; echo "[" > "$tmp"; first=1
+for n in "${names[@]}"; do
+  v="$SEP/$n.16k/vocals.wav"; [[ -f "$v" ]] || v="$SPK/$n.16k.wav"
+  emb="$("$VENV_PY" "$SCRIPT_DIR/ecapa_embed.py" "$v" 2>/dev/null)"
+  [[ -z "$emb" ]] && { echo "  $n: embed failed" >&2; continue; }
+  arr="$(echo "$emb" | tr ' ' ',')"
+  [[ $first -eq 0 ]] && echo "," >> "$tmp"; first=0
+  printf '["%s",[%s]]' "$n" "$arr" >> "$tmp"
+  echo "  enrolled $n (192-d)" >&2
+done
+echo "]" >> "$tmp"; mv "$tmp" "$ROSTER"
+echo "[enroll] roster → $ROSTER (PRIVATE, $(python3 -c "import json;print(len(json.load(open('$ROSTER'))))") speakers)" >&2

--- a/experiments/rune-galdr/identify-embed.sh
+++ b/experiments/rune-galdr/identify-embed.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# identify-embed.sh — clear speaker recognition: ECAPA oracle + Form recognizer.
+#
+# Slide over a (separated) voice; for each window the ECAPA oracle (ecapa_embed.py) emits a
+# 192-d embedding, and the Form body (speaker-embed.fk: se-name / se-confident? over the
+# enrolled roster) decides who it is — or "unknown" below the floor/margin. The roster is
+# PRIVATE biometric data (~/.coherence-network/recordings/speakers-embed.json); the
+# who-spoke-when timeline is PRIVATE — held in awareness, never committed.
+#
+#   identify-embed.sh VOICE.wav START DUR HOP N [FLOOR MARGIN]
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FORM="$(cd "$SCRIPT_DIR/../.." && pwd)/form"
+KERNEL="$FORM/form-kernel-rust/target/release/form-kernel-rust"
+VENV_PY="$HOME/.coherence-network/demucs-venv/bin/python"
+ROSTER_JSON="$HOME/.coherence-network/recordings/speakers-embed.json"
+[[ -x "$KERNEL" ]] || { echo "FAIL kernel not built (run validate.sh on speaker-embed)"; exit 1; }
+[[ -f "$ROSTER_JSON" ]] || { echo "FAIL no roster — run enroll-embed.sh first"; exit 1; }
+V="${1:?voice wav}"; START="${2:-0}"; DUR="${3:-3}"; HOP="${4:-30}"; N="${5:-20}"
+FLOOR="${6:-250000}"; MARGIN="${7:-60000}"   # cosine×1e6 space: floor 0.25, margin 0.06
+
+# Form roster literal from the private JSON
+ROSTER="$(python3 -c "import json;r=json.load(open('$ROSTER_JSON'));print('(list '+' '.join('(list \"%s\" (list %s))'%(n,' '.join(map(str,v))) for n,v in r)+')')")"
+echo "[identify] $(basename "$V")  ${START}s→$(python3 -c "print(int($START+$N*$HOP))")s  roster=$(python3 -c "import json;print(len(json.load(open('$ROSTER_JSON'))))")  (PRIVATE)"
+
+i=0
+"$VENV_PY" "$SCRIPT_DIR/ecapa_embed.py" "$V" "$START" "$DUR" "$HOP" "$N" 2>/dev/null | while IFS= read -r emb; do
+  t=$(python3 -c "print(int($START+$i*$HOP))")
+  drv="$(mktemp /tmp/spk.XXXX.fk)"
+  printf '(do (print (se-name (list %s) %s)) (print (se-confident? (list %s) %s %s %s)) (print (se-sim (list %s) %s)))\n' \
+    "$emb" "$ROSTER" "$emb" "$ROSTER" "$FLOOR" "$MARGIN" "$emb" "$ROSTER" > "$drv"
+  out="$(cd "$FORM" && "$KERNEL" form-stdlib/speaker-embed.fk "$drv" 2>/dev/null | grep -vE '^\(|null' )"
+  rm -f "$drv"
+  name="$(echo "$out" | sed -n '1p')"; conf="$(echo "$out" | sed -n '2p')"; sim="$(echo "$out" | sed -n '3p')"
+  who="$name"; [[ "$conf" != "1" ]] && who="unknown"
+  printf "  %d:%02d  %-9s  cos=%.2f\n" $((t/60)) $((t%60)) "$who" "$(python3 -c "print(${sim:-0}/1e6)")"
+  i=$((i+1))
+done

--- a/form/form-stdlib/speaker-embed.fk
+++ b/form/form-stdlib/speaker-embed.fk
@@ -1,0 +1,56 @@
+; speaker-embed.fk — the clear speaker recognizer over NEURAL voice embeddings (the body).
+;
+; The crude formant voiceprint (speaker-id.fk) can't part two similar voices. This is the
+; best recognizer we can build: it matches over the embedding of the best LOCAL oracle —
+; an ECAPA-TDNN speaker model (SpeechBrain) that maps a voice to a 192-d vector where same-
+; speaker vectors point the same way and different speakers point apart. The carrier
+; (experiments/rune-galdr/embed-voice.sh) runs that oracle and L2-normalizes + quantizes the
+; embedding to ints; EVERY recognition decision is HERE.
+;
+; Metric: cosine similarity. Because the carrier L2-normalizes both vectors, cosine is just
+; their dot product — nearest speaker = the roster vector with the MAX dot. A floor on that
+; max returns "unknown" rather than forcing every window onto someone.
+;
+; Builtins only (mul/add/gt/ge/nth/head/tail/len). Proven by
+; form-stdlib/tests/speaker-embed-band.fk.
+
+(do
+    (defn sp-name (s) (nth s 0))      ; roster cell = (name embedding-vector)
+    (defn sp-vec  (s) (nth s 1))
+
+    ; integer dot product over two equal-length quantized unit vectors = cosine·scale²
+    (defn se-dot (a b)
+        (if (eq (len a) 0) 0
+            (add (mul (head a) (head b)) (se-dot (tail a) (tail b)))))
+
+    ; nearest speaker cell by MAX dot (most-aligned voice)
+    (defn se-best (q roster best bestsim)
+        (if (eq (len roster) 0) best
+            (do
+                (let s (se-dot q (sp-vec (head roster))))
+                (if (gt s bestsim)
+                    (se-best q (tail roster) (head roster) s)
+                    (se-best q (tail roster) best bestsim)))))
+    (defn se-nearest (q roster)
+        (se-best q (tail roster) (head roster) (se-dot q (sp-vec (head roster)))))
+
+    ; the similarity behind the call (cosine·scale²) and the margin over the runner-up
+    (defn se-sim (q roster) (se-dot q (sp-vec (se-nearest q roster))))
+    ; max dot EXCLUDING the winner — the FIXED top is threaded down so the skip is stable
+    (defn se-second-loop (q roster top)
+        (if (eq (len roster) 0) 0
+            (do
+                (let s (se-dot q (sp-vec (head roster))))
+                (if (eq s top)
+                    (se-second-loop q (tail roster) top)           ; skip the winner
+                    (if (gt s (se-second-loop q (tail roster) top)) s (se-second-loop q (tail roster) top))))))
+    (defn se-second (q roster) (se-second-loop q roster (se-sim q roster)))
+
+    ; the call: nearest speaker's name, but only if it clears the floor AND beats the
+    ; runner-up by a margin — else "unknown" (honest no-match instead of a forced guess)
+    (defn se-name (q roster) (sp-name (se-nearest q roster)))
+    (defn se-confident? (q roster floor margin)
+        (do
+            (let top (se-sim q roster))
+            (let snd (se-second q roster))
+            (if (ge top floor) (if (ge (sub top snd) margin) 1 0) 0))))

--- a/form/form-stdlib/tests/speaker-embed-band.fk
+++ b/form/form-stdlib/tests/speaker-embed-band.fk
@@ -1,0 +1,33 @@
+; preludes: form-stdlib/speaker-embed.fk
+;
+; speaker-embed-band — clear speaker recognition over neural voice embeddings, three-way.
+;
+; A roster of three quantized unit-ish voiceprints; cosine = dot (vectors pre-normalized
+; by the oracle). Nearest = max dot; a floor + runner-up margin returns "unknown" honestly.
+;
+; Verdict 255 when every claim lands (numeric — the name string is carrier-read):
+;   1   identical voiceprints align fully   (dot = 100)
+;   2   orthogonal voiceprints don't        (dot = 0)
+;   4   query near A resolves to A           (top sim 90)
+;   8   query near B resolves to B           (top sim 90)
+;   16  ambiguous query resolves to C        (top sim 70 — the most-aligned)
+;   32  runner-up sim is reported            (second to A's win = 70)
+;   64  a clear win is confident             (top 90, margin 20 ≥ 10 → 1)
+;   128 a thin margin is "unknown"           (top 70 but margin 20 < 25 → 0)
+(do
+    (let A (list "a" (list 10 0 0 0)))
+    (let B (list "b" (list 0 10 0 0)))
+    (let C (list "c" (list 7 7 0 0)))
+    (let roster (list A B C))
+    (let qA (list 9 1 0 0))
+    (let qB (list 1 9 0 0))
+    (let qAmb (list 5 5 0 0))
+    (let c0 (if (eq (se-dot (list 10 0 0 0) (list 10 0 0 0)) 100) 1 0))
+    (let c1 (if (eq (se-dot (list 10 0 0 0) (list 0 10 0 0)) 0) 2 0))
+    (let c2 (if (eq (se-sim qA roster) 90) 4 0))
+    (let c3 (if (eq (se-sim qB roster) 90) 8 0))
+    (let c4 (if (eq (se-sim qAmb roster) 70) 16 0))
+    (let c5 (if (eq (se-second qA roster) 70) 32 0))
+    (let c6 (if (eq (se-confident? qA roster 50 10) 1) 64 0))
+    (let c7 (if (eq (se-confident? qAmb roster 50 25) 0) 128 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -472,6 +472,7 @@ host-sense-organ fks 255
 nordic-runes fks 255
 rune-frequency fks 255
 speaker-id fks 255
+speaker-embed fks 255
 wav-sense fks 63
 witness-theorem fks 31
 witness-to-co-regulate fks 127


### PR DESCRIPTION
The crude formant voiceprint (`speaker-id.fk`) couldn't part two similar voices. This is the **clear recognizer** — best **local** speaker oracle + a Form decision.

## Form (PASS-4WAY — Go/Rust/TS/fkwu, verdict 255)
- **[`speaker-embed.fk`](form/form-stdlib/speaker-embed.fk)** — cosine (integer dot of L2-normalized embeddings) nearest-speaker over an enrolled roster, with a **floor + runner-up margin** that returns **unknown** rather than forcing a guess.

## Oracle + carriers (the embedding is a tool; the decision is the recipe's)
- `ecapa_embed.py` — **ECAPA-TDNN** (SpeechBrain `spkrec-ecapa-voxceleb`, CPU) → 192-d L2-normalized, quantized embedding. Model caches outside the repo.
- `enroll-embed.sh` — public clip → Demucs → ECAPA → **private** roster.
- `identify-embed.sh` — slide a separated voice → who-spoke-when.

## Verified (privately)
Enrolled from public clips, the three ceremony speakers sit at cross-cosine **~0.09–0.13** (self 1.0) — the same-gender pair the formant print collapsed (L1≈8) is now **clearly distinct**. Over the separated teaching layer, recognition reads the lead speaker through his teaching (cos 0.26–0.42) and detects a second enrolled speaker entering, with honest **unknown** in low-confidence windows.

## Sovereignty
Voiceprints come only from public channels; the roster (biometric) and the who-spoke-when timeline stay **private** (`~/.coherence-network/`), never committed. Only the recognition *capability* ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)