### PR TITLE
feat(speaker-lin): Challenger 2 (diagonal LDA) — four-way, honest negative vs C1

### DIFF
--- a/experiments/rune-galdr/CHALLENGERS.md
+++ b/experiments/rune-galdr/CHALLENGERS.md
@@ -33,14 +33,28 @@ cosine. No weights — the floor that pre-neural GMM/supervector systems stood o
 C1 separates clearly-different voices but **collapses on the hard same-gender pair** (margin 0.08).
 That collapse is precisely the value learning must add.
 
-## Challenger 2 — "Lin" (learned linear discriminant) — DESIGNED
+## Challenger 2 — "Lin" (learned linear discriminant) — BUILT & MEASURED (honest negative)
 
-C1's 40-d supervector → a trained linear projection `W` (40→32) that maximises between-speaker /
-within-speaker separation — the i-vector+LDA/PLDA backend that took classic systems to ~3–5% EER.
-Train by contrastive/triplet SGD (pull same-speaker supervectors together, push different apart)
-using `affine-train.fk` / `form-train-step.fk` / `autodiff-gradient.fk` (Form-native SGD, already
-four-way). Cheap to train, no audio model — just learns which supervector directions carry speaker
-identity. Expectation: cracks the hard pair that C1 collapses, well short of ECAPA.
+`speaker-lin.fk` (PASS-4WAY, verdict 1023): a diagonal LDA over C1's supervector. The training is
+Form — `sl-fisher` computes the per-dimension Fisher ratio (between-speaker / within-speaker
+variance) from a grouped corpus; `sl-fisher-clamped` tames an explosive near-zero-within dimension;
+`sl-center` signs the positive band features before scoring. Trained on 7 speakers × 3 windows.
+
+**Measured — it does NOT beat C1:**
+
+| pair | C1 | C2 (center + Fisher) |
+|---|---|---|
+| ubbe·brigitte | 0.512 | 0.875 |
+| ubbe·angelia | 0.619 | 0.998 |
+| brigitte·angelia (hard) | 0.768 | 0.885 |
+
+The honest finding: a *diagonal* reweighting of hand-crafted band energies can't separate voices
+whose identity isn't axis-aligned, and 7-speaker variance estimates are too noisy to trust — C2
+moved the cosines the wrong way. This is the real lesson of the race: the value ECAPA holds is not
+reweighting fixed features but **learned features + a full (rotating, nonlinear) embedder + data
+scale**. A *full* projection `W` (rotation, not just per-axis scale) trained by SGD over real data
+is the salvage path for a linear C2; the decisive jump is C3. Recipe + machinery are proven and
+reusable; the negative result is named, not hidden.
 
 ## Challenger 3 — "Net" (small neural embedder, the real ECAPA shape) — DESIGNED
 

--- a/form/form-stdlib/speaker-lin.fk
+++ b/form/form-stdlib/speaker-lin.fk
@@ -1,0 +1,61 @@
+; speaker-lin.fk — Challenger 2 ("Lin"): a learned LINEAR DISCRIMINANT over the C1 supervector.
+;
+; C1 (speaker-stat) weights every supervector dimension equally, so noisy dimensions drown the
+; discriminative ones and same-gender voices collapse together. C2 LEARNS a per-dimension weight
+; — Fisher's ratio, between-speaker variance / within-speaker variance — that lifts the dimensions
+; carrying speaker identity and damps the rest, then scores by weighted cosine (sl-apply ++
+; speaker-embed se-dot). This is the diagonal-LDA / i-vector-backend idea: the training is the
+; variance statistics; the model is the weight vector.
+;
+; The weights are LEARNED from a labeled corpus by sl-fisher (here, in Form — proven). They are
+; data; sl-apply is the inference op. Builds on speaker-stat (ss-mean/ss-add-vec/ss-scale-vec).
+;
+; preludes carry speaker-stat.fk. Proven by form-stdlib/tests/speaker-lin-band.fk.
+
+(do
+    ; --- inference: transform a supervector by the learned weights (fixed-point /1000) ---
+    (defn sl-apply (w x)
+        (if (eq (len w) 0) (empty)
+            (cons (div (mul (head w) (head x)) 1000) (sl-apply (tail w) (tail x)))))
+
+    ; --- training: Fisher weights from a GROUPED corpus ---
+    ; groups = list of speakers; each speaker = list of sample supervectors (the carrier groups by label).
+    (defn sl-sqdev-vec (v m)
+        (if (eq (len v) 0) (empty)
+            (cons (mul (sub (head v) (head m)) (sub (head v) (head m))) (sl-sqdev-vec (tail v) (tail m)))))
+    (defn sl-var-sum (samples m)
+        (if (eq (len samples) 1) (sl-sqdev-vec (head samples) m)
+            (ss-add-vec (sl-sqdev-vec (head samples) m) (sl-var-sum (tail samples) m))))
+    (defn sl-spk-var (samples)            ; per-dim variance within one speaker's samples
+        (do (let m (ss-mean samples)) (ss-scale-vec (sl-var-sum samples m) (len samples))))
+
+    (defn sl-within-sum (groups)
+        (if (eq (len groups) 1) (sl-spk-var (head groups))
+            (ss-add-vec (sl-spk-var (head groups)) (sl-within-sum (tail groups)))))
+    (defn sl-within (groups) (ss-scale-vec (sl-within-sum groups) (len groups)))   ; mean within-speaker var
+
+    (defn sl-spk-means (groups)
+        (if (eq (len groups) 0) (empty)
+            (cons (ss-mean (head groups)) (sl-spk-means (tail groups)))))
+    (defn sl-between (groups) (sl-spk-var (sl-spk-means groups)))                   ; variance of the speaker means
+
+    ; weight[i] = between[i] * scale / (within[i] + eps)  — Fisher's ratio, fixed-point
+    (defn sl-ratio-vec (b w)
+        (if (eq (len b) 0) (empty)
+            (cons (div (mul (head b) 1000) (add (head w) 1)) (sl-ratio-vec (tail b) (tail w)))))
+    (defn sl-fisher (groups) (sl-ratio-vec (sl-between groups) (sl-within groups)))
+
+    ; A dimension with near-zero within-speaker variance gets an explosive ratio and would
+    ; dominate the cosine, collapsing every pair to 1.0. Clamp each weight to [lo,hi] so the
+    ; reweighting stays a re-balancing, not a takeover — the diagonal-LDA regularizer.
+    (defn sl-clamp1 (v lo hi) (if (lt v lo) lo (if (gt v hi) hi v)))
+    (defn sl-clamp-vec (xs lo hi)
+        (if (eq (len xs) 0) (empty)
+            (cons (sl-clamp1 (head xs) lo hi) (sl-clamp-vec (tail xs) lo hi))))
+    (defn sl-fisher-clamped (groups lo hi) (sl-clamp-vec (sl-fisher groups) lo hi))
+
+    ; Band energies are all POSITIVE, so raw supervectors sit in one orthant and cosine is
+    ; inflated. Centering each supervector by the global mean turns it into a SIGNED deviation —
+    ; the move that makes a linear discriminant separate (LDA centers before it projects).
+    (defn sl-center (x m)
+        (if (eq (len x) 0) (empty) (cons (sub (head x) (head m)) (sl-center (tail x) (tail m))))))

--- a/form/form-stdlib/tests/speaker-lin-band.fk
+++ b/form/form-stdlib/tests/speaker-lin-band.fk
@@ -1,0 +1,37 @@
+; preludes: form-stdlib/speaker-stat.fk form-stdlib/speaker-lin.fk
+;
+; speaker-lin-band — Challenger 2's learned linear discriminant (Fisher weights), three-way.
+;
+; Two speakers, two samples each, two dims. dim0 separates them (means 10 vs 40, stable);
+; dim1 is noise (both ~50, jittering ±1). Fisher must lift dim0 and damp dim1.
+;
+; Verdict 1023 when every claim lands:
+;   1   sl-apply scales elementwise        (w=[2000,500] x=[10,20] → [20,10], head 20)
+;   2   sl-apply second element            (= 10)
+;   4   within-speaker var dim0 = 0         (each speaker's dim0 is constant)
+;   8   within-speaker var dim1 = 1         (±1 jitter)
+;   16  between-speaker var dim0 = 225      (means 10,40)
+;   32  between-speaker var dim1 = 1        (means 51,49)
+;   64  Fisher weight dim0 = 225000         (huge — discriminative)
+;   128 Fisher weight dim1 = 500            (small — noise)
+;   256 clamp tames the explosive weight    (clamp 225000 to [1000,5000] = 5000)
+;   512 centering signs the feature          (center [10,20] by [3,5] → head 7)
+(do
+    (let groups (list (list (list 10 50) (list 10 52)) (list (list 40 50) (list 40 48))))
+    (let wi (sl-within groups))
+    (let bt (sl-between groups))
+    (let fi (sl-fisher groups))
+    (let fc (sl-fisher-clamped groups 1000 5000))
+    (let ap (sl-apply (list 2000 500) (list 10 20)))
+    (let ce (sl-center (list 10 20) (list 3 5)))
+    (let c0 (if (eq (head ap) 20) 1 0))
+    (let c1 (if (eq (head (tail ap)) 10) 2 0))
+    (let c2 (if (eq (head wi) 0) 4 0))
+    (let c3 (if (eq (head (tail wi)) 1) 8 0))
+    (let c4 (if (eq (head bt) 225) 16 0))
+    (let c5 (if (eq (head (tail bt)) 1) 32 0))
+    (let c6 (if (eq (head fi) 225000) 64 0))
+    (let c7 (if (eq (head (tail fi)) 500) 128 0))
+    (let c8 (if (eq (head fc) 5000) 256 0))
+    (let c9 (if (eq (head ce) 7) 512 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 c9))))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -479,6 +479,7 @@ rune-frequency fks 255
 speaker-id fks 255
 speaker-embed fks 255
 speaker-stat fks 255
+speaker-lin fks 1023
 wav-sense fks 63
 witness-theorem fks 31
 witness-to-co-regulate fks 127


### PR DESCRIPTION
**Challenger 2 "Lin"** — a learned linear discriminant over C1's supervector. The training is **Form**: [`speaker-lin.fk`](form/form-stdlib/speaker-lin.fk) (PASS-4WAY, verdict 1023) carries `sl-fisher` (per-dimension between/within variance ratio over a grouped corpus), `sl-fisher-clamped` (tame the explosive near-zero-within dimension), `sl-center` (sign the positive band features). Trained on 7 speakers × 3 windows.

## Honest result — C2 does **not** beat C1

| pair | C1 | C2 (center + Fisher) |
|---|---|---|
| ubbe·brigitte | 0.512 | 0.875 |
| ubbe·angelia | 0.619 | 0.998 |
| brigitte·angelia (hard) | 0.768 | 0.885 |

A *diagonal* reweighting of hand-crafted band energies can't separate voices whose identity isn't axis-aligned, and 7-speaker variance estimates are too noisy — C2 moved the cosines the wrong way. The real lesson of the race: ECAPA's value is **learned features + a full rotating/nonlinear embedder + data scale**, not reweighting fixed features. A *full* projection `W` (rotation, SGD-trained on real data) is the salvage for a linear C2; the decisive jump is **C3**. The recipe + machinery are proven and reusable; the negative is named, not hidden ([CHALLENGERS.md](experiments/rune-galdr/CHALLENGERS.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)