### PR TITLE
feat(corpus): tap Claude Code transcripts for the weak tool-prediction lanes (~2.85x corpus)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 312 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 313 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_20260621_claude_corpus.json
+++ b/docs/system_audit/commit_evidence_20260621_claude_corpus.json
@@ -1,0 +1,96 @@
+{
+  "date": "2026-06-21",
+  "thread_branch": "claude/claude-corpus",
+  "commit_scope": "Find more training samples for the low-performing tool-prediction lanes the sovereignty attention signal named (Read/Edit/Write). Adds scripts/claude_corpus.py — a thin carrier that taps Claude Code session transcripts into (task -> tools-used) corpus turns, the untapped sibling source to codex_corpus.py. Claude Code sessions are Read/Edit/Write-heavy, so the tap over-samples exactly the weak lanes: it nearly triples the corpus (949 -> 2704) and adds Read +1242, Edit +769, Write +546.",
+  "files_owned": [
+    "scripts/claude_corpus.py",
+    "scripts/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_20260621_claude_corpus.json"
+  ],
+  "idea_ids": [
+    "claude-transcript-corpus-tap",
+    "grow-weak-tool-prediction-lanes"
+  ],
+  "spec_ids": [
+    "sovereignty-receipt"
+  ],
+  "task_ids": [
+    "task-2026-06-21-claude-corpus"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance-criteria"
+      ]
+    },
+    {
+      "contributor_id": "claude-sema",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "claude-code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "Grounding: the tool-use corpus (~/.coherence-network/form-cli-corpus/corpus.jsonl) is read by agent_tooluse_featurize.py (task text -> keyword features; steps[].tool -> labels) and was fed only from Codex sessions (codex_corpus.py). Claude Code transcripts (~/.claude/projects/**/*.jsonl) were untapped, yet carry hundreds of real Read/Edit/Write tool calls per session.",
+    "Schema matched from a real corpus line: keys task / oracle / steps[{tool}] / outcome / task_sig; the featurizer needs only task + steps[].tool.",
+    "Result: baseline 949 (codex) -> tap added 1755 new turns -> 2704 total (~2.85x). New-turn lane weighting: Bash 1703, Read 1242, Edit 769, Write 546 — the weak lanes (Read/Edit/Write) grew most.",
+    "Idempotent (after a fix): the first version computed the dedup key from the full task but stored it truncated to 1500 chars, so long (CLAUDE.md-injected) tasks re-added on re-run; fixed by truncating before keying. Verified: restore-to-baseline 949 -> tap 2704 -> RE-RUN adds 0 new turns.",
+    "Privacy: stores only task text (truncated) + tool names, never reasoning or answers; appends to a LOCAL file (~/.coherence-network/, not git); restricted to Coherence-Network sessions.",
+    "Carrier discipline: claude_corpus.py is a thin host-IO data-prep carrier, the exact sibling of codex_corpus.py (also Python). No new decision-logic; the featurize/label logic and the model (a Form FFN step) already exist.",
+    "Edges: scripts/INDEX.md + MANIFEST.md regenerated (--check clean).",
+    "Next (named, not in this change): retrain the tool-use predictor on the grown corpus (agent_tooluse_train.sh, M4 Max GPU) and re-measure the per-lane held-out scores to confirm the lift on Read/Edit/Write."
+  ],
+  "change_files": [
+    "scripts/claude_corpus.py",
+    "scripts/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_20260621_claude_corpus.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 scripts/claude_corpus.py --dry-run  (1797 candidate turns across 989 sessions)",
+      "restore baseline 949 -> python3 scripts/claude_corpus.py  (1755 new -> 2704) -> re-run (0 new, idempotent)",
+      "python3 scripts/agent_tooluse_featurize.py /tmp/tu.dat  (corpus featurizes; Read/Edit/Write base-rates rise)",
+      "python3 scripts/generate_repo_indexes.py --check"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "A data-prep carrier script; no kernel proof bands apply. INDEX --check clean."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed-agent-tooling",
+    "notes": "The corpus is a local training file (not git); the script reaches contributors through the repo. The retrain that turns these samples into a measured held-out lift is the named next step."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed (corpus grew, tap idempotent, INDEX clean); CI and merge remain pending; the predictor retrain to measure the lift is the next step."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Running scripts/claude_corpus.py grows the tool-use corpus from Claude Code transcripts, over-sampling the weak Read/Edit/Write lanes (~2.85x corpus growth), so the next predictor retrain has far more signal on exactly the lanes the attention report flagged.",
+    "public_endpoints": [
+      "none changed; the tap reads local transcripts and writes a local corpus file"
+    ],
+    "test_flows": [
+      "Dry-run reports candidate turns + lane distribution; real run grows the corpus and is idempotent on re-run.",
+      "The featurizer reads the grown corpus and shows raised Read/Edit/Write representation."
+    ]
+  }
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 312
+**Total files**: 313
 
 | File | Purpose |
 |---|---|
@@ -51,6 +51,7 @@
 | [check_spec_references.py](check_spec_references.py) | spec: full-code-traceability |
 | [check_traceability.py](check_traceability.py) | CI gate: check that new/modified specs have idea_id and code files have spec refs. |
 | [check_web_docker_context.py](check_web_docker_context.py) | Catch web/ imports reaching above the Docker build context. |
+| [claude_corpus.py](claude_corpus.py) | claude_corpus.py — CARRIER (data prep only). Taps Claude Code session transcripts |
 | [clear_queue_and_start_flow.sh](clear_queue_and_start_flow.sh) | Clear agent task queue and reset PM so the next pipeline run starts in the right order |
 | [cluster_watch_history.py](cluster_watch_history.py) | Cluster a YouTube/podcast watch-history into main influences. |
 | [code_tool_learning_receipt.py](code_tool_learning_receipt.py) | Emit a bounded code-tool-learning coding-act receipt for a committed turn. |

--- a/scripts/claude_corpus.py
+++ b/scripts/claude_corpus.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# claude_corpus.py — CARRIER (data prep only). Taps Claude Code session transcripts
+# (~/.claude/projects/**/*.jsonl) into (task -> tools-used) corpus turns and appends them
+# to the shared tool-use corpus (~/.coherence-network/form-cli-corpus/corpus.jsonl) that
+# codex_corpus.py / agent_tooluse_featurize.py already read. Claude Code sessions are
+# Read/Edit/Write-heavy, so this grows exactly the low-performing tool-prediction lanes the
+# sovereignty attention signal (attention-signal.fk) names. Sibling to codex_corpus.py.
+#
+# Privacy: stores only the task text (truncated) + the tool names used — never reasoning or
+# answers — and appends to a LOCAL file (~/.coherence-network/, not git). Idempotent: a turn
+# whose (task, tool-set) is already present is skipped, so re-running never duplicates.
+import json, os, glob, hashlib, sys, collections
+
+PROJECTS = os.path.expanduser("~/.claude/projects")
+CORPUS = os.path.expanduser("~/.coherence-network/form-cli-corpus/corpus.jsonl")
+
+
+def _human_prompt(rec):
+    """A genuine human prompt (not a tool_result, which also arrives as user-role)."""
+    if rec.get("type") != "user":
+        return None
+    m = rec.get("message", {})
+    if not isinstance(m, dict) or m.get("role") != "user":
+        return None
+    c = m.get("content")
+    if isinstance(c, str):
+        return c.strip()
+    if isinstance(c, list):
+        texts = [b.get("text", "") for b in c if isinstance(b, dict) and b.get("type") == "text"]
+        has_tool_result = any(isinstance(b, dict) and b.get("type") == "tool_result" for b in c)
+        if texts and not has_tool_result:
+            return " ".join(texts).strip()
+    return None
+
+
+def _assistant_tools(rec):
+    if rec.get("type") != "assistant":
+        return []
+    m = rec.get("message", {})
+    c = m.get("content") if isinstance(m, dict) else None
+    if not isinstance(c, list):
+        return []
+    return [b.get("name") for b in c if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name")]
+
+
+def _turns(path):
+    """Yield (task, tools) per human-prompt -> assistant-tools exchange."""
+    task, tools = None, []
+    try:
+        lines = open(path, encoding="utf-8").read().splitlines()
+    except OSError:
+        return
+    for line in lines:
+        try:
+            rec = json.loads(line)
+        except Exception:
+            continue
+        hp = _human_prompt(rec)
+        if hp is not None:
+            if task and tools:
+                yield task, tools
+            task, tools = hp, []
+            continue
+        tools.extend(_assistant_tools(rec))
+    if task and tools:
+        yield task, tools
+
+
+def _key(task, tools):
+    body = task + "|" + ",".join(sorted({t for t in tools if t}))
+    return hashlib.sha1(body.encode("utf-8")).hexdigest()[:16]
+
+
+def main():
+    dry = "--dry-run" in sys.argv
+    seen = set()
+    if os.path.exists(CORPUS):
+        for line in open(CORPUS, encoding="utf-8"):
+            try:
+                e = json.loads(line)
+                seen.add(_key(e.get("task", ""), [s.get("tool") for s in e.get("steps", [])]))
+            except Exception:
+                pass
+
+    files = [f for f in glob.glob(os.path.join(PROJECTS, "**", "*.jsonl"), recursive=True)
+             if "Coherence-Network" in f]
+    added, lane = 0, collections.Counter()
+    os.makedirs(os.path.dirname(CORPUS), exist_ok=True)
+    out = None if dry else open(CORPUS, "a", encoding="utf-8")
+    for f in files:
+        for task, tools in _turns(f):
+            task = task[:1500]  # truncate FIRST so the dedup key matches what is stored (idempotent)
+            k = _key(task, tools)
+            if k in seen:
+                continue
+            seen.add(k)
+            rec = {
+                "task": task, "oracle": "claude", "outcome": "success",
+                "source": "claude-transcript",
+                "steps": [{"tool": t} for t in tools],
+                "task_sig": hashlib.sha1(task.encode("utf-8")).hexdigest()[:16],
+            }
+            if out:
+                out.write(json.dumps(rec) + "\n")
+            added += 1
+            for t in set(tools):
+                lane[t] += 1
+    if out:
+        out.close()
+    print(f"[claude corpus] {len(files)} session(s) -> {added} new turns"
+          f"{' (dry-run, not written)' if dry else ' -> ' + CORPUS}")
+    for t, n in lane.most_common(12):
+        print(f"  {t:<26} {n} turns")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The ask (Urs)

*Can we find more samples for low-performing lanes?* — the attention signal flagged **Read/Edit/Write** tool-prediction (~65%, high volume) and a corpus of only ~7 logged asks.

**Yes — and the richest source was sitting untapped.**

## The finding

The tool-use corpus (`~/.coherence-network/form-cli-corpus/corpus.jsonl`) was fed **only from Codex sessions** (`codex_corpus.py`). **Claude Code transcripts** — hundreds of real Read/Edit/Write calls per session — were never tapped. `scripts/claude_corpus.py` taps them into `(task → tools-used)` corpus turns, the sibling of `codex_corpus.py`.

## The result (measured)

- **949 → 2704 turns (~2.85×)** in one pass.
- New turns over-weight **exactly the weak lanes**: **Read +1242, Edit +769, Write +546** (Bash +1703).
- **Idempotent** (after a truncate-before-key fix): re-run adds **0**.

Thin host-IO carrier: stores only task text (truncated) + tool names — never reasoning/answers — to a **local** file (not git); restricted to Coherence-Network sessions.

**Next breath**: retrain the predictor (`agent_tooluse_train.sh`, M4 Max GPU) on the grown corpus and re-measure the per-lane held-out scores to confirm the lift on Read/Edit/Write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)