### PR TITLE
feat(form-cli): continuous learning — SessionEnd trigger auto-runs form-cli learn

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 314 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 315 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_20260621_learn_on_session.json
+++ b/docs/system_audit/commit_evidence_20260621_learn_on_session.json
@@ -1,0 +1,94 @@
+{
+  "date": "2026-06-21",
+  "thread_branch": "claude/learn-on-session",
+  "commit_scope": "Make tool-use learning truly CONTINUOUS: a SessionEnd trigger (scripts/form_cli_learn_on_session.sh) runs `form-cli learn` detached on every session end, so the corpus grows and the predictor retrains automatically. Guarded (no-op unless bin/form-cli is built; never overlaps GPU retrains via a pid lock) and bash-3.2-safe. The capability is committed; activation is per-machine (a SessionEnd hook in settings.local.json, because the corpus + GPU are local).",
+  "files_owned": [
+    "scripts/form_cli_learn_on_session.sh",
+    "scripts/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_20260621_learn_on_session.json"
+  ],
+  "idea_ids": [
+    "continuous-learning-session-end-trigger",
+    "form-cli-learn-on-session"
+  ],
+  "spec_ids": [
+    "sovereignty-receipt"
+  ],
+  "task_ids": [
+    "task-2026-06-21-learn-on-session"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "cadence-decision",
+        "acceptance-criteria"
+      ]
+    },
+    {
+      "contributor_id": "claude-sema",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "claude-code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "Cadence chosen by Urs: full learn on every session-stop. Verified hook event via claude-code-guide: SessionEnd fires ONCE per session (Stop fires once per turn, wrong for a 15s GPU job); a SessionEnd hook can launch a detached process that survives teardown as long as the hook itself exits cleanly.",
+    "form_cli_learn_on_session.sh launches `form-cli learn` detached (nohup ... &), guarded: (1) exits 0 silently unless bin/form-cli is built — safe on clones without the GPU/corpus; (2) skips if the last learn's pid is still alive (no overlapping GPU retrains).",
+    "Live proof of both guards: trigger 1 -> exit 0, lock pid 52084 written and alive; trigger 2 -> exit 0 with NO new job launched (learn-process count before=1, after=1). bash -n clean.",
+    "bash 3.2 fix: the first version used $BASHPID (absent on macOS bash 3.2) under set -u and errored, so the lock never wrote and the overlap guard failed; rewritten to use $! and a kill -0 staleness check (no trap), which is portable.",
+    "Activation is per-machine and NOT committed: the SessionEnd hook is added to settings.local.json on the GPU/corpus machine (Urs's Mac); other clones get the committed capability but no auto-trigger until they opt in. This avoids running a GPU retrain on contributors' machines.",
+    "Edges: scripts/INDEX.md + MANIFEST.md regenerated (--check clean).",
+    "Honest nuance carried from form-cli learn: this improves form-cli's OWN agent predictor (the sovereign path); it does not make a rented Claude Code session native — the predictor drives form-cli-as-agent."
+  ],
+  "change_files": [
+    "scripts/form_cli_learn_on_session.sh",
+    "scripts/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_20260621_learn_on_session.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "bash -n scripts/form_cli_learn_on_session.sh",
+      "trigger 1 -> launches detached learn, writes lock (pid alive); trigger 2 -> skips (no second job)",
+      "python3 scripts/generate_repo_indexes.py --check"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "A carrier trigger script; no kernel proof bands apply. INDEX --check clean."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed-agent-tooling",
+    "notes": "Local agent tooling; the committed script is a no-op without form-cli built. Activation is a local settings.local.json SessionEnd hook on the GPU/corpus machine."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed (detached launch + overlap guard proven); CI and merge pending. Activation hook lands in local settings (not this PR)."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "On a GPU/corpus machine with the SessionEnd hook wired, every session end now auto-runs form-cli learn (tap the session into the corpus, re-featurize, retrain) in the background — closing the loop from manual command to continuous learning.",
+    "public_endpoints": [
+      "none changed; local agent tooling"
+    ],
+    "test_flows": [
+      "Trigger launches a detached learn and records a pid lock; a concurrent trigger skips; a clone without form-cli built no-ops."
+    ]
+  }
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 314
+**Total files**: 315
 
 | File | Purpose |
 |---|---|
@@ -105,6 +105,7 @@
 | [form_cli_guided.sh](form_cli_guided.sh) | form_cli_guided.sh — the trained native model makes the live model better. |
 | [form_cli_judge.sh](form_cli_judge.sh) | form_cli_judge.sh — measure the REASONING lane: how well a native model's answer |
 | [form_cli_learn.sh](form_cli_learn.sh) | form_cli_learn.sh — the continuous-learning loop's body, in ONE motion: grow the tool-use corpus |
+| [form_cli_learn_on_session.sh](form_cli_learn_on_session.sh) | form_cli_learn_on_session.sh — the SessionEnd trigger that makes tool-use learning CONTINUOUS. |
 | [form_cli_neural_lm_train.sh](form_cli_neural_lm_train.sh) | form_cli_neural_lm_train.sh — train the Form-native neural LM (neural-lm.fk) on the |
 | [form_cli_preflight.sh](form_cli_preflight.sh) | form_cli_preflight.sh — air-gap readiness check for the form-cli. |
 | [form_cli_prove4.sh](form_cli_prove4.sh) | form_cli_prove4.sh — promote a closed recipe to a FOUR-WAY-proven stdlib cell. |

--- a/scripts/form_cli_learn_on_session.sh
+++ b/scripts/form_cli_learn_on_session.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# form_cli_learn_on_session.sh — the SessionEnd trigger that makes tool-use learning CONTINUOUS.
+# On session end it runs `form-cli learn` (tap -> featurize -> retrain) DETACHED, so it never blocks
+# session teardown and survives it. Guarded so it is safe to wire anywhere:
+#   - no-op unless bin/form-cli is built (the GPU/corpus machine) — other clones skip silently;
+#   - never overlaps a GPU retrain (a running learn holds a lock; a new trigger skips).
+# Activation is per-machine (settings.local.json SessionEnd hook), because the corpus + GPU are local;
+# the capability is committed, the trigger is opt-in. Carrier only.
+set -u
+ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COH="$HOME/.coherence-network"
+LOCK="$COH/.form-cli-learn.lock"
+LOG="$COH/form-cli-learn.log"
+mkdir -p "$COH" 2>/dev/null
+
+# guard 1: only where form-cli is built (the corpus/GPU machine); silent no-op elsewhere
+[ -x "$ROOT/bin/form-cli" ] || exit 0
+
+# guard 2: never overlap GPU retrains — if the last learn's pid is still alive, skip this trigger.
+# (A stale lock pointing at a dead pid fails kill -0, so it is ignored and overwritten below — no
+# trap needed, which keeps this safe on macOS bash 3.2 where $BASHPID does not exist.)
+if [ -f "$LOCK" ] && kill -0 "$(cat "$LOCK" 2>/dev/null)" 2>/dev/null; then
+  exit 0
+fi
+
+# launch the one-motion learn DETACHED: never blocks teardown, survives it; record its pid for guard 2
+nohup bash "$ROOT/scripts/form_cli_learn.sh" >>"$LOG" 2>&1 &
+echo "$!" > "$LOCK"
+disown 2>/dev/null || true
+exit 0


### PR DESCRIPTION
## Closes the loop: command → continuous

You chose **full learn on every session-stop**. `form_cli_learn_on_session.sh` runs `form-cli learn` (tap → featurize → retrain) **detached** on session end, so the corpus grows and the predictor retrains **automatically**.

Verified hook event (via claude-code-guide): **SessionEnd** fires *once per session* (Stop fires once per *turn* — wrong for a 15s GPU job) and can launch a detached process that survives teardown.

## Guards (so it's safe everywhere)

- **No-op unless `bin/form-cli` is built** → a clone without the GPU/corpus skips silently.
- **Never overlaps GPU retrains** → a running learn holds a pid lock; a concurrent trigger skips.
- **bash 3.2 safe** → uses `$!` + a `kill -0` staleness check (the first cut used `$BASHPID`, absent on macOS bash 3.2 under `set -u` — caught and fixed).

Proven live: trigger 1 launches + writes the lock (pid alive); trigger 2 returns with **no second job**.

## Capability committed, activation local

The trigger runs a **GPU retrain**, and the corpus + GPU are on one machine — so the committed script is the capability, and the **activation is a SessionEnd hook in `settings.local.json`** on that machine (this PR doesn't impose a GPU job on any contributor's clone).

**Honest nuance:** this improves `form-cli`'s *own* agent predictor — the sovereign path. It doesn't make a rented Claude Code session native; it grows the native agent that's meant to replace the rental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)