### PR TITLE
feat(form): str-lower in Form — the missing primitive that kept forcing bash; encoder surface-robust in Form

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -165,10 +165,14 @@
 ;        neutral symbol at phase water; corpus words translate four-way (nl-translate-band → 16383) and run live
 ;        (the company is home → perusahaan adalah rumah). Remaining on (a): MDL-minimal symbol assignment
 ;        (frequent meaning → short symbol), the full 373 pairs, and then the learned encoder/decoder (gap 6
-;        dynamic, gap 7b optimizer fixed) replacing the hand templates. (b) SURFACE-ROBUST
-;        encoding — case / punctuation / contractions owned by the Form ENCODER, not the carrier's input
-;        cleaning (the live loop surfaced this: whisper returns "The kernel is native."; needs a four-way
-;        Form str-lower, not yet present). (c) the round-trip
+;        dynamic, gap 7b optimizer fixed) replacing the hand templates. (b) SURFACE-ROBUST encoding — DONE:
+;        form-stdlib/string-case.fk (str-lower / str-strip-punct / str-normalize, the four-way Form string
+;        primitive whose absence kept forcing text work into bash — band → 31 four-way) is now called by the
+;        nl-translate ENCODER, so "The Source Is Native." canonicalizes INSIDE Form (no shell cleaning); the
+;        carrier dropped its `tr` step (nl-translate-band → 32767). Remaining (b): contractions / unicode
+;        case. NOTE — the same primitive unblocks the Form-native PROJECTOR: scripts/grow_nl_lexicon.sh's
+;        bash+python should become a Form recipe over read_file + json-parse + string-case + write_file_text
+;        (fsh / shell-grammar.fk is the form-native shell for the host-exec shims). (c) the round-trip
 ;        QUALITY gate (translation-quality.fk essence/vitality/trust) on the pivot. (d) STT END-TO-END (gap 1)
 ;        and (e) Form-native TTS — UNBUILT, the long pole — to drop the last two oracles (whisper-cli, say) so
 ;        the whole voice→voice pipeline is sovereign. Companion floor/north-star: translation-pipeline-pivot.form.

--- a/experiments/coherence-sense-android/native-translate-speak.sh
+++ b/experiments/coherence-sense-android/native-translate-speak.sh
@@ -21,7 +21,7 @@ STD="$ROOT/form/form-stdlib"; GO="$ROOT/form/form-kernel-go/bin-go"
 [[ -x "$GO" ]] || { echo "FAIL no Form kernel (bin-go) — build: (cd $ROOT/form/form-kernel-go && go build -o bin-go .)"; exit 1; }
 # core.fk is the only source-compiled prelude; nl-translate's deps are all builtins
 # + already-low-level cells, so the native translate runs without it.
-PRELUDE=(json cache form-ontology-loader line-grammar bmf-core bmf-grammar nl-translate)
+PRELUDE=(json cache form-ontology-loader line-grammar bmf-core bmf-grammar string-case nl-translate)
 SRCS=(); for p in "${PRELUDE[@]}"; do SRCS+=("$STD/$p.fk"); done
 
 # native translate: ONE kernel call, all logic is Form. dir = en-id | id-en
@@ -52,12 +52,9 @@ if [[ "$MODE" == "voice" ]]; then
   rm -f "$wav" "$aiff"
 fi
 
-# surface I/O cleaning: STT yields capitalized, punctuated text ("The kernel is
-# native."); the grammar tokenizes canonical lowercase words. This is input
-# sanitation, not translation logic. (Making the Form ENCODER own surface
-# normalization — case, contractions, richer punctuation — is the next refinement.)
-CLEAN="$(printf '%s' "$TEXT" | tr '[:upper:]' '[:lower:]' | tr -d '.,!?;:')"
-OUT="$(translate "$CLEAN" "$DIR")"
+# surface normalization (case, punctuation) is now owned by the Form ENCODER
+# (str-normalize in form-stdlib/string-case.fk) — no shell cleaning here.
+OUT="$(translate "$TEXT" "$DIR")"
 echo "[native-translate · form-stdlib/nl-translate.fk · $DIR]  \"$TEXT\"  ->  \"$OUT\""
 if command -v say >/dev/null; then say "$OUT" 2>/dev/null && echo "[tts-oracle say] spoke the translation"; fi
 

--- a/form/form-stdlib/nl-translate.fk
+++ b/form/form-stdlib/nl-translate.fk
@@ -115,6 +115,9 @@
     (defn dec-en (p) (nlt-sp "the" (nlt-sp (nlt-c->en (nlt-kidv p 0)) (nlt-sp "is" (nlt-c->en (nlt-kidv p 1))))))
     (defn dec-id (p) (nlt-sp (nlt-c->id (nlt-kidv p 0)) (nlt-sp "adalah" (nlt-c->id (nlt-kidv p 1)))))
     ;; --- the translators: encode one tongue -> pivot -> decode the other ---
-    (defn tr-en-id (x) (dec-id (norm-en (g-parse (nl-en) x))))
-    (defn tr-id-en (x) (dec-en (norm-id (g-parse (nl-id) x))))
+    ;; the ENCODER owns surface normalization (str-normalize from string-case.fk:
+    ;; lowercase + strip punctuation), so noisy real input — "The Source Is Native." —
+    ;; canonicalizes INSIDE Form, not in a shell carrier.
+    (defn tr-en-id (x) (dec-id (norm-en (g-parse (nl-en) (str-normalize x)))))
+    (defn tr-id-en (x) (dec-en (norm-id (g-parse (nl-id) (str-normalize x)))))
     0)

--- a/form/form-stdlib/string-case.fk
+++ b/form/form-stdlib/string-case.fk
@@ -1,0 +1,41 @@
+; string-case.fk — Form-native case folding + punctuation stripping.
+;
+; The four-way string primitive whose ABSENCE kept pushing text work into bash/python:
+; lowercasing and punctuation-stripping, built from pure substring + str_eq +
+; str_concat — no host, no codepoint arithmetic. This is surface normalization the
+; ENCODER can own, so noisy real input ("The Kernel Is Native.") reaches a clean
+; canonical surface inside Form instead of being scrubbed by a shell carrier.
+;
+; A 26-letter map (upper <-> lower) read by index keeps it codepoint-free and so
+; trivially four-way; the recursion depth is the string length (short surfaces).
+
+(do
+    (defn sc-upper () "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+    (defn sc-lower () "abcdefghijklmnopqrstuvwxyz")
+    ;; index of a 1-char string ch in s, or -1
+    (defn sc-idx (s ch i)
+        (if (ge i (str_len s)) -1
+            (if (str_eq (substring s i (add i 1)) ch) i
+                (sc-idx s ch (add i 1)))))
+    (defn sc-fold-char (ch i) (if (lt i 0) ch (substring (sc-lower) i (add i 1))))
+    (defn sc-lc-char (ch) (sc-fold-char ch (sc-idx (sc-upper) ch 0)))
+    (defn str-lower-from (s i acc)
+        (if (ge i (str_len s)) acc
+            (str-lower-from s (add i 1) (str_concat acc (sc-lc-char (substring s i (add i 1)))))))
+    ;; str-lower — every A..Z folded to a..z, all else unchanged
+    (defn str-lower (s) (str-lower-from s 0 ""))
+
+    ;; punctuation set to drop; sc-keep? is true when a char is NOT punctuation
+    (defn sc-punct () ".,!?;:")
+    (defn sc-keep? (ch) (lt (sc-idx (sc-punct) ch 0) 0))
+    (defn str-strip-punct-from (s i acc)
+        (if (ge i (str_len s)) acc
+            (str-strip-punct-from s (add i 1)
+                (if (sc-keep? (substring s i (add i 1)))
+                    (str_concat acc (substring s i (add i 1))) acc))))
+    ;; str-strip-punct — drop . , ! ? ; :
+    (defn str-strip-punct (s) (str-strip-punct-from s 0 ""))
+
+    ;; str-normalize — the surface canonicalizer: lowercase, then drop punctuation
+    (defn str-normalize (s) (str-strip-punct (str-lower s)))
+    0)

--- a/form/form-stdlib/tests/nl-translate-band.fk
+++ b/form/form-stdlib/tests/nl-translate-band.fk
@@ -7,9 +7,9 @@
 ; DATA ROWS (vocabulary is data), AND the PIVOT speaking the body's own NEUTRAL symbol
 ; (n0 — not any tongue's lemma, no language privileged) with ice/water/gas phase tags.
 ; Plus three words GROWN from the real parallel corpus (web/messages/*). Bitmask
-; witness; all fourteen → 16383, across Go / Rust / TS / fkwu.
+; witness; all fifteen → 32767 (+ surface-robust encoding owned by the Form encoder), across Go / Rust / TS / fkwu.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/nl-translate.fk
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/string-case.fk form-stdlib/nl-translate.fk
 
 (do
     (defn chk (got exp bit) (if (node_eq got exp) bit 0))
@@ -40,4 +40,7 @@
         ;; scripts/grow_nl_lexicon.sh translate four-way — vocabulary grows from data, no code change
         (if (str_eq (tr-en-id "the company is home")  "perusahaan adalah rumah") 2048 0)
         (if (str_eq (tr-en-id "the research is open")  "riset adalah buka")      4096 0)
-        (if (str_eq (tr-id-en "tempat adalah riset")   "the place is research")  8192 0))))
+        (if (str_eq (tr-id-en "tempat adalah riset")   "the place is research")  8192 0)
+        ;; 15. SURFACE-ROBUST: the Form encoder (str-normalize) canonicalizes noisy STT-shaped
+        ;; input — capitals + punctuation — with no shell carrier cleaning
+        (if (str_eq (tr-en-id "The Source Is Native.") "sumber adalah asli")    16384 0))))

--- a/form/form-stdlib/tests/string-case-band.fk
+++ b/form/form-stdlib/tests/string-case-band.fk
@@ -1,0 +1,18 @@
+; string-case-band.fk — proves form-stdlib/string-case.fk four-way.
+;
+; Form-native lowercasing + punctuation stripping. Real STT-shaped input
+; ("The Source Is Native.") canonicalizes inside Form. Bitmask witness; all
+; five → 31, across Go / Rust / TS / fkwu.
+;
+; preludes: form-stdlib/core.fk form-stdlib/string-case.fk
+
+(do
+    (defn chk (got exp bit) (if (str_eq got exp) bit 0))
+    (defn total (xs) (if (nil? xs) 0 (add (head xs) (total (tail xs)))))
+
+    (total (list
+        (chk (str-lower "The Kernel Is Native")      "the kernel is native" 1)
+        (chk (str-lower "SUMBER")                     "sumber"               2)
+        (chk (str-strip-punct "native.")             "native"               4)
+        (chk (str-normalize "The Source Is Native.")  "the source is native" 8)
+        (chk (str-lower "already-lower 9")            "already-lower 9"     16))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -689,7 +689,7 @@ natural-language fks 262143
 # NodeID, no tongue privileged; self-authored-symbol-space MDL refines it minimal),
 # each symbol carrying an ice/water/gas phase (substrate-thermodynamics).
 # 2047 = all eleven checks.
-nl-translate fks 16383
+nl-translate fks 32767
 # form.bml lifted onto the cursor: the form.bml grammar PARSES `def ..=expr;` on
 # the fourth arm too (cursor-only; rides bmf-core/bmf-grammar's op families). The
 # recipe-shape parity vs the hand line compiler is the three-way band
@@ -839,3 +839,4 @@ model-search fks 31
 tooluse-model-search fks 63
 continued-learning fks 63
 feature-selection fkc 63
+string-case fks 31


### PR DESCRIPTION
*"more shell scripts, why not form native shell or form native code?"* — a fair catch.

The body already has the form-native shell (`fsh` / `shell-grammar.fk`), Form file I/O (`read_file` / `write_file_text`), and `json-parse`. I defaulted to bash+python out of habit. The recurring **root** reason I reached for a host shell on *text* tasks: a missing four-way Form string primitive — **lowercasing / punctuation-stripping**. So I built it.

## The primitive
[`form-stdlib/string-case.fk`](form/form-stdlib/string-case.fk) — `str-lower` / `str-strip-punct` / `str-normalize`, from pure `substring` + `str_eq` + `str_concat` (a 26-letter index map, codepoint-free → trivially four-way). `string-case-band` **→ 31 four-way** (Go/Rust/TS/fkwu).

## Applied at the root (surface-robust encoding, gap 8b)
The `nl-translate` **encoder** now calls `str-normalize`, so `"The Source Is Native."` canonicalizes **inside Form**. The carrier (`native-translate-speak.sh`) **dropped its `tr '[:upper:]' | tr -d punct` cleaning** — the body owns surface normalization now.

- `nl-translate-band` **16383 → 32767** four-way.
- Live: `The COMPANY is Home!` → `perusahaan adalah rumah` with **no shell cleaning**.

## What this unblocks (named)
The same primitive unblocks the Form-native **projector**: `grow_nl_lexicon.sh`'s bash+python should become a Form recipe over `read_file` + `json-parse` + `string-case` + `write_file_text` (the next Form-native rebuild). The honest irreducible host boundary is only the *exec* of external tools (say/whisper) — which `fsh` reaches by passthrough until STT/TTS go native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)