### PR TITLE
fix(test): heal homepage-invitation drift (main red since #3333) — assert the new door-list copy

### DIFF
--- a/api/tests/test_agent_invitation.py
+++ b/api/tests/test_agent_invitation.py
@@ -264,7 +264,9 @@ def test_homepage_invites_anyone_or_anything_to_canonical_paths() -> None:
     assert 't("home.meetEyebrow")' in source
     assert 't("home.meetBody")' in source
     assert "For anyone or anything finding us" in home_messages["meetEyebrow"]
-    assert "shared doorway is the human web page" in home_messages["meetBody"]
+    # the web page is named as one shared door among the body's surfaces (the invitation framing
+    # #3333 moved to: "the web page, API, CLI, MCP, Form, source, and witness" — same intent, body-altitude)
+    assert "web page, API, CLI, MCP, Form, source, and witness" in home_messages["meetBody"]
     assert "same body answers" in home_messages["meetBody"]
     assert 'href="/come-in"' in source
     assert 'href="/with-us"' in source


### PR DESCRIPTION
## Why
`test_homepage_invites_anyone_or_anything_to_canonical_paths` has been **red on main since [#3333](https://github.com/seeker71/Coherence-Network/pull/3333)** rewrote `home.meetBody`. The test still asserted the old phrase `shared doorway is the human web page`, which #3333 composted. This blocks every PR whose CI runs the API suite (caught it on #3488).

## Fix
The new copy carries the same intent at body-altitude — *"The same body answers through the web page, API, CLI, MCP, Form, source, and witness"*. The test now asserts that door list (the web page named as one shared door among the body's surfaces). The test's meaning is preserved; only the stale phrase is realigned. Deterministic static-file assertion (not a flake); the healed test passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)