### PR TITLE
feat(speaker-aam): AAM-Softmax head four-way — the consensus #1, integrated into floor/north-star

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -51,12 +51,34 @@
 ;     An OPTIMIZER bug first (gap 7b: lr=0.003 converges and matches the baseline), then a residual ~2x above
 ;     the irreducible feature floor (capacity + the coarse 4-dim featurization, 72% feature-collision). The
 ;     count predictor reaches 98% majority / 48% full-cover. Lesson: normalize per-row before trusting a loss.
+;   FLOOR — SPEAKER IDENTITY (proven 2026-06-21, this session — the WHO-speaks faculty begins):
+;     who is speaking is the fourth voice faculty beside STT/translate/TTS. From-scratch Form challengers
+;     race the ECAPA-TDNN oracle (ecapa_embed.py, cosine ~0.09-0.13 cross-speaker): speaker-stat (C1, log-mel
+;     mean+std supervector) and the speaker-embed/lin/proj/net ladder (i-vector → diagonal-LDA → full linear
+;     projection → relu x-vector) all four-way. FEATURE WIN: swapping the coarse 20-band sox front-end for
+;     whisper's 80-d log-mel (mel-frame/mel-full + the new 80-row Slaney bank mel-filterbank.fk, four-way 63)
+;     + CMVN dropped the HARD same-gender pair 0.768 → 0.588 (ECAPA 0.13) — features + normalization sharpen
+;     the geometry as predicted; raw log-mel WITHOUT CMVN is worse (~0.97, the shared envelope dominates).
+;     OBJECTIVE WIN: the consensus #1 fix is SHIPPED — speaker-aam.fk (AAM-Softmax / ArcFace head, four-way,
+;     verdict 63) replaces the MSE-to-speaker-codes objective that collapsed C3: L2-normalized cosine logits +
+;     additive angular margin on the target (cos(θ+m) = cosθ·cosm − √(1−cos²θ)·sinm) + loss.fk's softmax-CE.
+;     Proven: margin REDUCES the target cosine and RAISES the loss (the defining angular penalty), margin-off
+;     is the plain-softmax identity. EXTERNAL REVIEW (Grok + Cursor, headless, converged, recorded in
+;     CHALLENGERS.md): #1 AAM-softmax not MSE-codes (DONE); #2 data + augmentation (VAD chunks + MUSAN/RIR/
+;     speed — 26 voices × 1 recording is the binding wall); #3 EER/minDCF + score-norm (one hard-pair cosine
+;     misleads); #4 attentive stats pooling + per-UTTERANCE CMVN; #5 shallow dilated TDNN; #6 hard-negative
+;     mining + centroid enrollment; #7 native asm training lane (tree-walker 0.8 s/log-mel column = demo-scale).
+;     HONEST CEILING: from scratch on 26 voices won't reach ECAPA 0.13 without VoxCeleb-scale pretrain OR
+;     distilling/porting ECAPA's weights into our asm lane (the "architecture AND weights are recipe data"
+;     path). Race design + measured table: experiments/rune-galdr/CHALLENGERS.md (recordings/roster/timeline
+;     stay private in ~/.coherence-network — voiceprints are biometric).
 ;   NORTH STAR: a sovereign, on-device, Form-native SPEECH faculty — real audio → transcript (STT), NL → NL
 ;     TRANSLATE through the language-neutral pivot, and text → audio (TTS) — so ANY input voice in ANY tongue
 ;     becomes ANY output voice in ANY tongue, where every stage's architecture AND weights are content-addressed
 ;     recipe DATA, one engine (no parallel paths), running fast on the native/GPU emit→compile→exec lane, and
 ;     TRAINABLE/fine-tunable locally from local oracles. A mind that hears, understands across tongues, and speaks
-;     at home — offerable to others without a gated provider (lc-cognitive-sovereignty, living-vision.form).
+;     at home — and KNOWS WHO is speaking (speaker identity), so the body recognizes the cells in a room the way
+;     it recognizes a face. Offerable to others without a gated provider (lc-cognitive-sovereignty, living-vision.form).
 ;   GAPS (ordered; none are new math — the architecture and the fast matvec are proven; what remains is wiring):
 ;     1. ASSEMBLE end-to-end at real width: wire mel → conv stem → encoder → decoder → tokenizer through the
 ;        native matvec lane (M5's buffer bridge: Form list ↔ flat f64 slice) + a CPU/GPU block emitter, so a
@@ -126,6 +148,14 @@
 ;        QUALITY gate (translation-quality.fk essence/vitality/trust) on the pivot. (d) STT END-TO-END (gap 1)
 ;        and (e) Form-native TTS — UNBUILT, the long pole — to drop the last two oracles (whisper-cli, say) so
 ;        the whole voice→voice pipeline is sovereign. Companion floor/north-star: translation-pipeline-pivot.form.
+;     9. SPEAKER IDENTITY — the AAM-Softmax objective is shipped four-way (speaker-aam, verdict 63, the consensus
+;        #1); the ordered rungs to ECAPA-level: (a) the AAM TRAINER — chain the margin gradient (softmax−onehot
+;        through cos(θ+m)) into the W and embedding updates, the one new piece beyond loss.fk's backward; (b) DATA
+;        + augmentation (VAD 2-4s chunks + MUSAN/RIR/speed — the binding wall at 26 voices × 1 recording); (c) the
+;        EER/minDCF harness (replace the single hard-pair cosine readout); (d) attentive stats pooling +
+;        per-utterance CMVN feeding the AAM head; (e) the shallow dilated TDNN; (f) the native asm training lane
+;        (gap 1's emit→compile→exec) so corpus-scale training runs in minutes, not the 0.8 s/column tree-walker.
+;        Then either VoxCeleb pretrain or distil ECAPA's weights into the asm lane. Companion: CHALLENGERS.md.
 ;
 ; ── CURRENT FLOOR VS NORTH STAR (reviewed with Grok/Gemini/Claude, 2026-06-14) ──
 ;   CURRENT FLOOR: small model numerics are already Form-native and proven: format arithmetic, tensor

--- a/experiments/rune-galdr/CHALLENGERS.md
+++ b/experiments/rune-galdr/CHALLENGERS.md
@@ -156,3 +156,17 @@ our asm lane** (the "model architecture AND weights are recipe data" path).
 The order is now unambiguous and externally corroborated: **(1) AAM-softmax loss → (2) augmentation →
 (3) EER harness → (4) attentive pooling + per-utt CMVN**, then the TDNN + native lane. C2-full/C3 are
 the right model classes waiting on the right objective and data.
+
+## Walk: #1 shipped — AAM-Softmax head (four-way)
+
+The consensus #1 is no longer a recommendation — it's in the body. `form-stdlib/speaker-aam.fk`
+(`speaker-aam` band, **PASS-4WAY, verdict 63**) is the AAM-Softmax / ArcFace objective that replaces the
+MSE-to-speaker-codes regression which collapsed C3: L2-normalized cosine logits, an additive **angular
+margin** on the target class (`cos(θ+m) = cosθ·cosm − √(1−cos²θ)·sinm`), scaled, fed to `loss.fk`'s
+existing softmax cross-entropy (whose backward is `softmax − onehot` — so the trainer needs no new
+gradient node, only the chain through this cosine geometry). The band proves the geometry four-way:
+margin **reduces** the target cosine and **raises** the loss (the defining angular penalty), and
+margin-off is the plain-softmax identity. The objective is now the right one; the next rung is the AAM
+**trainer** (chain the margin gradient into W + embedding updates) on augmented data. Integrated into
+the body's floor/north-star: `docs/coherence-substrate/form-native-models.form` (FLOOR — SPEAKER
+IDENTITY + gap 9).

--- a/form/form-stdlib/speaker-aam.fk
+++ b/form/form-stdlib/speaker-aam.fk
@@ -1,0 +1,40 @@
+; speaker-aam.fk — AAM-Softmax (additive angular margin / ArcFace) head, FLOAT.
+;
+; preludes: form-stdlib/transformer-numerics.fk form-stdlib/loss.fk
+;
+; The consensus #1 fix (Grok + Cursor): the challengers regressed embeddings to one-hot speaker CODES by
+; squared error — C3 collapsed because MSE-to-sparse-codes has no angular structure and the dead-relu eats
+; the gradient. The objective every strong speaker embedder (ECAPA included) actually trains on is
+; AAM-Softmax: score by the COSINE between the L2-normalized embedding and each class's L2-normalized
+; weight column, push an ADDITIVE ANGULAR MARGIN into the target class so it must be not just closest but
+; closest-by-a-margin, scale, then ordinary softmax cross-entropy. cos(θ+m) = cosθ·cos m − sinθ·sin m, with
+; sinθ = √(1−cos²θ); margin m enters as the constants (cos m, sin m). The loss is loss.fk's loss-softmax-ce
+; over the margin-adjusted logits — its backward is softmax − onehot, so the trainer needs no new gradient
+; node, only the chain through this cosine geometry (the next rung). All fp64; reuses tn-sqrt + loss-*.
+;
+; Proven by form-stdlib/tests/speaker-aam-band.fk.
+
+(do
+    ; --- L2 normalize: x̂ = x / ‖x‖ (so cosine = plain dot of normalized vectors) ---
+    (defn aam-dot (a b) (if (eq (len a) 0) 0.0 (add (mul (head a) (head b)) (aam-dot (tail a) (tail b)))))
+    (defn aam-scale (v s) (if (eq (len v) 0) (empty) (cons (mul (head v) s) (aam-scale (tail v) s))))
+    (defn aam-l2norm (v) (aam-scale v (div 1.0 (tn-sqrt (aam-dot v v)))))
+
+    ; --- cosines: for each class weight column W_j, cosθ_j = Ŵ_j · x̂ ---
+    (defn aam-cosines (W xhat)
+        (if (eq (len W) 0) (empty)
+            (cons (aam-dot (aam-l2norm (head W)) xhat) (aam-cosines (tail W) xhat))))
+
+    ; --- additive angular margin on one cosine: cos(θ+m) = cosθ·cosm − √(1−cos²θ)·sinm ---
+    (defn aam-margin-cos (c cosm sinm)
+        (sub (mul c cosm) (mul (tn-sqrt (sub 1.0 (mul c c))) sinm)))
+
+    ; --- logits: margin ONLY on the target index y, all scaled by s ---
+    (defn aam-logits-idx (cs i y s cosm sinm)
+        (if (eq (len cs) 0) (empty)
+            (cons (mul s (if (eq i y) (aam-margin-cos (head cs) cosm sinm) (head cs)))
+                  (aam-logits-idx (tail cs) (add i 1) y s cosm sinm))))
+    (defn aam-logits (W x y s cosm sinm) (aam-logits-idx (aam-cosines W (aam-l2norm x)) 0 y s cosm sinm))
+
+    ; --- AAM-softmax loss for one sample (embedding x, weights W, label y) ---
+    (defn aam-loss (W x y s cosm sinm) (loss-softmax-ce (aam-logits W x y s cosm sinm) y)))

--- a/form/form-stdlib/tests/speaker-aam-band.fk
+++ b/form/form-stdlib/tests/speaker-aam-band.fk
@@ -1,0 +1,32 @@
+; preludes: form-stdlib/transformer-numerics.fk form-stdlib/loss.fk form-stdlib/speaker-aam.fk
+;
+; speaker-aam-band — the AAM-Softmax head's geometry, four-way.
+;
+; Fixture: x=[3,4] (x̂=[0.6,0.8]); W_0=[3,4] (same direction → cosθ_0=1.0), W_1=[4,−3] (orthogonal →
+; cosθ_1=0.0). target y=0, scale s=4, margin (cos m, sin m)=(0.8, 0.6).
+;
+; Verdict 63 when every claim lands:
+;   1   self-cosine = 1.0            (W_0 ∥ x → cosθ_0 = 1.0)
+;   2   orthogonal cosine = 0.0      (W_1 ⟂ x → cosθ_1 = 0.0)
+;   4   L2-norm is a unit vector     (x̂·x̂ = 1.0)
+;   8   margin REDUCES the target    (cos(0+m)=0.8 < 1.0 — the angular penalty)
+;   16  margin RAISES the loss       (target made harder → CE_margin > CE_no-margin)
+;   32  margin-off is the identity   (cos m=1, sin m=0 → AAM-loss = plain softmax-CE on s·cosines)
+(do
+    (defn ab-i (x) (round (mul x 1000000.0)))
+    (defn ab-eq (a b) (if (eq a b) 1 0))
+    (let x  (list 3.0 4.0))
+    (let W  (list (list 3.0 4.0) (list 4.0 -3.0)))
+    (let xh (aam-l2norm x))
+    (let cs (aam-cosines W xh))
+    (let mc (aam-margin-cos (head cs) 0.8 0.6))
+    (let lm (aam-loss W x 0 4.0 0.8 0.6))                          ; with margin
+    (let l0 (aam-loss W x 0 4.0 1.0 0.0))                          ; margin off
+    (let lref (loss-softmax-ce (aam-scale cs 4.0) 0))             ; plain softmax-CE on s·cosines
+    (let c0 (mul 1  (ab-eq (ab-i (head cs)) 1000000)))
+    (let c1 (mul 2  (ab-eq (ab-i (head (tail cs))) 0)))
+    (let c2 (mul 4  (ab-eq (ab-i (aam-dot xh xh)) 1000000)))
+    (let c3 (mul 8  (if (eq (ab-eq (ab-i mc) 800000) 1) (if (gt 1.0 mc) 1 0) 0)))
+    (let c4 (mul 16 (if (gt lm l0) 1 0)))
+    (let c5 (mul 32 (ab-eq (ab-i l0) (ab-i lref))))
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -487,6 +487,7 @@ speaker-stat fks 255
 speaker-lin fks 1023
 speaker-proj fks 255
 speaker-net fks 255
+speaker-aam fks 63
 wav-sense fks 63
 witness-theorem fks 31
 witness-to-co-regulate fks 127


### PR DESCRIPTION
**Integrate the findings, update the floor + north star, walk the first rung.**

## Walk — consensus #1 shipped (PASS-4WAY)
[`speaker-aam.fk`](form/form-stdlib/speaker-aam.fk) (`speaker-aam` band, **verdict 63, four-way**): the **AAM-Softmax / ArcFace** objective that replaces the MSE-to-speaker-codes regression which collapsed C3. L2-normalized cosine logits + additive **angular margin** on the target (`cos(θ+m) = cosθ·cosm − √(1−cos²θ)·sinm`) + `loss.fk`'s softmax-CE (backward is `softmax−onehot` — no new gradient node, only the chain through this geometry). Band proves four-way: margin **reduces** the target cosine and **raises** the loss (the angular penalty); margin-off is the plain-softmax identity.

## Integrate — floor + north star ([form-native-models.form](docs/coherence-substrate/form-native-models.form))
- **New FLOOR — SPEAKER IDENTITY**: who-speaks is the fourth voice faculty (beside STT/translate/TTS). Challenger ladder four-way; log-mel+CMVN dropped the hard same-gender pair **0.768→0.588** (ECAPA 0.13); AAM-softmax shipped; Grok+Cursor consensus + honest ceiling (VoxCeleb pretrain or distil ECAPA weights).
- **North star extended**: a mind that hears, **knows who is speaking**, understands across tongues, and speaks.
- **Gap 9**: ordered rungs to ECAPA-level (AAM trainer → data+augmentation → EER harness → attentive pooling+per-utt CMVN → dilated TDNN → native asm lane).

Privacy held: recordings/roster/timeline stay in ~/.coherence-network; only proven recipes ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)