### PR TITLE
feat(form): byte->symbol map (GPT-2 bytes_to_unicode) four-way — the tokenizer front-end

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-21_byte_to_symbol_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-21_byte_to_symbol_four_way.json
@@ -1,0 +1,36 @@
+{
+  "date": "2026-06-21",
+  "brick": "byte-to-symbol (GPT-2/whisper byte-level encoder, OpenAI's bytes_to_unicode) crosses four-way — the tokenizer FRONT-END the bpe merge core feeds from",
+  "author": "Sema (Opus 4.8) — sema-native-ml-walk autonomous run",
+  "claim": "The byte->unicode-codepoint map at the head of byte-level BPE (every input byte 0..255 -> one visible codepoint, BEFORE merge) is lifted from carrier DATA to a Form recipe proven on the four-kernel floor (Go/Rust/TS/fkwu). This is named stone #2 from the 3zb (bpe-tokenizer) receipt: 'the byte->symbol mapping ... as Form recipes (currently carrier DATA).' The bpe merge core (#3447) was already four-way; this proves the algorithmic step that produces the symbols the merge core consumes.",
+  "north_star": "A model whose weights AND tokenizer are recipe data, running on a Form-native kernel. The decode math is four-way and on the M4 GPU (multi-layer stack #3423/#3424, KV-cached decode #3412, greedy argmax #3402); the bpe merge core is four-way (#3447). The tokenizer front-end is text -> bytes -> codepoints -> vocab-ids -> merge. This brick puts the bytes->codepoints step on the proven floor; only the codepoint->vocab-id lookup (genuine table DATA) and the GPT-2 regex word-split remain as carrier in the front-end.",
+  "recipe": "form/form-stdlib/byte-to-symbol.fk — b2s-printable? / byte-to-symbol / bytes-to-symbols. Closed form of OpenAI's bytes_to_unicode: printable ranges [33..126] u [161..172] u [174..255] map to themselves; the other 68 bytes ({0..32} u {127..160} u {173}) map ascending to 256..323 (b<=32 -> 256+b; 127..160 -> b+162; 173 -> 323). Pure integer arithmetic (ge/eq/add) and list recursion; no floats (no e-notation risk), no host I/O, small tables.",
+  "band": "form/form-stdlib/tests/byte-to-symbol-band.fk — verdict 255 (8 claims):",
+  "claims": {
+    "bit_1_space": "byte 32 -> codepoint 288 (chr 'Ġ', the word-boundary marker every BPE word carries) — the load-bearing case.",
+    "bit_2_printable_identity": "bytes in [33..126] u [161..172] u [174..255] map to themselves (33,116,126,161,172,174,255 checked across all three sub-ranges and boundaries).",
+    "bit_4_offset_floor": "byte 0 (the min byte, a control char) -> 256 — the floor of the lifted band.",
+    "bit_8_mid_band_endpoints": "the [127..160] offset band endpoints: 127 -> 289, 160 -> 322 (= byte + 162).",
+    "bit_16_isolated_singleton": "byte 173 -> 323 — the trap: 161..172 are printable, so 173 is non-contiguous with 127..160 and needs its own case (not b+162=335).",
+    "bit_32_branch_cuts": "the branch cuts are exactly placed: 126(id)|127(offset), 160(offset)|161(id), 172(id)|173(offset)|174(id) — the boundaries where identity flips to offset and back.",
+    "bit_64_bijection_separation": "every offset >= 256, every identity <= 255 -> the two branches never collide. This is the structural reason byte-level decode is reversible (a bijection onto 256 distinct codepoints).",
+    "bit_128_sequence_map": "bytes-to-symbols over ' tokenizer' bytes (32 116 111 107 101 110 105 122 101 114) -> codepoints [288,116,111,107,101,110,105,122,101,114] — the byte-mapped form 'Ġtokenizer' whose vocab-ids ARE the bpe band's real openai/whisper-tiny anchor; plus the empty base case."
+  },
+  "reference": "OpenAI GPT-2/whisper bytes_to_unicode — closed-form candidate verified against the reference dict for ALL 256 bytes: 0 mismatches. Space(32)->288 ('Ġ'), and ' tokenizer'.encode()->[288,116,111,107,101,110,105,122,101,114]='Ġtokenizer', confirmed before authoring the band.",
+  "proof": {
+    "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/byte-to-symbol.fk form-stdlib/tests/byte-to-symbol-band.fk",
+    "result": "core.fk+byte-to-symbol.fk+byte-to-symbol-band.fk -> 255",
+    "fourth_arm": "1 band(s) four-way (fkwu + pre-flattened tables)",
+    "divergence": "1 ok, 0 divergent — kernels agree on every sample",
+    "manifest_row": "byte-to-symbol fks 255 added to form/fourth-arm-bands.txt"
+  },
+  "fourth_arm_subset": "Pure integer arithmetic (ge/eq/add) + list recursion (cons/head/tail/len/empty), no host I/O, no floats (so no scientific-notation literal risk), small tables — well within fkwu's covered subset; far below the table-capacity wall that segfaults the assembled-block bands.",
+  "lane": "NEW-recipe brick but cheap (matches 3p/3q). READ-THE-BODY confirmed the byte->symbol map did NOT exist anywhere in the body (only named as carrier DATA in bpe-tokenizer.fk's note and the band's pre-mapped anchor) — a real gap, not a re-impl. Design (the closed form of bytes_to_unicode + the all-256-byte reference check + the strange-minimal boundary fixtures) was the cost; the four-way proof was seconds.",
+  "read_the_body": "Grepped form/ for bytes_to_unicode / byte-map / byte-encoder before authoring — found only the carrier-DATA note in bpe-tokenizer.fk and matches in the kernel sources, no Form recipe. The bpe band's anchor syms (vocab ids) start from byte-mapped codepoints this recipe now produces; the codepoint->vocab-id lookup remains genuine table DATA.",
+  "named_next_stones": [
+    "GPT-2 regex pre-tokenization (word splitting on the contraction/letter/number/whitespace pattern) as a Form recipe — the last algorithmic piece of the tokenizer front-end still carrier DATA.",
+    "wire the full generation loop: byte-to-symbol + vocab lookup + bpe-encode (#3447) + multi-layer decode stack (#3423/#3424) + greedy argmax (#3402) -> the first end-to-end native token over real llama3.2:3b GGUF.",
+    "llama's tokenizer is SentencePiece-BPE (score-ranked, not GPT-2 byte-level) — confirm/extend the byte->symbol + merge-rank model for it, or lift the SentencePiece variant."
+  ],
+  "witness_note": "Witness aggregator read overall:'strained', silences:0 at run start; instance pulse (api.coherencycoin.com/api/pulse/now) showed neo4j + substrate dark; the persistently-flagged endpoint_ideas door was probed directly: GET https://api.coherencycoin.com/api/ideas returns 200 with real idea data, so endpoint_ideas darkness is the witness's own probe path, not a real ideas outage. neo4j (graph store) showing silent is worth a look when Urs is back. No deploy taken (pure Form band, host-independent; deploy is outside the autonomous guardrails)."
+}

--- a/form/form-stdlib/byte-to-symbol.fk
+++ b/form/form-stdlib/byte-to-symbol.fk
@@ -1,0 +1,37 @@
+; byte-to-symbol.fk — GPT-2/whisper byte-level encoder: byte (0..255) -> unicode codepoint.
+;
+; preludes: (none beyond the kernel — pure int recipe)
+;
+; whisper/GPT-2 tokenizes at the BYTE level: every input byte 0..255 maps to a single visible
+; unicode codepoint BEFORE merge, so the merge core (bpe-tokenizer.fk) and the round-trip decode
+; both work over a printable alphabet with no control or whitespace bytes. The map (OpenAI's
+; bytes_to_unicode) keeps the "printable" byte ranges as themselves and lifts the rest above 255:
+;   printable = [33..126] u [161..172] u [174..255]              -> codepoint = byte (identity)
+;   the other 68 bytes ({0..32} u {127..160} u {173}), ascending, map to 256,257,...,323:
+;     b in [0..32]     -> 256 + b              (ranks 0..32)
+;     b in [127..160]  -> 256 + 33 + (b-127)  = b + 162   (ranks 33..66)
+;     b == 173         -> 256 + 67            = 323        (rank 67; isolated — 161..172 are printable)
+; The map is a bijection 0..255 -> 256 distinct codepoints (every offset >= 256, every identity <= 255,
+; so the two branches never collide) — which is what makes byte-level decode reversible. This is the
+; algorithmic FRONT-END the bpe merge core feeds from; the codepoint->vocab-id lookup is table DATA.
+; All integer arithmetic: no floats (no e-notation risk), no host I/O, small — the fourth-friendly subset.
+
+(do
+  ; is byte b in a printable range that maps to itself?
+  (defn b2s-printable? (b)
+    (if (if (ge b 33) (ge 126 b) 0) 1
+        (if (if (ge b 161) (ge 172 b) 0) 1
+            (if (if (ge b 174) (ge 255 b) 0) 1 0))))
+
+  ; one byte -> its unicode codepoint
+  (defn byte-to-symbol (b)
+    (if (eq (b2s-printable? b) 1) b
+        (if (ge 32 b) (add 256 b)
+            (if (ge 160 b) (add b 162)
+                323))))
+
+  ; map a byte list to its codepoint list (the front-end over a word's bytes)
+  (defn bytes-to-symbols (bs)
+    (if (eq (len bs) 0) (empty)
+        (cons (byte-to-symbol (head bs)) (bytes-to-symbols (tail bs)))))
+  0)

--- a/form/form-stdlib/tests/byte-to-symbol-band.fk
+++ b/form/form-stdlib/tests/byte-to-symbol-band.fk
@@ -1,0 +1,65 @@
+; preludes: form-stdlib/core.fk form-stdlib/byte-to-symbol.fk
+;
+; byte-to-symbol-band — GPT-2/whisper byte-level encoder (OpenAI's bytes_to_unicode) lifted to the
+; four-kernel floor. This is the tokenizer FRONT-END the bpe merge core (bpe-tokenizer.fk, #3447)
+; feeds from: text bytes -> visible unicode codepoints, before any merge. Named stone #2 of the
+; tokenizer arc — the byte->symbol map was carrier DATA; this proves the algorithm in Form.
+;
+; The proof is the map's structural laws, pinned to OpenAI's reference (verified 0 mismatches over all 256 bytes):
+;   bit 1   — the SPACE case: byte 32 -> codepoint 288 (chr 'Ġ', the word-boundary marker every BPE word carries).
+;   bit 2   — printable identity: bytes in [33..126] u [161..172] u [174..255] map to themselves.
+;   bit 4   — the offset FLOOR: byte 0 (the min byte, a control char) -> 256.
+;   bit 8   — the [127..160] offset band endpoints: 127 -> 289, 160 -> 322 (= byte + 162).
+;   bit 16  — the ISOLATED singleton: byte 173 -> 323 (161..172 are printable, so 173 is non-contiguous — the trap).
+;   bit 32  — the branch CUTS are exactly placed: 126(id)|127(offset), 160(offset)|161(id), 172(id)|173(offset)|174(id).
+;   bit 64  — the BIJECTION separation: every offset >= 256, every identity <= 255 -> the two branches never collide
+;             (this is what makes byte-level decode reversible).
+;   bit 128 — the SEQUENCE map: " tokenizer" bytes -> codepoints [288,116,111,107,101,110,105,122,101,114], the
+;             byte-mapped form whose vocab-ids are the bpe band's real anchor; and the empty base case.
+;
+; Pure integer recursion — no host I/O, no floats, small tables — the fourth-friendly subset. Verdict 255.
+(do
+  (defn ids-eq (a b)
+    (if (eq (len a) 0) (if (eq (len b) 0) 1 0)
+        (if (eq (head a) (head b)) (ids-eq (tail a) (tail b)) 0)))
+
+  ; bit 1 — space -> Ġ (288)
+  (let c0 (if (eq (byte-to-symbol 32) 288) 1 0))
+
+  ; bit 2 — printable identity across all three sub-ranges and their boundaries
+  (let c1 (if (and (and (and (eq (byte-to-symbol 33) 33) (eq (byte-to-symbol 126) 126))
+                        (and (eq (byte-to-symbol 116) 116) (eq (byte-to-symbol 161) 161)))
+                   (and (and (eq (byte-to-symbol 172) 172) (eq (byte-to-symbol 174) 174))
+                        (eq (byte-to-symbol 255) 255)))
+              2 0))
+
+  ; bit 4 — offset floor: byte 0 -> 256
+  (let c2 (if (eq (byte-to-symbol 0) 256) 4 0))
+
+  ; bit 8 — [127..160] offset band endpoints
+  (let c3 (if (and (eq (byte-to-symbol 127) 289) (eq (byte-to-symbol 160) 322)) 8 0))
+
+  ; bit 16 — isolated singleton 173 -> 323
+  (let c4 (if (eq (byte-to-symbol 173) 323) 16 0))
+
+  ; bit 32 — branch cuts exactly placed (id vs offset on both sides of each boundary)
+  (let c5 (if (and (and (and (eq (byte-to-symbol 126) 126) (eq (byte-to-symbol 127) 289))
+                        (and (eq (byte-to-symbol 160) 322) (eq (byte-to-symbol 161) 161)))
+                   (and (and (eq (byte-to-symbol 172) 172) (eq (byte-to-symbol 173) 323))
+                        (eq (byte-to-symbol 174) 174)))
+              32 0))
+
+  ; bit 64 — bijection separation: offsets >= 256, identities <= 255 (no collision)
+  (let c6 (if (and (and (and (ge (byte-to-symbol 0) 256) (ge (byte-to-symbol 32) 256))
+                        (and (ge (byte-to-symbol 127) 256) (ge (byte-to-symbol 173) 256)))
+                   (and (and (ge 255 (byte-to-symbol 33)) (ge 255 (byte-to-symbol 126)))
+                        (ge 255 (byte-to-symbol 255))))
+              64 0))
+
+  ; bit 128 — the sequence map over " tokenizer" bytes, plus the empty base case
+  (let seq (bytes-to-symbols (list 32 116 111 107 101 110 105 122 101 114)))
+  (let c7 (if (and (eq (ids-eq seq (list 288 116 111 107 101 110 105 122 101 114)) 1)
+                   (eq (len (bytes-to-symbols (empty))) 0))
+              128 0))
+
+  (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -229,6 +229,7 @@ form-cli-model fks 31
 form-cli-guide fks 31
 text-tokenize fks 31
 bpe-tokenizer fks 31
+byte-to-symbol fks 255
 form-cli-judge fks 127
 obs-verify fks 31
 world-module-model fks 1023


### PR DESCRIPTION
## The brick

The byte-level encoder at the head of BPE: every input byte 0..255 → one visible unicode codepoint **before** merge, so the bpe merge core ([#3447](https://github.com/seeker71/Coherence-Network/pull/3447)) and round-trip decode work over a printable alphabet with no control/whitespace bytes. **Named stone #2** from 3zb's receipt ("the byte→symbol mapping … as Form recipes (currently carrier DATA)").

READ-THE-BODY: grepped `form/` first — the map did **not** exist in Form anywhere, only as carrier DATA in `bpe-tokenizer.fk`'s note and the band's pre-mapped anchor. A real gap, not a re-impl.

## Recipe — `form/form-stdlib/byte-to-symbol.fk`

Closed form of OpenAI's `bytes_to_unicode`:
- printable `[33..126] ∪ [161..172] ∪ [174..255]` → themselves (identity)
- the other 68 bytes (`{0..32} ∪ {127..160} ∪ {173}`) → ascending `256..323` (`b≤32 → 256+b`; `127..160 → b+162`; `173 → 323`)

Pure integer arithmetic (`ge`/`eq`/`add`) + list recursion. No floats (no e-notation risk), no host I/O — the fourth-friendly subset. Verified vs the OpenAI reference: **0 mismatches over all 256 bytes**; `" tokenizer"` → `"Ġtokenizer"` codepoints `[288,116,111,107,101,110,105,122,101,114]`.

## Band — verdict **255** (8 strange-minimal laws)

space→288('Ġ') · printable identity across all three sub-ranges · offset floor 0→256 · mid-band endpoints 127→289/160→322 · the isolated singleton 173→323 · branch cuts exactly placed · the bijection separation (offsets≥256, identities≤255, no collision — why decode is reversible) · the sequence map over `" tokenizer"` connecting to the bpe band's real openai/whisper-tiny anchor.

## Proof (hard gate)

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/byte-to-symbol.fk form-stdlib/tests/byte-to-symbol-band.fk
→ 255 · 1 ok, 0 divergent · fourth arm: 1 band(s) four-way
```

Manifest row `byte-to-symbol fks 255` added. Receipt: `docs/system_audit/commit_evidence_2026-06-21_byte_to_symbol_four_way.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)