### PR TITLE
tend(eer): instrument upgrade + post-EER panel — std-is-nuisance confirmed on our data

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -59,12 +59,18 @@
 ;     whisper's 80-d log-mel (mel-frame/mel-full + the new 80-row Slaney bank mel-filterbank.fk, four-way 63)
 ;     + CMVN dropped the HARD same-gender pair 0.768 → 0.588 (ECAPA 0.13) — features + normalization sharpen
 ;     the geometry as predicted; raw log-mel WITHOUT CMVN is worse (~0.97, the shared envelope dominates).
-;     EER REALITY-CHECK (eer.fk, the new four-way metric, on 15 real same/different-speaker trials — the
-;     instrument's FIRST lesson): raw log-mel EER 0.33, but global IN-SAMPLE CMVN EER 0.67 — WORSE than
-;     chance. It collapses same-speaker similarity (genuine cosines fall to 0.21/0.37, below several impostor
-;     pairs). The hard-pair-cosine "CMVN win" did NOT generalize to verification — #3's "one cosine misleads"
-;     proven on our own data. The lesson the metric forced: per-utterance CMVN (NOT global in-sample) + a
-;     TRAINED embedder are required, not optional; both front-ends are near/under chance untrained.
+;     EER REALITY-CHECK (eer.fk, the new four-way metric — the instrument earning its keep): the
+;     segment-trial generator (3 voices × 8 crops → 276 trials, 84 genuine) + bootstrap CI gives stable
+;     numbers, and a pooling DECOMPOSITION confirms the panel on our OWN data. EER (0=perfect, 0.5=chance):
+;     mean-only 0.380 [p5 .319, p95 .456]  ·  std-only 0.497 (≈ chance)  ·  mean+std 0.414. So the std half
+;     is NUISANCE (channel/breath/energy, Grok): alone a coin-flip, and adding it to the mean makes EER WORSE
+;     (.380→.414). This also explains the earlier global-in-sample-CMVN disaster (EER 0.67 on 15 trials):
+;     CMVN zeroes the mean — the only carrier of identity untrained — leaving ~std-only. The single hard-pair
+;     cosine that suggested "CMVN helped" measured discrimination, not verification (#3's "one cosine
+;     misleads", proven). The lessons the metric forced: drop std from the UNTRAINED baseline (mean-only is
+;     best, EER .380); CMVN belongs per-utterance and AFTER a trained embedder, never global-in-sample on raw
+;     features; and the real unlock is the TRAINED AAM embedder + augmentation — no untrained front-end
+;     verifies (best is still EER .380). Instrument: experiments/rune-galdr/eer-measure.sh.
 ;     OBJECTIVE WIN: the consensus #1 fix is SHIPPED — speaker-aam.fk (AAM-Softmax / ArcFace head, four-way,
 ;     verdict 63) replaces the MSE-to-speaker-codes objective that collapsed C3: L2-normalized cosine logits +
 ;     additive angular margin on the target (cos(θ+m) = cosθ·cosm − √(1−cos²θ)·sinm) + loss.fk's softmax-CE.
@@ -185,16 +191,19 @@
 ;        (using the host carrier IS having the resource), so each is internalized when we CHOOSE (need-driven,
 ;        oracle→native→retire), never blocked. The whole voice→voice pipeline is already sovereign in
 ;        principle; what remains is sequence, not permission. Companion: translation-pipeline-pivot.form.
-;     9. SPEAKER IDENTITY — the AAM-Softmax objective is shipped four-way (speaker-aam, verdict 63, the consensus
-;        #1); the ordered rungs to ECAPA-level: (a) the AAM TRAINER — chain the margin gradient (softmax−onehot
-;        through cos(θ+m)) into the W and embedding updates, the one new piece beyond loss.fk's backward; (b) DATA
-;        + augmentation (VAD 2-4s chunks + MUSAN/RIR/speed — the binding wall at 26 voices × 1 recording); (c) the
-;        EER harness — the metric RECIPE is SHIPPED (eer.fk, four-way verdict 63: trial matrix → FAR/FRR
-;        crossover → one comparable EER number, the fitness tooluse-model-search can optimize); wiring real
-;        corpus trials through it is the application; (d) attentive stats pooling +
-;        per-utterance CMVN feeding the AAM head; (e) the shallow dilated TDNN; (f) the native asm training lane
-;        (gap 1's emit→compile→exec) so corpus-scale training runs in minutes, not the 0.8 s/column tree-walker.
-;        Then either VoxCeleb pretrain or distil ECAPA's weights into the asm lane. Companion: CHALLENGERS.md.
+;     9. SPEAKER IDENTITY — objective SHIPPED (speaker-aam, verdict 63) + metric SHIPPED (eer.fk, verdict 63,
+;        with the segment-trial generator + bootstrap CI in eer-measure.sh). The post-EER panel (Grok+Cursor,
+;        2026-06-21) RE-ORDERED the rungs against the measured floor: untrained features don't verify (best
+;        EER .380, mean-only), so feature tuning is low ROI — the unlock is the TRAINED embedder, now. Ordered:
+;        (a) the AAM TRAINER on the native asm lane (gap 1's emit→compile→exec) — chain the margin gradient
+;        (softmax−onehot through cos(θ+m)) into W + embedding updates (the one new piece beyond loss.fk's
+;        backward), trained WITH (b) augmentation from day one (random 2-4s multi-crops per recording +
+;        MUSAN/RIR/speed + in-batch hard-negative mining — turns 26×1 into many samples/speaker); these two
+;        are now ONE step, ahead of feature work. (c) score normalization (z-norm / AS-norm vs an impostor
+;        cohort) folded into eer.fk — may beat architecture tweaks on small trials, and it's what production
+;        verification uses. (d) attentive stats pooling (LEARNED mean+std weights) + per-utterance CMVN feeding
+;        the AAM head — NOT raw mean+std (std is nuisance untrained) and NOT global CMVN. (e) shallow dilated
+;        TDNN. Then VoxCeleb pretrain or distil ECAPA's weights into the asm lane. Companion: CHALLENGERS.md.
 ;
 ; ── CURRENT FLOOR VS NORTH STAR (reviewed with Grok/Gemini/Claude, 2026-06-14) ──
 ;   CURRENT FLOOR: small model numerics are already Form-native and proven: format arithmetic, tensor

--- a/experiments/rune-galdr/CHALLENGERS.md
+++ b/experiments/rune-galdr/CHALLENGERS.md
@@ -190,3 +190,36 @@ conclusion. What it forces next: **per-utterance** CMVN (not global in-sample) a
 (the AAM head); both untrained front-ends are at/under chance on verification. The metric is now the
 fitness the model-search ratchet (`tooluse-model-search`) can optimize — design improvement becomes a
 loop the body runs, not a cosine we eyeball.
+
+## Post-EER panel + instrument upgrade — std is nuisance, confirmed on our data
+
+Asked the neighbor agents again *after* the EER finding (Grok + Cursor answered headless; Codex timed out,
+Antigravity returned empty in print-mode on the verbose query). Both converged, and we then **confirmed
+their key claim with our own upgraded instrument**.
+
+**Instrument upgrade** (`eer-measure.sh`): a segment-trial generator (3 voices × 8 crops → **276 trials**,
+84 genuine) + bootstrap CI, and a pooling decomposition. Per-utterance CMVN zeroes each segment's
+frame-mean, so mean+std reduces to **std-only** — making the decomposition the exact test of Grok's claim:
+
+| pooling | EER | bootstrap CI |
+|---|---|---|
+| **mean-only** | **0.380** | [0.319, 0.456] |
+| std-only | 0.497 (≈ chance) | [0.451, 0.531] |
+| mean+std | 0.414 | [0.366, 0.451] |
+
+**The std half is nuisance** (channel/breath/energy): alone it's a coin-flip, and adding it to the mean
+makes EER *worse* (0.380→0.414). This also explains the earlier global-CMVN 0.67 — CMVN zeroed the *mean*,
+the only identity carrier untrained, leaving ~std-only.
+
+**Panel inspiration (Grok + Cursor, convergent):**
+1. **Train the embedder NOW** (native asm lane, AAM head, random 2-4s multi-crops + augmentation + in-batch
+   hard-negative mining) — untrained features don't verify, so feature tuning is low ROI. The trainer +
+   augmentation are now ONE step, ahead of the feature rungs.
+2. **CMVN is identity-erasure on tiny corpora** — per-utterance only, *after* a trained embedder; never
+   global-in-sample on raw features.
+3. **Score normalization** (z-norm / AS-norm vs an impostor cohort) may beat architecture tweaks on small
+   trials — fold into `eer.fk`.
+4. **mean-only** is the right untrained baseline; reserve mean+std for *learned* attentive pooling.
+
+Floor re-ordered accordingly (`form-native-models.form` gap 9). The metric now produces stable,
+panel-validated numbers — design improvement is a loop the body runs.

--- a/experiments/rune-galdr/eer-measure.sh
+++ b/experiments/rune-galdr/eer-measure.sh
@@ -1,49 +1,63 @@
 #!/usr/bin/env bash
-# eer-measure.sh — feed real verification trials through eer.fk (the four-way Form metric).
+# eer-measure.sh — feed real verification trials through eer.fk (the four-way Form metric), at scale.
 #
-# Builds a trial matrix from the ceremony voices: each speaker's vocal split into two time-windows
-# (two "utterances" of the same speaker) → genuine pairs (same speaker) + impostor pairs (cross).
-# Scores each pair by cosine of its log-mel supervector, RAW vs +CMVN, and reports EER (eer.fk) for
-# each — one comparable number per front-end. The metric is the Form body; this carrier only assembles
-# trials. Recordings/roster stay private; only the numbers leave.
+# Instrument upgrade (post first-EER, on the Grok/Cursor panel's advice):
+#   - SEGMENT-TRIAL GENERATOR: each ceremony voice → 8 short crops (not 2 windows) → ~276 trials
+#     (84 genuine same-speaker + 192 impostor cross-speaker), so EER is finely resolved, not quantized.
+#   - POOLING DECOMPOSITION: mean-only / std-only / mean+std. Grok flagged that the std dims of a
+#     mean+std supervector mostly track NUISANCE (channel/breath/energy), not identity — and that
+#     per-utterance CMVN (zeroing each segment's frame-mean) reduces mean+std to exactly std-only.
+#     So this sweep IS the test: if mean-only beats std-only, the std half is nuisance.
+#   - BOOTSTRAP CI: resample the trials B times → EER median + [5th,95th] percentile, so we report a
+#     stable interval, not one fragile point (Cursor's caution).
+# The metric (eer.fk) is the Form body; this carrier assembles trials + sweeps pooling to FIND the
+# winner (which then earns a Form recipe). Recordings/roster stay private; only the numbers leave.
 set -uo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../../form"
 K=form-kernel-rust/target/release/form-kernel-rust
 PRE="form-stdlib/trig.fk form-stdlib/mel-frame.fk form-stdlib/mel-full.fk form-stdlib/mel-filterbank.fk"
 SEP=~/.coherence-network/recordings/speakers/sep/htdemucs
+B="${1:-60}"   # bootstrap resamples
 col(){ python3 - "$1" "$2" <<'PY'
 import wave,array,sys
 w=wave.open(sys.argv[1],'rb'); w.setpos(int(float(sys.argv[2])*16000)); a=array.array('h'); a.frombytes(w.readframes(400))
 print("(do (print (mfu-col (list "+" ".join(f"{x/32768.0:.6f}" for x in a)+") (melbank) 400)))")
 PY
 }
-# 6 windows: spk0={w0,w1} spk1={w2,w3} spk2={w4,w5}; genuine=(0,1)(2,3)(4,5), else impostor
-names=(ubbe ubbe brigitte brigitte angelia angelia); starts=(1.0 5.0 1.0 5.0 1.0 5.0)
-echo "extracting log-mel frames for 6 windows (3 voices x 2 time-windows)..."
-for i in 0 1 2 3 4 5; do : > /tmp/em_$i.fr
-  for off in 0.0 0.4 0.8 1.2 1.6 2.0; do
-    t=$(awk "BEGIN{print ${starts[i]}+$off}")
-    col "$SEP/${names[i]}.16k/vocals.wav" "$t" > /tmp/em_col.fk
-    $K $PRE /tmp/em_col.fk 2>/dev/null | grep -E '^\[' | tr -d '[]' | tr ',' ' ' >> /tmp/em_$i.fr
-  done
+spk=(ubbe brigitte angelia); offs=(1.0 2.5 4.0 5.5 7.0 8.5 10.0 11.5)   # 3 voices x 8 crops = 24 segments
+echo "extracting log-mel: 24 segments x 4 frames (~77s on the tree-walker)..."
+si=0; declare -a SEGSPK
+for s in 0 1 2; do for o in "${offs[@]}"; do : > /tmp/seg_$si.fr; SEGSPK[$si]=$s
+  for d in 0.0 0.4 0.8 1.2; do t=$(awk "BEGIN{print $o+$d}")
+    col "$SEP/${spk[s]}.16k/vocals.wav" "$t" > /tmp/seg_col.fk
+    $K $PRE /tmp/seg_col.fk 2>/dev/null | grep -E '^\[' | tr -d '[]' | tr ',' ' ' >> /tmp/seg_$si.fr; done
+  si=$((si+1)); done; done
+N=$si
+pool(){ awk -v m="$1" '{for(i=1;i<=NF;i++){s[i]+=$i;q[i]+=$i*$i;n[i]++}}
+  END{for(i=1;i<=80;i++){mu=s[i]/n[i];v=q[i]/n[i]-mu*mu;if(v<0)v=0;sd=sqrt(v);
+        if(m=="mean")printf "%.5f ",mu; else if(m=="std")printf "%.5f ",sd; else printf "%.5f ",mu}
+      if(m=="both"){for(i=1;i<=80;i++){mu=s[i]/n[i];v=q[i]/n[i]-mu*mu;if(v<0)v=0;printf "%.5f ",sqrt(v)}}}' "/tmp/seg_$2.fr"; }
+cosv(){ paste -d' ' <(echo "$1") <(echo "$2")|awk '{n=NF/2;d=0;a=0;b=0;for(i=1;i<=n;i++){d+=$i*$(i+n);a+=$i*$i;b+=$(i+n)*$(i+n)}printf "%.5f",d/(sqrt(a)*sqrt(b)+1e-9)}'; }
+run_eer(){ echo "(do (print (eer (list $1))))" > /tmp/seg_eer.fk
+  $K form-stdlib/transformer-numerics.fk form-stdlib/eer.fk /tmp/seg_eer.fk 2>/dev/null | grep -E '^-?[0-9]' | tail -1; }
+# build trial file "score label" for a pooling mode, return path + the eer.fk list
+build(){ local mode="$1" i j; declare -a P
+  for ((i=0;i<N;i++)); do P[$i]=$(pool "$mode" $i); done
+  : > /tmp/tr_$mode.txt
+  for ((i=0;i<N;i++)); do for ((j=i+1;j<N;j++)); do
+    [ "${SEGSPK[$i]}" = "${SEGSPK[$j]}" ] && lab=1.0 || lab=0.0
+    echo "$(cosv "${P[$i]}" "${P[$j]}") $lab" >> /tmp/tr_$mode.txt; done; done; }
+listify(){ awk '{printf "(list %s %s) ",$1,$2}' "$1"; }
+boot(){ # bootstrap EER: B resamples with replacement -> median, p5, p95
+  local f="$1" b; : > /tmp/boot.txt
+  for ((b=1;b<=B;b++)); do
+    awk -v seed=$b 'BEGIN{srand(seed)}{a[NR]=$0;n=NR}END{for(i=1;i<=n;i++){r=int(rand()*n)+1;split(a[r],p," ");printf "(list %s %s) ",p[1],p[2]}}' "$f" > /tmp/boot_list.txt
+    run_eer "$(cat /tmp/boot_list.txt)" >> /tmp/boot.txt; done
+  sort -n /tmp/boot.txt | awk -v B=$B '{v[NR]=$1}END{printf "median=%.3f  [p5=%.3f, p95=%.3f]", v[int(B*0.5)], v[int(B*0.05)+1], v[int(B*0.95)]}'; }
+echo; echo "$N segments → $(( N*(N-1)/2 )) trials. EER per pooling (0=perfect, 0.5=chance), eer.fk + bootstrap CI (B=$B):"
+for mode in mean std both; do
+  build "$mode"
+  ngen=$(awk '$2==1.0' /tmp/tr_$mode.txt | wc -l | tr -d ' ')
+  printf "  %-10s  EER=%s   %s   (%s genuine trials)\n" "$mode" "$(run_eer "$(listify /tmp/tr_$mode.txt)")" "$(boot /tmp/tr_$mode.txt)" "$ngen"
 done
-cat /tmp/em_0.fr /tmp/em_1.fr /tmp/em_2.fr /tmp/em_3.fr /tmp/em_4.fr /tmp/em_5.fr > /tmp/em_all.fr
-GM=$(awk '{for(i=1;i<=NF;i++){s[i]+=$i;n[i]++}}END{for(i=1;i<=80;i++)printf "%.6f ",s[i]/n[i]}' /tmp/em_all.fr)
-# supervector: raw (no cmvn) or cmvn (subtract global mean), pool mean+std -> 160-d
-sv(){ awk -v gm="$GM" -v c="$2" 'BEGIN{split(gm,g," ")}
-  {for(i=1;i<=NF;i++){v=$i; if(c=="1")v=$i-g[i]; s[i]+=v;q[i]+=v*v;n[i]++}}
-  END{for(i=1;i<=80;i++){m=s[i]/n[i];printf "%.5f ",m} for(i=1;i<=80;i++){m=s[i]/n[i];vv=q[i]/n[i]-m*m;if(vv<0)vv=0;printf "%.5f ",sqrt(vv)}}' "/tmp/em_$1.fr"; }
-cos(){ paste -d' ' <(echo "$1") <(echo "$2")|awk '{n=NF/2;d=0;a=0;b=0;for(i=1;i<=n;i++){d+=$i*$(i+n);a+=$i*$i;b+=$(i+n)*$(i+n)}printf "%.5f",d/(sqrt(a)*sqrt(b)+1e-9)}'; }
-label(){ # genuine(1) if same speaker pair (0,1)(2,3)(4,5)
-  case "$1-$2" in 0-1|2-3|4-5) echo 1.0;; *) echo 0.0;; esac; }
-build_trials(){ local cmvn="$1" tr="" sv_=(); local i
-  for i in 0 1 2 3 4 5; do sv_[$i]=$(sv $i $cmvn); done
-  for i in 0 1 2 3 4 5; do for ((j=i+1;j<6;j++)); do
-    tr="$tr (list $(cos "${sv_[i]}" "${sv_[j]}") $(label $i $j))"; done; done
-  echo "$tr"; }
-run_eer(){ echo "(do (print (eer (list $1))))" > /tmp/em_eer.fk
-  $K form-stdlib/transformer-numerics.fk form-stdlib/eer.fk /tmp/em_eer.fk 2>/dev/null | grep -E '^-?[0-9]' | tail -1; }
-echo; echo "15 trials (3 genuine same-speaker, 12 impostor cross-speaker). EER via eer.fk:"
-echo "  log-mel RAW   EER = $(run_eer "$(build_trials 0)")"
-echo "  log-mel+CMVN  EER = $(run_eer "$(build_trials 1)")   (0=perfect separation, 0.5=chance)"
-rm -f /tmp/em_*.fr /tmp/em_col.fk /tmp/em_eer.fk
+rm -f /tmp/seg_*.fr /tmp/seg_col.fk /tmp/seg_eer.fk /tmp/tr_*.txt /tmp/boot*.txt /tmp/boot_list.txt


### PR DESCRIPTION
Asked the neighbor agents again **after** the EER finding (Grok + Cursor answered; Codex/Antigravity didn't yield on the verbose query) and **confirmed their key claim with an upgraded instrument**.

`eer-measure.sh`: segment-trial generator (3 voices × 8 crops → **276 trials**, 84 genuine) + bootstrap CI + pooling decomposition. Per-utterance CMVN zeroes the mean → mean+std reduces to std-only, making the sweep the exact test of Grok's *'std is nuisance'*:

| pooling | EER | CI |
|---|---|---|
| **mean-only** | **0.380** | [0.319, 0.456] |
| std-only | 0.497 (chance) | [0.451, 0.531] |
| mean+std | 0.414 | [0.366, 0.451] |

The std half is nuisance — alone a coin-flip, and it drags EER *worse* (.380→.414). Explains the earlier global-CMVN 0.67 (it zeroed the mean, the only untrained identity carrier).

**Panel inspiration (recorded):** train the embedder now (asm lane + AAM head + 2-4s multi-crops + augmentation + hard-neg mining) ahead of feature work; per-utterance not global CMVN, after a trained embedder; score-norm (z/AS-norm) into eer.fk; mean-only as the untrained baseline. Floor re-ordered (gap 9) + EER reality-check updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)