### PR TITLE
feat(form): the gen conductor — compile source → RAM recipe → run → share over a byte channel

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -2938,6 +2938,20 @@ func (k *Kernel) registerNatives() {
 		}
 		return Value{Kind: VNodeID, Nid: root}
 	})
+	// form_compile source-string → recipe NodeID. Parses Form source into a
+	//   content-addressed recipe in RAM and returns its root NodeID — the
+	//   shareable handle. The "generate into RAM" leg of the gen conductor.
+	//   (Plain Form recipe surface; section/class source rides the compile
+	//   chain, the named follow-on.)
+	k.registerNative("form_compile", catWitness(), func(k *Kernel, args []Value) Value {
+		return Value{Kind: VNodeID, Nid: readRootFromSource(k, args[0].Str)}
+	})
+	// form_walk recipe-NodeID → value. Executes a recipe in RAM on a fresh
+	//   frame — the "run" leg. Pairs with form_compile (run what you generated)
+	//   and bytes_to_recipe (run what a peer shared over a byte channel).
+	k.registerNative("form_walk", catWitness(), func(k *Kernel, args []Value) Value {
+		return k.walk(args[0].AsNid(), NewFrame(nil))
+	})
 	// jit_compile form-name-str → 1 if a host-JIT compile succeeded,
 	//   0 if the compile fell back (toolchain missing, body uses ops the
 	//   emitter can't lower, plugin.Open failed), -1 if the name isn't

--- a/form/form-stdlib/form-gen.fk
+++ b/form/form-stdlib/form-gen.fk
@@ -1,0 +1,58 @@
+; form-gen.fk — the form-cli gen conductor: compile source into a RAM recipe,
+; run it, and hand it to another cell over a byte channel.
+;
+; gen is Go-hosted — it runs where the compiler lives. The LOGIC is here in
+; Form; the carriers are thin kernel primitives:
+;   form_compile   source -> recipe NodeID (RAM, content-addressed) — the handle
+;   form_walk      recipe NodeID -> value                            — run it
+;   recipe_to_bytes / bytes_to_recipe   recipe <-> bytes             — the channel
+;   node_eq        two NodeIDs equal?                                — integrity
+;
+; Content-addressing is the channel: a recipe one cell generates and one a peer
+; deserializes are the SAME NodeID if structurally identical — so the handle is
+; verifiable end-to-end, no trust in the wire.
+;
+; Honest seams: the run leg (form_walk over an arbitrary recipe) is Go/Rust/TS;
+; fkwu runs FLATTENED recipes, so the four-way composable evaluator is the named
+; deeper rung (docs/coherence-substrate/form-engine.form). form_compile takes the
+; plain Form recipe surface; section/class source rides the compile chain next.
+; gen is Go-hosted, like serve/jit — the conductor runs where the compiler lives.
+;
+; Demo (Go kernel):
+;   printf '(gen "(add 1 2)")\n' > /tmp/g.fk
+;   form/form-kernel-go/bin-go form/form-stdlib/form-gen.fk /tmp/g.fk     ; [3, @0.2.12.48]
+;   printf '(gen-share-roundtrip "(add (mul 6 7) 1)")\n' > /tmp/g.fk
+;   form/form-kernel-go/bin-go form/form-stdlib/form-gen.fk /tmp/g.fk     ; [43, 43, 1]
+;
+; preludes: (none — uses only kernel primitives)
+
+(do
+    ; the content-addressed handle for a piece of source: compile into RAM
+    (defn gen-handle (src) (form_compile src))
+
+    ; run a recipe you generated — or one a peer handed you
+    (defn gen-run (recipe) (form_walk recipe))
+
+    ; gen: compile source into a RAM recipe and run it -> (value handle)
+    (defn gen (src)
+        (do
+            (let r (form_compile src))
+            (list (form_walk r) r)))
+
+    ; the channel legs: a recipe <-> bytes any cell can carry
+    (defn gen-to-bytes (recipe) (recipe_to_bytes recipe))
+    (defn gen-from-bytes (bytes) (bytes_to_recipe bytes))
+
+    ; the whole arc end to end: generate here, run, serialize to bytes, let a
+    ; peer deserialize and run the SAME content-addressed recipe.
+    ; -> (value-here value-there same-node?)
+    (defn gen-share-roundtrip (src)
+        (do
+            (let r (form_compile src))
+            (let v (form_walk r))
+            (let wire (recipe_to_bytes r))
+            (let r2 (bytes_to_recipe wire))
+            (let v2 (form_walk r2))
+            (list v v2 (node_eq r r2))))
+
+    0)


### PR DESCRIPTION
## What

The spine of the form-cli **compile-and-distribute** vision: `gen` turns source into a content-addressed recipe **in RAM**, runs it, and hands it to another cell as bytes that deserialize to the **same NodeID**.

The logic is **Form** ([`form-gen.fk`](form/form-stdlib/form-gen.fk)); the carriers are thin kernel primitives — two new, the rest already present:

| carrier | role | status |
|---|---|---|
| `form_compile source → recipe NodeID` | generate into RAM (content-addressed handle) | **new** (thin) |
| `form_walk recipe NodeID → value` | run what you generated / were handed | **new** (thin) |
| `recipe_to_bytes` / `bytes_to_recipe` | the channel (recipe ↔ bytes) | already here |
| `node_eq` | integrity — the handle verifies end to end | already here |

**Content-addressing *is* the channel:** a recipe one cell generates and one a peer deserializes are the *same* NodeID if structurally identical — so the handle is verifiable over the wire, no trust in it.

## Proof (Go kernel)

```
(gen "(add 1 2)")                         → [3, @0.2.12.48]   (value + handle)
(gen-share-roundtrip "(add (mul 6 7) 1)") → [43, 43, 1]       (here = there = same node)
```

So: **generate → RAM → run → serialize → share-over-channel → run**, content-addressed.

## Honest seams (named, not hidden)

- `gen` is **Go-hosted** like `serve`/`jit` — the conductor runs where the compiler lives. The additive natives don't touch the four-way `form-cli` *reasoning* router (`form-cli` band still **511** four-way).
- The run leg (`form_walk` over an *arbitrary* recipe) is Go/Rust/TS; **fkwu runs *flattened* recipes**, so the four-way composable evaluator ([`form-engine.form`](docs/coherence-substrate/form-engine.form)) is the named deeper rung.
- `form_compile` takes the **plain Form recipe surface**; section/class source rides the compile chain. Cross-kernel parity for the two natives and a `form-cli gen` *verb* surface are the next thin steps.

## Why this matters

The bones for the whole vision were already in the body — compile→RAM, `.fkb` serialize/deserialize, content-addressing, socket/storage channels, all mostly proven. This is the **conductor** that ties generate → RAM (and next: disk `.fkb` / substrate / channel) → execute → share into one cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)