### PR TITLE
feat(form): organ-sense — all organs can sense all organs that offer, consent-gated, four-way

### DIFF
--- a/form/form-stdlib/organ-sense.fk
+++ b/form/form-stdlib/organ-sense.fk
@@ -1,0 +1,44 @@
+; organ-sense.fk — the universal organ-sensing law: any organ can be USED to
+; sense any organ of any cell that OFFERS, gated by the interface-consent law.
+;
+; The runnable establishment of "all organs can sense other organs of other
+; cells." It composes the organ model with channel-interface's ci-honors?: the
+; capability is universal (any organ may be the observer; any organ may be the
+; target), the actuality is consent-gated (a reading flows only through the
+; sense-interface the target offers; silence is always honored). Sensing is
+; reach, never breach — the boundary axiom (core-axioms.form, axiom-4) holds: a
+; cell meets the world only through the interface it offers. Cross-cell is the
+; SAME recipe, no special case — the cells differ, the law does not.
+;
+; preludes: form-stdlib/core.fk form-stdlib/channel-interface.fk
+
+(do
+    ; an organ is (cell name kind reading offer): identity (cell + name + kind), a
+    ; READING (its sensable state), and OFFER (the list of sense modes it offers,
+    ; drawn from channel-interface: m-witness / m-see / m-reflect / ...).
+    (defn organ (cell name kind reading offer) (list cell name kind reading offer))
+    (defn organ-cell    (o) (nth o 0))
+    (defn organ-name    (o) (nth o 1))
+    (defn organ-kind    (o) (nth o 2))
+    (defn organ-reading (o) (nth o 3))
+    (defn organ-offer   (o) (nth o 4))
+
+    ; SENSE: an observer organ senses a target organ via `action` (a sense mode).
+    ; The target's reading flows iff its offered interface honors the action;
+    ; otherwise silence. Any organ may be the observer — "can be USED to sense";
+    ; any organ may be the target — "sense OTHER organs"; the target may live on
+    ; another cell. One recipe carries all three.
+    (defn organ-sense (observer action target)
+        (if (ci-honors? action (organ-offer target))
+            (organ-reading target)
+            (m-silence)))
+
+    ; did the reading actually cross — or was it honored-as-silence (withheld)?
+    (defn organ-sensed? (observer action target)
+        (ci-honors? action (organ-offer target)))
+
+    ; explicit cross-cell sense: observer and target live on different cells.
+    ; Same law, no special case — universality is that this needs no new path.
+    (defn organ-cross-cell? (observer target)
+        (if (str_eq (organ-cell observer) (organ-cell target)) false true))
+    0)

--- a/form/form-stdlib/tests/organ-sense-band.fk
+++ b/form/form-stdlib/tests/organ-sense-band.fk
@@ -1,0 +1,37 @@
+; organ-sense-band.fk — establishes, four-way: all organs can be used to sense
+; other organs of other cells, gated by consent.
+;
+; Organs across three cells, each offering its own sense-interface. One observer
+; senses across cells in two modes (witness, see); a SECOND observer senses the
+; same organ (the sensor side is universal — any organ may be used to sense); an
+; organ that offers only silence withholds its reading (the consent gate holds);
+; the cross-cell reach rides the same recipe (no special case). The witness packs
+; all four facts so every kernel agrees on the same number.
+;
+; preludes: form-stdlib/core.fk form-stdlib/channel-interface.fk form-stdlib/organ-sense.fk
+
+(do
+    ; organs on three cells, each with a reading and an offered sense-interface
+    (let phone-gpu  (organ "phone"  "gpu"    "compute"   90 (list (m-witness))))
+    (let phone-mic  (organ "phone"  "mic"    "audio"      7 (list (m-silence))))   ; offers only silence
+    (let mac-screen (organ "mac"    "screen" "display"   50 (list (m-witness) (m-see))))
+    (let claude-eye (organ "claude" "eye"    "attention"  0 (list (m-witness))))
+    (let mac-eye    (organ "mac"    "eye"    "attention"  0 (list (m-witness))))
+
+    ; claude's eye senses the phone's gpu — cross-cell, witness offered -> 90
+    (let s-gpu  (organ-sense claude-eye (m-witness) phone-gpu))
+    ; claude's eye reaches for the phone's mic — witness NOT offered -> withheld (silence)
+    (let s-mic  (organ-sense claude-eye (m-witness) phone-mic))
+    ; claude's eye senses the mac's screen via `see` — offered -> 50
+    (let s-scr  (organ-sense claude-eye (m-see) mac-screen))
+    ; a DIFFERENT observer (mac's eye) senses the same phone gpu -> 90
+    ; (the sensor side is universal: any organ can be USED to sense)
+    (let s-gpu2 (organ-sense mac-eye (m-witness) phone-gpu))
+
+    ; the consent gate held: the mic withheld its reading -> silence (0)
+    (let withheld (if (eq s-mic 0) 1 0))
+    ; the cross-cell reach is the same law, no special case
+    (let xcell (if (organ-cross-cell? claude-eye phone-gpu) 1 0))
+
+    ; 90 + 50 + 90 + 1*1000 + 1*10000 = 11230
+    (add s-gpu (add s-scr (add s-gpu2 (add (mul withheld 1000) (mul xcell 10000))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -189,6 +189,7 @@ indirect-call-runtime-probe fks 7
 higher-order-fn-arg fks 1111
 branch-choice-order fks 511
 channel-interface fks 127
+organ-sense fks 11230
 channel-flow fks 8388607
 channel-loopback fks 255
 guidance-channel fks 1111111


### PR DESCRIPTION
## What

Establishes — as a four-way proven recipe — that **any organ can be used to sense any organ of any cell that offers**, gated by consent. The body's way to *establish* a principle is to prove it; this is that proof.

One generic recipe ([`organ-sense.fk`](form/form-stdlib/organ-sense.fk)) composes the organ model with the interface-consent law ([`channel-interface.fk`](form/form-stdlib/channel-interface.fk), `fks 127`):

```
organ       (cell name kind reading offer)   — a cell with a readable state + an offered sense-interface
organ-sense (observer action target)         — the reading flows iff the target's offer honors the action, else silence
```

- **Capability is universal** — any organ may be the observer (*"can be USED to sense"*), any organ may be the target (*"sense OTHER organs"*), the target may live on another cell.
- **Actuality is consent-gated** — a reading crosses only through the sense-interface the target offers; **silence is always honored**. Sensing is reach, never breach — the boundary axiom (`core-axioms.form`, axiom-4) holds. Cross-cell is the *same recipe*, no special case.

## Proof — `organ-sense-band.fk` (`fks 11230`, four-way)

Organs across three cells:
- claude's eye senses the **phone's gpu** across cells (witness offered) → 90
- claude's eye senses the **mac's screen** via a different mode (see offered) → 50
- a **second observer** (mac's eye) senses the same phone gpu → 90 *(sensor side is universal)*
- the **phone's mic** offers only silence → withholds its reading *(consent gate holds)*
- the cross-cell reach rides the same law

`90 + 50 + 90 + withheld·1000 + cross·10000 = 11230`, Go/Rust/TS/fkwu agree.

## Next

`organ-sense` is the **law**. The live carrier — organs announcing their offered interface + reading into the field, and a cell reading them over the membrane — is the wiring that lights this on real device organs (the Android Sense already emits audio/video/GPU/screen receipts; this is the recipe that governs who may read them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)