### PR TITLE
fix(form-cli): ask+ escalation writes under temp_dir(), not /tmp — runs on Android

### DIFF
--- a/form/form-stdlib/form-cli-ask-plus.fk
+++ b/form/form-stdlib/form-cli-ask-plus.fk
@@ -73,9 +73,14 @@ section [form.bml] {
     }
 
     ; ── escalate to the remote oracle (the subscription agent CLI) ───────────
+    ; the prompt file lives under temp_dir() (the kernel's $TMPDIR), not a hardcoded
+    ; /tmp — so the same recipe escalates on macOS, Termux, and an Android device
+    ; (/data/local/tmp), where /tmp does not exist. The question goes through a file
+    ; rather than the command line so its content is never re-parsed by the shell.
     def fcap-escalate(remote, question) {
-        let wrote = host-write("/tmp/fca_plus_prompt.txt", question);
-        host-exec(str_concat(remote, " < /tmp/fca_plus_prompt.txt 2>/dev/null"));
+        let pf = str_concat(temp_dir(), "/fca_plus_prompt.txt");
+        let wrote = host-write(pf, question);
+        host-exec(str_concat(remote, str_concat(" < ", str_concat(pf, " 2>/dev/null"))));
     }
 
     ; ── pack THIS turn's outcome: the live trust row (from the four-way-proven


### PR DESCRIPTION
The body runs on Android too — `form/form-kernel-go/build-android.sh` cross-compiles a genuine arm64 kernel that runs natively in Termux and via `adb` on `/data/local/tmp` ([kernel-on-android.form](docs/coherence-substrate/kernel-on-android.form)). `ask+`'s escalation wrote its prompt to a hardcoded `/tmp/fca_plus_prompt.txt` — but **Android has no `/tmp`**, so `host-write` would fail and escalation break on a phone.

`fcap-escalate` now builds the path from the **`temp_dir()`** native (`$TMPDIR`, falling back to `/tmp` on hosts that have it), so the same recipe escalates on macOS, Termux (`$TMPDIR` set), and an Android device.

Already portable, no change needed:
- the **local lane** (the sovereignty-first default) uses `http-fetch` sockets — no temp file;
- **`form_cli_ask.sh`** uses `mktemp`, which respects `$TMPDIR`.

## Verified

- Escalation works on macOS (`temp_dir()` → `/var/folders/.../T`).
- With `TMPDIR` routed to a non-`/tmp` dir, the prompt file lands there (the Android shape) and escalation still returns the answer.
- `form-cli-ask` four-way **16383** unchanged (the gate is untouched; this is carrier-only).

On-device end-to-end (a real phone running the ask+ stack through `bin-go-android`) is unrun here — no device/NDK in this session — the same honest carrier-work bar `kernel-on-android.form` names. This removes the one code-level blocker that would have failed on the device regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)