### PR TITLE
feat(form): gen → content-addressed store — a recipe found by its own address, no path agreed in advance

### DIFF
--- a/form/form-stdlib/form-gen.fk
+++ b/form/form-stdlib/form-gen.fk
@@ -28,6 +28,11 @@
 ;   form/form-kernel-go/bin-go form/form-stdlib/form-gen.fk /tmp/g.fk     ; writes /tmp/a.fkb
 ;   printf '(gen-run-file "/tmp/a.fkb")\n' > /tmp/g.fk
 ;   form/form-kernel-go/bin-go form/form-stdlib/form-gen.fk /tmp/g.fk     ; 43 (loaded from disk)
+;   mkdir -p /tmp/cas
+;   printf '(gen-cas-roundtrip "/tmp/cas" "(add (mul 6 7) 1)")\n' > /tmp/g.fk
+;   form/form-kernel-go/bin-go form/form-stdlib/form-gen.fk /tmp/g.fk     ; [43, 276117490, 1, 1]
+;   printf '(gen-fetch-run "/tmp/cas" 276117490)\n' > /tmp/g.fk           ; share only the address
+;   form/form-kernel-go/bin-go form/form-stdlib/form-gen.fk /tmp/g.fk     ; 43 (found by content-address)
 ;
 ; preludes: (none — uses only kernel primitives)
 
@@ -87,5 +92,48 @@
             (let r2 (bytes_to_recipe (read_file_bytes path)))
             (let v2 (form_walk r2))
             (list v v2 (node_eq r r2))))
+
+    ; --- content-addressed store: a recipe lands at its OWN address ---------
+    ; A recipe's serialized bytes are stable, so a checksum of them is a durable
+    ; NAME the content itself produces. Store the bytes at that name; any cell
+    ; that re-derives or receives the recipe computes the same address and
+    ; fetches it — discovery WITHOUT a path agreed in advance, the substrate's
+    ; core move (and the disk sink's missing half: there you had to know where).
+    ; The address is the bridge to the lattice NodeID. (Floor: a content-addressed
+    ; dir + a 31-bit rolling hash — honest, low-collision for now; widen the
+    ; digest in gen-address and every caller follows. The Neo4j/Postgres lattice
+    ; ingest — domain/name/graph edges — is the next rung: a Form-native
+    ; substrate write door, Python-ingest today.)
+
+    ; a stable content-hash of the serialized recipe (polynomial rolling hash)
+    (defn gen-hash-loop (bytes acc)
+        (if (eq (len bytes) 0) acc
+            (gen-hash-loop (tail bytes) (mod (add (mul acc 31) (head bytes)) 2147483647))))
+    (defn gen-address (r) (gen-hash-loop (recipe_to_bytes r) 0))
+
+    (defn gen-store-path (dir addr)
+        (str_concat dir (str_concat "/" (str_concat (int_to_str addr) ".fkb"))))
+
+    ; store a generated recipe at its content-address -> the address (the handle)
+    (defn gen-store (dir src)
+        (do
+            (let r (form_compile src))
+            (let addr (gen-address r))
+            (write_file_bytes (gen-store-path dir addr) (recipe_to_bytes r))
+            addr))
+
+    ; fetch / run a recipe by content-address — no path, just the address
+    (defn gen-fetch (dir addr) (bytes_to_recipe (read_file_bytes (gen-store-path dir addr))))
+    (defn gen-fetch-run (dir addr) (form_walk (gen-fetch dir addr)))
+
+    ; content-addressed discovery: store, then prove a fresh compile of the SAME
+    ; source re-derives the SAME address and SAME node, fetched by address alone.
+    ; -> (value addr addr-stable? same-node?)
+    (defn gen-cas-roundtrip (dir src)
+        (do
+            (let addr (gen-store dir src))
+            (let r2 (gen-fetch dir addr))
+            (let addr2 (gen-address (form_compile src)))
+            (list (form_walk r2) addr (eq addr addr2) (node_eq (form_compile src) r2))))
 
     0)


### PR DESCRIPTION
## What

The **substrate sink** — the disk sink's missing half. Last rung you had to know *where* the `.fkb` was; here **the recipe names its own place**. A recipe's serialized bytes are stable, so a hash of them is a durable address the content itself produces. Store the bytes there; any cell that re-derives or receives the recipe computes the same address and fetches it — **discovery without prior coordination**, the substrate's core move. Pure Form over the existing byte-file carriers:

```
gen-address r        recipe → a stable content-address (rolling hash of its bytes)
gen-store dir src    compile → store at the content-address → the address
gen-fetch[-run]      fetch / run by address alone — no path
gen-cas-roundtrip    store, then prove a fresh compile re-derives the SAME address + node
```

## Proof (Go kernel)

```
(gen-cas-roundtrip "/tmp/cas" "(add (mul 6 7) 1)") → [43, 276117490, 1, 1]
# the file lands as 276117490.fkb; then a SEPARATE cell, given ONLY 276117490:
(gen-fetch-run "/tmp/cas" 276117490)               → 43
```

`addr-stable? = 1` and `same-node? = 1`: re-compiling the same source re-derives the identical address and node, fetched by address alone.

## Where the vision stands

| sink / surface | state |
|---|---|
| RAM · channel · disk · **content-addressed store** | ✅ |
| lattice ingest (domain/name/graph edges) | next — a Form-native substrate write door (Python-ingest today) |
| `form-cli gen` verb surface | thin step |
| four-way composable eval | deeper rung ([`form-engine.form`](docs/coherence-substrate/form-engine.form)) |

## Honest floor

A content-addressed dir + a 31-bit rolling hash — honest and low-collision for now; widen the digest in `gen-address` and every caller follows. This is the *functional* substrate-node behaviour (durable, content-addressed, retrievable, executable, content = namespace); the Neo4j/Postgres lattice ingest with graph edges is the named next rung. No Go changes; no four-way band affected (the run leg stays Go-hosted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)