### PR TITLE
feat(eer): Equal Error Rate fitness recipe four-way — the speaker faculty's real metric

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -165,7 +165,9 @@
 ;        #1); the ordered rungs to ECAPA-level: (a) the AAM TRAINER — chain the margin gradient (softmax−onehot
 ;        through cos(θ+m)) into the W and embedding updates, the one new piece beyond loss.fk's backward; (b) DATA
 ;        + augmentation (VAD 2-4s chunks + MUSAN/RIR/speed — the binding wall at 26 voices × 1 recording); (c) the
-;        EER/minDCF harness (replace the single hard-pair cosine readout); (d) attentive stats pooling +
+;        EER harness — the metric RECIPE is SHIPPED (eer.fk, four-way verdict 63: trial matrix → FAR/FRR
+;        crossover → one comparable EER number, the fitness tooluse-model-search can optimize); wiring real
+;        corpus trials through it is the application; (d) attentive stats pooling +
 ;        per-utterance CMVN feeding the AAM head; (e) the shallow dilated TDNN; (f) the native asm training lane
 ;        (gap 1's emit→compile→exec) so corpus-scale training runs in minutes, not the 0.8 s/column tree-walker.
 ;        Then either VoxCeleb pretrain or distil ECAPA's weights into the asm lane. Companion: CHALLENGERS.md.

--- a/form/form-stdlib/eer.fk
+++ b/form/form-stdlib/eer.fk
@@ -1,0 +1,44 @@
+; eer.fk — Equal Error Rate over a verification trial matrix, the speaker faculty's FITNESS function.
+;
+; preludes: form-stdlib/transformer-numerics.fk
+;
+; A single hard-pair cosine misleads (both external oracles flagged it #3): the real metric is EER over a
+; TRIAL MATRIX. A trial is (score, label): score = cosine similarity of two utterances, label = 1.0 for a
+; GENUINE pair (same speaker) or 0.0 for an IMPOSTOR pair (different speakers). At a decision threshold θ:
+;   FAR(θ) = impostors accepted (score ≥ θ) / impostors      — false-accept rate
+;   FRR(θ) = genuines rejected (score < θ) / genuines        — false-reject rate
+; FAR falls and FRR rises as θ climbs; the EER is where they cross (FAR = FRR). We sweep θ over the trial
+; scores themselves (the only thresholds where the rates change) and return the rate at the θ minimizing
+; |FAR − FRR| — one comparable number per design, the fitness the model-search ratchet (tooluse-model-search)
+; can optimize. Lower is better; 0.0 = perfect separation, 0.5 = chance. All fp64; reuses tn-abs.
+
+(do
+    (defn eer-score (t) (nth t 0))
+    (defn eer-label (t) (nth t 1))                                        ; 1.0 genuine, 0.0 impostor
+
+    ; --- per-trial indicators: 1.0 when this trial is an error at threshold th, else 0.0 ---
+    (defn eer-fa1 (t th) (if (lt (eer-label t) 0.5) (if (ge (eer-score t) th) 1.0 0.0) 0.0))  ; impostor accepted
+    (defn eer-fr1 (t th) (if (gt (eer-label t) 0.5) (if (lt (eer-score t) th) 1.0 0.0) 0.0))  ; genuine rejected
+
+    ; --- folds over the trial list: error counts and class sizes ---
+    (defn eer-sum-fa (ts th) (if (eq (len ts) 0) 0.0 (add (eer-fa1 (head ts) th) (eer-sum-fa (tail ts) th))))
+    (defn eer-sum-fr (ts th) (if (eq (len ts) 0) 0.0 (add (eer-fr1 (head ts) th) (eer-sum-fr (tail ts) th))))
+    (defn eer-n-imp (ts) (if (eq (len ts) 0) 0.0 (add (if (lt (eer-label (head ts)) 0.5) 1.0 0.0) (eer-n-imp (tail ts)))))
+    (defn eer-n-gen (ts) (if (eq (len ts) 0) 0.0 (add (if (gt (eer-label (head ts)) 0.5) 1.0 0.0) (eer-n-gen (tail ts)))))
+
+    ; --- the two rates at a threshold ---
+    (defn eer-far (ts th) (div (eer-sum-fa ts th) (eer-n-imp ts)))
+    (defn eer-frr (ts th) (div (eer-sum-fr ts th) (eer-n-gen ts)))
+
+    ; --- sweep θ over the trial scores; keep the rate where |FAR − FRR| is smallest (the crossover) ---
+    (defn eer-scores (ts) (if (eq (len ts) 0) (empty) (cons (eer-score (head ts)) (eer-scores (tail ts)))))
+    (defn eer-sweep (ts cands bestdiff besteer)
+        (if (eq (len cands) 0) besteer
+            (do (let th (head cands))
+                (let fa (eer-far ts th))
+                (let fr (eer-frr ts th))
+                (let d  (tn-abs (sub fa fr)))
+                (if (lt d bestdiff)
+                    (eer-sweep ts (tail cands) d (mul 0.5 (add fa fr)))
+                    (eer-sweep ts (tail cands) bestdiff besteer)))))
+    (defn eer (ts) (eer-sweep ts (eer-scores ts) 1000000.0 1.0)))

--- a/form/form-stdlib/tests/eer-band.fk
+++ b/form/form-stdlib/tests/eer-band.fk
@@ -1,0 +1,28 @@
+; preludes: form-stdlib/transformer-numerics.fk form-stdlib/eer.fk
+;
+; eer-band — Equal Error Rate over a trial matrix, four-way.
+;
+; OVERLAP fixture (genuine and impostor scores interleave so EER > 0):
+;   genuine (label 1): 0.8 0.6 0.4   ·   impostor (label 0): 0.7 0.5 0.3
+;   the FAR/FRR crossover is at θ=0.6: FAR=1/3 (impostor 0.7 accepted), FRR=1/3 (genuine 0.4 rejected) → EER=1/3.
+; SEPARABLE fixture: genuine 0.9 0.8, impostor 0.2 0.1 → a clean threshold exists → EER = 0.
+;
+; Verdict 63 when every claim lands:
+;   1   FAR at the crossover θ=0.6 = 1/3
+;   2   FRR at the crossover θ=0.6 = 1/3
+;   4   EER (swept) = 1/3            (the rates meet at θ=0.6)
+;   8   separable trials → EER = 0
+;   16  FAR at θ=0 = 1.0             (every impostor accepted)
+;   32  FRR at θ=1 = 1.0             (every genuine rejected)
+(do
+    (defn eb-i (x) (round (mul x 1000000.0)))
+    (defn eb-eq (a b) (if (eq a b) 1 0))
+    (let T (list (list 0.8 1.0) (list 0.6 1.0) (list 0.4 1.0) (list 0.7 0.0) (list 0.5 0.0) (list 0.3 0.0)))
+    (let S (list (list 0.9 1.0) (list 0.8 1.0) (list 0.2 0.0) (list 0.1 0.0)))
+    (let c0 (mul 1  (eb-eq (eb-i (eer-far T 0.6)) 333333)))
+    (let c1 (mul 2  (eb-eq (eb-i (eer-frr T 0.6)) 333333)))
+    (let c2 (mul 4  (eb-eq (eb-i (eer T)) 333333)))
+    (let c3 (mul 8  (eb-eq (eb-i (eer S)) 0)))
+    (let c4 (mul 16 (eb-eq (eb-i (eer-far T 0.0)) 1000000)))
+    (let c5 (mul 32 (eb-eq (eb-i (eer-frr T 1.0)) 1000000)))
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -488,6 +488,7 @@ speaker-lin fks 1023
 speaker-proj fks 255
 speaker-net fks 255
 speaker-aam fks 63
+eer fks 63
 wav-sense fks 63
 witness-theorem fks 31
 witness-to-co-regulate fks 127


### PR DESCRIPTION
The instrument the design was missing — both external oracles flagged that a single hard-pair cosine misleads (#3).

[`eer.fk`](form/form-stdlib/eer.fk) (`eer` band, **PASS-4WAY, verdict 63**): a trial is `(score, label)` (1=genuine/same-speaker, 0=impostor); EER sweeps the threshold to the **FAR=FRR crossover** and returns one comparable number (0=perfect, 0.5=chance) — the **fitness** the existing model-search ratchet ([tooluse-model-search.fk](form/form-stdlib/tooluse-model-search.fk)) can optimize. This turns *how do we improve* from a question we ask into a loop the body runs.

Band proves four-way: overlap fixture → EER=1/3 at the θ=0.6 crossover; separable fixture → EER=0; FAR/FRR boundary behavior. Floor gap 9(c) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)