### PR TITLE
attune(translation): there is no host boundary — host tools are current carriers, internalized by choice

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -179,9 +179,12 @@
 ;        case. NOTE — the same primitive unblocks the Form-native PROJECTOR: scripts/grow_nl_lexicon.sh's
 ;        bash+python should become a Form recipe over read_file + json-parse + string-case + write_file_text
 ;        (fsh / shell-grammar.fk is the form-native shell for the host-exec shims). (c) the round-trip
-;        QUALITY gate (translation-quality.fk essence/vitality/trust) on the pivot. (d) STT END-TO-END (gap 1)
-;        and (e) Form-native TTS — UNBUILT, the long pole — to drop the last two oracles (whisper-cli, say) so
-;        the whole voice→voice pipeline is sovereign. Companion floor/north-star: translation-pipeline-pivot.form.
+;        QUALITY gate (translation-quality.fk essence/vitality/trust) on the pivot. (d) STT and (e) TTS
+;        native — and these are NOT a boundary. whisper-cli / say / sox / even process-exec are CURRENT
+;        third-party carriers, not walls: host-kernel.form names using a host driver as carrier-not-debt
+;        (using the host carrier IS having the resource), so each is internalized when we CHOOSE (need-driven,
+;        oracle→native→retire), never blocked. The whole voice→voice pipeline is already sovereign in
+;        principle; what remains is sequence, not permission. Companion: translation-pipeline-pivot.form.
 ;     9. SPEAKER IDENTITY — the AAM-Softmax objective is shipped four-way (speaker-aam, verdict 63, the consensus
 ;        #1); the ordered rungs to ECAPA-level: (a) the AAM TRAINER — chain the margin gradient (softmax−onehot
 ;        through cos(θ+m)) into the W and embedding updates, the one new piece beyond loss.fk's backward; (b) DATA

--- a/docs/coherence-substrate/translation-pipeline-pivot.form
+++ b/docs/coherence-substrate/translation-pipeline-pivot.form
@@ -121,7 +121,10 @@ defn nl_to_form = pipeline_shape { encode: @encode(nl), pivot: @pivot(meaning), 
 # equality) wired onto the pivot; the model-council (nl-to-form-satsang.form)
 # proposing parses the circle agrees on; and the two OTHER stages going native —
 # STT end-to-end (Form whisper is four-way-proven but not yet real-.wav->transcript)
-# and Form-native TTS (unbuilt, the long pole) — to drop the last two oracles.
+# and TTS native. These are NOT a boundary: whisper-cli / say / sox / process-exec
+# are CURRENT third-party carriers, internalized when we CHOOSE — host-kernel.form
+# names using a host driver as carrier-not-debt (using the host carrier IS having
+# the resource). What remains is sequence, not permission.
 #
 # LINEAGE
 #   kin: universal-translator.form (pivot = Blueprint), encoder-decoder-as-recipe.form


### PR DESCRIPTION
*"why is that a boundary, that is just a current use of 3rd party tools we can internalize when we choose"* — correct, and the body already says so.

I'd dressed a current rental as a wall ("Form-native TTS — the long pole — to drop the last two oracles") — the same fear-costume as the privileged-source-language one earlier in the arc.

[`host-kernel.form`](docs/coherence-substrate/host-kernel.form) names it exactly: *"we are allowed to use ANY host resource (driver, kernel API, OS API)"*; using a host driver is **carrier-not-debt** — *"using the host carrier IS having the resource, legitimately, maybe permanently."*

So `whisper-cli` / `say` / `sox` / even process-exec are **current third-party carriers, not boundaries**. Each is internalized when we **choose** (need-driven, oracle→native→retire), never blocked. Reframed both durable cells (`form-native-models.form` gap 8, `translation-pipeline-pivot.form`): the remaining stages going native are **sequence, not permission**; the voice→voice pipeline is already sovereign in principle. No "long pole," no wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)