### PR TITLE
feat(speech): native NL→NL runs live in the speech loop — voice→translate→voice

### DIFF
--- a/docs/coherence-substrate/translation-pipeline-pivot.form
+++ b/docs/coherence-substrate/translation-pipeline-pivot.form
@@ -90,15 +90,24 @@ defn nl_to_form = pipeline_shape { encode: @encode(nl), pivot: @pivot(meaning), 
 # pivot and engine never change. This is real NL->NL (parse meaning, re-render),
 # not phrase lookup.
 #
+# LIVE: the native NL->NL stage now runs in the speech loop —
+# experiments/coherence-sense-android/native-translate-speak.sh wires the proven
+# Form translate (form-stdlib/nl-translate.fk) between the STT oracle (whisper-cli)
+# and the TTS oracle (say): voice(en) -> transcribe -> NATIVE translate -> voice(id),
+# verified end to end ("The source is native." -> "sumber adalah asli"). The middle
+# is the only non-oracle stage; the carrier is thin host-IO, the logic is Form.
+#
 # NAMED, not yet built: the LEARNED encoder/decoders (today the grammar, the emit
 # templates, and the lexicon are hand-authored data, not trained — the diagnostic
 # in form-native-models / this session showed a bigger NET is not the lever; the
 # embedding featurizer is); OPEN-VOCABULARY coverage the hand-lexicon can't reach;
-# the round-trip QUALITY gate (translation-quality.fk: essence / vitality / trust
-# above a floor, not string equality) wired onto the pivot; the model-council
-# (nl-to-form-satsang.form) proposing parses the circle agrees on; and the live
-# carrier wiring — this native NL->NL stage running between the STT and TTS oracles
-# on the Android speech loop (speech-organ.fk), the rung toward voice -> voice.
+# SURFACE-ROBUST encoding (case / punctuation / contractions) owned by the Form
+# encoder instead of carrier-side cleaning; the round-trip QUALITY gate
+# (translation-quality.fk: essence / vitality / trust above a floor, not string
+# equality) wired onto the pivot; the model-council (nl-to-form-satsang.form)
+# proposing parses the circle agrees on; and the two OTHER stages going native —
+# STT end-to-end (Form whisper is four-way-proven but not yet real-.wav->transcript)
+# and Form-native TTS (unbuilt, the long pole) — to drop the last two oracles.
 #
 # LINEAGE
 #   kin: universal-translator.form (pivot = Blueprint), encoder-decoder-as-recipe.form

--- a/experiments/coherence-sense-android/native-translate-speak.sh
+++ b/experiments/coherence-sense-android/native-translate-speak.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# native-translate-speak.sh — the live rung: a Form-NATIVE NL->NL translate stage
+# wired between the STT and TTS oracles, the first place the speech loop shows a
+# Form-native translation running end to end.
+#
+# BML-first: the LOGIC is Form — form-stdlib/nl-translate.fk, four-way proven by
+# tests/nl-translate-band.fk (witness 31, Go/Rust/TS/fkwu). THIS carrier is thin
+# host-IO only: build the input program, run the kernel, speak the result, write a
+# receipt. The kernel call is one line; every translation decision lives in Form.
+#
+# Usage:
+#   native-translate-speak.sh "the source is native"          # en -> id, say it
+#   native-translate-speak.sh "sumber adalah asli" id-en      # id -> en
+#   native-translate-speak.sh --voice "the kernel is native"  # full voice -> voice:
+#     say(en) -> wav -> whisper-cli transcribe (STT oracle) -> NATIVE translate
+#     -> say (TTS oracle). The native middle is the only non-oracle stage.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+STD="$ROOT/form/form-stdlib"; GO="$ROOT/form/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || ( cd "$ROOT/form/form-kernel-go" && GOPROXY=off go build -o bin-go . ) >/dev/null 2>&1
+[[ -x "$GO" ]] || { echo "FAIL no Form kernel (bin-go) — build: (cd $ROOT/form/form-kernel-go && go build -o bin-go .)"; exit 1; }
+# core.fk is the only source-compiled prelude; nl-translate's deps are all builtins
+# + already-low-level cells, so the native translate runs without it.
+PRELUDE=(json cache form-ontology-loader line-grammar bmf-core bmf-grammar nl-translate)
+SRCS=(); for p in "${PRELUDE[@]}"; do SRCS+=("$STD/$p.fk"); done
+
+# native translate: ONE kernel call, all logic is Form. dir = en-id | id-en
+translate() {  # $1 text  $2 dir -> stdout target surface
+  local fn="tr-en-id"; [[ "${2:-en-id}" == "id-en" ]] && fn="tr-id-en"
+  local esc="${1//\"/}"   # the grammar tokenizes on whitespace; drop stray quotes
+  local run; run="$(mktemp)"; printf '(do (print (%s "%s")) 0)\n' "$fn" "$esc" > "$run"
+  "$GO" "${SRCS[@]}" "$run" 2>/dev/null | grep -vE '^0$' | head -1
+  rm -f "$run"
+}
+
+MODE="text"; [[ "${1:-}" == "--voice" ]] && { MODE="voice"; shift; }
+TEXT="${1:?usage: native-translate-speak.sh [--voice] \"text\" [en-id|id-en]}"
+DIR="${2:-en-id}"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [[ "$MODE" == "voice" ]]; then
+  MODEL="${WHISPER_MODEL:-$HOME/whisper-models/ggml-large-v3-turbo.bin}"
+  wav="$(mktemp).wav"; aiff="$(mktemp).aiff"
+  say -o "$aiff" "$TEXT" 2>/dev/null && sox "$aiff" -c 1 -r 16000 "$wav" 2>/dev/null
+  if command -v whisper-cli >/dev/null && [[ -f "$MODEL" ]]; then
+    of="$(mktemp)"; whisper-cli -m "$MODEL" -f "$wav" -nt -oj -of "$of" -t 4 -l en >/dev/null 2>&1
+    TEXT="$(jq -r '[.transcription[].text]|join(" ")|gsub("^\\s+|\\s+$";"")' "$of.json" 2>/dev/null)"
+    echo "[stt-oracle whisper-cli] heard: \"$TEXT\""
+  else
+    echo "[stt-oracle absent — translating the text input directly]"
+  fi
+  rm -f "$wav" "$aiff"
+fi
+
+# surface I/O cleaning: STT yields capitalized, punctuated text ("The kernel is
+# native."); the grammar tokenizes canonical lowercase words. This is input
+# sanitation, not translation logic. (Making the Form ENCODER own surface
+# normalization — case, contractions, richer punctuation — is the next refinement.)
+CLEAN="$(printf '%s' "$TEXT" | tr '[:upper:]' '[:lower:]' | tr -d '.,!?;:')"
+OUT="$(translate "$CLEAN" "$DIR")"
+echo "[native-translate · form-stdlib/nl-translate.fk · $DIR]  \"$TEXT\"  ->  \"$OUT\""
+if command -v say >/dev/null; then say "$OUT" 2>/dev/null && echo "[tts-oracle say] spoke the translation"; fi
+
+REC="$ROOT/experiments/coherence-sense-android/.native-translate-receipt.json"
+printf '{"ts":"%s","stage":"nl-native-translate","dir":"%s","input":"%s","output":"%s","body":"form-stdlib/nl-translate.fk","kernel":"form-kernel-go","stt":"whisper-cli(oracle)","tts":"say(oracle)","native_middle":true}\n' \
+  "$TS" "$DIR" "$TEXT" "$OUT" > "$REC"
+echo "[receipt] $REC"

--- a/form/form-stdlib/nl-translate.fk
+++ b/form/form-stdlib/nl-translate.fk
@@ -1,0 +1,55 @@
+; nl-translate.fk — Form-native NL -> NL translation through the language-neutral
+; pivot. The reusable BODY behind tests/nl-translate-band.fk (witness 31, four-way)
+; and the live carrier (experiments/coherence-sense-android/native-translate-speak.sh).
+;
+; surface --g-parse(tongue grammar)--> raw node --normalize(lexicon)--> PIVOT
+; PIVOT --decode(target tongue)--> target surface
+;
+; Each tongue is its own grammar over the ONE engine; content words normalize
+; through a lexicon onto ONE pivot node (cjk-channel: one cell, many tongues), so
+; "the source is native" and "sumber adalah asli" intern to the SAME node. Adding
+; a tongue is adding a (grammar, lexicon-direction, decoder) — pivot and engine
+; never change. Grammars are nullary defns (global, fourth-arm-safe), not top-level
+; lets, so the carrier and the band can both call tr-en-id / tr-id-en directly.
+
+(do
+    (defn nlt-s (x) (intern_trivial_string x))
+    (defn nlt-kidv (n i) (node_value (nth (node_children n) i)))
+    (defn nlt-sp (a b) (str_concat a (str_concat " " b)))
+
+    ;; --- the two tongue grammars (data over the one engine) ---
+    (defn nl-en ()
+        (grammar "s" (list
+            (rule3 "s" (p-cap "v" (p-ref "prop")) (t-splice "v"))
+            (rule3 "prop"
+                (list "seq" (p-lit "the") (p-cap "s" (p-run "alpha")) (p-lit "is") (p-cap "a" (p-run "alpha")))
+                (t-emit "property" (list (t-splice "s") (t-splice "a")))))))
+    (defn nl-id ()
+        (grammar "s" (list
+            (rule3 "s" (p-cap "v" (p-ref "prop")) (t-splice "v"))
+            (rule3 "prop"
+                (list "seq" (p-cap "s" (p-run "alpha")) (p-lit "adalah") (p-cap "a" (p-run "alpha")))
+                (t-emit "property" (list (t-splice "s") (t-splice "a")))))))
+
+    ;; --- the lexicon: content words <-> neutral concept (English lemma here) ---
+    (defn nlt-en->c (w) w)
+    (defn nlt-c->en (w) w)
+    (defn nlt-id->c (w)
+        (if (str_eq w "sumber") "source"
+        (if (str_eq w "asli")   "native"
+        (if (str_eq w "inti")   "kernel" w))))
+    (defn nlt-c->id (w)
+        (if (str_eq w "source") "sumber"
+        (if (str_eq w "native") "asli"
+        (if (str_eq w "kernel") "inti" w))))
+
+    ;; --- normalize raw parse -> PIVOT ---
+    (defn norm-en (n) (intern_node (bp "property") (list (nlt-s (nlt-en->c (nlt-kidv n 0))) (nlt-s (nlt-en->c (nlt-kidv n 1))))))
+    (defn norm-id (n) (intern_node (bp "property") (list (nlt-s (nlt-id->c (nlt-kidv n 0))) (nlt-s (nlt-id->c (nlt-kidv n 1))))))
+    ;; --- decode PIVOT -> a tongue's surface ---
+    (defn dec-en (p) (nlt-sp "the" (nlt-sp (nlt-c->en (nlt-kidv p 0)) (nlt-sp "is" (nlt-c->en (nlt-kidv p 1))))))
+    (defn dec-id (p) (nlt-sp (nlt-c->id (nlt-kidv p 0)) (nlt-sp "adalah" (nlt-c->id (nlt-kidv p 1)))))
+    ;; --- the translators: encode one tongue -> pivot -> decode the other ---
+    (defn tr-en-id (x) (dec-id (norm-en (g-parse (nl-en) x))))
+    (defn tr-id-en (x) (dec-en (norm-id (g-parse (nl-id) x))))
+    0)

--- a/form/form-stdlib/tests/nl-translate-band.fk
+++ b/form/form-stdlib/tests/nl-translate-band.fk
@@ -1,70 +1,21 @@
-; nl-translate-band.fk — Form-native NL -> NL translation through the language-
-; neutral pivot. The north-star rung: real translation (parse meaning, re-render
-; in another tongue), NOT a phrase lookup. English and Indonesian share ONE pivot
-; — the universal recipe node — so cross-tongue equality falls out of content-
-; addressing (cjk-channel: one cell, many tongues). Adding a tongue is adding a
-; (grammar, lexicon-direction, decoder); the pivot and the engine never change.
+; nl-translate-band.fk — proves form-stdlib/nl-translate.fk four-way.
 ;
-; Pipeline, both directions, all four-way (Go / Rust / TS / fkwu):
-;   surface --g-parse(tongue grammar)--> raw node --normalize(lexicon)--> PIVOT
-;   PIVOT --decode(target tongue)--> target surface
-; The lexicon canonicalizes content words to a neutral concept (here the English
-; lemma; a neutral concept-id is the later refinement). The pivot holds the
-; concept, so "the source is native" and "sumber adalah asli" intern to the SAME
-; node. Bitmask witness; all five → 31.
+; Form-native NL -> NL translation through the language-neutral pivot. The logic
+; lives in form-stdlib/nl-translate.fk (loaded as a prelude); this band exercises
+; it: cross-tongue PIVOT equality, both translation directions, a second content
+; pair (not hard-coded), and a full round-trip held stable. Bitmask witness; all
+; five → 31, across Go / Rust / TS / fkwu.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/nl-translate.fk
 
 (do
-    (defn s (x) (intern_trivial_string x))
-    (defn kidv (n i) (node_value (nth (node_children n) i)))
-    (defn sp (a b) (str_concat a (str_concat " " b)))
-
-    ;; --- the two tongue grammars (same engine, different rows of data) ---
-    ;; English property: "the SUBJ is ADJ"
-    (let nl-en (grammar "s" (list
-        (rule3 "s" (p-cap "v" (p-ref "prop")) (t-splice "v"))
-        (rule3 "prop"
-            (list "seq" (p-lit "the") (p-cap "s" (p-run "alpha")) (p-lit "is") (p-cap "a" (p-run "alpha")))
-            (t-emit "property" (list (t-splice "s") (t-splice "a")))))))
-    ;; Indonesian property: "SUBJ adalah ADJ" (no article)
-    (let nl-id (grammar "s" (list
-        (rule3 "s" (p-cap "v" (p-ref "prop")) (t-splice "v"))
-        (rule3 "prop"
-            (list "seq" (p-cap "s" (p-run "alpha")) (p-lit "adalah") (p-cap "a" (p-run "alpha")))
-            (t-emit "property" (list (t-splice "s") (t-splice "a")))))))
-
-    ;; --- the lexicon: content words <-> neutral concept (English lemma here) ---
-    ;; content-addressed: both tongues' words map onto ONE concept token.
-    (defn en->c (w) w)   ;; English surface IS the canonical concept
-    (defn c->en (w) w)
-    (defn id->c (w)
-        (if (str_eq w "sumber") "source"
-        (if (str_eq w "asli")   "native"
-        (if (str_eq w "inti")   "kernel" w))))
-    (defn c->id (w)
-        (if (str_eq w "source") "sumber"
-        (if (str_eq w "native") "asli"
-        (if (str_eq w "kernel") "inti" w))))
-
-    ;; --- normalize raw parse -> PIVOT (subject + adjective through the lexicon) ---
-    (defn norm-en (n) (intern_node (bp "property") (list (s (en->c (kidv n 0))) (s (en->c (kidv n 1))))))
-    (defn norm-id (n) (intern_node (bp "property") (list (s (id->c (kidv n 0))) (s (id->c (kidv n 1))))))
-    ;; --- decode PIVOT -> a tongue's surface ---
-    (defn dec-en (p) (sp "the" (sp (c->en (kidv p 0)) (sp "is" (c->en (kidv p 1))))))
-    (defn dec-id (p) (sp (c->id (kidv p 0)) (sp "adalah" (c->id (kidv p 1)))))
-    ;; --- the translators: encode one tongue -> pivot -> decode the other ---
-    (defn tr-en-id (x) (dec-id (norm-en (g-parse nl-en x))))
-    (defn tr-id-en (x) (dec-en (norm-id (g-parse nl-id x))))
-
     (defn chk (got exp bit) (if (node_eq got exp) bit 0))
     (defn total (xs) (if (nil? xs) 0 (add (head xs) (total (tail xs)))))
 
-    ;; one witness — all five → 31
     (total (list
         ;; 1. cross-tongue PIVOT equality: en and id surfaces intern to ONE node
-        (chk (norm-en (g-parse nl-en "the source is native"))
-             (norm-id (g-parse nl-id "sumber adalah asli")) 1)
+        (chk (norm-en (g-parse (nl-en) "the source is native"))
+             (norm-id (g-parse (nl-id) "sumber adalah asli")) 1)
         ;; 2. translate en -> id
         (if (str_eq (tr-en-id "the source is native") "sumber adalah asli") 2 0)
         ;; 3. translate id -> en


### PR DESCRIPTION
*"yes, please"* (Urs) — wire the proven native NL→NL translate into the live speech loop. The translate stage is **no longer rented**: it runs as Form between the STT and TTS oracles.

## What runs now
`experiments/coherence-sense-android/native-translate-speak.sh --voice "the source is native"`:
```
say(en) → wav → whisper-cli STT (oracle) → NATIVE Form translate → say(id) (oracle)
"The source is native."  →  "sumber adalah asli"
"The kernel is native."  →  "inti adalah asli"
```
The **middle is the only non-oracle stage**. The receipt records `"native_middle": true` and names the oracle ends.

## Structure (BML-first)
- **Body** [`form-stdlib/nl-translate.fk`](form/form-stdlib/nl-translate.fk) — grammars (nullary defns, globally callable), lexicon, normalize→pivot, decode, `tr-en-id`/`tr-id-en`. [`tests/nl-translate-band.fk`](form/form-stdlib/tests/nl-translate-band.fk) now *loads* it (single source) and still proves it **four-way, witness 31**.
- **Carrier** the shell script — thin host-IO only: one kernel call does the translate; logic stays in Form.

## What the live loop surfaced (the value of real wiring)
The toy band hid it: whisper returns capitalized, punctuated text (`"The kernel is native."`) that the case/punct-exact grammar dropped to empty. Fixed with thin carrier-side input sanitation, and named the honest next refinement: **surface-robust encoding owned by the Form encoder**, not the carrier.

## Named-open (the remaining north-star rungs)
Embedding featurizer (open vocab), surface-robust encoding, the round-trip quality gate, the model-council, and the two other stages going native — STT end-to-end and Form-native TTS (the long pole) — to drop the last two oracles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)