### PR TITLE
feat(form-cli): ask+ escalation pipes to stdin in-memory — no temp folder at all

### DIFF
--- a/form/form-kernel-go/main.go
+++ b/form/form-kernel-go/main.go
@@ -1979,7 +1979,15 @@ func (k *Kernel) registerNatives() {
 	// not part of the four-way output-identity floor. The kernel already shells out (JIT
 	// go-build, plugin load), so this exposes an existing capability, not a new class.
 	k.registerNative("host-exec", catMethod(), func(_ *Kernel, args []Value) Value {
-		out, _ := exec.Command("sh", "-c", args[0].Str).CombinedOutput()
+		cmd := exec.Command("sh", "-c", args[0].Str)
+		// Optional second arg = the process's stdin, piped in-memory: no temp file,
+		// no writable filesystem. The bytes go kernel -> subprocess directly, so a
+		// question never spills to disk and a host with no writable /tmp (Android)
+		// still escalates. One-arg callers are unchanged.
+		if len(args) > 1 {
+			cmd.Stdin = strings.NewReader(args[1].Str)
+		}
+		out, _ := cmd.CombinedOutput()
 		return Value{Kind: VStr, Str: string(out)}
 	})
 	k.registerNative("host-read", catMethod(), func(_ *Kernel, args []Value) Value {

--- a/form/form-stdlib/form-cli-ask-plus.fk
+++ b/form/form-stdlib/form-cli-ask-plus.fk
@@ -73,14 +73,12 @@ section [form.bml] {
     }
 
     ; ── escalate to the remote oracle (the subscription agent CLI) ───────────
-    ; the prompt file lives under temp_dir() (the kernel's $TMPDIR), not a hardcoded
-    ; /tmp — so the same recipe escalates on macOS, Termux, and an Android device
-    ; (/data/local/tmp), where /tmp does not exist. The question goes through a file
-    ; rather than the command line so its content is never re-parsed by the shell.
+    ; the question is piped to the remote's stdin IN MEMORY (host-exec's second arg),
+    ; so nothing touches the filesystem: no temp file, no writable /tmp, no shell
+    ; re-parsing the question's content. The same recipe escalates on macOS, Termux,
+    ; and a bare Android device where there is no writable temp dir at all.
     def fcap-escalate(remote, question) {
-        let pf = str_concat(temp_dir(), "/fca_plus_prompt.txt");
-        let wrote = host-write(pf, question);
-        host-exec(str_concat(remote, str_concat(" < ", str_concat(pf, " 2>/dev/null"))));
+        host-exec(remote, question);
     }
 
     ; ── pack THIS turn's outcome: the live trust row (from the four-way-proven


### PR DESCRIPTION
**Answering "why do we need a temp folder — can we use Form-native storage?"**

The temp folder existed for exactly one reason: `host-exec` ran `sh -c <cmd>` with **no stdin**, so the only way to hand `claude -p` the question was `claude -p < file`. That file is a **bridge to a foreign process**, not storage *we* use — and Form-native storage (the content-addressed CAS / `write_form_binary`) can't replace it, because the reader is an external program, not the Form kernel. (Form-native storage *is* the right home for our **own** data — e.g. a session log as a content-addressed cell — which is a separate thing.)

So the honest fix is to **delete the file**, not relocate it:

- **`host-exec`** (form-kernel-go — the only kernel that carries it; host-io, *not* on the four-way floor) now takes an **optional second arg = the process's stdin**, piped in-memory via `cmd.Stdin = strings.NewReader(...)`. One-arg callers (`form-native-run.fk`, etc.) are unchanged.
- **`fcap-escalate`** is now just `host-exec(remote, question)` — the question goes kernel → subprocess directly. No temp file, no `temp_dir()`, no `host-write`, no writable filesystem.

This **supersedes the `temp_dir()` carrier-fix ([#3507](https://github.com/seeker71/Coherence-Network/pull/3507))**: the file is gone, not relocated. Strictly more portable — escalation now works on a bare Android device with *no writable temp dir at all* (verified with `TMPDIR` pointed at an unwritable path).

**The north star past this:** reach the remote oracle over a **socket like the local lane** (`http-fetch`), so ask+ has one lane shape for local and remote — no subprocess, no shell, no file. That needs the remote to expose an HTTP endpoint (an API base or a local claude proxy) instead of the `claude -p` CLI; until then, in-memory stdin is the filesystem-free bridge.

## Verified

- 2-arg `host-exec` pipes stdin (`cat` / `tr a-z A-Z` echo it back); 1-arg unchanged (`echo`).
- Escalation end-to-end touches **no filesystem** (no file created; works with an unwritable `TMPDIR`).
- `form-cli-ask` four-way **16383** and `form-native-run` **63** unchanged; Go build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)