### PR TITLE
feat(form): import declarations + compile-time unresolved-ref errors

### DIFF
--- a/form/form-stdlib/source-compiler.fk
+++ b/form/form-stdlib/source-compiler.fk
@@ -1263,6 +1263,10 @@
         (do
             (let value (fsc-strip-semi line))
             (if (fsc-bml-comment-line? value) (empty)
+            ;; `import NAME;` is a declaration consumed by the ref resolver, not
+            ;; runtime code — it adds NAME to the section's known-abstraction set
+            ;; and lowers to nothing.
+            (if (fsc-prefix? value "import ") (empty)
             (if (fsc-prefix? value "template ")
                 (list (fsc-compile-form-bml-template-recipe value))
             (if (fsc-prefix? value "class ")
@@ -1271,7 +1275,7 @@
                 (list (fsc-compile-form-bml-def-recipe value))
             (if (fsc-prefix? value "let ")
                 (list (fsc-compile-form-bml-let-recipe value))
-                (list (fsc-compile-form-bml-expr-recipe value)))))))))
+                (list (fsc-compile-form-bml-expr-recipe value))))))))))
 
     ;; --- plain generic stdlib class ----------------------------------
     ;;
@@ -1489,8 +1493,76 @@
                             (fsc-line-next body p)
                             (fsc-rec-append-rev line-recipes acc))))))))))
 
+    ;; --- import + ref resolution (compile-time) ----------------------
+    ;;
+    ;; A `ref NAME = TARGET;` member names another abstraction. TARGET must
+    ;; resolve to a class defined in THIS section or a declared `import NAME;`.
+    ;; An unresolved ref is a COMPILE error here — a clear diagnostic at the
+    ;; ref site — not an `unbound identifier` crash when the recipe is later
+    ;; walked. Scope is deliberately narrow: only ref TARGETS (which name
+    ;; abstractions) are gated. Method-body names still resolve at runtime
+    ;; against the prelude, so existing sections are unaffected. (Whether an
+    ;; imported name actually exists in some prelude is the cross-prelude
+    ;; resolver's job — the next step; the import here is the honest
+    ;; declaration that satisfies the ref.)
+
+    ;; leading identifier of an expression: "Seed()" -> "Seed", "Foo" -> "Foo"
+    (defn fsc-bml-leading-name (s)
+        (do
+            (let t (fsc-trim s))
+            (fsc-sub t 0 (fsc-bml-word-end t 0))))
+
+    (defn fsc-bml-member? (xs name)
+        (if (fsc-empty? xs) 0
+            (if (str_eq (head xs) name) 1
+                (fsc-bml-member? (tail xs) name))))
+
+    ;; referenced targets that resolve to no known abstraction
+    (defn fsc-bml-unresolved-refs (known targets)
+        (if (fsc-empty? targets) (empty)
+            (if (eq (fsc-bml-member? known (head targets)) 1)
+                (fsc-bml-unresolved-refs known (tail targets))
+                (cons (head targets) (fsc-bml-unresolved-refs known (tail targets))))))
+
+    ;; one line-scan, dispatched by prefix, collecting whichever names the
+    ;; caller asked for: "class " names, "import " names, or "ref " targets.
+    (defn fsc-bml-section-names-loop (body i prefix kind acc)
+        (do
+            (let p (fsc-skip-spaces body i))
+            (if (ge p (str_len body)) (fsc-rev acc)
+                (do
+                    (let e (fsc-line-end body p))
+                    (let line (fsc-trim (fsc-sub body p e)))
+                    (if (fsc-prefix? line prefix)
+                        (fsc-bml-section-names-loop body (fsc-line-next body p) prefix kind
+                            (cons
+                                (if (str_eq kind "ref")
+                                    (do
+                                        (let eq-pos (fsc-find-char-from line "=" (str_len prefix)))
+                                        (fsc-bml-leading-name
+                                            (fsc-sub line (add eq-pos 1) (str_len line))))
+                                    (fsc-bml-leading-name
+                                        (fsc-sub line (str_len prefix) (str_len line))))
+                                acc))
+                        (fsc-bml-section-names-loop body (fsc-line-next body p) prefix kind acc))))))
+
+    (defn fsc-bml-check-section-refs (body)
+        (do
+            (let classes (fsc-bml-section-names-loop body 0 "class " "name" (empty)))
+            (let imports (fsc-bml-section-names-loop body 0 "import " "name" (empty)))
+            (let known (fsc-list-append classes imports))
+            (let targets (fsc-bml-section-names-loop body 0 "ref " "ref" (empty)))
+            (let unresolved (fsc-bml-unresolved-refs known targets))
+            (if (fsc-empty? unresolved) 0
+                (fsc-compiler-error
+                    (str_concat "unresolved ref target: "
+                        (str_concat (head unresolved)
+                            " — define it as a class in this section or declare `import <name>;`"))))))
+
     (defn fsc-compile-form-bml-section-recipe (body)
-        (fsc-rec-do (fsc-form-bml-lines-recipes-loop body 0 (empty))))
+        (do
+            (fsc-bml-check-section-refs body)
+            (fsc-rec-do (fsc-form-bml-lines-recipes-loop body 0 (empty)))))
 
     (defn fsc-compile-form-route-section-recipe (body)
         (fsc-compile-form-bml-section-recipe body))

--- a/form/form-stdlib/tests/bml-import-ref-resolution-band.fk
+++ b/form/form-stdlib/tests/bml-import-ref-resolution-band.fk
@@ -1,0 +1,44 @@
+; bml-import-ref-resolution-band.fk — a `ref` target resolves at COMPILE time
+; against the section's classes and its declared imports; the resolved refs are
+; usable abstractions at runtime, four-way.
+;
+; import NAME;        declares an external abstraction available to refs
+; ref X = Target();   must resolve to a same-section class OR a declared import,
+;                     else the source-compiler errors at the ref site (proven
+;                     separately by a direct compile that fails).
+;
+; Widget refs Num (allowed because `import Num;` is declared) and Seed (a
+; same-section class). The feature this band proves is COMPILE-TIME resolution:
+; both refs compile (an undeclared one is a compile error — proven separately),
+; and the descriptor records both. The same-section ref is also read back at
+; runtime as the Seed abstraction. (The imported target's runtime VALUE is NOT
+; asserted: whether `Num` actually exists on every runtime — e.g. the fourth
+; arm's shim — is the cross-prelude resolver's job, the next step; `import`
+; here is the honest declaration that satisfies the ref at compile time.)
+; Computed inside the one section form so it reads identically on every kernel.
+;
+; preludes: form-stdlib/core.fk
+
+section [form.bml] {
+    import Num;
+
+    class Seed<T> {
+        field val = 41;
+    }
+
+    class Widget<E> {
+        ref base = Num();
+        ref seed = Seed();
+        field k = 7;
+    }
+
+    ; the descriptor records both refs in declaration order (index 5 = refs)
+    let refs = nth(Widget(), 5);
+    let nrefs = len(refs);
+    let r0 = if str_eq(nth(refs, 0), "base") then 1 else 0;
+    let r1 = if str_eq(nth(refs, 1), "seed") then 1 else 0;
+    ; the same-section ref is usable at runtime as the Seed abstraction
+    let ns = if str_eq(nth(seed(), 1), "Seed") then 1 else 0;
+    ; 1 + 1*10 + 1*100 + 2*1000 = 2111
+    add(ns, add(mul(r0, 10), add(mul(r1, 100), mul(nrefs, 1000))));
+}

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -250,6 +250,7 @@ field-model-form-runtime-lift fks 1
 bml-route-source-object fks 2047
 bml-generic-class-stdlib fks 31112009
 bml-class-fields-refs-thoughts fks 41101341
+bml-import-ref-resolution fks 2111
 bml-protocol-capability-row fks 65535
 bml-choice-routing-metadata fks 4095
 bml-choice-receipt-row fks 131071


### PR DESCRIPTION
## What

Wires the **third walk** (resolution) into the live compile pipeline for `ref` targets, and adds `import` declarations to feed it.

Last breath's `ref NAME = X;` recorded a reference but never *resolved* it — an unresolved target lowered silently and crashed at **runtime** with `unbound identifier`. Now the form.bml section compiler resolves every `ref` target at **compile time** against (classes defined in this section) ∪ (declared `import`s), and fails at the ref site:

```
source-compile: unresolved ref target: Nonexistent — define it as a class in this section or declare `import <name>;`
```

`import NAME;` is a new section declaration — adds NAME to the known-abstraction set, lowers to nothing.

## Grounded in what the body already holds

The body already described resolution (`docs/coherence-substrate/name-resolution-as-recipe.form`, bootstrap `form_check.py`, surface `coh substrate check`) and an import/package data floor (`bml-native-interface-package-import.fk`, `pack-manifest.fk`). This is the first piece of that resolution-walk wired into `form-source-compile-file` itself, instead of a separate manual command.

## Why it's safe (narrow + backward-compatible)

Only ref **targets** (which name abstractions) are gated — method-body names still resolve at runtime against the prelude, so no existing section changes behavior:
- the one prior ref in the tree (same-section `Seed`) still resolves
- ref-free sections untouched: `core.fk` (0), `adler32` (5), `pack-manifest` (1023), generic-class band (31112009) — all still four-way.

## Proof

- **`bml-import-ref-resolution-band.fk`** (manifest `fks 2111`, **four-way**) — an imported ref (`import Num; ref base = Num();`) and a same-section ref (`ref seed = Seed();`) both compile and are recorded in the descriptor; the same-section ref is usable at runtime as the `Seed` abstraction.
- **Error path** proven by a direct compile of `ref base = Nonexistent();` → aborts with the diagnostic above, no output written (traced to `fsc-compiler-error ← fsc-compile-form-bml-section-recipe`).

## Honest floor / next steps

- The `import` is a compile-time **declaration** that satisfies the ref; whether the imported name actually **exists at runtime on every arm** is the cross-prelude resolver's job (the next step). Concretely: core's `Num` descriptor isn't yet on the fourth-arm shim, so the band tests compile-time resolution + recording, not the imported target's runtime value.
- Still ahead: method-body name checking (needs the cross-prelude symbol table), and lowering `import` → `bml-native-import` rows so the package substrate (`pack-manifest`) sees declared dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)