### PR TITLE
attune(speaker-proj+net): floats not integer fixed-point — precision wall removed (four-way)

### DIFF
--- a/experiments/rune-galdr/CHALLENGERS.md
+++ b/experiments/rune-galdr/CHALLENGERS.md
@@ -56,39 +56,40 @@ scale**. A *full* projection `W` (rotation, not just per-axis scale) trained by 
 is the salvage path for a linear C2; the decisive jump is C3. Recipe + machinery are proven and
 reusable; the negative result is named, not hidden.
 
-## Challenger 2-full — "Proj" (full linear projection, SGD) — BUILT & FOUR-WAY
+## Challenger 2-full — "Proj" (full linear projection, FLOAT SGD) — BUILT & FOUR-WAY
 
 `speaker-proj.fk` (PASS-4WAY, 255): the diagonal's salvage — a full matrix `W` (K×N) trained by
-squared-loss SGD toward speaker codes (the affine-train loop lifted to multi-output). Unlike the
-diagonal it can *rotate*. The band proves the loop genuinely descends: one step drops the fixture
-loss 4,000,000 → 2,560,000 and moves an off-axis weight, four-way.
+squared-loss SGD toward speaker codes (affine-train lifted to multi-output), on **plain floats** (the
+whisper-block arithmetic, fp64). Unlike the diagonal it can *rotate*. The band descends 1.0 → 0.0625
+in one step and moves an off-axis weight, four-way.
 
-## Challenger 3 — "Net" (nonlinear neural embedder, SGD) — BUILT & FOUR-WAY
+## Challenger 3 — "Net" (nonlinear neural embedder, FLOAT SGD) — BUILT & FOUR-WAY
 
-`speaker-net.fk` (PASS-4WAY, 255): `emb = relu(W·x)` with relu-GATED backprop — the one thing
-C1/C2 lack, a nonlinearity. The band proves a dead unit passes zero gradient while the active
-unit's gradient reaches its off-axis weight, and the step descends 5,000,000 → 3,190,400, four-way.
-One layer here; stacking is the same recipe repeated (the deep TDNN).
+`speaker-net.fk` (PASS-4WAY, 255): `emb = relu(W·x)` with relu-GATED backprop on floats — the
+nonlinearity C1/C2 lack. The band: a dead unit passes zero gradient, the active unit's gradient
+reaches its off-axis weight, loss descends 2.0 → 1.0625, four-way. One layer; stacking is the deep TDNN.
 
-## Race result — the moat is features + precision + data, not the model
+## Race result — float fixed PRECISION; the binding wall is now DATA
 
-C2-full and C3 are built and four-way proven (their training loops descend on clean fixtures). But
-**training them on the real corpus collapses** — measured, named, not hidden:
+First built on integer fixed-point — wrong choice (copied form-train-step, the toy). Its `/1000`
+rounding zeroed the small gradients, so training "collapsed". The kernel runs **fp64 natively** (the
+whisper block trains on it, four-way), so the recipes were rebuilt on floats. Then, measured honestly:
 
-- **Features.** The hand-crafted sox 20-band supervector rounds to small ints (0–99); coarse 0/1-ish
-  patterns carry enough for C1's cosine but almost no gradient signal for a learned embedder.
-- **Precision.** Integer fixed-point SGD rounds the small per-step weight updates toward zero — the
-  gradient that the clean-fixture band shows descending vanishes on real-scale features.
-- **Data.** 26 voices × 2 training windows is far below what discriminative training needs; held-out
-  generalization has almost nothing to learn from.
+- **Precision — FIXED by floats.** C2-full now genuinely trains: it produces real, varied embeddings
+  (ubbe·brig 0.605, ubbe·ang 0.844) where the integer version output all-zeros. The gradient no
+  longer rounds away.
+- **Data — the binding wall now.** C2-full's held-out hard pair (brig·ang 0.881) still does **not**
+  beat C1 (0.768): 52 training samples can't learn a *generalizing* 8×40 projection — it can't
+  transfer to a held-out window. More speakers/utterances is the unlock, not more model.
+- **C3 init/loss.** relu at zero-init is dead (z=0 gates the gradient off); with a small positive
+  init it wakes but the sparse code targets collapse the embedding to ~1 active dim on this little
+  data. Needs Xavier-ish init + a margin/softmax loss + data — known fixes, not blockers.
 
-So the decisive lesson of the whole race: C1 (stats) ≈ usable on easy pairs; C2-diagonal lost;
-C2-full and C3 are the right model classes but can't be *trained* to beat C1 on this footing. **ECAPA's
-power is not the model class — it is the learned log-mel front-end, float training, and VoxCeleb-scale
-data.** Approaching it means meeting it on those: (1) a learned/log-mel feature front-end (the Form mel
-recipes, not coarse bands); (2) the native float training lane (emit→asm), not the tree-walker's integer
-fixed-point; (3) a real multi-speaker corpus. The recipes are the proven, reusable bodies waiting for
-that footing — the same recipe that proves four-way is the one that will crystallize and train native.
+So the corrected lesson: the kernel's **float training is real and four-way** (your call — floats, not
+fixed-point). C1 (stats) is still the only challenger usable today, on easy pairs. The remaining climb
+to ECAPA is now squarely **features + data**: a log-mel front-end (the Form mel recipes, not coarse
+bands) and a real multi-speaker corpus (hundreds of voices), trained through these proven float recipes
+— the same recipe that proves four-way is the one that crystallizes and trains native.
 
 ## Evaluation harness
 

--- a/experiments/rune-galdr/CHALLENGERS.md
+++ b/experiments/rune-galdr/CHALLENGERS.md
@@ -56,16 +56,39 @@ scale**. A *full* projection `W` (rotation, not just per-axis scale) trained by 
 is the salvage path for a linear C2; the decisive jump is C3. Recipe + machinery are proven and
 reusable; the negative result is named, not hidden.
 
-## Challenger 3 — "Net" (small neural embedder, the real ECAPA shape) — DESIGNED
+## Challenger 2-full — "Proj" (full linear projection, SGD) — BUILT & FOUR-WAY
 
-A scaled-down x-vector/ECAPA: mel frames → 2–3 time-delay (conv) layers with frame context →
-statistics pooling (mean+std over time) → 1–2 dense layers → 128-d embedding, trained with
-AAM-softmax (or triplet) over many speakers. This is the architecture that *is* ECAPA minus the
-Res2Net/SE depth and the data scale. Built from the proven transformer-training tissue
-(`transformer-corpus-train.fk`, `transformer-block.fk`, `softmax-ln.fk`, `form-train-step.fk`) —
-the same recipes that train the Form whisper block four-way; native speed via the emit→asm lane.
-Expectation: the closest to ECAPA — single-digit EER reachable with enough public speaker data;
-the residual to <1% is the VoxCeleb-scale data wall.
+`speaker-proj.fk` (PASS-4WAY, 255): the diagonal's salvage — a full matrix `W` (K×N) trained by
+squared-loss SGD toward speaker codes (the affine-train loop lifted to multi-output). Unlike the
+diagonal it can *rotate*. The band proves the loop genuinely descends: one step drops the fixture
+loss 4,000,000 → 2,560,000 and moves an off-axis weight, four-way.
+
+## Challenger 3 — "Net" (nonlinear neural embedder, SGD) — BUILT & FOUR-WAY
+
+`speaker-net.fk` (PASS-4WAY, 255): `emb = relu(W·x)` with relu-GATED backprop — the one thing
+C1/C2 lack, a nonlinearity. The band proves a dead unit passes zero gradient while the active
+unit's gradient reaches its off-axis weight, and the step descends 5,000,000 → 3,190,400, four-way.
+One layer here; stacking is the same recipe repeated (the deep TDNN).
+
+## Race result — the moat is features + precision + data, not the model
+
+C2-full and C3 are built and four-way proven (their training loops descend on clean fixtures). But
+**training them on the real corpus collapses** — measured, named, not hidden:
+
+- **Features.** The hand-crafted sox 20-band supervector rounds to small ints (0–99); coarse 0/1-ish
+  patterns carry enough for C1's cosine but almost no gradient signal for a learned embedder.
+- **Precision.** Integer fixed-point SGD rounds the small per-step weight updates toward zero — the
+  gradient that the clean-fixture band shows descending vanishes on real-scale features.
+- **Data.** 26 voices × 2 training windows is far below what discriminative training needs; held-out
+  generalization has almost nothing to learn from.
+
+So the decisive lesson of the whole race: C1 (stats) ≈ usable on easy pairs; C2-diagonal lost;
+C2-full and C3 are the right model classes but can't be *trained* to beat C1 on this footing. **ECAPA's
+power is not the model class — it is the learned log-mel front-end, float training, and VoxCeleb-scale
+data.** Approaching it means meeting it on those: (1) a learned/log-mel feature front-end (the Form mel
+recipes, not coarse bands); (2) the native float training lane (emit→asm), not the tree-walker's integer
+fixed-point; (3) a real multi-speaker corpus. The recipes are the proven, reusable bodies waiting for
+that footing — the same recipe that proves four-way is the one that will crystallize and train native.
 
 ## Evaluation harness
 

--- a/form/form-stdlib/speaker-net.fk
+++ b/form/form-stdlib/speaker-net.fk
@@ -1,0 +1,34 @@
+; speaker-net.fk — Challenger 3 ("Net"): a NONLINEAR neural embedder, SGD-trained.
+;
+; C2 (linear, diagonal and full) can only carve speakers apart with hyperplanes. C3 adds the
+; one thing ECAPA's power rests on — a NONLINEARITY. The minimal x-vector: emb = relu(W·x),
+; trained by squared loss to speaker target codes with relu-GATED backprop (gradient flows only
+; through active units). One nonlinear layer here; stacking more (the deep TDNN) is the same
+; recipe repeated — this proves the loop. Reuses speaker-proj's matvec + row-SGD.
+;
+; Fixed-point scale 1000. Builds on speaker-embed (se-dot) + speaker-proj (sp-*). Proven by
+; form-stdlib/tests/speaker-net-band.fk.
+
+(do
+    ; --- forward: emb = relu(W·x) ---
+    (defn sn-relu-vec (v)
+        (if (eq (len v) 0) (empty)
+            (cons (if (lt (head v) 0) 0 (head v)) (sn-relu-vec (tail v)))))
+    (defn sn-forward (W x) (sn-relu-vec (sp-matvec W x)))
+
+    ; --- relu-gated error: dL/dz_j = (relu(z)_j − t_j) if z_j>0 else 0 (dead units pass no gradient) ---
+    (defn sn-gated-err (z t)
+        (if (eq (len z) 0) (empty)
+            (cons (if (gt (head z) 0) (sub (head z) (head t)) 0)
+                  (sn-gated-err (tail z) (tail t)))))
+
+    ; --- one SGD step: update each row by its gated error (sp-row-step is the squared-loss rule) ---
+    (defn sn-step (W x t lr) (sp-step-rows W x (sn-gated-err (sp-matvec W x) t) lr))
+    (defn sn-epoch (W corpus lr)
+        (if (eq (len corpus) 0) W
+            (sn-epoch (sn-step W (sp-x (head corpus)) (sp-t (head corpus)) lr) (tail corpus) lr)))
+    (defn sn-train (W corpus lr epochs)
+        (if (eq epochs 0) W (sn-train (sn-epoch W corpus lr) corpus lr (sub epochs 1))))
+
+    ; --- loss on the post-relu embedding ---
+    (defn sn-loss (W x t) (sp-sqsum (sp-err (sn-forward W x) t))))

--- a/form/form-stdlib/speaker-net.fk
+++ b/form/form-stdlib/speaker-net.fk
@@ -1,25 +1,24 @@
-; speaker-net.fk — Challenger 3 ("Net"): a NONLINEAR neural embedder, SGD-trained.
+; speaker-net.fk — Challenger 3 ("Net"): a NONLINEAR neural embedder, FLOAT SGD.
 ;
-; C2 (linear, diagonal and full) can only carve speakers apart with hyperplanes. C3 adds the
-; one thing ECAPA's power rests on — a NONLINEARITY. The minimal x-vector: emb = relu(W·x),
-; trained by squared loss to speaker target codes with relu-GATED backprop (gradient flows only
-; through active units). One nonlinear layer here; stacking more (the deep TDNN) is the same
-; recipe repeated — this proves the loop. Reuses speaker-proj's matvec + row-SGD.
+; C2 (linear) can only carve with hyperplanes; C3 adds the nonlinearity ECAPA's power rests on.
+; The minimal x-vector: emb = relu(W·x), trained by squared loss to speaker codes with relu-GATED
+; backprop (gradient flows only through active units). Plain floats (fp64, the whisper-block
+; arithmetic, four-way) — not integer fixed-point. One nonlinear layer here; stacking more (the
+; deep TDNN) is the same recipe repeated. Reuses speaker-proj's float matvec + row-SGD.
 ;
-; Fixed-point scale 1000. Builds on speaker-embed (se-dot) + speaker-proj (sp-*). Proven by
-; form-stdlib/tests/speaker-net-band.fk.
+; Proven by form-stdlib/tests/speaker-net-band.fk.
 
 (do
     ; --- forward: emb = relu(W·x) ---
     (defn sn-relu-vec (v)
         (if (eq (len v) 0) (empty)
-            (cons (if (lt (head v) 0) 0 (head v)) (sn-relu-vec (tail v)))))
+            (cons (if (lt (head v) 0.0) 0.0 (head v)) (sn-relu-vec (tail v)))))
     (defn sn-forward (W x) (sn-relu-vec (sp-matvec W x)))
 
-    ; --- relu-gated error: dL/dz_j = (relu(z)_j − t_j) if z_j>0 else 0 (dead units pass no gradient) ---
+    ; --- relu-gated error: dL/dz_j = (relu(z)_j − t_j) if z_j>0 else 0.0 (dead units pass none) ---
     (defn sn-gated-err (z t)
         (if (eq (len z) 0) (empty)
-            (cons (if (gt (head z) 0) (sub (head z) (head t)) 0)
+            (cons (if (gt (head z) 0.0) (sub (head z) (head t)) 0.0)
                   (sn-gated-err (tail z) (tail t)))))
 
     ; --- one SGD step: update each row by its gated error (sp-row-step is the squared-loss rule) ---

--- a/form/form-stdlib/speaker-proj.fk
+++ b/form/form-stdlib/speaker-proj.fk
@@ -1,33 +1,28 @@
-; speaker-proj.fk — Challenger 2-full ("Proj"): a learned FULL linear projection, SGD-trained.
+; speaker-proj.fk — Challenger 2-full ("Proj"): a learned FULL linear projection, FLOAT SGD.
 ;
-; C2-diagonal (speaker-lin) only rescaled axes and lost — speaker identity that lives in a
-; COMBINATION of bands needs a rotation, not per-axis gain. This learns a full matrix W
-; (K rows × N) by squared-loss SGD toward speaker target codes — the i-vector→LDA projection,
-; the affine-train loop lifted to multi-output. W·x rotates the supervector into a space where
-; speakers separate; cosine (speaker-embed se-dot) scores there.
+; C2-diagonal only rescaled axes and lost; identity that lives in a COMBINATION of bands needs a
+; rotation. This learns a full matrix W (K rows × N) by squared-loss SGD toward speaker target
+; codes — the i-vector→LDA projection. It runs on plain floats (the same arithmetic the Form
+; whisper block trains on, fp64, four-way) — NOT integer fixed-point, whose rounding silently
+; zeroed the small gradients. W·x rotates the supervector; cosine scores in that space.
 ;
-; Fixed-point scale 1000 (like affine-train): weights ×1000, a product folds back with /1000.
-; Builds on speaker-embed (se-dot). Proven by form-stdlib/tests/speaker-proj-band.fk.
+; All float (0.0 init, float lr). Proven by form-stdlib/tests/speaker-proj-band.fk.
 
 (do
-    ; --- forward: y_j = (W_j · x) / 1000 for each row ---
-    (defn sp-matvec (W x)
-        (if (eq (len W) 0) (empty)
-            (cons (div (se-dot (head W) x) 1000) (sp-matvec (tail W) x))))
+    ; --- float dot + forward: y_j = W_j · x ---
+    (defn sp-dot (w x) (if (eq (len w) 0) 0.0 (add (mul (head w) (head x)) (sp-dot (tail w) (tail x)))))
+    (defn sp-matvec (W x) (if (eq (len W) 0) (empty) (cons (sp-dot (head W) x) (sp-matvec (tail W) x))))
     (defn sp-project (W x) (sp-matvec W x))
 
-    ; --- errors e = y − t ---
-    (defn sp-err (y t)
-        (if (eq (len y) 0) (empty) (cons (sub (head y) (head t)) (sp-err (tail y) (tail t)))))
-    (defn sp-sqsum (e) (if (eq (len e) 0) 0 (add (mul (head e) (head e)) (sp-sqsum (tail e)))))
+    ; --- errors e = y − t and squared loss ---
+    (defn sp-err (y t) (if (eq (len y) 0) (empty) (cons (sub (head y) (head t)) (sp-err (tail y) (tail t)))))
+    (defn sp-sqsum (e) (if (eq (len e) 0) 0.0 (add (mul (head e) (head e)) (sp-sqsum (tail e)))))
     (defn sp-loss (W x t) (sp-sqsum (sp-err (sp-matvec W x) t)))
 
-    ; --- SGD: one row's update given its scalar error e_j (squared loss, lr fixed-point ×1000) ---
-    ;   w_i <- w_i − lr · 2 · e_j · x_i           (each ·x_i and ·lr folds back /1000)
+    ; --- SGD: w_i <- w_i − lr · 2 · e_j · x_i   (pure float — no fixed-point, no rounding) ---
     (defn sp-row-step (w x ej lr)
         (if (eq (len w) 0) (empty)
-            (cons (sub (head w) (div (mul lr (div (mul (mul 2 ej) (head x)) 1000)) 1000))
-                  (sp-row-step (tail w) (tail x) ej lr))))
+            (cons (sub (head w) (mul lr (mul (mul 2.0 ej) (head x)))) (sp-row-step (tail w) (tail x) ej lr))))
     (defn sp-step-rows (W x e lr)
         (if (eq (len W) 0) (empty)
             (cons (sp-row-step (head W) x (head e) lr) (sp-step-rows (tail W) x (tail e) lr))))

--- a/form/form-stdlib/speaker-proj.fk
+++ b/form/form-stdlib/speaker-proj.fk
@@ -1,0 +1,43 @@
+; speaker-proj.fk — Challenger 2-full ("Proj"): a learned FULL linear projection, SGD-trained.
+;
+; C2-diagonal (speaker-lin) only rescaled axes and lost — speaker identity that lives in a
+; COMBINATION of bands needs a rotation, not per-axis gain. This learns a full matrix W
+; (K rows × N) by squared-loss SGD toward speaker target codes — the i-vector→LDA projection,
+; the affine-train loop lifted to multi-output. W·x rotates the supervector into a space where
+; speakers separate; cosine (speaker-embed se-dot) scores there.
+;
+; Fixed-point scale 1000 (like affine-train): weights ×1000, a product folds back with /1000.
+; Builds on speaker-embed (se-dot). Proven by form-stdlib/tests/speaker-proj-band.fk.
+
+(do
+    ; --- forward: y_j = (W_j · x) / 1000 for each row ---
+    (defn sp-matvec (W x)
+        (if (eq (len W) 0) (empty)
+            (cons (div (se-dot (head W) x) 1000) (sp-matvec (tail W) x))))
+    (defn sp-project (W x) (sp-matvec W x))
+
+    ; --- errors e = y − t ---
+    (defn sp-err (y t)
+        (if (eq (len y) 0) (empty) (cons (sub (head y) (head t)) (sp-err (tail y) (tail t)))))
+    (defn sp-sqsum (e) (if (eq (len e) 0) 0 (add (mul (head e) (head e)) (sp-sqsum (tail e)))))
+    (defn sp-loss (W x t) (sp-sqsum (sp-err (sp-matvec W x) t)))
+
+    ; --- SGD: one row's update given its scalar error e_j (squared loss, lr fixed-point ×1000) ---
+    ;   w_i <- w_i − lr · 2 · e_j · x_i           (each ·x_i and ·lr folds back /1000)
+    (defn sp-row-step (w x ej lr)
+        (if (eq (len w) 0) (empty)
+            (cons (sub (head w) (div (mul lr (div (mul (mul 2 ej) (head x)) 1000)) 1000))
+                  (sp-row-step (tail w) (tail x) ej lr))))
+    (defn sp-step-rows (W x e lr)
+        (if (eq (len W) 0) (empty)
+            (cons (sp-row-step (head W) x (head e) lr) (sp-step-rows (tail W) x (tail e) lr))))
+    (defn sp-step (W x t lr) (sp-step-rows W x (sp-err (sp-matvec W x) t) lr))
+
+    ; --- fold over the corpus (list of (x t)) for N epochs ---
+    (defn sp-x (s) (nth s 0))
+    (defn sp-t (s) (nth s 1))
+    (defn sp-epoch (W corpus lr)
+        (if (eq (len corpus) 0) W
+            (sp-epoch (sp-step W (sp-x (head corpus)) (sp-t (head corpus)) lr) (tail corpus) lr)))
+    (defn sp-train (W corpus lr epochs)
+        (if (eq epochs 0) W (sp-train (sp-epoch W corpus lr) corpus lr (sub epochs 1)))))

--- a/form/form-stdlib/tests/speaker-net-band.fk
+++ b/form/form-stdlib/tests/speaker-net-band.fk
@@ -1,37 +1,30 @@
-; preludes: form-stdlib/speaker-embed.fk form-stdlib/speaker-proj.fk form-stdlib/speaker-net.fk
+; preludes: form-stdlib/speaker-proj.fk form-stdlib/speaker-net.fk
 ;
-; speaker-net-band — Challenger 3's nonlinear relu embedder + gated backprop, three-way.
+; speaker-net-band — Challenger 3's FLOAT relu embedder + gated backprop, three-way.
 ;
-; W=identity×1000, x=[3000,−2000] → z=[3000,−2000] → relu emb=[3000,0] (unit1 DEAD).
-; t=[1000,1000]; loss=(3000−1000)²+(0−1000)²=5,000,000. The dead unit passes NO gradient;
-; the active unit's gradient flows to BOTH its weights (incl. the off-axis one). One step
-; (lr=10) → w00 880, w01 80; loss falls to 3,190,400.
+; Identity W, x=[2,−1] → z=[2,−1] → relu emb=[2,0] (unit1 DEAD). t=[1,1]; loss=2. Dead unit
+; passes no gradient; active unit's gradient reaches its off-axis weight. Step lr=0.125: w00→0.5,
+; w01→0.25, loss 2→1.0625. All f64-exact.
 ;
-; Verdict 255 when every claim lands — the nonlinearity behaves:
-;   1   relu keeps the positive unit    (emb0 = 3000)
-;   2   relu zeroes the negative unit    (emb1 = 0)
-;   4   dead unit gets zero gradient     (gated-err1 = 0)
-;   8   active unit's error              (gated-err0 = 2000)
-;   16  loss before                      (= 5,000,000)
-;   32  loss strictly falls              (after < before)
-;   64  gradient reaches the off-axis w   (w01 0 → 80)
-;   128 loss after exact                 (= 3,190,400)
+; Verdict 255:
+;   1 emb0=2.0   2 emb1=0.0 (relu)   4 gated-err1=0.0 (dead)   8 gated-err0=1.0
+;   16 loss-before=2.0   32 loss strictly falls   64 w01=0.25 (off-axis got gradient)   128 loss-after=1.0625
 (do
-    (let W (list (list 1000 0) (list 0 1000)))
-    (let x (list 3000 -2000))
-    (let t (list 1000 1000))
+    (let W (list (list 1.0 0.0) (list 0.0 1.0)))
+    (let x (list 2.0 -1.0))
+    (let t (list 1.0 1.0))
     (let z (sp-matvec W x))
     (let emb (sn-forward W x))
     (let ge (sn-gated-err z t))
     (let before (sn-loss W x t))
-    (let W2 (sn-step W x t 10))
+    (let W2 (sn-step W x t 0.125))
     (let after (sn-loss W2 x t))
-    (let c0 (if (eq (head emb) 3000) 1 0))
-    (let c1 (if (eq (head (tail emb)) 0) 2 0))
-    (let c2 (if (eq (head (tail ge)) 0) 4 0))
-    (let c3 (if (eq (head ge) 2000) 8 0))
-    (let c4 (if (eq before 5000000) 16 0))
+    (let c0 (if (eq (head emb) 2.0) 1 0))
+    (let c1 (if (eq (head (tail emb)) 0.0) 2 0))
+    (let c2 (if (eq (head (tail ge)) 0.0) 4 0))
+    (let c3 (if (eq (head ge) 1.0) 8 0))
+    (let c4 (if (eq before 2.0) 16 0))
     (let c5 (if (lt after before) 32 0))
-    (let c6 (if (eq (head (tail (head W2))) 80) 64 0))
-    (let c7 (if (eq after 3190400) 128 0))
+    (let c6 (if (eq (head (tail (head W2))) 0.25) 64 0))
+    (let c7 (if (eq after 1.0625) 128 0))
     (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/form-stdlib/tests/speaker-net-band.fk
+++ b/form/form-stdlib/tests/speaker-net-band.fk
@@ -1,0 +1,37 @@
+; preludes: form-stdlib/speaker-embed.fk form-stdlib/speaker-proj.fk form-stdlib/speaker-net.fk
+;
+; speaker-net-band — Challenger 3's nonlinear relu embedder + gated backprop, three-way.
+;
+; W=identity×1000, x=[3000,−2000] → z=[3000,−2000] → relu emb=[3000,0] (unit1 DEAD).
+; t=[1000,1000]; loss=(3000−1000)²+(0−1000)²=5,000,000. The dead unit passes NO gradient;
+; the active unit's gradient flows to BOTH its weights (incl. the off-axis one). One step
+; (lr=10) → w00 880, w01 80; loss falls to 3,190,400.
+;
+; Verdict 255 when every claim lands — the nonlinearity behaves:
+;   1   relu keeps the positive unit    (emb0 = 3000)
+;   2   relu zeroes the negative unit    (emb1 = 0)
+;   4   dead unit gets zero gradient     (gated-err1 = 0)
+;   8   active unit's error              (gated-err0 = 2000)
+;   16  loss before                      (= 5,000,000)
+;   32  loss strictly falls              (after < before)
+;   64  gradient reaches the off-axis w   (w01 0 → 80)
+;   128 loss after exact                 (= 3,190,400)
+(do
+    (let W (list (list 1000 0) (list 0 1000)))
+    (let x (list 3000 -2000))
+    (let t (list 1000 1000))
+    (let z (sp-matvec W x))
+    (let emb (sn-forward W x))
+    (let ge (sn-gated-err z t))
+    (let before (sn-loss W x t))
+    (let W2 (sn-step W x t 10))
+    (let after (sn-loss W2 x t))
+    (let c0 (if (eq (head emb) 3000) 1 0))
+    (let c1 (if (eq (head (tail emb)) 0) 2 0))
+    (let c2 (if (eq (head (tail ge)) 0) 4 0))
+    (let c3 (if (eq (head ge) 2000) 8 0))
+    (let c4 (if (eq before 5000000) 16 0))
+    (let c5 (if (lt after before) 32 0))
+    (let c6 (if (eq (head (tail (head W2))) 80) 64 0))
+    (let c7 (if (eq after 3190400) 128 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/form-stdlib/tests/speaker-proj-band.fk
+++ b/form/form-stdlib/tests/speaker-proj-band.fk
@@ -1,0 +1,34 @@
+; preludes: form-stdlib/speaker-embed.fk form-stdlib/speaker-proj.fk
+;
+; speaker-proj-band — Challenger 2-full's SGD-trained linear projection, three-way.
+;
+; Identity W=[[1000,0],[0,1000]], sample x=[3000,1000], target t=[1000,1000] (fixed-point ×1000).
+; Forward y = x = [3000,1000]; err=[2000,0]; loss=2000²=4,000,000. One SGD step (lr=10 → 0.01)
+; pulls row0 down its gradient: w00 1000→880, w01 0→−40; loss falls to 1600²=2,560,000.
+;
+; Verdict 255 when every claim lands — the training loop genuinely descends:
+;   1   forward row0           (y0 = 3000)
+;   2   forward row1           (y1 = 1000)
+;   4   error                  (e0 = 2000)
+;   8   loss before            (= 4,000,000)
+;   16  loss strictly falls    (after-step loss < before)
+;   32  gradient update w00     (1000 → 880)
+;   64  signed update w01       (0 → −40 — the off-axis weight moved negative)
+;   128 loss after exact        (= 2,560,000)
+(do
+    (let W (list (list 1000 0) (list 0 1000)))
+    (let x (list 3000 1000))
+    (let t (list 1000 1000))
+    (let y (sp-matvec W x))
+    (let before (sp-loss W x t))
+    (let W2 (sp-step W x t 10))
+    (let after (sp-loss W2 x t))
+    (let c0 (if (eq (head y) 3000) 1 0))
+    (let c1 (if (eq (head (tail y)) 1000) 2 0))
+    (let c2 (if (eq (head (sp-err y t)) 2000) 4 0))
+    (let c3 (if (eq before 4000000) 8 0))
+    (let c4 (if (lt after before) 16 0))
+    (let c5 (if (eq (head (head W2)) 880) 32 0))
+    (let c6 (if (eq (head (tail (head W2))) -40) 64 0))
+    (let c7 (if (eq after 2560000) 128 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/form-stdlib/tests/speaker-proj-band.fk
+++ b/form/form-stdlib/tests/speaker-proj-band.fk
@@ -1,34 +1,27 @@
-; preludes: form-stdlib/speaker-embed.fk form-stdlib/speaker-proj.fk
+; preludes: form-stdlib/speaker-proj.fk
 ;
-; speaker-proj-band — Challenger 2-full's SGD-trained linear projection, three-way.
+; speaker-proj-band — Challenger 2-full's FLOAT-SGD linear projection, three-way.
 ;
-; Identity W=[[1000,0],[0,1000]], sample x=[3000,1000], target t=[1000,1000] (fixed-point ×1000).
-; Forward y = x = [3000,1000]; err=[2000,0]; loss=2000²=4,000,000. One SGD step (lr=10 → 0.01)
-; pulls row0 down its gradient: w00 1000→880, w01 0→−40; loss falls to 1600²=2,560,000.
+; Identity W, x=[2,1], t=[1,1] (all f64-exact). y=[2,1]; err=[1,0]; loss=1. One step lr=0.125
+; descends: w00 1→0.5, w01 0→−0.25, loss 1→0.0625. Pure float — gradients no longer round away.
 ;
-; Verdict 255 when every claim lands — the training loop genuinely descends:
-;   1   forward row0           (y0 = 3000)
-;   2   forward row1           (y1 = 1000)
-;   4   error                  (e0 = 2000)
-;   8   loss before            (= 4,000,000)
-;   16  loss strictly falls    (after-step loss < before)
-;   32  gradient update w00     (1000 → 880)
-;   64  signed update w01       (0 → −40 — the off-axis weight moved negative)
-;   128 loss after exact        (= 2,560,000)
+; Verdict 255:
+;   1 y0=2.0   2 y1=1.0   4 err0=1.0   8 loss-before=1.0   16 loss strictly falls
+;   32 w00=0.5   64 w01=−0.25   128 loss-after=0.0625
 (do
-    (let W (list (list 1000 0) (list 0 1000)))
-    (let x (list 3000 1000))
-    (let t (list 1000 1000))
+    (let W (list (list 1.0 0.0) (list 0.0 1.0)))
+    (let x (list 2.0 1.0))
+    (let t (list 1.0 1.0))
     (let y (sp-matvec W x))
     (let before (sp-loss W x t))
-    (let W2 (sp-step W x t 10))
+    (let W2 (sp-step W x t 0.125))
     (let after (sp-loss W2 x t))
-    (let c0 (if (eq (head y) 3000) 1 0))
-    (let c1 (if (eq (head (tail y)) 1000) 2 0))
-    (let c2 (if (eq (head (sp-err y t)) 2000) 4 0))
-    (let c3 (if (eq before 4000000) 8 0))
+    (let c0 (if (eq (head y) 2.0) 1 0))
+    (let c1 (if (eq (head (tail y)) 1.0) 2 0))
+    (let c2 (if (eq (head (sp-err y t)) 1.0) 4 0))
+    (let c3 (if (eq before 1.0) 8 0))
     (let c4 (if (lt after before) 16 0))
-    (let c5 (if (eq (head (head W2)) 880) 32 0))
-    (let c6 (if (eq (head (tail (head W2))) -40) 64 0))
-    (let c7 (if (eq after 2560000) 128 0))
+    (let c5 (if (eq (head (head W2)) 0.5) 32 0))
+    (let c6 (if (eq (head (tail (head W2))) -0.25) 64 0))
+    (let c7 (if (eq after 0.0625) 128 0))
     (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -480,6 +480,8 @@ speaker-id fks 255
 speaker-embed fks 255
 speaker-stat fks 255
 speaker-lin fks 1023
+speaker-proj fks 255
+speaker-net fks 255
 wav-sense fks 63
 witness-theorem fks 31
 witness-to-co-regulate fks 127


### PR DESCRIPTION
Urs caught it — **"small ints? should we not use floats?"** Yes. The kernel runs **fp64 natively** (the Form whisper block trains on it, four-way); C2-full/C3 were wrongly built on **integer fixed-point** (I copied `form-train-step`, the toy), whose `/1000` rounding zeroed the small gradients — *that* was the "precision wall," self-inflicted.

## Rebuilt on floats (still PASS-4WAY, 255)
Both recipes now use plain float arithmetic (the whisper-block ops). f64-exact fixtures: [`speaker-proj.fk`](form/form-stdlib/speaker-proj.fk) descends 1.0→0.0625; [`speaker-net.fk`](form/form-stdlib/speaker-net.fk) 2.0→1.0625; off-axis weights move; dead ReLU units gate to zero gradient.

## Measured — precision wall GONE, data wall now binding
- **C2-full now genuinely trains**: real varied embeddings (ubbe·brig 0.605, ubbe·ang 0.844) where the integer version output **all-zeros**.
- **Still doesn't beat C1**: held-out hard pair brig·ang **0.881** vs C1 **0.768** — 52 training samples can't learn a *generalizing* projection.
- **C3** is dead at zero-init (z=0 gates the gradient off); wakes with a positive init but collapses on sparse code targets with this little data. Known fixes: Xavier init + margin/softmax loss + data.

**Corrected lesson** ([CHALLENGERS.md](experiments/rune-galdr/CHALLENGERS.md)): float training is real and four-way; the binding wall is now **features + data** — a log-mel front-end (the Form mel recipes) + a real multi-speaker corpus through these proven float recipes. C1 (stats) remains the only challenger usable today, on easy pairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)