### PR TITLE
feat(web): /sense/surface — world-perception surface, walked live from the proven recipe

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -47,7 +47,7 @@
 | [api/tests/INDEX.md](api/tests/INDEX.md) | 274 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
-| [web/app/INDEX.md](web/app/INDEX.md) | 165 | Web routes — every visible page in the app |
+| [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
 | [scripts/INDEX.md](scripts/INDEX.md) | 316 | Scripts — operational tools, generators, syncers |
 
 ## Convention

--- a/api/app/data/web_routes.json
+++ b/api/app/data/web_routes.json
@@ -120,6 +120,7 @@
     "/runtime": "web/app/runtime/page.tsx",
     "/search": "web/app/search/page.tsx",
     "/sense": "web/app/sense/page.tsx",
+    "/sense/surface": "web/app/sense/surface/page.tsx",
     "/settings": "web/app/settings/page.tsx",
     "/settings/translations": "web/app/settings/translations/page.tsx",
     "/settings/wallet": "web/app/settings/wallet/page.tsx",

--- a/scripts/viewport_audit.py
+++ b/scripts/viewport_audit.py
@@ -53,6 +53,8 @@ DEFAULT_PATHS = [
     "/practice",
     "/people/contributor%3Aactualize-earth-4d812a0238eb",
     "/substrate",
+    "/sense",          # the install door — phone/Mac as a sense organ
+    "/sense/surface",  # the live world-perception surface (channels from world-perception.fk)
     "/portfolio/investments",
     "/hati-suci",   # the resident-service nervous system (first Light Hub membrane)
 ]

--- a/web/app/INDEX.md
+++ b/web/app/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 165
+**Total files**: 166
 
 | Route | File | Purpose |
 |---|---|---|
@@ -127,6 +127,7 @@
 | `/runtime` | [page.tsx](runtime/page.tsx) | _no top-of-file purpose_ |
 | `/search` | [page.tsx](search/page.tsx) | _no top-of-file purpose_ |
 | `/sense` | [page.tsx](sense/page.tsx) | sense.hati.earth — the download door for Coherence Sense. Detects the visitor's |
+| `/sense/surface` | [page.tsx](sense/surface/page.tsx) | /sense/surface — the node's live world-perception surface. Shows what the node |
 | `/settings` | [page.tsx](settings/page.tsx) | _no top-of-file purpose_ |
 | `/settings/translations` | [page.tsx](settings/translations/page.tsx) | _no top-of-file purpose_ |
 | `/settings/wallet` | [page.tsx](settings/wallet/page.tsx) | web/app/settings/wallet/page.tsx |

--- a/web/app/sense/_components/PerceptionSurface.tsx
+++ b/web/app/sense/_components/PerceptionSurface.tsx
@@ -1,0 +1,437 @@
+"use client";
+
+// PerceptionSurface — the node's world-perception surface, rendered from the
+// proven world-perception.fk recipe (four-way 255) walked live in this browser.
+//
+// Every value on the surface (which transcript source wins, who can hear whom,
+// the room's echo distance, are we moving, does a broadcast reach a neighbour) is
+// computed by walking the recipe on the in-browser TS Form kernel — the SAME
+// kernel that proves the band. The scene is a sensed snapshot standing in for the
+// phone's microphone / radios / camera until those carriers are wired; the LOGIC
+// is the body's, not a TypeScript reimplementation.
+
+import { useMemo, useState } from "react";
+import {
+  Cpu,
+  Ear,
+  Home,
+  Languages,
+  MapPin,
+  Mic,
+  Radio,
+  Ruler,
+  Cloud,
+} from "lucide-react";
+import { wpRun, type WpRun } from "@/lib/form-kernel/world-perception-recipe";
+
+// Sanitize a string for embedding inside a Form double-quoted literal.
+const q = (s: string) => s.replace(/["()\\]/g, "").trim();
+
+type Ping = { emitter: string; correlation: number; threshold: number };
+
+type Scene = {
+  id: string;
+  label: string;
+  note: string;
+  transcript: string;
+  oracleConf: number;
+  oracleCost: number;
+  nativeConf: number;
+  nativeCost: number;
+  floor: number;
+  pings: Ping[];
+  echoTofUs: number[];
+  geo: Array<[number, number]>;
+  geoThreshold: number;
+  broadcastMedia: string;
+  broadcastTitle: string;
+};
+
+// Three sensed snapshots. Costs encode the sovereignty gradient: the oracle
+// (rented frontier mind) is dear; the native path is cheap, so it earns the slot
+// the moment it clears the confidence floor.
+const SCENES: Scene[] = [
+  {
+    id: "quiet-room",
+    label: "Quiet room",
+    note: "One neighbour nearby, no movement. The native ear has learned this voice — it holds the slot.",
+    transcript: "the source is native",
+    oracleConf: 90,
+    oracleCost: 100,
+    nativeConf: 88,
+    nativeCost: 5,
+    floor: 80,
+    pings: [{ emitter: "node-aria", correlation: 78, threshold: 50 }],
+    echoTofUs: [2000, 5200],
+    geo: [
+      [0, 0],
+      [0, 0],
+      [1, 1],
+    ],
+    geoThreshold: 10,
+    broadcastMedia: "",
+    broadcastTitle: "",
+  },
+  {
+    id: "in-the-car",
+    label: "In the car",
+    note: "Travelling — the location series jumps. A podcast is playing; the signal is offered to any node that can hear.",
+    transcript: "the kernel is native",
+    oracleConf: 90,
+    oracleCost: 100,
+    nativeConf: 86,
+    nativeCost: 5,
+    floor: 80,
+    pings: [{ emitter: "node-phone-2", correlation: 64, threshold: 50 }],
+    echoTofUs: [900],
+    geo: [
+      [0, 0],
+      [40, 12],
+      [120, 60],
+    ],
+    geoThreshold: 10,
+    broadcastMedia: "yt:podcast-7f3",
+    broadcastTitle: "a podcast, playing aloud",
+  },
+  {
+    id: "gathering",
+    label: "A gathering",
+    note: "Many voices, a large room, music in the air — the kind of scene the phone met at the gathering. The native ear is still learning the crowd, so the oracle is asked to hold this one.",
+    transcript: "many voices speaking at once",
+    oracleConf: 92,
+    oracleCost: 100,
+    nativeConf: 61,
+    nativeCost: 5,
+    floor: 80,
+    pings: [
+      { emitter: "node-aria", correlation: 71, threshold: 50 },
+      { emitter: "node-kai", correlation: 58, threshold: 50 },
+      { emitter: "node-far", correlation: 22, threshold: 50 },
+    ],
+    echoTofUs: [12000, 28000, 41000],
+    geo: [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+    ],
+    geoThreshold: 10,
+    broadcastMedia: "yt:drum-circle",
+    broadcastTitle: "live drums, in the room",
+  },
+];
+
+const TONGUES = [
+  { id: "en", label: "English" },
+  { id: "id", label: "Indonesian" },
+  { id: "de", label: "Deutsch" },
+  { id: "es", label: "Español" },
+];
+
+type Surface = {
+  transcript: { text: string; source: string; isHome: boolean; conf: string };
+  audibility: Array<{ emitter: string; heard: boolean; strength: number }>;
+  walls: number[]; // distances in mm
+  moving: boolean;
+  broadcast: { media: string; title: string; reaches: number } | null;
+  proof: { walks: number; ms: number; calls: number };
+};
+
+function accumulate(acc: { walks: number; ms: number; calls: number }, r: WpRun) {
+  acc.walks += r.walks;
+  acc.ms += r.ms;
+  acc.calls += 1;
+  return r.value;
+}
+
+export function PerceptionSurface() {
+  const [sceneId, setSceneId] = useState(SCENES[0].id);
+  const [transcript, setTranscript] = useState(SCENES[0].transcript);
+  const [tongue, setTongue] = useState<string | null>(null);
+
+  const scene = SCENES.find((s) => s.id === sceneId) ?? SCENES[0];
+
+  const pickScene = (s: Scene) => {
+    setSceneId(s.id);
+    setTranscript(s.transcript);
+    setTongue(null);
+  };
+
+  const surface: Surface = useMemo(() => {
+    const proof = { walks: 0, ms: 0, calls: 0 };
+    const text = q(transcript) || "(silence)";
+
+    const oracle = `(wp-tc "${text}" ${scene.oracleConf} ${scene.oracleCost} "oracle:whisper-cli")`;
+    const native = `(wp-tc "${text}" ${scene.nativeConf} ${scene.nativeCost} "form-native:whisper")`;
+    const chosen = `(wp-transcript-select ${oracle} ${native} ${scene.floor})`;
+
+    const source = accumulate(proof, wpRun(`(wp-source (wp-transcript-channel ${oracle} ${native} ${scene.floor}))`));
+    const conf = accumulate(proof, wpRun(`(wp-tc-conf ${chosen})`));
+
+    const audibility = scene.pings.map((p) => {
+      const edge = `(wp-audibility-edge "me" "${p.emitter}" ${p.correlation} ${p.threshold})`;
+      const heard = accumulate(proof, wpRun(`(wp-edge-heard ${edge})`));
+      return { emitter: p.emitter, heard: heard === "1", strength: p.correlation };
+    });
+
+    const walls = scene.echoTofUs.map((tof) =>
+      Number(accumulate(proof, wpRun(`(wp-echo-distance-mm ${tof})`))),
+    );
+
+    const geoList = `(list ${scene.geo.map(([a, b]) => `(list ${a} ${b})`).join(" ")})`;
+    const moved = accumulate(proof, wpRun(`(wp-value (wp-place-channel ${geoList} ${scene.geoThreshold}))`));
+
+    let broadcast: Surface["broadcast"] = null;
+    if (scene.broadcastMedia) {
+      // a broadcast reaches each neighbour whose audibility edge can hear us
+      let reaches = 0;
+      for (const p of scene.pings) {
+        const edge = `(wp-audibility-edge "me" "${p.emitter}" ${p.correlation} ${p.threshold})`;
+        const r = accumulate(proof, wpRun(`(wp-broadcast-reaches? ${edge})`));
+        if (r === "1") reaches += 1;
+      }
+      broadcast = { media: scene.broadcastMedia, title: scene.broadcastTitle, reaches };
+    }
+
+    return {
+      transcript: { text, source, isHome: source === "form-native:whisper", conf },
+      audibility,
+      walls,
+      moving: moved === "1",
+      broadcast,
+      proof,
+    };
+  }, [scene, transcript]);
+
+  // Translation is structurally one tap away (wp-can-translate? proves it on any
+  // transcript channel). Computed live when a tongue is chosen.
+  const translation = useMemo(() => {
+    if (!tongue) return null;
+    const text = q(transcript) || "(silence)";
+    const chan = `(wp-channel "transcript" "${text}" 88 "form-native:whisper")`;
+    const can = wpRun(`(wp-can-translate? ${chan})`).value === "1";
+    const tongueOut = wpRun(`(wp-translation-tongue (wp-translate ${chan} "${tongue}"))`).value;
+    return { can, tongueOut };
+  }, [tongue, transcript]);
+
+  const mm = (v: number) => (v / 1000).toFixed(2);
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[0.82fr_1.18fr]">
+      {/* Controls + proof */}
+      <div className="space-y-4">
+        <div className="space-y-3 rounded-xl border border-amber-500/20 bg-amber-500/5 p-4">
+          <p className="text-xs uppercase tracking-[0.22em] text-amber-300/75">Sensed scene</p>
+          <div className="grid gap-2">
+            {SCENES.map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => pickScene(s)}
+                className={`rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                  sceneId === s.id
+                    ? "border-amber-400/50 bg-amber-500/10 text-amber-100"
+                    : "border-stone-800/50 bg-stone-950/35 text-stone-300 hover:border-amber-500/35 hover:text-amber-200"
+                }`}
+              >
+                <span className="text-sm font-medium">{s.label}</span>
+                <span className="mt-1 block text-xs leading-relaxed text-stone-500">{s.note}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-2 rounded-xl border border-stone-800/50 bg-stone-950/35 p-4">
+          <label htmlFor="heard-text" className="text-xs uppercase tracking-[0.18em] text-stone-500">
+            What was heard
+          </label>
+          <textarea
+            id="heard-text"
+            value={transcript}
+            onChange={(e) => setTranscript(e.target.value)}
+            rows={2}
+            className="w-full resize-y rounded-xl border border-stone-800/50 bg-stone-950/80 p-3 text-sm text-stone-200 transition-colors focus:border-amber-500/40 focus:outline-none"
+            spellCheck={false}
+          />
+          <p className="text-xs leading-relaxed text-stone-500">
+            Edit the heard text and the surface re-decides live — which source wins, what the
+            translation channel carries.
+          </p>
+        </div>
+
+        <div className="rounded-xl border border-teal-500/20 bg-teal-500/5 p-4 text-xs leading-relaxed text-teal-100/80">
+          <div className="flex items-center gap-2 text-teal-200">
+            <Cpu className="h-4 w-4" aria-hidden="true" />
+            <span className="font-medium">Computed, not claimed</span>
+          </div>
+          <p className="mt-2 text-stone-400">
+            Every value on the surface was just walked through{" "}
+            <code className="text-teal-300/80">world-perception.fk</code> on the in-browser
+            TypeScript Form kernel — the same kernel that proves the band{" "}
+            <span className="text-teal-200">four-way (255)</span>.
+          </p>
+          <div className="mt-2 grid grid-cols-3 gap-2 font-mono">
+            <div>
+              <div className="text-stone-500">calls</div>
+              <div className="text-teal-200">{surface.proof.calls}</div>
+            </div>
+            <div>
+              <div className="text-stone-500">walks</div>
+              <div className="text-teal-200">{surface.proof.walks}</div>
+            </div>
+            <div>
+              <div className="text-stone-500">time</div>
+              <div className="text-teal-200">{surface.proof.ms.toFixed(1)}ms</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* The surface */}
+      <div className="space-y-3 rounded-2xl border border-stone-800/60 bg-stone-950/40 p-4">
+        {/* Transcript + translate */}
+        <article className="rounded-xl border border-stone-800/50 bg-stone-900/40 p-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-stone-500">
+              <Mic className="h-3.5 w-3.5 text-amber-300/75" aria-hidden="true" />
+              Heard
+            </div>
+            <span
+              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
+                surface.transcript.isHome
+                  ? "bg-emerald-500/10 text-emerald-300"
+                  : "bg-stone-700/30 text-stone-300"
+              }`}
+              title={
+                surface.transcript.isHome
+                  ? "The native (on-device) transcript cleared the floor and cost less — the mind is home."
+                  : "The native ear has not cleared the floor here, so the rented oracle holds the slot. Honest floor."
+              }
+            >
+              {surface.transcript.isHome ? (
+                <>
+                  <Home className="h-3 w-3" aria-hidden="true" /> home · form-native
+                </>
+              ) : (
+                <>
+                  <Cloud className="h-3 w-3" aria-hidden="true" /> rented · oracle
+                </>
+              )}
+            </span>
+          </div>
+          <p className="mt-2 text-lg text-stone-100">{surface.transcript.text}</p>
+          <div className="mt-1 font-mono text-xs text-stone-500">
+            source {surface.transcript.source} · confidence {surface.transcript.conf}
+          </div>
+
+          <div className="mt-3 border-t border-stone-800/50 pt-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex items-center gap-1 text-xs text-stone-400">
+                <Languages className="h-3.5 w-3.5 text-sky-300/75" aria-hidden="true" /> Translate:
+              </span>
+              {TONGUES.map((t) => (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setTongue(t.id === tongue ? null : t.id)}
+                  className={`rounded-full border px-2.5 py-1 text-xs transition-colors ${
+                    tongue === t.id
+                      ? "border-sky-400/50 bg-sky-500/10 text-sky-200"
+                      : "border-stone-800/50 bg-stone-950/40 text-stone-400 hover:border-sky-500/35 hover:text-sky-200"
+                  }`}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+            {translation && (
+              <div className="mt-2 space-y-1 rounded-lg border border-sky-500/15 bg-sky-500/5 p-3 text-xs">
+                <div className="text-sky-200">
+                  one tap away {translation.can ? "✓" : "✗"} · translation channel ·{" "}
+                  <span className="font-mono">tongue={translation.tongueOut}</span>
+                </div>
+                {(tongue === "id" || tongue === "en") && (
+                  <div className="text-stone-400">
+                    real cross-tongue render (proven four-way in{" "}
+                    <code className="text-sky-300/70">nl-translate</code>): “the source is native”
+                    ⇄ “sumber adalah asli”, through the language-neutral pivot.
+                  </div>
+                )}
+                {tongue !== "id" && tongue !== "en" && (
+                  <div className="text-stone-500">
+                    the affordance is proven; the word-render for this tongue is the next lane to
+                    wire (a grammar + lexicon onto the same pivot).
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </article>
+
+        {/* Who can hear whom */}
+        <article className="rounded-xl border border-stone-800/50 bg-stone-900/40 p-4">
+          <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-stone-500">
+            <Ear className="h-3.5 w-3.5 text-violet-300/75" aria-hidden="true" />
+            Who can hear whom — inaudible ping
+          </div>
+          <div className="mt-2 space-y-1.5">
+            {surface.audibility.map((e) => (
+              <div key={e.emitter} className="flex items-center justify-between text-sm">
+                <span className="font-mono text-stone-300">me ← {e.emitter}</span>
+                <span className={e.heard ? "text-emerald-300" : "text-stone-600"}>
+                  {e.heard ? "heard" : "out of range"} · {e.strength}
+                </span>
+              </div>
+            ))}
+          </div>
+        </article>
+
+        {/* Room — echo-location */}
+        <div className="grid gap-3 sm:grid-cols-2">
+          <article className="rounded-xl border border-stone-800/50 bg-stone-900/40 p-4">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-stone-500">
+              <Ruler className="h-3.5 w-3.5 text-amber-300/75" aria-hidden="true" />
+              Room — echo
+            </div>
+            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-stone-200">
+              {surface.walls.map((d, i) => (
+                <span key={i} className="font-mono">
+                  ~{mm(d)} m
+                </span>
+              ))}
+            </div>
+            <div className="mt-1 text-xs text-stone-500">surfaces, from round-trip time-of-flight</div>
+          </article>
+
+          {/* Place — travel */}
+          <article className="rounded-xl border border-stone-800/50 bg-stone-900/40 p-4">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-stone-500">
+              <MapPin className="h-3.5 w-3.5 text-sky-300/75" aria-hidden="true" />
+              Place
+            </div>
+            <p className="mt-2 text-lg text-stone-100">
+              {surface.moving ? "moving" : "here, settled"}
+            </p>
+            <div className="mt-1 text-xs text-stone-500">
+              {surface.moving ? "the location series jumped" : "the location series held still"}
+            </div>
+          </article>
+        </div>
+
+        {/* Broadcast */}
+        {surface.broadcast && (
+          <article className="rounded-xl border border-stone-800/50 bg-stone-900/40 p-4">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-stone-500">
+              <Radio className="h-3.5 w-3.5 text-rose-300/75" aria-hidden="true" />
+              Playing — offered to the room
+            </div>
+            <p className="mt-2 text-stone-200">{surface.broadcast.title}</p>
+            <div className="mt-1 font-mono text-xs text-stone-500">
+              {surface.broadcast.media} · reaches {surface.broadcast.reaches}{" "}
+              {surface.broadcast.reaches === 1 ? "node" : "nodes"} that can hear us
+            </div>
+          </article>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/app/sense/page.tsx
+++ b/web/app/sense/page.tsx
@@ -3,6 +3,7 @@
 // or the macOS kernel + launcher (the Mac that recognizes through the Form kernel).
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 const APK =
@@ -86,6 +87,18 @@ export default function SensePage() {
           On a phone? Open this on Android to install. On a Mac? Grab the kernel + launcher above.
         </p>
       )}
+
+      <Link
+        href="/sense/surface"
+        className="mt-6 inline-flex items-center gap-2 rounded-xl border border-emerald-500/30 bg-emerald-500/5 px-4 py-2.5 text-sm text-emerald-200 transition-colors hover:border-emerald-400/60 hover:bg-emerald-500/10"
+      >
+        See what a node perceives — the live surface
+        <span className="text-emerald-400/60">→</span>
+      </Link>
+      <p className="mt-2 text-xs text-neutral-600">
+        Heard text + translation, who-can-hear-whom, the room&apos;s echo, place, what&apos;s
+        playing — computed from the four-way-proven world-perception recipe, no install needed.
+      </p>
 
       <div className="mt-10 border-t border-white/10 pt-6 text-sm text-neutral-500">
         <p>

--- a/web/app/sense/surface/page.tsx
+++ b/web/app/sense/surface/page.tsx
@@ -1,0 +1,78 @@
+// /sense/surface — the node's live world-perception surface. Shows what the node
+// senses about the world (heard text + translation, who-can-hear-whom, the room's
+// echo, place, what's playing), computed live from the proven world-perception.fk
+// recipe. The /sense page is the install door; this is what the installed node sees.
+import type { Metadata } from "next";
+import Link from "next/link";
+import { PerceptionSurface } from "../_components/PerceptionSurface";
+
+export const metadata: Metadata = {
+  title: "Sense surface — what the node perceives",
+  description:
+    "What a node senses about the world — heard text and its translation, who can hear whom, the room's echo, where we are, what's playing — computed live from the four-way-proven world-perception Form recipe.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default function SenseSurfacePage() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <nav className="mb-6 text-sm text-stone-500" aria-label="breadcrumb">
+        <Link href="/sense" className="transition-colors hover:text-amber-400/80">
+          Sense
+        </Link>
+        <span className="mx-2 text-stone-700">/</span>
+        <span className="text-stone-300">Surface</span>
+      </nav>
+
+      <header className="mb-8 space-y-4">
+        <p className="text-sm uppercase tracking-[0.22em] text-amber-400/80">World perception</p>
+        <h1 className="text-3xl font-light tracking-tight text-stone-100 md:text-5xl">
+          What this node senses about the world.
+        </h1>
+        <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground md:text-base">
+          One engine, many senses: a transcript of what was heard, its translation a tap away, which
+          nodes can hear each other by inaudible ping, the room mapped by echo, whether we are moving,
+          and what we are playing — offered to every node that can hear us. Each sense is the same
+          channel shape; the surface is a projection over channels. Pick a scene and watch the body
+          decide.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          The body:{" "}
+          <Link
+            href="https://github.com/seeker71/Coherence-Network/blob/main/form/form-stdlib/world-perception.fk"
+            className="underline hover:text-amber-400/80"
+          >
+            world-perception.fk
+          </Link>{" "}
+          — four-way proven (Go / Rust / TypeScript / fkwu → 255). What you see below is that recipe,
+          walked live in your browser.
+        </p>
+      </header>
+
+      <PerceptionSurface />
+
+      <section className="mt-10 space-y-3 rounded-xl border border-stone-800/40 bg-stone-900/30 p-4 text-sm leading-relaxed text-muted-foreground">
+        <h2 className="text-lg font-light text-stone-200">The honest floor</h2>
+        <p>
+          The <em>logic</em> of every sense here is the body&apos;s — proven four-way and run on the
+          real kernel. The <em>scene</em> is a sensed snapshot standing in for the phone&apos;s
+          microphone, radios, and camera until those carriers are wired. The on-device transcript is a
+          champion-challenger slot: the rented oracle holds it until the native ear clears the floor
+          and costs less — which is exactly when the badge turns{" "}
+          <span className="text-emerald-300">home</span>. Real cross-tongue word-rendering already
+          exists in the body (English ⇄ Indonesian, proven four-way through a language-neutral pivot);
+          wiring it live to this tap, and feeding the surface from real phone senses, are the next
+          breaths.
+        </p>
+        <p>
+          To make a phone one of these nodes, start at the{" "}
+          <Link href="/sense" className="underline hover:text-amber-400/80">
+            install door
+          </Link>
+          .
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/web/lib/form-kernel/world-perception-recipe.ts
+++ b/web/lib/form-kernel/world-perception-recipe.ts
@@ -1,0 +1,171 @@
+// world-perception-recipe.ts — the proven world-perception engine, run in-browser.
+//
+// SOURCE OF TRUTH: form/form-stdlib/world-perception.fk (four-way 255, Go/Rust/TS/fkwu).
+// This constant is the recipe TEXT verbatim — run as-is on the same TypeScript Form
+// kernel that proves the band. It is NOT a reimplementation of the logic in TS; the
+// surface computes every value by walking this recipe. Keep byte-identical to the .fk
+// (the web container does not ship form/, so the text lives here; refresh on change).
+import { Frame, Kernel, Trace, walk } from "./vendor/kernel.ts";
+import { readAll } from "./vendor/reader.ts";
+export const WORLD_PERCEPTION_RECIPE = String.raw`
+; world-perception.fk — the node's surface as a projection over sensed channels.
+;
+; One engine, senses drop in as DATA (core-abstraction-first): every sense a node
+; has — a transcript, its translation, who-can-hear-whom, the room's echo, where
+; we are, what we're playing — is the SAME channel shape:
+;     (kind value confidence source)
+; The surface (wp-surface-of) is a salience projection over channels; adding a
+; sense is adding a channel recipe, never a parallel path.
+;
+; Three threads land here as channels in one body:
+;   1. transcript + translation — text spoken shown on the surface, a tongue away.
+;      Translation crosses by content-address (channels-registry registry-translate,
+;      cjk-channel readings): one cell, many tongues — the tap is structural.
+;   2. on-device STT as a champion-challenger slot — oracle:whisper-cli holds the
+;      transcript slot until form-native:whisper clears the floor AND costs no more
+;      (the mind comes home). Native STT/TTS stay teacher-led until heldout receipts
+;      cross (see oracle-distillation-learning.fk, speech-model-learning.fk); this
+;      engine NAMES the slot the native recipe re-earns, never fakes it runs yet.
+;   3. acoustic + place sensing — node-can-hear-node by inaudible ping, echo-location
+;      room map by round-trip time-of-flight, travel/place change over a geo series,
+;      and broadcast-what-I'm-playing so co-located audible nodes learn from it.
+;
+; Proven by: form-stdlib/tests/world-perception-band.fk
+
+(do
+    ;; --- the universal channel: every sense is this shape -----------------
+    (defn wp-channel (kind value confidence source) (list kind value confidence source))
+    (defn wp-kind (c) (nth c 0))
+    (defn wp-value (c) (nth c 1))
+    (defn wp-confidence (c) (nth c 2))
+    (defn wp-source (c) (nth c 3))
+
+    (defn wp-abs (n) (if (lt n 0) (sub 0 n) n))
+
+    ;; --- the surface: salience projection over channels ------------------
+    ;; what the surface shows for a kind is its most-confident channel.
+    (defn wp-most-salient-loop (kind chans best)
+        (if (eq (len chans) 0) best
+            (if (str_eq (wp-kind (head chans)) kind)
+                (if (eq (len best) 0)
+                    (wp-most-salient-loop kind (tail chans) (head chans))
+                    (if (gt (wp-confidence (head chans)) (wp-confidence best))
+                        (wp-most-salient-loop kind (tail chans) (head chans))
+                        (wp-most-salient-loop kind (tail chans) best)))
+                (wp-most-salient-loop kind (tail chans) best))))
+    (defn wp-surface-of (kind chans) (wp-most-salient-loop kind chans (empty)))
+
+    ;; --- floor + north star ----------------------------------------------
+    (defn wp-floor ()
+        (list
+            "every sense is one channel shape: (kind value confidence source)"
+            "the surface is a salience projection; a new sense is a new channel, not a path"
+            "the transcript shows on the surface and its translation is always one tap away"
+            "on-device STT is a named champion-challenger slot, oracle-held until native crosses"
+            "acoustic, echo, place, and broadcast senses are channels in the same body"))
+    (defn wp-north-star ()
+        (list
+            "the node perceives, transcribes, translates, and speaks at home — no gated provider"
+            "architecture and weights are recipe DATA; one engine emits proof and native alike"
+            "nodes sense each other and the room by inaudible sound; what one hears, all may learn"))
+
+    ;; === THREAD 1+2 — transcript + translation, champion-challenger STT ===
+    ;; a transcript candidate carries cost so the cheaper sovereign path can win.
+    (defn wp-tc (text confidence cost source) (list text confidence cost source))
+    (defn wp-tc-text (c) (nth c 0))
+    (defn wp-tc-conf (c) (nth c 1))
+    (defn wp-tc-cost (c) (nth c 2))
+    (defn wp-tc-source (c) (nth c 3))
+
+    ;; the native challenger earns the slot only when it clears the floor AND is
+    ;; no more costly than the oracle champion — else the oracle honestly holds.
+    (defn wp-transcript-select (champion challenger floor)
+        (if (lt (wp-tc-conf challenger) floor) champion
+            (if (gt (wp-tc-cost challenger) (wp-tc-cost champion)) champion
+                challenger)))
+    (defn wp-tc->chan (chosen)
+        (wp-channel "transcript" (wp-tc-text chosen) (wp-tc-conf chosen) (wp-tc-source chosen)))
+    (defn wp-transcript-channel (champion challenger floor)
+        (wp-tc->chan (wp-transcript-select champion challenger floor)))
+
+    ;; translation is ALWAYS derivable from a transcript (the tap is structural,
+    ;; not an optional field). it crosses by content-address — one cell, many tongues.
+    (defn wp-translate (transcript-chan target-tongue)
+        (wp-channel "translation"
+            (list target-tongue (wp-value transcript-chan))
+            (wp-confidence transcript-chan)
+            "content-address"))
+    (defn wp-translation-tongue (tc) (nth (wp-value tc) 0))
+    (defn wp-translation-text (tc) (nth (wp-value tc) 1))
+    ;; the affordance is present for any transcript channel — proof it's one tap away.
+    (defn wp-can-translate? (chan) (if (str_eq (wp-kind chan) "transcript") 1 0))
+
+    ;; === THREAD 3 — acoustic node-sensing, echo room-map, place, broadcast ==
+    ;; node-can-hear-node: an inaudible ping from an emitter, heard by a listener
+    ;; above a correlation threshold, is an audibility edge (strength = correlation).
+    (defn wp-audible? (correlation threshold) (if (lt correlation threshold) 0 1))
+    (defn wp-audibility-edge (listener emitter correlation threshold)
+        (wp-channel "audibility"
+            (list listener emitter (wp-audible? correlation threshold))
+            correlation
+            "acoustic-ping"))
+    (defn wp-edge-listener (e) (nth (wp-value e) 0))
+    (defn wp-edge-emitter (e) (nth (wp-value e) 1))
+    (defn wp-edge-heard (e) (nth (wp-value e) 2))
+
+    ;; echo-location: a ping's round-trip time-of-flight (microseconds) off a wall
+    ;; maps to distance. sound = 343 mm/ms; the round trip halves it.
+    ;;     dist_mm = tof_us * 343 / 2000
+    (defn wp-echo-distance-mm (tof-us) (div (mul tof-us 343) 2000))
+    (defn wp-echo-channel (tof-us)
+        (wp-channel "echo" (wp-echo-distance-mm tof-us) tof-us "acoustic-ping"))
+
+    ;; travel / place: a location series moved if any consecutive step exceeds a
+    ;; threshold (manhattan over scaled lat/lon). confidence = the count of fixes.
+    (defn wp-step (a b)
+        (add (wp-abs (sub (nth a 0) (nth b 0)))
+             (wp-abs (sub (nth a 1) (nth b 1)))))
+    (defn wp-moved-loop (pts threshold)
+        (if (lt (len pts) 2) 0
+            (if (gt (wp-step (head pts) (head (tail pts))) threshold) 1
+                (wp-moved-loop (tail pts) threshold))))
+    (defn wp-place-channel (pts threshold)
+        (wp-channel "place" (wp-moved-loop pts threshold) (len pts) "geo-series"))
+
+    ;; broadcast-what-I'm-playing: a node offers its media so co-located nodes learn
+    ;; from it. an audible co-located node RECEIVES the broadcast (the edge gates it).
+    (defn wp-broadcast (media-id title)
+        (wp-channel "broadcast" (list media-id title) 100 "self-play"))
+    (defn wp-broadcast-reaches? (edge) (wp-edge-heard edge))
+)
+`;
+
+// The recipe is one (do ...) of defns. To run a witness against it we wrap the
+// inner defns with the witness expression as the last form in a fresh (do ...).
+function wpInnerDefns(): string {
+  const r = WORLD_PERCEPTION_RECIPE;
+  const after = r.slice(r.indexOf("(do") + 3);
+  return after.slice(0, after.lastIndexOf(")"));
+}
+
+export function wpProgram(witness: string): string {
+  return `(do ${wpInnerDefns()}
+${witness})`;
+}
+
+export type WpRun = { value: string; walks: number; ms: number };
+
+// Walk one witness against the recipe on the in-browser TS Form kernel. Returns
+// the rendered value (string-quotes stripped) plus the walk count + elapsed ms so
+// the surface can show that the number was computed, not hard-coded.
+export function wpRun(witness: string): WpRun {
+  const kernel = new Kernel({ writeStdout: () => {}, writeStderr: () => {} });
+  kernel.trace = new Trace();
+  const start = performance.now();
+  const root = readAll(kernel, wpProgram(witness));
+  const rendered = kernel.render(walk(kernel, root, new Frame(null)));
+  const ms = performance.now() - start;
+  const trace = kernel.trace.toJSON() as { total_walks?: number };
+  const value = rendered.replace(/^"(.*)"$/s, "$1");
+  return { value, walks: trace.total_walks ?? 0, ms };
+}


### PR DESCRIPTION
## What

The web twin of the phone's perception screen, at **/sense/surface** (linked from the `/sense` install door). It shows what a node senses about the world — every sense rendered as the same channel card:

- **Heard** — the transcript, with a **home / rented** badge and a **translate tap** (tongue chips)
- **Who can hear whom** — audibility edges from inaudible ping (heard / out-of-range + strength)
- **Room** — echo-location wall distances from round-trip time-of-flight
- **Place** — moving / settled
- **Playing** — what's broadcast, and how many audible nodes it reaches

## The honest core

Every value is computed by **walking `world-perception.fk` (four-way 255) on the in-browser TypeScript Form kernel — the same kernel that proves the band.** `world-perception-recipe.ts` holds the recipe **text verbatim** (the web container doesn't ship `form/`) and runs it as-is — *not* a TypeScript reimplementation. A proof panel shows calls / walks / ms so the numbers are visibly computed.

The champion-challenger slot is visible live: in the **quiet room** the native ear wins (badge → `home · form-native`, conf 88); in the **gathering** it hasn't cleared the floor so the rented oracle holds (`rented · oracle`, conf 92). That's "the mind comes home" you can watch.

## Honest floor (in the page)

The three scenes (quiet room / in the car / a gathering) stand in for the phone's mic, radios, and camera until those carriers are wired — the **logic** is the body's, proven four-way. Real cross-tongue word-rendering already exists (EN ⇄ ID, four-way `nl-translate` pivot) and is attested on the translate block; wiring it live and feeding real phone senses are the next breaths.

## Verification

- `/sense/surface` renders on **desktop (two-column, fills width) and mobile (single column)** — both checked.
- Kernel computes live and correct: quiet-room → home/0.34·0.89 m/settled; gathering → rented/audibility(aria·71 heard, kai·58 heard, far·22 out-of-range)/walls 2.06·4.80·7.03 m/broadcast reaches 2.
- Scene switch + translate tap interactions verified in-browser. `tsc --noEmit` → 0 errors.

Builds on sibling PR [#3474](https://github.com/seeker71/Coherence-Network/pull/3474) (the engine) and [#3475](https://github.com/seeker71/Coherence-Network/pull/3475) (the nl-translate pivot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)