### PR TITLE
feat(form-cli): 'form-cli learn' — one motion grows the corpus + retrains, no stale cache

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 313 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 314 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/bin/form-cli
+++ b/bin/form-cli
@@ -39,6 +39,10 @@ form-cli — the one door (local-first, Form-native)
   form-cli train [hid epochs lr]
         train the native tool-use predictor on the real agent corpus (M4 Max GPU),
         caching its held-out scores for `form-cli stats` tool->native
+  form-cli learn [hid epochs lr]
+        ONE motion (the continuous-learning step): grow the corpus from this machine's
+        Claude Code sessions, then retrain the predictor on the GROWN corpus — always
+        re-featurizes, so "more samples" actually reach the model (no stale cache)
   form-cli shadow [N] [model]
         SHADOW MODE: replay N real captured agent turns through the native lane and
         score its tool-prediction against what the agent actually did (vs baseline)
@@ -83,6 +87,7 @@ case "$cmd" in
   do)        exec bash "$ROOT/scripts/form_cli_agent.sh" "$@" ;;  # tiered agent loop (local-first, escalate)
   stats)     exec python3 "$ROOT/scripts/form_cli_stats.py" "$@" ;;
   train)     exec bash "$ROOT/scripts/agent_tooluse_train.sh" "$@" ;;
+  learn)     exec bash "$ROOT/scripts/form_cli_learn.sh" "$@" ;;
   shadow)    exec env FORM_CLI_CORPUS="${FORM_CLI_CORPUS:-$HOME/.coherence-network/form-cli-corpus/corpus.jsonl}" \
                   bash "$ROOT/scripts/form_cli_replay.sh" "$@" ;;
   search)    exec python3 "$RAG" search "$@" ;;

--- a/docs/system_audit/commit_evidence_20260621_form_cli_learn.json
+++ b/docs/system_audit/commit_evidence_20260621_form_cli_learn.json
@@ -1,0 +1,94 @@
+{
+  "date": "2026-06-21",
+  "thread_branch": "claude/form-cli-learn",
+  "commit_scope": "Collapse the manual, 3-step, stale-cache-prone tool-use learning loop into ONE reliable motion: form-cli learn (scripts/form_cli_learn.sh) taps this machine's Claude Code sessions into the corpus, ALWAYS re-featurizes the grown corpus (busting the stale /tmp cache that silently froze it), then retrains the native predictor and caches the held-out metric. Foundation for continuous learning — still a manual command; auto-triggering is the named remaining step.",
+  "files_owned": [
+    "scripts/form_cli_learn.sh",
+    "bin/form-cli",
+    "scripts/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_20260621_form_cli_learn.json"
+  ],
+  "idea_ids": [
+    "form-cli-learn-one-motion",
+    "continuous-tool-predictor-learning"
+  ],
+  "spec_ids": [
+    "sovereignty-receipt"
+  ],
+  "task_ids": [
+    "task-2026-06-21-form-cli-learn"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance-criteria"
+      ]
+    },
+    {
+      "contributor_id": "claude-sema",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "claude-code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "Honest grounding for the change: grep over .claude/.codex/scripts/Makefile found NO hook/cron/make target that runs claude_corpus.py or agent_tooluse_train.sh — the loop was manual, and the train script silently reused a stale /tmp/agent_tooluse.dat (the trap that made the 2026-06-21 retrain report 939 turns until busted).",
+    "form_cli_learn.sh runs one motion: (1) python3 scripts/claude_corpus.py (idempotent tap), (2) rm -f /tmp/agent_tooluse.dat then re-featurize the grown corpus, (3) DATA=... agent_tooluse_train.sh (caches the held-out metric for form-cli stats).",
+    "Live proof: bin/form-cli learn -> 'corpus: 2704 -> 2709 turns' (the tap picked up 5 new turns from the live session), featurize '2686 turns -> 2148 train, 538 held', train 'REAL agent corpus: 2148 train, 538 held-out' — i.e. trained on the GROWN corpus, not the stale 939. Per-tool held vs baseline: Edit 64.3% vs 55.8%, Write 74.0% vs 65.8%, Read 66.7% vs 66.4%, Bash 96.7%.",
+    "Wired into bin/form-cli: new 'learn)' case beside 'train)', plus a help entry. Carrier discipline: form_cli_learn.sh only orchestrates existing carriers (tap, featurize, train); the model is a Form FFN step.",
+    "Edges: scripts/INDEX.md + MANIFEST.md regenerated (--check clean).",
+    "Honest scope: this makes the loop ONE reliable command, not yet AUTOMATIC. True continuity needs a trigger (a session-stop tap + a retrain cadence) — named, not built here, because auto-GPU-retrain is a standing-resource decision."
+  ],
+  "change_files": [
+    "scripts/form_cli_learn.sh",
+    "bin/form-cli",
+    "scripts/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_20260621_form_cli_learn.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "bash -n scripts/form_cli_learn.sh",
+      "bin/form-cli learn  (corpus 2704->2709, featurize 2686 turns, train 2148/538, beats baseline on Edit/Write/Read)",
+      "python3 scripts/generate_repo_indexes.py --check"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "A carrier orchestration script + a bin/form-cli subcommand; no kernel proof bands apply. INDEX --check clean."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed-agent-tooling",
+    "notes": "Local agent tooling; reaches contributors through the repo. The corpus + model are local (not git). Auto-triggering (continuous, not just one-command) is the named next step."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed (one-motion learn ran end to end on the grown corpus); CI and merge remain pending; auto-trigger for true continuity is the next step."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "form-cli learn now grows the corpus from sessions and retrains the predictor on the grown corpus in one command, always re-featurizing so new samples actually reach the model. The 3-step manual loop and its stale-cache trap are gone.",
+    "public_endpoints": [
+      "none changed; local agent tooling"
+    ],
+    "test_flows": [
+      "bin/form-cli learn taps -> re-featurizes -> retrains on the grown corpus and caches the held-out metric; per-tool scores beat baseline on the weak lanes."
+    ]
+  }
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 313
+**Total files**: 314
 
 | File | Purpose |
 |---|---|
@@ -104,6 +104,7 @@
 | [form_cli_gaps.sh](form_cli_gaps.sh) | form_cli_gaps.sh — the catalog of what is OPEN, walked from the live body. |
 | [form_cli_guided.sh](form_cli_guided.sh) | form_cli_guided.sh — the trained native model makes the live model better. |
 | [form_cli_judge.sh](form_cli_judge.sh) | form_cli_judge.sh — measure the REASONING lane: how well a native model's answer |
+| [form_cli_learn.sh](form_cli_learn.sh) | form_cli_learn.sh — the continuous-learning loop's body, in ONE motion: grow the tool-use corpus |
 | [form_cli_neural_lm_train.sh](form_cli_neural_lm_train.sh) | form_cli_neural_lm_train.sh — train the Form-native neural LM (neural-lm.fk) on the |
 | [form_cli_preflight.sh](form_cli_preflight.sh) | form_cli_preflight.sh — air-gap readiness check for the form-cli. |
 | [form_cli_prove4.sh](form_cli_prove4.sh) | form_cli_prove4.sh — promote a closed recipe to a FOUR-WAY-proven stdlib cell. |

--- a/scripts/form_cli_learn.sh
+++ b/scripts/form_cli_learn.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# form_cli_learn.sh — the continuous-learning loop's body, in ONE motion: grow the tool-use corpus
+# from this machine's sessions, then retrain the native predictor on the GROWN corpus — ALWAYS
+# re-featurizing so the stale /tmp cache that silently froze the corpus (the trap of 2026-06-21)
+# cannot bite again. `form-cli learn` runs this. Carrier only — the model is a Form FFN step
+# (the Form recipe jte-mlp-train-msl); this orchestrates tap -> featurize -> train -> cache metric.
+set -u
+ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+CORPUS="$HOME/.coherence-network/form-cli-corpus/corpus.jsonl"
+DAT="/tmp/agent_tooluse.dat"
+
+echo "⟐ form-cli learn — grow the corpus from sessions, then retrain the native predictor on it"
+
+before=$(wc -l < "$CORPUS" 2>/dev/null || echo 0)
+
+# 1. tap this machine's Claude Code sessions into the corpus (idempotent; Read/Edit/Write-heavy)
+python3 "$ROOT/scripts/claude_corpus.py" 2>&1 | head -1
+
+after=$(wc -l < "$CORPUS" 2>/dev/null || echo 0)
+echo "  corpus: ${before} -> ${after} turns"
+
+# 2. ALWAYS re-featurize the grown corpus — this is what makes "more samples" actually reach the model
+#    (agent_tooluse_train.sh skips featurize when $DAT exists, so we regenerate it here every time).
+rm -f "$DAT"
+python3 "$ROOT/scripts/agent_tooluse_featurize.py" "$DAT" 2>&1 | head -1
+
+# 3. retrain on the fresh dataset; agent_tooluse_train.sh caches the held-out metric for `form-cli stats`
+DATA="$DAT" exec bash "$ROOT/scripts/agent_tooluse_train.sh" "$@"


### PR DESCRIPTION
## The honest answer to 'is it continuous now?'

**No — it was manual and trap-prone.** No hook/cron/make target ran the tap or the retrain, and the train script silently reused a stale `/tmp` featurize cache (the trap that made yesterday's retrain report 939 turns until I busted it).

This makes the loop **one reliable motion** — the foundation of continuous learning, though still a command you run.

## What — `form-cli learn`

`scripts/form_cli_learn.sh` (wired as `form-cli learn`):
1. **tap** this machine's Claude Code sessions into the corpus (idempotent, Read/Edit/Write-heavy),
2. **always re-featurize** the grown corpus — so 'more samples' actually reach the model (no stale cache),
3. **retrain** the predictor and cache the held-out metric for `form-cli stats`.

## Live proof

```
corpus: 2704 -> 2709 turns          (picked up 5 turns from the RUNNING session)
featurize: 2686 turns -> 2148 train, 538 held
train: REAL agent corpus 2148 train, 538 held-out   (the grown set, not the stale 939)
  Edit 64.3% vs 55.8%  ·  Write 74.0% vs 65.8%  ·  Read 66.7%  ·  Bash 96.7%
```

Carrier only — orchestrates existing tap/featurize/train; the model is a Form FFN step.

## What's still NOT continuous (named honestly)

`form-cli learn` is a **command**, not a trigger. True continuity needs: a **session-stop tap** (cheap, auto-grows the corpus every session) + a **retrain cadence** (the GPU step, gated — daily, or when the corpus grew by N). That's a standing-resource decision, so it's named, not silently committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)