### PR TITLE
tend(eer): first real EER numbers — the instrument overturns the cosine

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -59,6 +59,12 @@
 ;     whisper's 80-d log-mel (mel-frame/mel-full + the new 80-row Slaney bank mel-filterbank.fk, four-way 63)
 ;     + CMVN dropped the HARD same-gender pair 0.768 → 0.588 (ECAPA 0.13) — features + normalization sharpen
 ;     the geometry as predicted; raw log-mel WITHOUT CMVN is worse (~0.97, the shared envelope dominates).
+;     EER REALITY-CHECK (eer.fk, the new four-way metric, on 15 real same/different-speaker trials — the
+;     instrument's FIRST lesson): raw log-mel EER 0.33, but global IN-SAMPLE CMVN EER 0.67 — WORSE than
+;     chance. It collapses same-speaker similarity (genuine cosines fall to 0.21/0.37, below several impostor
+;     pairs). The hard-pair-cosine "CMVN win" did NOT generalize to verification — #3's "one cosine misleads"
+;     proven on our own data. The lesson the metric forced: per-utterance CMVN (NOT global in-sample) + a
+;     TRAINED embedder are required, not optional; both front-ends are near/under chance untrained.
 ;     OBJECTIVE WIN: the consensus #1 fix is SHIPPED — speaker-aam.fk (AAM-Softmax / ArcFace head, four-way,
 ;     verdict 63) replaces the MSE-to-speaker-codes objective that collapsed C3: L2-normalized cosine logits +
 ;     additive angular margin on the target (cos(θ+m) = cosθ·cosm − √(1−cos²θ)·sinm) + loss.fk's softmax-CE.

--- a/experiments/rune-galdr/CHALLENGERS.md
+++ b/experiments/rune-galdr/CHALLENGERS.md
@@ -170,3 +170,23 @@ margin-off is the plain-softmax identity. The objective is now the right one; th
 **trainer** (chain the margin gradient into W + embedding updates) on augmented data. Integrated into
 the body's floor/north-star: `docs/coherence-substrate/form-native-models.form` (FLOOR — SPEAKER
 IDENTITY + gap 9).
+
+## First EER numbers — the instrument earns its keep (and overturns a cosine)
+
+`eer.fk` (four-way) wired to a real trial matrix via `eer-measure.sh`: each of the 3 ceremony voices
+split into two time-windows → 3 genuine (same-speaker) + 12 impostor (cross-speaker) trials, scored by
+log-mel-supervector cosine.
+
+| front-end | EER (0=perfect, 0.5=chance) | what the distributions show |
+|---|---|---|
+| log-mel RAW | **0.33** | genuine 0.97–0.99 and impostor 0.97–0.99 **all tangled** (shared envelope) |
+| log-mel + global CMVN | **0.67** (worse than chance) | genuine collapses (ubbe 0.21, brig 0.37) **below** impostor pairs |
+
+The lesson, immediate and humbling: the earlier "CMVN win" (hard pair 0.768→0.588) measured cross-speaker
+*discrimination*, but on the actual *verification* metric, **global in-sample CMVN is anti-correlated** —
+it destroys same-speaker similarity. This is exactly the consensus #3 warning ("one hard-pair cosine
+misleads") **proven on our own data with our own metric**. EER didn't just give a number — it overturned a
+conclusion. What it forces next: **per-utterance** CMVN (not global in-sample) and a **trained** embedder
+(the AAM head); both untrained front-ends are at/under chance on verification. The metric is now the
+fitness the model-search ratchet (`tooluse-model-search`) can optimize — design improvement becomes a
+loop the body runs, not a cosine we eyeball.

--- a/experiments/rune-galdr/eer-measure.sh
+++ b/experiments/rune-galdr/eer-measure.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# eer-measure.sh — feed real verification trials through eer.fk (the four-way Form metric).
+#
+# Builds a trial matrix from the ceremony voices: each speaker's vocal split into two time-windows
+# (two "utterances" of the same speaker) → genuine pairs (same speaker) + impostor pairs (cross).
+# Scores each pair by cosine of its log-mel supervector, RAW vs +CMVN, and reports EER (eer.fk) for
+# each — one comparable number per front-end. The metric is the Form body; this carrier only assembles
+# trials. Recordings/roster stay private; only the numbers leave.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../form"
+K=form-kernel-rust/target/release/form-kernel-rust
+PRE="form-stdlib/trig.fk form-stdlib/mel-frame.fk form-stdlib/mel-full.fk form-stdlib/mel-filterbank.fk"
+SEP=~/.coherence-network/recordings/speakers/sep/htdemucs
+col(){ python3 - "$1" "$2" <<'PY'
+import wave,array,sys
+w=wave.open(sys.argv[1],'rb'); w.setpos(int(float(sys.argv[2])*16000)); a=array.array('h'); a.frombytes(w.readframes(400))
+print("(do (print (mfu-col (list "+" ".join(f"{x/32768.0:.6f}" for x in a)+") (melbank) 400)))")
+PY
+}
+# 6 windows: spk0={w0,w1} spk1={w2,w3} spk2={w4,w5}; genuine=(0,1)(2,3)(4,5), else impostor
+names=(ubbe ubbe brigitte brigitte angelia angelia); starts=(1.0 5.0 1.0 5.0 1.0 5.0)
+echo "extracting log-mel frames for 6 windows (3 voices x 2 time-windows)..."
+for i in 0 1 2 3 4 5; do : > /tmp/em_$i.fr
+  for off in 0.0 0.4 0.8 1.2 1.6 2.0; do
+    t=$(awk "BEGIN{print ${starts[i]}+$off}")
+    col "$SEP/${names[i]}.16k/vocals.wav" "$t" > /tmp/em_col.fk
+    $K $PRE /tmp/em_col.fk 2>/dev/null | grep -E '^\[' | tr -d '[]' | tr ',' ' ' >> /tmp/em_$i.fr
+  done
+done
+cat /tmp/em_0.fr /tmp/em_1.fr /tmp/em_2.fr /tmp/em_3.fr /tmp/em_4.fr /tmp/em_5.fr > /tmp/em_all.fr
+GM=$(awk '{for(i=1;i<=NF;i++){s[i]+=$i;n[i]++}}END{for(i=1;i<=80;i++)printf "%.6f ",s[i]/n[i]}' /tmp/em_all.fr)
+# supervector: raw (no cmvn) or cmvn (subtract global mean), pool mean+std -> 160-d
+sv(){ awk -v gm="$GM" -v c="$2" 'BEGIN{split(gm,g," ")}
+  {for(i=1;i<=NF;i++){v=$i; if(c=="1")v=$i-g[i]; s[i]+=v;q[i]+=v*v;n[i]++}}
+  END{for(i=1;i<=80;i++){m=s[i]/n[i];printf "%.5f ",m} for(i=1;i<=80;i++){m=s[i]/n[i];vv=q[i]/n[i]-m*m;if(vv<0)vv=0;printf "%.5f ",sqrt(vv)}}' "/tmp/em_$1.fr"; }
+cos(){ paste -d' ' <(echo "$1") <(echo "$2")|awk '{n=NF/2;d=0;a=0;b=0;for(i=1;i<=n;i++){d+=$i*$(i+n);a+=$i*$i;b+=$(i+n)*$(i+n)}printf "%.5f",d/(sqrt(a)*sqrt(b)+1e-9)}'; }
+label(){ # genuine(1) if same speaker pair (0,1)(2,3)(4,5)
+  case "$1-$2" in 0-1|2-3|4-5) echo 1.0;; *) echo 0.0;; esac; }
+build_trials(){ local cmvn="$1" tr="" sv_=(); local i
+  for i in 0 1 2 3 4 5; do sv_[$i]=$(sv $i $cmvn); done
+  for i in 0 1 2 3 4 5; do for ((j=i+1;j<6;j++)); do
+    tr="$tr (list $(cos "${sv_[i]}" "${sv_[j]}") $(label $i $j))"; done; done
+  echo "$tr"; }
+run_eer(){ echo "(do (print (eer (list $1))))" > /tmp/em_eer.fk
+  $K form-stdlib/transformer-numerics.fk form-stdlib/eer.fk /tmp/em_eer.fk 2>/dev/null | grep -E '^-?[0-9]' | tail -1; }
+echo; echo "15 trials (3 genuine same-speaker, 12 impostor cross-speaker). EER via eer.fk:"
+echo "  log-mel RAW   EER = $(run_eer "$(build_trials 0)")"
+echo "  log-mel+CMVN  EER = $(run_eer "$(build_trials 1)")   (0=perfect separation, 0.5=chance)"
+rm -f /tmp/em_*.fr /tmp/em_col.fk /tmp/em_eer.fk


### PR DESCRIPTION
`eer-measure.sh` wires [`eer.fk`](form/form-stdlib/eer.fk) to a real trial matrix (3 ceremony voices × 2 time-windows → 3 genuine + 12 impostor pairs).

| front-end | EER | distributions |
|---|---|---|
| log-mel RAW | **0.33** | genuine & impostor all tangled at 0.97–0.99 (shared envelope) |
| log-mel + global CMVN | **0.67** (worse than chance) | genuine collapses (0.21/0.37) below impostor pairs |

**The instrument's first lesson:** the earlier hard-pair-cosine 'CMVN win' (0.768→0.588) measured cross-speaker *discrimination*, but on the *verification* metric global in-sample CMVN is **anti-correlated**. This is the consensus #3 warning ('one cosine misleads') **proven on our own data**. EER overturned a conclusion — and names the true next step: **per-utterance** CMVN + a **trained** embedder. Recorded in floor + CHALLENGERS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)