### PR TITLE
feat(form-cli): ask+ prints a live per-step trust row (four-way 16383)

### DIFF
--- a/bin/form-cli
+++ b/bin/form-cli
@@ -34,7 +34,9 @@ form-cli — the one door (local-first, Form-native)
         (form-cli-sufficiency.fk via form-cli-ask-gate.fk) escalates to the
         subscription oracle when local is not enough. Sovereignty-first by default
         (a usable local answer stands; a local failure escalates); --judge-gate adds
-        the judge model as the content scorer — claude-code quality at its latency
+        the judge model as the content scorer — claude-code quality at its latency.
+        Prints a live trust row per query to stderr (path / grounded / freq / suffic —
+        native vs rented); pipe the answer with 2>/dev/null to drop the row
   form-cli stats
         dashboard: learning · models · tools · tool->native · local/remote oracle
         (counts read from the body's records; stats by form-cli-stats.fk, four-way)

--- a/form/form-stdlib/form-cli-ask-gate.fk
+++ b/form/form-stdlib/form-cli-ask-gate.fk
@@ -2,7 +2,7 @@
 ; answer-signals into the accept / retry / escalate decision, composing the
 ; four-way-proven form-cli-sufficiency.fk.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk
+; preludes: form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/trust-row.fk
 ;
 ; form-cli-sufficiency.fk reads six signals and returns accept / retry / escalate.
 ; This is the ask lane's adapter onto it: the live carrier (form-cli-ask.fk) reads
@@ -61,4 +61,14 @@
 ; the trust-row PATH signal, read from the FINAL verdict (after any retry resolved):
 ; 1 = native (the local body answered and stood), 0 = rented (escalated to the oracle)
 (defn fca-ask-path (final-verdict) (if (eq final-verdict 0) 1 0))
+
+; ── the live per-step trust row: render THIS step's trust matrix as one line via
+;    the four-way-proven trust-row.fk. For the ask+ lane the body-only signals read
+;    from the verdict — path is native + suffic when local stood, rented + not when
+;    it escalated. grounded and freq are 0: the pure oracle lane carries neither a
+;    substrate NodeID nor a freq reading, so the row honestly shows them absent and
+;    the answer never claims full trust-observation. The row makes the native-vs-
+;    rented mix visible on every query. ──
+(defn fca-ask-trace-row (final-verdict)
+    (tr-row (fca-ask-path final-verdict) 0 0 (fca-ask-path final-verdict)))
 0

--- a/form/form-stdlib/form-cli-ask-plus.fk
+++ b/form/form-stdlib/form-cli-ask-plus.fk
@@ -1,7 +1,7 @@
 ; form-cli-ask-plus.fk — the `ask+` daily-driver: local-first, then the four-way
 ; sufficiency gate escalates to the subscription oracle when local is not enough.
 ;
-; preludes: form-stdlib/core.fk form-stdlib/http-client.fk form-stdlib/form-cli-ask.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/form-cli-ask-gate.fk
+; preludes: form-stdlib/core.fk form-stdlib/http-client.fk form-stdlib/form-cli-ask.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/trust-row.fk form-stdlib/form-cli-ask-gate.fk
 ;
 ; form-cli-ask.fk's `fca-ask` is the PURE local verb (the native binary's `ask`:
 ; one socket call to the local oracle, no host-exec). This is its escalating
@@ -78,25 +78,33 @@ section [form.bml] {
         host-exec(str_concat(remote, " < /tmp/fca_plus_prompt.txt 2>/dev/null"));
     }
 
-    ; ── one ask turn: local -> gate -> accept / retry-once / escalate ────────
+    ; ── pack THIS turn's outcome: the live trust row (from the four-way-proven
+    ;    fca-ask-trace-row in the gate) on line 1, the answer below it ──────────
+    def fcap-traced(verdict, answer) {
+        str_concat(fca-ask-trace-row(verdict), str_concat("\n", answer));
+    }
+
+    ; ── one ask turn, traced: local -> gate -> accept / retry-once / escalate ──
+    ; each terminal carries its verdict so the trust row reads the real path/suffic.
     def fcap-decide(local, question, model, judge, remote, trust, retries, usejudge) {
-        let okp = fca-usable?(local);
-        let verdict = fca-ask-verdict(okp, fcap-content(usejudge, judge, question, local), trust, retries);
-        if eq(verdict, 0) then local else
+        let verdict = fca-ask-verdict(fca-usable?(local), fcap-content(usejudge, judge, question, local), trust, retries);
+        if eq(verdict, 0) then fcap-traced(0, local) else
         if eq(verdict, 1) then fcap-retry(question, model, judge, remote, trust, usejudge)
-        else fcap-escalate(remote, question);
+        else fcap-traced(2, fcap-escalate(remote, question));
     }
     ; retry re-runs the local lane once with no re-tries left: accept it or escalate.
     def fcap-retry(question, model, judge, remote, trust, usejudge) {
         let local = fca-ask-model(model, question);
-        let okp = fca-usable?(local);
-        let verdict = fca-ask-verdict(okp, fcap-content(usejudge, judge, question, local), trust, 0);
-        if eq(verdict, 0) then local else fcap-escalate(remote, question);
+        let verdict = fca-ask-verdict(fca-usable?(local), fcap-content(usejudge, judge, question, local), trust, 0);
+        if eq(verdict, 0) then fcap-traced(0, local) else fcap-traced(2, fcap-escalate(remote, question));
     }
 
-    def fca-ask-plus(question, model, judge, remote, trust, retries, usejudge) {
+    ; the traced verb the carrier runs: returns "trust-row\nanswer". The carrier
+    ; shows the row (the live field) and the answer on separate streams — answer-only
+    ; is the answer stream alone.
+    def fca-ask-plus-traced(question, model, judge, remote, trust, retries, usejudge) {
         if eq(str_len(question), 0) then
-            "ask+: usage - ask+ <question>   (local-first; the sufficiency gate escalates to the oracle when local is not enough)"
+            fcap-traced(2, "ask+: usage - ask+ <question>   (local-first; the sufficiency gate escalates to the oracle when local is not enough)")
         else
             fcap-decide(fca-ask-model(model, question), question, model, judge, remote, trust, retries, usejudge);
     }

--- a/form/form-stdlib/tests/form-cli-ask-band.fk
+++ b/form/form-stdlib/tests/form-cli-ask-band.fk
@@ -1,4 +1,4 @@
-; preludes: form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/form-cli-ask-gate.fk
+; preludes: form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/trust-row.fk form-stdlib/form-cli-ask-gate.fk
 ;
 ; form-cli-ask-band — the ask verb's posterior accept / retry / escalate decision, proven
 ; four-way. Eight strange-minimal cases walk the boundary at the trust=60 prior: a usable,
@@ -21,6 +21,8 @@
 ;   512   the "[ask: .." error marker is NOT usable (okp 0)
 ;   1024  a real answer IS usable         (okp 1)
 ;   2048  intrinsic content: usable -> 70, unusable -> 0  (the sovereignty-first read)
+;   4096  the live trust row for a native accept  (path:native suffic:yes -> native-partial)
+;   8192  the live trust row for a rented escalate (path:rented suffic:no  -> rented)
 (do
     (let c0  (if (eq  (fca-ask-verdict 1 80 60 1) 0)                                       1    0))
     (let c1  (if (and (eq (fca-ask-verdict 1 40 60 1) 2) (eq (fca-ask-reason 1 40 60 1) 3))  2  0))
@@ -34,6 +36,10 @@
     (let c9  (if (eq  (fca-usable? "[ask: no answer from the local oracle]") 0)            512  0))
     (let c10 (if (eq  (fca-usable? "Four.") 1)                                             1024 0))
     (let c11 (if (and (eq (fca-content-intrinsic "Four.") 70) (eq (fca-content-intrinsic "") 0)) 2048 0))
+    (let c12 (if (str_eq (fca-ask-trace-row 0)
+                  "trust  path:native  grounded:no  freq:no  suffic:yes  -> native-partial") 4096 0))
+    (let c13 (if (str_eq (fca-ask-trace-row 2)
+                  "trust  path:rented  grounded:no  freq:no  suffic:no  -> rented")          8192 0))
 
     (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7
-        (add c8 (add c9 (add c10 c11))))))))))))
+        (add c8 (add c9 (add c10 (add c11 (add c12 c13))))))))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -745,7 +745,7 @@ mel-full fks 1
 mel-filterbank fks 63
 transformer-real-train fks 31
 form-cli-sufficiency fks 255
-form-cli-ask fks 4095
+form-cli-ask fks 16383
 form-cli-stats fks 255
 form-native-run fks 63
 part-self-update fks 127

--- a/scripts/form_cli_ask.sh
+++ b/scripts/form_cli_ask.sh
@@ -68,11 +68,18 @@ HTTP="$(compile_bml "$STD/http-client.fk")"
 ASK="$(compile_bml "$STD/form-cli-ask.fk")"
 ASKPLUS="$(compile_bml "$STD/form-cli-ask-plus.fk")"
 
-# ── invoke: local-first ask through the escalating flow ──
+# ── invoke: local-first ask through the escalating flow, traced ──
+# fca-ask-plus-traced returns the live trust row on line 1 and the answer below it.
+# The row (the per-query "field": native vs rented, grounded/freq/sufficient) goes to
+# stderr — visible at a terminal, out of the way of a piped answer; the answer goes to
+# stdout. The trust LOGIC is Form (form-cli-ask-gate.fk, four-way proven); the shell
+# only routes the two streams.
 esc(){ printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
-printf '(print (fca-ask-plus "%s" "%s" "%s" "%s" %s %s %s))\n' \
+printf '(print (fca-ask-plus-traced "%s" "%s" "%s" "%s" %s %s %s))\n' \
   "$(esc "$Q")" "$(esc "$MODEL")" "$(esc "$JUDGE")" "$(esc "$REMOTE")" "$TRUST" "$RETRIES" "$JUDGE_GATE" > "$work/ask.fk"
 
-"$GO" "$CORE" "$HTTP" "$ASK" \
-  "$STD/form-cli-router.fk" "$STD/form-cli-judge.fk" "$STD/form-cli-sufficiency.fk" "$STD/form-cli-ask-gate.fk" \
-  "$ASKPLUS" "$work/ask.fk" | sed '/^null$/d'
+out="$("$GO" "$CORE" "$HTTP" "$ASK" \
+  "$STD/form-cli-router.fk" "$STD/form-cli-judge.fk" "$STD/form-cli-sufficiency.fk" "$STD/trust-row.fk" "$STD/form-cli-ask-gate.fk" \
+  "$ASKPLUS" "$work/ask.fk" | sed '/^null$/d')"
+printf '%s\n' "$out" | sed -n '1p' >&2   # line 1: the live trust row -> stderr
+printf '%s\n' "$out" | sed '1d'          # the answer -> stdout


### PR DESCRIPTION
Follow-on to [#3505](https://github.com/seeker71/Coherence-Network/pull/3505) (ask+ runs end-to-end). Every `ask+` query now prints the trust matrix as one line — the live "field" — via the four-way-proven `trust-row.fk`, so on each step the user sees the form-native-vs-rented-oracle mix.

## What it renders

```
$ form-cli ask+ "Capital of Japan? One word."
trust  path:native  grounded:no  freq:no  suffic:yes  -> native-partial   # <- stderr
 Tokyo.                                                                     # <- stdout
```

```
$ form-cli ask+ -m no-such-model --remote "claude -p" "..."
trust  path:rented  grounded:no  freq:no  suffic:no  -> rented             # <- stderr
<the oracle's answer>                                                       # <- stdout
```

Pipe with `2>/dev/null` to drop the row and keep only the answer.

## How (trust logic in Form, carrier-last)

- **`form-cli-ask-gate.fk`** — `fca-ask-trace-row(verdict)` composes the two already-four-way-proven cells: `fca-ask-path` (native vs rented from the gate verdict) and `tr-row` (`trust-row.fk`'s one-line renderer). For the pure oracle `ask+` lane: `path = suffic = native?(verdict)`; **`grounded` and `freq` are 0** — this lane carries neither a substrate NodeID nor a freq reading, so the row honestly shows them absent and the answer never claims full trust-observation. When `ask+` later gains body-grounding or a freq check, those flip and the row reads `OBSERVED`.
- **`tests/form-cli-ask-band.fk`** — pins the exact rendered rows (`native-partial` / `rented`) across all four kernels; now **16383** (+2 trace-row cases).
- **`form-cli-ask-plus.fk`** — `fca-ask-plus-traced` returns `"trust-row\nanswer"`; each terminal carries its verdict so the row reads the real path/suffic. The inert answer-only entry is composted (the carrier's stream-split is answer-only).
- **`form_cli_ask.sh`** — routes line 1 (the trust row) to stderr and the answer to stdout. The shell only routes the two streams; the trust logic is the gate's.

## Proof

`form-cli-ask` four-way **16383** (Go/Rust/TS/fkwu agree). `trust-row` 255 · `trust-matrix` 255 · `form-cli-band` 511 · `form-cli-sufficiency` 255 — all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)