### PR TITLE
feat(form-cli): ask+ runs end-to-end — source-compile the BML body + wire the sufficiency gate (four-way 4095)

### DIFF
--- a/bin/form-cli
+++ b/bin/form-cli
@@ -29,10 +29,12 @@ form-cli — the one door (local-first, Form-native)
 
   form-cli ask "<question>" [-k N] [-m MODEL]
         answer from the body + local docs, grounded (local oracle, no network)
-  form-cli ask+ "<question>" [-m LOCAL] [-j JUDGE] [--remote "claude -p"]
-        daily-driver ask: local-first, then a multi-signal sufficiency check
-        (form-cli-sufficiency.fk, four-way proven) escalates to the subscription
-        oracle for the real answer when local is not enough — claude-code quality
+  form-cli ask+ "<question>" [-m LOCAL] [-j JUDGE] [--remote "claude -p"] [--judge-gate]
+        daily-driver ask: local-first, then the four-way-proven sufficiency gate
+        (form-cli-sufficiency.fk via form-cli-ask-gate.fk) escalates to the
+        subscription oracle when local is not enough. Sovereignty-first by default
+        (a usable local answer stands; a local failure escalates); --judge-gate adds
+        the judge model as the content scorer — claude-code quality at its latency
   form-cli stats
         dashboard: learning · models · tools · tool->native · local/remote oracle
         (counts read from the body's records; stats by form-cli-stats.fk, four-way)

--- a/form/form-stdlib/form-cli-ask-gate.fk
+++ b/form/form-stdlib/form-cli-ask-gate.fk
@@ -1,0 +1,64 @@
+; form-cli-ask-gate.fk — the ask verb's POSTERIOR gate: turn THIS run's local
+; answer-signals into the accept / retry / escalate decision, composing the
+; four-way-proven form-cli-sufficiency.fk.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk
+;
+; form-cli-sufficiency.fk reads six signals and returns accept / retry / escalate.
+; This is the ask lane's adapter onto it: the live carrier (form-cli-ask.fk) reads
+; the real local answer this turn and reduces it to four numbers; the gate maps
+; those into the sufficiency signal list and lets the proven verdict decide. The
+; gate is pure + numeric, so it crosses four-way; the oracle calls (local lane via
+; http-fetch, judge via http-fetch, remote escalation via host-exec) wrap it.
+;
+; Signals the carrier computes from the real local answer:
+;   okp      1 if the local oracle produced a usable answer (non-empty, not an
+;            error / refusal marker), else 0 — it feeds BOTH has-output and
+;            shape-ok (an unusable answer fails both at once)
+;   content  0..100 substance score: the judge's coverage rating when a judge ran,
+;            else the carrier's intrinsic read of the answer
+;   trust    0..100 prior trust in this local lane — it seeds the confidence and
+;            trust axes alike (the policy seed until per-lane stats are tracked)
+;   retries  local re-tries still available this turn
+;
+; Proven by: form-stdlib/tests/form-cli-ask-band.fk (four-way at validate.sh)
+
+; ── read the local answer into signals (pure; the carrier hands over the text) ──
+; the local lane returns its "[ask: ..." marker when the oracle did not answer.
+(defn fca-error-marker? (answer)
+    (if (eq (str_find answer "[ask:" 0) 0) 1 0))
+
+; usable: a real answer — non-empty and not the error marker. This is okp.
+(defn fca-usable? (answer)
+    (if (eq (str_len answer) 0) 0
+        (if (eq (fca-error-marker? answer) 1) 0 1)))
+
+; intrinsic content (sovereignty-first): trust ANY usable answer above the gate's
+; accept threshold; an unusable one reads 0 so the gate escalates. Length is not
+; substance — only the presence of a real answer is. The carrier's judge can refine
+; this score when its gate is on; this is the default.
+(defn fca-content-intrinsic (answer)
+    (if (eq (fca-usable? answer) 1) 70 0))
+
+; assemble the sufficiency signal list for one ask turn. okp drives has-output AND
+; shape-ok; trust seeds confidence and trust alike.
+(defn fca-ask-signals (okp content trust retries)
+    (fsuf-signals okp okp content trust trust retries))
+
+; the posterior verdict for this turn: 0 accept (local stands) / 1 retry / 2 escalate
+(defn fca-ask-verdict (okp content trust retries)
+    (fsuf-verdict (fca-ask-signals okp content trust retries)))
+
+; why it ruled that way (0 ok / 1 empty / 2 bad-shape / 3 weak / 4 low-conf / 5 low-trust)
+(defn fca-ask-reason (okp content trust retries)
+    (fsuf-reason (fca-ask-signals okp content trust retries)))
+
+; the three carrier gates over a verdict
+(defn fca-ask-accept?   (v) (if (eq v 0) 1 0))
+(defn fca-ask-retry?    (v) (if (eq v 1) 1 0))
+(defn fca-ask-escalate? (v) (if (eq v 2) 1 0))
+
+; the trust-row PATH signal, read from the FINAL verdict (after any retry resolved):
+; 1 = native (the local body answered and stood), 0 = rented (escalated to the oracle)
+(defn fca-ask-path (final-verdict) (if (eq final-verdict 0) 1 0))
+0

--- a/form/form-stdlib/form-cli-ask-plus.fk
+++ b/form/form-stdlib/form-cli-ask-plus.fk
@@ -1,0 +1,105 @@
+; form-cli-ask-plus.fk — the `ask+` daily-driver: local-first, then the four-way
+; sufficiency gate escalates to the subscription oracle when local is not enough.
+;
+; preludes: form-stdlib/core.fk form-stdlib/http-client.fk form-stdlib/form-cli-ask.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/form-cli-ask-gate.fk
+;
+; form-cli-ask.fk's `fca-ask` is the PURE local verb (the native binary's `ask`:
+; one socket call to the local oracle, no host-exec). This is its escalating
+; sibling — the verb `ask+` runs. The flow:
+;
+;   1. ask the LOCAL oracle (model) over http-fetch — same socket lane as fca-ask
+;   2. read THIS run's signals: usable? (non-empty, not an error marker) and a
+;      0..100 content score. The DEFAULT score is the intrinsic, sovereignty-first
+;      read — a usable answer is trusted; only a local failure reads 0. With the
+;      judge gate on, the judge model's coverage rating replaces it (a small judge
+;      is noisy enough to escalate correct answers, so it is opt-in)
+;   3. let form-cli-ask-gate.fk (composing the four-way-proven form-cli-sufficiency.fk)
+;      return the verdict: accept (local stands) / retry (re-run local once) / escalate
+;   4. on escalate, run the REMOTE oracle (the subscription agent CLI, e.g. claude -p)
+;      via host-exec — the only host-exec in the path; the local + judge lanes stay
+;      pure socket calls
+;
+; The decision math is the gate's, proven four-way; this file is the live carrier
+; that feeds it real signals and carries the verdict out to the oracles.
+
+section [form.bml] {
+    ; usable? and the intrinsic content read live in form-cli-ask-gate.fk (pure,
+    ; four-way proven): fca-usable? / fca-content-intrinsic. This carrier composes
+    ; them; the judge path below is the opt-in refinement.
+
+    ; ── scan the first integer out of a reply (the judge's 0..100) ───────────
+    def fcap-digit?(c) {
+        let cp = ord(c);
+        if lt(cp, 48) then 0 else if gt(cp, 57) then 0 else 1;
+    }
+    ; index of the first digit, or str_len(s) when the reply carries no digit
+    def fcap-first-digit(s, i) {
+        if ge(i, str_len(s)) then str_len(s) else
+        if eq(fcap-digit?(char_at(s, i)), 1) then i else fcap-first-digit(s, add(i, 1));
+    }
+    def fcap-take-int(s, i, acc) {
+        if ge(i, str_len(s)) then acc else
+        if eq(fcap-digit?(char_at(s, i)), 1) then
+            fcap-take-int(s, add(i, 1), add(mul(acc, 10), sub(ord(char_at(s, i)), 48)))
+        else acc;
+    }
+    def fcap-clamp100(n) {
+        if gt(n, 100) then 100 else n;
+    }
+
+    ; ── the judge content score (the membrane: a local judge model rates the
+    ;    local answer's coverage; intrinsic read when the judge errors or
+    ;    returns no number) ──
+    def fcap-judge-prompt(question, answer) {
+        str_concat("Rate 0 to 100 how fully the ANSWER addresses the QUESTION. Reply with ONLY the integer.\nQUESTION: ",
+            str_concat(question, str_concat("\nANSWER: ", answer)));
+    }
+    def fcap-judge-content(judge, question, answer) {
+        let reply = fca-ask-model(judge, fcap-judge-prompt(question, answer));
+        if eq(fca-usable?(reply), 0) then fca-content-intrinsic(answer) else
+        if ge(fcap-first-digit(reply, 0), str_len(reply)) then fca-content-intrinsic(answer) else
+            fcap-clamp100(fcap-take-int(reply, fcap-first-digit(reply, 0), 0));
+    }
+
+    ; the content signal for one answer: 0 for an unusable answer (escalate); else
+    ; the judge's coverage score when the judge gate is on, otherwise the intrinsic
+    ; sovereignty-first read (trust the local body). The judge gate is opt-in because
+    ; a small local judge is noisy enough to escalate correct answers — off, the body
+    ; is trusted; on, the membrane refines the score.
+    def fcap-content(usejudge, judge, question, answer) {
+        if eq(fca-usable?(answer), 0) then 0 else
+        if eq(usejudge, 1) then fcap-judge-content(judge, question, answer)
+        else fca-content-intrinsic(answer);
+    }
+
+    ; ── escalate to the remote oracle (the subscription agent CLI) ───────────
+    def fcap-escalate(remote, question) {
+        let wrote = host-write("/tmp/fca_plus_prompt.txt", question);
+        host-exec(str_concat(remote, " < /tmp/fca_plus_prompt.txt 2>/dev/null"));
+    }
+
+    ; ── one ask turn: local -> gate -> accept / retry-once / escalate ────────
+    def fcap-decide(local, question, model, judge, remote, trust, retries, usejudge) {
+        let okp = fca-usable?(local);
+        let verdict = fca-ask-verdict(okp, fcap-content(usejudge, judge, question, local), trust, retries);
+        if eq(verdict, 0) then local else
+        if eq(verdict, 1) then fcap-retry(question, model, judge, remote, trust, usejudge)
+        else fcap-escalate(remote, question);
+    }
+    ; retry re-runs the local lane once with no re-tries left: accept it or escalate.
+    def fcap-retry(question, model, judge, remote, trust, usejudge) {
+        let local = fca-ask-model(model, question);
+        let okp = fca-usable?(local);
+        let verdict = fca-ask-verdict(okp, fcap-content(usejudge, judge, question, local), trust, 0);
+        if eq(verdict, 0) then local else fcap-escalate(remote, question);
+    }
+
+    def fca-ask-plus(question, model, judge, remote, trust, retries, usejudge) {
+        if eq(str_len(question), 0) then
+            "ask+: usage - ask+ <question>   (local-first; the sufficiency gate escalates to the oracle when local is not enough)"
+        else
+            fcap-decide(fca-ask-model(model, question), question, model, judge, remote, trust, retries, usejudge);
+    }
+}
+
+0

--- a/form/form-stdlib/tests/form-cli-ask-band.fk
+++ b/form/form-stdlib/tests/form-cli-ask-band.fk
@@ -1,0 +1,39 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/form-cli-ask-gate.fk
+;
+; form-cli-ask-band — the ask verb's posterior accept / retry / escalate decision, proven
+; four-way. Eight strange-minimal cases walk the boundary at the trust=60 prior: a usable,
+; substantive local answer STANDS (native); a weak one ESCALATES for the real answer; an
+; unusable answer RETRIES while a re-try remains then ESCALATES when exhausted; a strong
+; answer from an UNTRUSTED lane still escalates; and the path label reads native on accept,
+; rented on escalate. The gate adds nothing to fsuf's math — it only adapts the ask lane's
+; four signals onto it — so these cases pin that the adapter routes each shape correctly.
+;
+; Verdict 4095 when every claim lands — the full default decision path, read-to-route:
+;   1     usable + strong content   -> ACCEPT      (v=0)
+;   2     usable + weak content      -> ESCALATE    (v=2) reason weak (3)
+;   4     unusable + a re-try left    -> RETRY       (v=1)
+;   8     unusable + exhausted        -> ESCALATE    (v=2) reason empty (1)
+;   16    strong but low-trust lane    -> ESCALATE    (v=2) reason low-conf (4)
+;   32    accept -> path native         (1)
+;   64    escalate -> path rented        (0)
+;   128   borderline content 60          -> ACCEPT    (v=0)
+;   256   empty answer is NOT usable      (okp 0)
+;   512   the "[ask: .." error marker is NOT usable (okp 0)
+;   1024  a real answer IS usable         (okp 1)
+;   2048  intrinsic content: usable -> 70, unusable -> 0  (the sovereignty-first read)
+(do
+    (let c0  (if (eq  (fca-ask-verdict 1 80 60 1) 0)                                       1    0))
+    (let c1  (if (and (eq (fca-ask-verdict 1 40 60 1) 2) (eq (fca-ask-reason 1 40 60 1) 3))  2  0))
+    (let c2  (if (eq  (fca-ask-verdict 0 0 60 1) 1)                                        4    0))
+    (let c3  (if (and (eq (fca-ask-verdict 0 0 60 0) 2) (eq (fca-ask-reason 0 0 60 0) 1))    8  0))
+    (let c4  (if (and (eq (fca-ask-verdict 1 80 10 1) 2) (eq (fca-ask-reason 1 80 10 1) 4))  16 0))
+    (let c5  (if (eq  (fca-ask-path 0) 1)                                                  32   0))
+    (let c6  (if (eq  (fca-ask-path 2) 0)                                                  64   0))
+    (let c7  (if (eq  (fca-ask-verdict 1 60 60 1) 0)                                       128  0))
+    (let c8  (if (eq  (fca-usable? "") 0)                                                  256  0))
+    (let c9  (if (eq  (fca-usable? "[ask: no answer from the local oracle]") 0)            512  0))
+    (let c10 (if (eq  (fca-usable? "Four.") 1)                                             1024 0))
+    (let c11 (if (and (eq (fca-content-intrinsic "Four.") 70) (eq (fca-content-intrinsic "") 0)) 2048 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7
+        (add c8 (add c9 (add c10 c11))))))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -741,6 +741,7 @@ mel-full fks 1
 mel-filterbank fks 63
 transformer-real-train fks 31
 form-cli-sufficiency fks 255
+form-cli-ask fks 4095
 form-cli-stats fks 255
 form-native-run fks 63
 part-self-update fks 127

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -92,7 +92,7 @@
 | [form_cat_demo.sh](form_cat_demo.sh) | form_cat_demo.sh — `cat`, a real unix command, built with ZERO clang and direct |
 | [form_cli.py](form_cli.py) | form_cli.py — Form-native CLI: ask, generate, execute, convert. |
 | [form_cli_agent.sh](form_cli_agent.sh) | form_cli_agent.sh — thin WITNESS: the kernel runs the TIERED agent loop (form-native-run.fk). |
-| [form_cli_ask.sh](form_cli_ask.sh) | form_cli_ask.sh — thin WITNESS: the kernel runs form-cli-ask.fk (the body is Form, not this shell). |
+| [form_cli_ask.sh](form_cli_ask.sh) | form_cli_ask.sh — thin WITNESS for `form-cli ask+`. The body is Form: the kernel |
 | [form_cli_ask_smart.py](form_cli_ask_smart.py) | form_cli_ask_smart.py — thin REPL CARRIER. The form-cli interactive shell. |
 | [form_cli_asm.sh](form_cli_asm.sh) | form_cli_asm.sh — interrogate LLVM offline: how does clang lower / optimize this? |
 | [form_cli_capture.sh](form_cli_capture.sh) | form_cli_capture.sh — capture agent turns as training samples for the form-cli. |

--- a/scripts/form_cli_ask.sh
+++ b/scripts/form_cli_ask.sh
@@ -1,17 +1,26 @@
 #!/usr/bin/env bash
-# form_cli_ask.sh — thin WITNESS: the kernel runs form-cli-ask.fk (the body is Form, not this shell).
+# form_cli_ask.sh — thin WITNESS for `form-cli ask+`. The body is Form: the kernel
+# runs form-cli-ask-plus.fk (local-first; the four-way-proven sufficiency gate
+# escalates to the subscription oracle when local is not enough — claude-code quality).
 #
-# This carrier only marshals args and invokes the Go kernel on the recipe — exactly the
-# form_native_run.sh pattern. The ask flow (local oracle -> judge -> sufficiency verdict ->
-# escalate to claude -p) lives in form-stdlib/form-cli-ask.fk and executes IN the kernel via host-io.
+# This carrier only source-compiles the BML sections the body is written in — core,
+# http-client, form-cli-ask (the local lane), form-cli-ask-plus (the escalating flow)
+# — exactly the way validate.sh does (form-source-compile-file through the compiler
+# chain, content-cached), links them with the s-expr gate recipes (router / judge /
+# sufficiency / ask-gate), and invokes the kernel on the recipe. The decision math is
+# the gate's, proven four-way; this shell marshals args and wires the carriers.
 #
-# Usage: form_cli_ask.sh [-m local-model] [-j judge] [--remote "claude -p"] [--trust N] "question..."
+# Usage: form_cli_ask.sh [-m local-model] [-j judge] [--remote "claude -p"] [--trust N] [--retries N] [--judge-gate] "question..."
+#   By default the local body is trusted (sovereignty-first): a usable local answer
+#   stands, and only a local FAILURE (empty / error / refusal) escalates to the oracle.
+#   --judge-gate turns on the judge model as the content scorer — claude-code quality at
+#   the cost of the judge's latency and noise (a small judge can mis-score a good answer).
 set -u
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GO="$ROOT/form/form-kernel-go/bin-go"; STD="$ROOT/form/form-stdlib"
 [[ -x "$GO" ]] || (cd "$ROOT/form/form-kernel-go" && go build -o bin-go .)
 
-MODEL="coder"; JUDGE="llama3.2:3b"; REMOTE="claude -p"; TRUST=60; RETRIES=1
+MODEL="coder"; JUDGE="llama3.2:3b"; REMOTE="claude -p"; TRUST=60; RETRIES=1; JUDGE_GATE=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -m|--model)  MODEL="$2"; shift 2 ;;
@@ -19,15 +28,51 @@ while [[ $# -gt 0 ]]; do
     --remote)    REMOTE="$2"; shift 2 ;;
     --trust)     TRUST="$2"; shift 2 ;;
     --retries)   RETRIES="$2"; shift 2 ;;
+    --judge-gate) JUDGE_GATE=1; shift ;;
     *)           break ;;
   esac
 done
 Q="$*"
-[[ -n "$Q" ]] || { echo "usage: form-cli ask+ [-m model] [-j judge] \"question\"" >&2; exit 2; }
+[[ -n "$Q" ]] || { echo "usage: form-cli ask+ [-m model] [-j judge] [--remote CMD] \"question\"" >&2; exit 2; }
 
-esc(){ printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
 work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
-{ cat "$STD/form-cli-router.fk" "$STD/form-cli-judge.fk" "$STD/form-cli-sufficiency.fk" "$STD/form-cli-ask.fk"
-  echo "(print (fca-ask \"$(esc "$Q")\" \"$(esc "$MODEL")\" \"$(esc "$JUDGE")\" \"$(esc "$REMOTE")\" $TRUST $RETRIES))"
-} > "$work/ask.fk"
-"$GO" "$work/ask.fk" 2>/dev/null | sed '/^null$/d'
+
+# ── source-compile the BML sections (content-cached, shared with validate.sh) ──
+# A `section [...]` file is the BML maintenance dialect; the kernel runs the lowered
+# s-expr the source-compiler emits. The cache key is the file content + the compiler
+# chain + the kernel, so an unchanged source compiles once across runs (and shares
+# validate.sh's cache dir), and a real compile failure surfaces instead of being fed
+# raw to the kernel as a parse error.
+CACHE="$STD/.cache/source-compiled"; mkdir -p "$CACHE"
+CHAIN=("$STD/form-ontology-loader.fk" "$STD/line-grammar.fk" "$STD/bmf-core.fk" "$STD/bmf-grammar.fk" "$STD/bml.fk" "$STD/bml-source.fk" "$STD/source-compiler.fk" "$STD/grammars/form-bml.fk" "$STD/form-bml-lower.fk")
+hash16() { cat "$@" 2>/dev/null | shasum -a 256 | cut -c1-16; }
+stamp="$(hash16 "${CHAIN[@]}" "$GO")"
+compile_bml() {  # src -> path to compiled s-expr on stdout (cached); exits on failure
+  local src="$1" key cached out drv
+  key="$(hash16 "$src")-$stamp"; cached="$CACHE/$key.fk"
+  if [[ ! -s "$cached" ]]; then
+    out="$(mktemp "$CACHE/.tmp.XXXXXX")"; drv="$work/compile.fk"
+    printf '(do (form-source-compile-file "%s" "%s"))\n' "$src" "$out" > "$drv"
+    if "$GO" "${CHAIN[@]}" "$drv" >/dev/null 2>"$work/cerr" && [[ -s "$out" ]]; then
+      mv -f "$out" "$cached"
+    else
+      echo "form-cli ask+: failed to source-compile $src" >&2
+      sed 's/^/  /' "$work/cerr" >&2
+      rm -f "$out"; exit 3
+    fi
+  fi
+  printf '%s\n' "$cached"
+}
+CORE="$(compile_bml "$STD/core.fk")"
+HTTP="$(compile_bml "$STD/http-client.fk")"
+ASK="$(compile_bml "$STD/form-cli-ask.fk")"
+ASKPLUS="$(compile_bml "$STD/form-cli-ask-plus.fk")"
+
+# ── invoke: local-first ask through the escalating flow ──
+esc(){ printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+printf '(print (fca-ask-plus "%s" "%s" "%s" "%s" %s %s %s))\n' \
+  "$(esc "$Q")" "$(esc "$MODEL")" "$(esc "$JUDGE")" "$(esc "$REMOTE")" "$TRUST" "$RETRIES" "$JUDGE_GATE" > "$work/ask.fk"
+
+"$GO" "$CORE" "$HTTP" "$ASK" \
+  "$STD/form-cli-router.fk" "$STD/form-cli-judge.fk" "$STD/form-cli-sufficiency.fk" "$STD/form-cli-ask-gate.fk" \
+  "$ASKPLUS" "$work/ask.fk" | sed '/^null$/d'


### PR DESCRIPTION
## What was broken

`form-cli ask+` returned **empty** on main. `scripts/form_cli_ask.sh` built its program by cat-piping `form-cli-router.fk form-cli-judge.fk form-cli-sufficiency.fk form-cli-ask.fk` straight into the Go kernel — but `form-cli-ask.fk` is a BML `section [form.bml]`, so the s-expr kernel parse-errored at the first BML `def` body (`expected verb after ( got STRING "{\"model\":"`), and `2>/dev/null` swallowed it. The shell also called `(fca-ask Q model judge remote trust retries)` (6 args) while the recipe defined `def fca-ask(question)` (1 arg) — the rich local→judge→sufficiency→escalate flow the 6 args imply was never wired.

## The fix (carrier-last; the body is Form, proven four-way)

- **`form/form-stdlib/form-cli-ask-gate.fk`** (NEW, s-expr, **four-way 4095**) — the ask lane's posterior gate. Reads the local answer into signals (`fca-usable?`, intrinsic sovereignty-first `fca-content-intrinsic`) and composes the four-way-proven `form-cli-sufficiency.fk` to return accept / retry / escalate + the trust-row path label. The whole default decision path (read answer → usable? → content → verdict → path) is pinned across **all four kernels** by `tests/form-cli-ask-band.fk`.
- **`form/form-stdlib/form-cli-ask-plus.fk`** (NEW, BML carrier) — the `ask+` body, `fca-ask-plus`. Local lane via `http-fetch` (the `model` arg, no longer the hardcoded `form-llama`); the gate decides; on escalate it runs the remote oracle (`claude -p`) via `host-exec` — the only `host-exec` in the path, the local + judge lanes stay pure socket calls. The native binary's pure `ask` (`fca-ask/1` in `form-cli-ask.fk`) is **untouched**, so `form-cli-band` (the native dispatch) stays four-way.
- **`scripts/form_cli_ask.sh`** — source-compiles the BML sections (core / http-client / form-cli-ask / form-cli-ask-plus) the `validate.sh` way (`form-source-compile-file` through the compiler chain, content-cached & shared with validate's cache), links the s-expr gate recipes, and invokes `fca-ask-plus`. A real compile failure now **surfaces** instead of being fed raw to the kernel.
- `fourth-arm-bands.txt`: `form-cli-ask fks 4095`. `bin/form-cli` + `scripts/INDEX.md` usage updated.

## Behavior

- **Default = sovereignty-first**: a usable local answer **stands** (e.g. "2+2" → "Four" no longer escalates on length); only a local **failure** (empty / error / refusal) escalates to the oracle.
- **`--judge-gate`** (opt-in): the judge model becomes the content scorer — claude-code quality at its latency. Off by default because a small local judge is noisy enough to escalate correct answers (observed: `llama3.2:3b` rated a correct "Four." as 0).

## Proof

- `form-cli-ask` four-way **4095** (Go/Rust/TS/fkwu agree); `form-cli-band` **511** and `form-cli-sufficiency` **255** unchanged.
- End-to-end via `bin/form-cli ask+`: sovereign accept fast (~0.3–0.6s), escalation wired through `host-exec` (verified with a `cat` stand-in remote echoing the prompt).

Follow-on (separate breath): a live per-step trust row via `trust-row.fk` — `(tr-row path grounded freq suffic)` printed per query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)