### PR TITLE
feat(hati-os): publish the proven Windows form-cli as a public download

### DIFF
--- a/.github/workflows/windows-host.yml
+++ b/.github/workflows/windows-host.yml
@@ -9,9 +9,20 @@ on:
   pull_request:
     branches: [main, master]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Build + upload the native Windows form-cli asset to a release"
+        type: boolean
+        default: false
+      release_tag:
+        description: "Release tag to upload the Windows asset to"
+        required: false
+        default: "hati-os-v0.2.0-20260614"
 
+# Write is only exercised by the publish steps below, which are gated on a
+# manual workflow_dispatch with publish=true. PR runs stay read-only proof.
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   windows-floor:
@@ -74,3 +85,47 @@ jobs:
           Push-Location form\form-kernel-go
           go test . -run 'TestWindows(RecipeDLL|BootstrapHost)' -count=1
           Pop-Location
+
+      # ---- Publish (manual dispatch only) -------------------------------------
+      # Reached only after every proof step above passed, so the uploaded binary
+      # is the exact form-cli.exe that just crossed the four-way Windows floor.
+      - name: Build the standalone Windows form-cli (kept)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+        shell: bash
+        run: |
+          cd form
+          ./build-form-cli.sh .cache/form-cli-win.exe
+          test -s .cache/form-cli-win.exe || { echo "::error::form-cli-win.exe not produced"; exit 1; }
+          # Prove the kept binary still answers with no toolchain on PATH.
+          printf 'ping\n' | ./.cache/form-cli-win.exe | grep -qx pong \
+            || { echo "::error::built form-cli.exe did not pong"; exit 1; }
+
+      - name: Package + checksum the Windows asset
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+        shell: pwsh
+        run: |
+          $cache = "form/.cache"
+          Copy-Item -LiteralPath "$cache/form-cli-win.exe" -Destination "$cache/form-cli.exe" -Force
+          $zip = "$cache/hati-os-windows-amd64.zip"
+          if (Test-Path $zip) { Remove-Item $zip -Force }
+          Compress-Archive -Path "$cache/form-cli.exe" -DestinationPath $zip -Force
+          $h = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip).Hash.ToLower()
+          # Match the shasum -a 256 two-space format the other assets use.
+          [System.IO.File]::WriteAllText("$zip.sha256", "$h  hati-os-windows-amd64.zip`n")
+          Get-Content "$zip.sha256"
+
+      - name: Upload the Windows asset to the release
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ inputs.release_tag }}"
+          echo "Uploading hati-os-windows-amd64.zip(+.sha256) to release $tag"
+          gh release upload "$tag" \
+            form/.cache/hati-os-windows-amd64.zip \
+            form/.cache/hati-os-windows-amd64.zip.sha256 \
+            --clobber --repo "$GITHUB_REPOSITORY"
+          echo "Published:"
+          gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets \
+            --jq '.assets[].name' | grep windows

--- a/scripts/build_hati_os_public_assets.sh
+++ b/scripts/build_hati_os_public_assets.sh
@@ -252,10 +252,14 @@ assets.append({
     "proof": "Android app release APK built by Gradle with a local non-committed signing key and verified by apksigner.",
     "note": "First migration from a debug-signed install requires uninstall/reinstall because Android rejects updates signed by a different key.",
 })
+import os
 data = {
     "stamp": stamp,
     "builder": "scripts/build_hati_os_public_assets.sh",
-    "release_tag": "hati-os-v0.1.0-20260613",
+    # The tag this manifest ships under. Set HATI_OS_RELEASE_TAG when cutting a
+    # release so the summary names the release it actually lands in (the old
+    # hardcoded literal is why v0.2.0 shipped a manifest that still said v0.1.0).
+    "release_tag": os.environ.get("HATI_OS_RELEASE_TAG", "hati-os-v0.2.0-20260614"),
     "assets": assets,
 }
 pathlib.Path(summary_path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")


### PR DESCRIPTION
## What

Windows had **no download**. [`windows-host.yml`](.github/workflows/windows-host.yml) proved the `form-cli.exe` floor on `windows-latest` (four-way agreement + standalone runtime) but never shipped the binary.

This adds a **manual publish path**: on `workflow_dispatch` with `publish=true`, *after every proof step passes*, it builds the standalone `form-cli.exe` (kept + re-checked for `pong`), packages `hati-os-windows-amd64.zip` + `.sha256`, and uploads to the release tag. The uploaded binary is the exact one that just crossed the four-way Windows floor — **proof and artifact are one**, no Mac cross-compile of an unproven binary.

Also fixes the builder literal that made v0.2.0 ship a manifest still naming **v0.1.0**: `release_tag` now reads `HATI_OS_RELEASE_TAG` (current tag as default).

## Safety

- Publish steps are gated `if: github.event_name == 'workflow_dispatch' && inputs.publish`. PR/push runs skip them and stay read-only proof.
- `contents: write` is only exercised by the gated publish step.
- Merging lands the *capability*; nothing is published until I explicitly dispatch with `publish=true`.

## Next (after merge)
1. Dispatch with `publish=true` → publishes the proven Windows asset to `hati-os-v0.2.0-20260614`.
2. Add the Windows row to the `/hati-os` page (separate PR, after the asset is verified live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)