### PR TITLE
feat(translation): update floor + north star, walk one rung — lexicon as DATA (open vocab)

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -34,11 +34,29 @@
 ;     Full suite: fourth arm 369 four-way, 0 divergent — the WHOLE whisper-tiny stack (mel-frame, mel-full,
 ;     positional, conv-stem, transformer-mh/decoder/generate, gelu-erf, whisper-mh-block-real) is four-way
 ;     proven (Go=Rust=TS=fkwu). mel-full was the same e-notation bug (its e-15 samples), masked by stale cache.
-;   NORTH STAR: a sovereign, on-device, Form-native SPEECH faculty — real audio → transcript (STT) and text →
-;     audio (TTS) — where the model's architecture AND weights are content-addressed recipe DATA, one engine
-;     (no parallel paths), running fast on the native/GPU emit→compile→exec lane, and TRAINABLE/fine-tunable
-;     locally from local oracles. A mind that hears and speaks at home, offerable to others without a gated
-;     provider (lc-cognitive-sovereignty, living-vision.form).
+;   FLOOR — TRANSLATE + VOICE LOOP (proven 2026-06-21, this session — the MIDDLE stage comes home):
+;     NL → Form parses ten English sentence classes into UNIVERSAL recipe nodes (fact / property / isa /
+;     relation / question / meaning + one generic subject-verb-object rule) four-way
+;     (tests/natural-language-band.fk, witness 262143), and the SAME band proves the full factored CODEC:
+;     ONE shared pivot (the universal recipe node = the "generic meaning"), the ENCODER (many surfaces → one
+;     pivot), and TWO decoders reading that pivot (→ NL surface round-trip, → Form s-expr). The translation
+;     PIPELINE is named decoupled (translation-pipeline-pivot.form): NL→NL and NL→Form share encode+pivot and
+;     differ ONLY in decode (a better encoder lifts both; a new target is a new decoder, never a new end-to-end
+;     model); the pivot lives in ice/water/gas. Native EN↔ID translate now runs LIVE in the speech loop
+;     (form-stdlib/nl-translate.fk, band 31 four-way; experiments/coherence-sense-android/native-translate-speak.sh):
+;     say(en) → whisper-cli STT → NATIVE translate → say(id), verified end to end ("The source is native." →
+;     "sumber adalah asli"). The translate stage is no longer rented. TRAINING DIAGNOSTIC (measured this session
+;     on the real 949-turn corpus): the wide Form transformer trains and generalizes (held-out loss 262→133,
+;     best ~epoch 40) but UNDERfits the tool-target — worse than predict-the-mean at lr=0.03 — NOT overfitting.
+;     An OPTIMIZER bug first (gap 7b: lr=0.003 converges and matches the baseline), then a residual ~2x above
+;     the irreducible feature floor (capacity + the coarse 4-dim featurization, 72% feature-collision). The
+;     count predictor reaches 98% majority / 48% full-cover. Lesson: normalize per-row before trusting a loss.
+;   NORTH STAR: a sovereign, on-device, Form-native SPEECH faculty — real audio → transcript (STT), NL → NL
+;     TRANSLATE through the language-neutral pivot, and text → audio (TTS) — so ANY input voice in ANY tongue
+;     becomes ANY output voice in ANY tongue, where every stage's architecture AND weights are content-addressed
+;     recipe DATA, one engine (no parallel paths), running fast on the native/GPU emit→compile→exec lane, and
+;     TRAINABLE/fine-tunable locally from local oracles. A mind that hears, understands across tongues, and speaks
+;     at home — offerable to others without a gated provider (lc-cognitive-sovereignty, living-vision.form).
 ;   GAPS (ordered; none are new math — the architecture and the fast matvec are proven; what remains is wiring):
 ;     1. ASSEMBLE end-to-end at real width: wire mel → conv stem → encoder → decoder → tokenizer through the
 ;        native matvec lane (M5's buffer bridge: Form list ↔ flat f64 slice) + a CPU/GPU block emitter, so a
@@ -90,6 +108,17 @@
 ;        200-row slice (~0.76) is the honest number. lr default moved 0.03 → 0.003; runner header has the full
 ;        learning. (7 overfits past epoch 20; 7b underfits until lr is fixed — same corpus, opposite diagnosis,
 ;        because the failure mode is the model+optimizer pairing, not the data.)
+;     8. THE LIVE VOICE LOOP — the translate stage is now NATIVE and running (2026-06-21), but the floor is
+;        honest: a TINY grammar + a small DATA lexicon (one sentence shape, EN↔ID, vocabulary grown by adding
+;        rows not editing code — form-stdlib/nl-translate.fk). The ordered rungs to the any-voice→any-voice
+;        north star: (a) OPEN VOCAB — grow the content-addressed word-cell lexicon by ingesting the parallel
+;        corpus (web/messages/* — the EN→FR learned-train seed of gap 6 is the same data), then let the learned
+;        encoder/decoder (gap 6 dynamic, gap 7b optimizer fixed) replace the hand templates. (b) SURFACE-ROBUST
+;        encoding — case / punctuation / contractions owned by the Form ENCODER, not the carrier's input
+;        cleaning (the live loop surfaced this: whisper returns "The kernel is native."). (c) the round-trip
+;        QUALITY gate (translation-quality.fk essence/vitality/trust) on the pivot. (d) STT END-TO-END (gap 1)
+;        and (e) Form-native TTS — UNBUILT, the long pole — to drop the last two oracles (whisper-cli, say) so
+;        the whole voice→voice pipeline is sovereign. Companion floor/north-star: translation-pipeline-pivot.form.
 ;
 ; ── CURRENT FLOOR VS NORTH STAR (reviewed with Grok/Gemini/Claude, 2026-06-14) ──
 ;   CURRENT FLOOR: small model numerics are already Form-native and proven: format arithmetic, tensor

--- a/form/form-stdlib/nl-translate.fk
+++ b/form/form-stdlib/nl-translate.fk
@@ -31,17 +31,31 @@
                 (list "seq" (p-cap "s" (p-run "alpha")) (p-lit "adalah") (p-cap "a" (p-run "alpha")))
                 (t-emit "property" (list (t-splice "s") (t-splice "a")))))))
 
-    ;; --- the lexicon: content words <-> neutral concept (English lemma here) ---
-    (defn nlt-en->c (w) w)
-    (defn nlt-c->en (w) w)
-    (defn nlt-id->c (w)
-        (if (str_eq w "sumber") "source"
-        (if (str_eq w "asli")   "native"
-        (if (str_eq w "inti")   "kernel" w))))
-    (defn nlt-c->id (w)
-        (if (str_eq w "source") "sumber"
-        (if (str_eq w "native") "asli"
-        (if (str_eq w "kernel") "inti" w))))
+    ;; --- the lexicon AS DATA: rows of (concept en id). A tongue is a COLUMN, a word
+    ;; is a ROW. Adding vocabulary is adding a row; adding a tongue is adding a column —
+    ;; never editing code. The north-star form grows this table by ingesting the
+    ;; parallel corpus (web/messages/*); seeded here from a small attested set.
+    (defn nlt-lexicon ()
+        (list
+            (list "source"  "source"  "sumber")
+            (list "native"  "native"  "asli")
+            (list "kernel"  "kernel"  "inti")
+            (list "body"    "body"    "tubuh")
+            (list "cell"    "cell"    "sel")
+            (list "recipe"  "recipe"  "resep")
+            (list "witness" "witness" "saksi")))
+    ;; generic lookup: scan rows for column-i == w, return column-j; passthrough unknown
+    (defn nlt-find (rows i w)
+        (if (nil? rows) (empty)
+            (if (str_eq (nth (head rows) i) w) (head rows)
+                (nlt-find (tail rows) i w))))
+    (defn nlt-pick (r j w) (if (nil? r) w (nth r j)))
+    (defn nlt-map (i j w) (nlt-pick (nlt-find (nlt-lexicon) i w) j w))
+    ;; the four tongue<->concept maps, all ONE generic lookup (col 0=concept 1=en 2=id)
+    (defn nlt-en->c (w) (nlt-map 1 0 w))
+    (defn nlt-c->en (w) (nlt-map 0 1 w))
+    (defn nlt-id->c (w) (nlt-map 2 0 w))
+    (defn nlt-c->id (w) (nlt-map 0 2 w))
 
     ;; --- normalize raw parse -> PIVOT ---
     (defn norm-en (n) (intern_node (bp "property") (list (nlt-s (nlt-en->c (nlt-kidv n 0))) (nlt-s (nlt-en->c (nlt-kidv n 1))))))

--- a/form/form-stdlib/tests/nl-translate-band.fk
+++ b/form/form-stdlib/tests/nl-translate-band.fk
@@ -3,8 +3,9 @@
 ; Form-native NL -> NL translation through the language-neutral pivot. The logic
 ; lives in form-stdlib/nl-translate.fk (loaded as a prelude); this band exercises
 ; it: cross-tongue PIVOT equality, both translation directions, a second content
-; pair (not hard-coded), and a full round-trip held stable. Bitmask witness; all
-; five → 31, across Go / Rust / TS / fkwu.
+; pair (not hard-coded), a full round-trip held stable, and three words added as
+; lexicon DATA ROWS (body / cell / recipe / witness) translating with no code change
+; — vocabulary is data. Bitmask witness; all eight → 255, across Go / Rust / TS / fkwu.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/nl-translate.fk
 
@@ -23,4 +24,8 @@
         ;; 4. a second content pair (not hard-coded): kernel <-> inti
         (if (str_eq (tr-en-id "the kernel is native") "inti adalah asli") 8 0)
         ;; 5. full round-trip through the pivot, both directions, stays stable
-        (if (str_eq (tr-en-id (tr-id-en "inti adalah asli")) "inti adalah asli") 16 0))))
+        (if (str_eq (tr-en-id (tr-id-en "inti adalah asli")) "inti adalah asli") 16 0)
+        ;; 6-8. vocabulary is DATA: words added as lexicon ROWS translate with no code change
+        (if (str_eq (tr-en-id "the body is native")   "tubuh adalah asli")  32 0)
+        (if (str_eq (tr-en-id "the cell is recipe")   "sel adalah resep")   64 0)
+        (if (str_eq (tr-id-en "saksi adalah asli")    "the witness is native") 128 0))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -679,8 +679,11 @@ natural-language fks 262143
 # normalize content words through a lexicon onto ONE pivot node, and decode to the
 # other tongue. Cross-tongue equality is content-addressing ("the source is native"
 # and "sumber adalah asli" intern to the same node); translation is encode->pivot->
-# decode, both directions, with a full round-trip held stable. 31 = all five checks.
-nl-translate fks 31
+# decode, both directions, with a full round-trip held stable. The lexicon is DATA
+# (rows of (concept en id)); adding vocabulary is adding a row, not editing code —
+# three added words (body/cell/recipe/witness) translate with no code change.
+# 255 = all eight checks.
+nl-translate fks 255
 # form.bml lifted onto the cursor: the form.bml grammar PARSES `def ..=expr;` on
 # the fourth arm too (cursor-only; rides bmf-core/bmf-grammar's op families). The
 # recipe-shape parity vs the hand line compiler is the three-way band


### PR DESCRIPTION
*"update the floor and the north star, let's walk towards the north star with purpose."*

## Floor + north star ([`form-native-models.form`](docs/coherence-substrate/form-native-models.form))
The canonical floor/north-star block predated this session's translate+voice arc. Updated:
- **New TRANSLATE + VOICE LOOP floor** — the four-way NL→Form codec (262143), the decoupled pipeline, native EN↔ID translate **live in the speech loop**, and the training diagnostic (aligned with the sibling-authored gap 7b: an *optimizer* bug at lr=0.03, **not** overfitting; residual is capacity+features).
- **North star expanded** from STT+TTS to the full **any-voice→any-voice** pipeline with TRANSLATE through the language-neutral pivot.
- **Gap 8** — the ordered rungs from the live loop to the sovereign voice→voice pipeline (open vocab → surface-robust encoder → quality gate → STT end-to-end → Form TTS).

## The purposeful rung walked (gap 8a — open vocab)
Lifted [`nl-translate.fk`](form/form-stdlib/nl-translate.fk)'s lexicon from a hand-coded if-chain to a **data table** — rows of `(concept en id)`, one generic lookup. **A tongue is a column, a word is a row**: adding vocabulary is adding a row, never editing code.

Proved by adding four words (body/cell/recipe/witness) as rows — they translate **four-way (band 31→255)** and run **live in the carrier** (`the body is native` → `tubuh adalah asli`) with no code change.

```
fourth arm: 1 band(s) four-way → 255   (lexicon is data; vocab grows by rows)
```

This is the core-abstraction move that makes the lexicon **corpus-ingestable**: the north-star form grows this table from the parallel corpus (`web/messages/*`), then the learned encoder/decoder (gap 6 dynamic) replaces the hand templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)