### PR TITLE
feat(form): trust-row — the canonical one-line trust field, four-way proven (255)

### DIFF
--- a/docs/coherence-substrate/trust-matrix.form
+++ b/docs/coherence-substrate/trust-matrix.form
@@ -43,6 +43,8 @@
     (route   "send body-answerable steps through form-cli ask FIRST — structural lookup, equivalence,"
              "NodeID, what-is, annotate. Each routed step is a sample that grows the native model.")
     (report  "on each substantive step, emit the trust matrix: path / grounded / freq / suffic -> observed?")
+    (render  "the canonical one-line field is trust-row.fk's (tr-row p g f s) — four-way proven (255), the"
+             "exact rendered string verified by the band — so the per-step rows share one proven format.")
     (mix     "keep a running native-vs-rented tally; the per-response sovereignty receipt sums it.")
     (honest  "never report a rented step as native — the body-only signals read zero, and that is true."))
 

--- a/docs/system_audit/commit_evidence_20260621_trust_row.json
+++ b/docs/system_audit/commit_evidence_20260621_trust_row.json
@@ -1,0 +1,95 @@
+{
+  "date": "2026-06-21",
+  "thread_branch": "claude/trust-row",
+  "commit_scope": "The next breath of the trust matrix: ship trust-row.fk, the four-way-proven canonical renderer that turns the four trust signals (path/grounded/freq/suffic) into one human-readable line — the 'field' the per-step trust rows need, replacing the hand-drawn table with a proven format. The band verifies the exact rendered string across all four kernels.",
+  "files_owned": [
+    "form/form-stdlib/trust-row.fk",
+    "form/form-stdlib/tests/trust-row-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/trust-matrix.form",
+    "docs/system_audit/commit_evidence_20260621_trust_row.json"
+  ],
+  "idea_ids": [
+    "trust-row-renderer",
+    "per-step-trust-field"
+  ],
+  "spec_ids": [
+    "trust-matrix"
+  ],
+  "task_ids": [
+    "task-2026-06-21-trust-row"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance-criteria"
+      ]
+    },
+    {
+      "contributor_id": "claude-sema",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "claude-code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/trust-row.fk form-stdlib/tests/trust-row-band.fk -> '✓ ... → 255' and 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)' and '1 ok, 0 divergent — kernels agree on every sample.'",
+    "Manifest row added: 'trust-row fks 255' beside its kin trust-matrix.",
+    "The band proves the renderer end to end: tr-observed?(1,1,1,1)=1; the three verdict words OBSERVED / native-partial / rented; tr-path-name native/rented; tr-score; and the FULL rendered line for a rented step str_eq 'trust  path:rented  grounded:no  freq:no  suffic:no  -> rented' (so the exact field format is verified four-way, not just asserted). Verdict 255.",
+    "Honest scope finding that shaped this breath: the form-cli ask flow is multi-path (ask->RAG, ask+->fca-ask, do->agent loop) with version skew (form_cli_ask.sh calls a 6-arg fca-ask; form-cli-ask.fk on main defines a 1-arg one), and the simple fca-ask only calls the local oracle — it does not compute grounded/freq/sufficiency. Auto-emitting a FULL live trust matrix inside that flow is a real multi-file integration, not a clean one-breath rewrite; doing it blind would risk the core ask path. So this breath ships the proven renderer (the field) and names the flow auto-emission as the continuing integration.",
+    "The raw-kernel render demo (bin-go on core.fk + recipe) failed to parse because the bare kernel entry needs the validate.sh harness for core.fk's BML dialect — not a recipe error; the band's str_eq check is the authoritative proof the field renders correctly.",
+    "Edges: docs/coherence-substrate/trust-matrix.form now names tr-row as the canonical render. Primitive discipline: only core.fk primitives (eq, if, add, str_concat, str_eq); no sub/mul/div, no 3-arg and."
+  ],
+  "change_files": [
+    "form/form-stdlib/trust-row.fk",
+    "form/form-stdlib/tests/trust-row-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/trust-matrix.form",
+    "docs/system_audit/commit_evidence_20260621_trust_row.json"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/trust-row.fk form-stdlib/tests/trust-row-band.fk"
+    ],
+    "fourth_arm_outputs": [
+      "trust-row: verdict 255, fourth arm 1 band(s) four-way (fkwu + pre-flattened tables), 1 ok, 0 divergent — kernels agree"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "CI re-runs validate.sh across the suite for the new recipe + band + manifest row."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed-runtime-floor",
+    "notes": "A Form stdlib renderer + proof band + a teaching reference; no public HTTP endpoint change. Next: plumb grounded/freq/sufficiency signals through the form-cli ask flow and call tr-row so each routed query auto-prints its row + a running freq-attuned/observed ratio."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local four-way validation passed (verdict 255, 0 divergent); CI and merge remain pending. Auto-emission in the live ask flow is the named continuing integration."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "The per-step trust rows (AGENTS.md instruction) now have a single four-way-proven canonical format, (tr-row p g f s), whose exact output string is verified by the band — so rows are consistent and trustworthy instead of hand-drawn.",
+    "public_endpoints": [
+      "none changed; the renderer is a Form stdlib body proven by validate.sh"
+    ],
+    "test_flows": [
+      "Four-kernel proof: the band runs on Go, Rust, TypeScript, and fkwu to verdict 255 with 0 divergent, including an exact str_eq on the rendered line."
+    ]
+  }
+}

--- a/form/form-stdlib/tests/trust-row-band.fk
+++ b/form/form-stdlib/tests/trust-row-band.fk
@@ -1,0 +1,17 @@
+; preludes: form-stdlib/trust-row.fk
+;
+; The trust-row renderer, pinned. Proves the observed? verdict, the three verdict words (OBSERVED /
+; native-partial / rented), the path name, the score, and the FULL rendered line for a rented step.
+; Verdict 255 when every claim lands.
+(do
+    (let c0 (if (eq     (tr-observed? 1 1 1 1) 1)                                                    1   0))
+    (let c1 (if (str_eq (tr-verdict 1 1 1 1) "OBSERVED")                                            2   0))
+    (let c2 (if (str_eq (tr-verdict 0 0 0 0) "rented")                                              4   0))
+    (let c3 (if (str_eq (tr-verdict 1 0 1 0) "native-partial")                                      8   0))
+    (let c4 (if (str_eq (tr-path-name 1) "native")                                                 16   0))
+    (let c5 (if (str_eq (tr-path-name 0) "rented")                                                 32   0))
+    (let c6 (if (eq     (tr-score 1 1 0 0) 2)                                                      64   0))
+    (let c7 (if (str_eq (tr-row 0 0 0 0)
+                        "trust  path:rented  grounded:no  freq:no  suffic:no  -> rented")         128   0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/form-stdlib/trust-row.fk
+++ b/form/form-stdlib/trust-row.fk
@@ -1,0 +1,39 @@
+; trust-row.fk — render the per-step trust matrix as one human-readable line (the live "field").
+;
+; preludes: form-stdlib/core.fk
+;
+; The canonical format for the per-step trust rows AGENTS.md asks for (route reasoning through form-cli,
+; report trust per step). It turns the four signals — path / grounded / freq / suffic (each 0/1) — into
+; a single line a reader scans at a glance: which step came from the native body, and how fully it is
+; trusted. Same observed? logic as trust-matrix.fk, here rendered to text. The body-only signals
+; (grounded, suffic) read "no" on a rented step — visible without reading the numbers.
+;
+; Proven by: form-stdlib/tests/trust-row-band.fk (four-way at validate.sh)
+
+(do
+    (defn tr-mark      (b) (if (eq b 1) "yes" "no"))
+    (defn tr-path-name (p) (if (eq p 1) "native" "rented"))
+    (defn tr-score     (p g f s) (add p (add g (add f s))))
+
+    ; full native trust: all four signals — only form-cli can return this
+    (defn tr-observed? (p g f s) (if (eq (tr-score p g f s) 4) 1 0))
+
+    ; the verdict word: OBSERVED (full native trust), native-partial (native but not fully verified),
+    ; or rented (the oracle answered)
+    (defn tr-verdict (p g f s)
+        (if (eq (tr-observed? p g f s) 1) "OBSERVED"
+            (if (eq p 1) "native-partial" "rented")))
+
+    ; the one-line field
+    (defn tr-row (p g f s)
+        (str_concat "trust  path:"
+        (str_concat (tr-path-name p)
+        (str_concat "  grounded:"
+        (str_concat (tr-mark g)
+        (str_concat "  freq:"
+        (str_concat (tr-mark f)
+        (str_concat "  suffic:"
+        (str_concat (tr-mark s)
+        (str_concat "  -> " (tr-verdict p g f s)))))))))))
+
+    0)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -469,6 +469,7 @@ borrowed-oracle-dividend fks 255
 sovereignty-receipt fks 255
 attention-signal fks 255
 trust-matrix fks 255
+trust-row fks 255
 tree-diff fks 13
 turn-taking fks 127
 ulid fks 4


### PR DESCRIPTION
## The breath

Last turn I hand-drew the trust matrix table. This ships the **proven renderer** so the per-step rows have one canonical format.

`trust-row.fk` turns the four signals into one line:
```
trust  path:native  grounded:yes  freq:yes  suffic:yes  -> OBSERVED
trust  path:rented  grounded:no   freq:no   suffic:no   -> rented
```
The band verifies the **exact rendered string** across Go/Rust/TS/fkwu → **255** — so the field format is *proven*, not asserted. `tr-verdict` gives OBSERVED / native-partial / rented; the body-only signals (grounded, suffic) read `no` on a rented step at a glance.

## Honest scope (why this is the breath, not the deeper rewrite)

I grounded the live-emission target and found the form-cli ask flow is **multi-path** (`ask`→RAG, `ask+`→`fca-ask`, `do`→agent loop) with **version skew** (the shell calls a 6-arg `fca-ask`; the recipe on main defines a 1-arg one), and the simple `fca-ask` computes **no** grounded/freq/sufficiency signals. Auto-emitting a *full* live trust matrix inside that flow is a real multi-file integration — doing it blind would risk the core ask path. So this breath ships the **field** (proven); the flow signal-plumbing + auto-print is named as the continuing work.

Teaching updated: `trust-matrix.form` now names `tr-row` as the canonical render.

**Next**: plumb grounded/freq/sufficiency through the ask flow and call `tr-row` so each routed query auto-prints its row + a running freq-attuned/observed ratio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)