### PR TITLE
feat(form): Go kernel → Android ARM64 build — the gen conductor's missing arm (carries form_compile)

### DIFF
--- a/docs/coherence-substrate/kernel-on-android.form
+++ b/docs/coherence-substrate/kernel-on-android.form
@@ -101,6 +101,20 @@
 ;     shortest line from "serves a route" to "runs on a phone" — but only behind the total shim
 ;     above. UNTESTED for this kernel: no gomobile bind of form-kernel-go has been built.
 ;
+;   STANDALONE CLI BINARY — the gen-conductor arm  [MEASURED 2026-06-21: built + ELF-checked + carries-conductor]:
+;     A SECOND, simpler Go->Android path than gomobile: a standalone ARM64 binary, no app, no JNI.
+;     form/form-kernel-go/build-android.sh cross-compiles GOOS=linux GOARCH=arm64 CGO_ENABLED=0 ->
+;     a statically linked "ELF 64-bit LSB executable, ARM aarch64", runnable on a device via Termux /
+;     adb push. No NDK, no cgo: the cgo dylib-JIT degrades to jit_inram_other, which the interpreter
+;     never needs. The script file-checks the ELF AND symbol-checks that the GEN CONDUCTOR's primitives
+;     ride along (form_compile / form_walk / recipe_to_bytes / bytes_to_recipe / write/read_file_bytes).
+;     This is the arm the conductor needs: form-gen.fk's compile leg is form_compile, a Go-kernel
+;     native, so "form-cli that can generate -> RAM / disk / content-addressed store -> execute" runs
+;     on a phone only through the Go kernel on ARM. UNRUN: on-device execution (Termux/adb) and
+;     qemu-aarch64 run are the carrier-work — a macOS host ships no qemu-user, so build + ELF +
+;     carries-conductor is the proof there (the same bar PATH A's Rust build is proven at; the
+;     build-android.sh qemu leg fires automatically on a Linux host where qemu-aarch64 is present).
+;
 ;
 ; ── PATH C: TYPESCRIPT -> ON-DEVICE JS ENGINE ──  [the kernel that needs no compile, but a host]
 ;

--- a/form/form-kernel-go/.gitignore
+++ b/form/form-kernel-go/.gitignore
@@ -1,4 +1,5 @@
 bin-go
+bin-go-android
 form-kernel-go
 
 # compiled form-cli native binary (build via scripts/build_form_cli.sh)

--- a/form/form-kernel-go/build-android.sh
+++ b/form/form-kernel-go/build-android.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# build-android.sh — cross-compile the Form Go kernel for Android ARM64.
+#
+# Why: the gen conductor (form-stdlib/form-gen.fk — "form-cli that can generate
+# → RAM / disk / content-addressed store → execute → share") lives where the
+# compiler lives. Its one essential primitive, form_compile, is a Go-kernel
+# native — so to run the conductor on a phone, the GO kernel must build for
+# Android. The Rust kernel already cross-compiles (build-android.sh, sibling);
+# the fkwu C arm cross-compiles too but cannot compile (no form_compile). This
+# is the missing Go arm.
+#
+# Default target: linux/arm64, CGO_ENABLED=0 — a STATICALLY LINKED ARM aarch64
+# ELF, runnable on a device via Termux / adb. No NDK, no cgo: the gen conductor
+# is pure interpreter, and the cgo dylib-JIT degrades to jit_inram_other on this
+# build (the conductor never needs it). For a bionic / linker64 system-linked
+# binary (app-embeddable), the GOOS=android path needs: brew install android-ndk
+# + CC=<ndk-clang> CGO_ENABLED=1 GOOS=android GOARCH=arm64.
+#
+# See docs/coherence-substrate/kernel-on-android.form for the on-device wiring.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+OUT="bin-go-android"
+FORMGEN="../form-stdlib/form-gen.fk"
+
+echo "→ cross-compiling the Go kernel for android/arm64 (linux/arm64, CGO_ENABLED=0) ..."
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$OUT" .
+
+echo
+file "$OUT"
+case "$(file "$OUT")" in
+  *"ARM aarch64"*) echo "✓ Android ARM64 Go kernel binary at $OUT" ;;
+  *) echo "✗ not an ARM aarch64 ELF — investigate"; exit 1 ;;
+esac
+
+# The gen conductor must be IN the binary — the whole point of the android arm.
+echo
+echo "→ verifying the gen conductor's primitives ride along:"
+# Dump the symbol strings ONCE to a file and grep the file — piping
+# `strings | grep -q` trips SIGPIPE under `set -o pipefail` (grep -q exits early,
+# strings dies 141, the pipeline reads as failure even on a match).
+syms="$(mktemp)"; strings "$OUT" > "$syms"
+miss=0
+for n in form_compile form_walk recipe_to_bytes bytes_to_recipe write_file_bytes read_file_bytes; do
+  if grep -qF "$n" "$syms"; then echo "  ✓ $n"; else echo "  ✗ $n MISSING"; miss=1; fi
+done
+rm -f "$syms"
+[ "$miss" = 0 ] || { echo "✗ a conductor primitive is missing — investigate"; exit 1; }
+
+# Execution proof where the tooling exists. Linux CI ships qemu-aarch64 (see
+# scripts/cross_isa_assembly_audit.sh); a macOS host does not ship qemu-user, so
+# there the ELF type + carries-conductor IS the proof (same bar the Rust android
+# build is proven at). On a device: adb push + run, or Termux.
+echo
+if command -v qemu-aarch64 >/dev/null 2>&1; then
+  echo "→ qemu-aarch64 present — running the gen conductor on the ARM64 binary:"
+  printf '(fg-dispatch "gen (add (mul 6 7) 1)")\n' > /tmp/gen-android-cmd.fk
+  val="$(qemu-aarch64 "$OUT" "$FORMGEN" /tmp/gen-android-cmd.fk 2>&1 | tail -1)"
+  echo "  gen \"(add (mul 6 7) 1)\" -> $val"
+  case "$val" in
+    *43*) echo "✓ the gen conductor EXECUTES on ARM64 (emulated)" ;;
+    *) echo "✗ unexpected result — investigate"; exit 1 ;;
+  esac
+else
+  echo "  qemu-aarch64 absent on this host — ELF + carries-conductor is the proof here."
+  echo "  on a device:  adb push $OUT /data/local/tmp/  &&  adb push ../form-stdlib /data/local/tmp/"
+  echo "                adb shell /data/local/tmp/$OUT form-stdlib/form-gen.fk cmd.fk   (or Termux)"
+fi
+
+echo
+echo "✓ the gen conductor cross-compiles to a genuine Android ARM64 binary."


### PR DESCRIPTION
## What

**Path to yes for "this runs on Android."** The gen conductor ([`form-gen.fk`](form/form-stdlib/form-gen.fk)) needs `form_compile` — a **Go-kernel native** — and there was no Go-kernel Android build (the Rust kernel cross-compiles but lacks `form_compile`; fkwu cross-compiles but can't compile). [`form/form-kernel-go/build-android.sh`](form/form-kernel-go/build-android.sh) closes that arm:

```
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build
  → "ELF 64-bit LSB executable, ARM aarch64", statically linked, Termux/adb-runnable
```

No NDK, no cgo: the cgo dylib-JIT degrades to `jit_inram_other`, which the interpreter never needs.

## Proof

The script file-checks the ELF **and** symbol-checks that the conductor's primitives ride along:

```
✓ form_compile   ✓ form_walk   ✓ recipe_to_bytes
✓ bytes_to_recipe   ✓ write_file_bytes   ✓ read_file_bytes
✓ the gen conductor cross-compiles to a genuine Android ARM64 binary.
```

So **"form-cli that can generate → RAM / disk / content-addressed store → execute"** cross-compiles to a real Android binary — proven at the same bar PATH A (Rust `build-android.sh`) is proven at (ELF type), plus the carries-conductor check.

## Honest lane

- **UNRUN:** on-device execution (Termux/adb). The script's `qemu-aarch64` leg fires automatically on a Linux host where qemu-user is present; a macOS host ships none, so **build + ELF + carries-conductor is the proof here** — same place the Rust android kernel sits.
- The check caught its own **SIGPIPE-under-`pipefail`** false-negative before shipping (`strings | grep -q` → dump to a file and grep the file).
- [`kernel-on-android.form`](docs/coherence-substrate/kernel-on-android.form) gains this as PATH B's standalone-CLI arm, lane-sorted (MEASURED build/ELF/carries vs UNRUN on-device). `bin-go-android` is gitignored.

The remaining "yes" is on-device: `adb push bin-go-android + form-stdlib`, run `fg-dispatch "gen ..."` in Termux. The engine cross-compiles; that's the carrier step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)