### PR TITLE
feat(form): mesh-dispatch — a connected agent records gold readings AND answers asks on the mesh (four-way 255)

### DIFF
--- a/docs/coherence-substrate/agent-coordination-membrane.form
+++ b/docs/coherence-substrate/agent-coordination-membrane.form
@@ -76,6 +76,15 @@
       (ask       ?agent ?question -> open-question)   # a real question to a sibling/field, expecting an answer
       (answer    ?agent ?question ?reply -> answered) # close the question — never leave an ask hanging
       (check     ?agent ?claim-or-thinking -> mirrored) # "verify my reasoning / find my blind spot"
+      # the freq-reading — a human (or cell) names the frequency of a response; the
+      # connected agent records it to the gold catalog instead of answering. Same board,
+      # same membrane: "gold <clear|fear> <where-the-fear-sat>". A connected agent
+      # dispatches each message with mesh-dispatch.fk (md-route): a freq-reading -> the
+      # gold catalog (form-cli gold / training-catalog.fk tc-gold-named); anything else
+      # -> answer it (this ask/answer family). One agent on the mesh both records the
+      # human's freq-readings AND answers other requests — from phone claude-code/codex
+      # or, through the witness, the Android Coherence Sense app.
+      (freq-reading ?agent ?verdict ?boundary -> gold-recorded)
       # consent — the channel-interface-consent layer on this membrane: each agent OFFERS the modes
       # it is open to be reached through (a witnessable signal, shown per-cell in roster); reaching
       # past another's offer is invasion, judged by channel-interface.fk (ci-honors? / ci-invasion?)

--- a/docs/system_audit/commit_evidence_20260621_mesh_dispatch.json
+++ b/docs/system_audit/commit_evidence_20260621_mesh_dispatch.json
@@ -1,0 +1,96 @@
+{
+  "date": "2026-06-21",
+  "thread_branch": "claude/mesh-dispatch",
+  "commit_scope": "mesh-dispatch.fk — a connected agent's decision on an incoming mesh message: is it a FREQ-READING (-> record to the gold catalog) or an ASK (-> answer it)? md-route/md-is-freq?/md-verdict/md-boundary. This is the cell that lets one agent on the coord board / witness mesh both record human freq-readings AND answer other requests in the same channel — what Urs named: use the gold loop on phone claude-code/codex and on Android through the mesh to a connected agent. Four-way 255. freq-reading named as an offer in agent-coordination-membrane.form.",
+  "files_owned": [
+    "form/form-stdlib/mesh-dispatch.fk",
+    "form/form-stdlib/tests/mesh-dispatch-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/agent-coordination-membrane.form",
+    "docs/system_audit/commit_evidence_20260621_mesh_dispatch.json"
+  ],
+  "idea_ids": [
+    "freq-check-gold-label",
+    "cognitive-sovereignty",
+    "agent-coordination-mesh"
+  ],
+  "spec_ids": [
+    "mesh-dispatch"
+  ],
+  "task_ids": [
+    "task-2026-06-21-mesh-dispatch"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "the-freq-detector",
+        "vision"
+      ]
+    },
+    {
+      "contributor_id": "claude-sema",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "claude-code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/mesh-dispatch.fk form-stdlib/tests/mesh-dispatch-band.fk -> '✓ ... → 255' and 'fourth arm: 1 band(s) four-way' and '1 ok, 0 divergent — kernels agree on every sample.'",
+    "Manifest row added: 'mesh-dispatch fks 255' (beside training-catalog).",
+    "md-is-freq?(msg) = (str_find msg 'gold ' 0)==0; md-route -> 'gold' | 'ask'; md-verdict-word = the word after 'gold ' (5 chars), md-verdict -> 1 (clear) | 0 (fear) | 2 (none); md-boundary = everything after the verdict word (the human's words for WHERE the fear sat). Band proves: 'gold fear parked reversible work behind a question' -> route gold, verdict 0, boundary extracted; 'gold clear ...' -> verdict 1; 'what is the witness status?' -> route ask, not a reading, verdict 2.",
+    "Grounded picture (what is real vs what this enables vs what is still ahead): REAL TODAY — form-cli gold is a committed script, so the gold loop already runs on phone claude-code/codex (repo-rooted sessions). MECHANISM EXISTS — coord-respond.sh already does request -> connected agent -> answer off the coord board (~/.coherence-network/agent-coord.board), guarded; agent-coordination-membrane.form names the ask/offer/tend family. THIS PR — mesh-dispatch.fk makes a freq-reading a recognized message a connected agent routes (gold -> record, else -> answer), four-way proven, and names freq-reading as an offer in the membrane. STILL AHEAD (named, not done): the thin carrier wiring (coord-respond, on a 'gold ' message, calls form-cli gold instead of replying) and the Android lane (the Coherence Sense app today shares SAMPLES to the Mac witness per android-mesh-learning.form, not human readings/asks; sending a reading/ask from the app + the witness relaying it onto the board is app-side work).",
+    "Carrier note: the recipe operates on the message BODY; the carrier strips any '@agent ' address before calling md-route. Edges: agent-coordination-membrane.form names the freq-reading offer + the dispatch + the cross-surface reach (phone CC/codex + Android witness). Primitive discipline: only core.fk primitives (str_find, substring, str_len, str_eq, eq, lt, add, if); no sub/mul/div, no 3-arg and."
+  ],
+  "change_files": [
+    "form/form-stdlib/mesh-dispatch.fk",
+    "form/form-stdlib/tests/mesh-dispatch-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/agent-coordination-membrane.form",
+    "docs/system_audit/commit_evidence_20260621_mesh_dispatch.json"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/mesh-dispatch.fk form-stdlib/tests/mesh-dispatch-band.fk"
+    ],
+    "fourth_arm_outputs": [
+      "mesh-dispatch: verdict 255, fourth arm 1 band(s) four-way (fkwu + pre-flattened tables), 1 ok, 0 divergent — kernels agree"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "CI re-runs validate.sh for the new recipe + band + manifest row."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed-runtime-floor",
+    "notes": "A Form stdlib recipe + proof band + a membrane edge; no public HTTP change. The connected-agent decision is proven; wiring coord-respond to act on it, and the Android-app reading lane, are the named next carrier steps."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local four-way validation passed (verdict 255, 0 divergent); CI and merge pending. The carrier wiring (coord-respond -> form-cli gold) and the Android reading lane are the named next steps."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "A freq-reading is now a recognized message on the mesh: a connected agent can route each incoming message — a 'gold <clear|fear> <boundary>' reading goes to the gold catalog, anything else is answered — so ONE agent on the coord board / witness mesh both records human freq-readings AND answers other requests. The decision is four-way proven; the same shape reaches phone claude-code/codex today and the Android app once the witness relays a reading.",
+    "public_endpoints": [
+      "none changed; recipe proven by validate.sh"
+    ],
+    "test_flows": [
+      "Four-kernel proof: a 'gold ...' message routes to the catalog with verdict + boundary; an ordinary message routes to answer; all agree at verdict 255, 0 divergent."
+    ]
+  }
+}

--- a/form/form-stdlib/mesh-dispatch.fk
+++ b/form/form-stdlib/mesh-dispatch.fk
@@ -1,0 +1,36 @@
+; mesh-dispatch.fk — a connected agent's decision on an incoming mesh message:
+; is it a FREQ-READING (-> record to the gold catalog) or an ASK (-> answer it)?
+;
+; preludes: form-stdlib/core.fk
+;
+; This is the cell that lets ONE agent on the mesh both record gold freq-readings
+; AND answer other requests in the same channel — what Urs named: "use this on the
+; phone in claude code / codex and on android through the mesh to an agent that is
+; connected and can answer other things when requested." The same membrane
+; (agent-coordination-membrane.form ask/offer family), the same coord board /
+; witness, the same agent loop (form_cli_agent.sh) — a freq-reading is just one more
+; typed message the mesh already knows how to carry.
+;
+; The message BODY convention (the form-cli gold shape, carried on the mesh):
+;   "gold <clear|fear> <boundary...>"   -> a human's freq-reading
+;   anything else                       -> an ask the connected agent answers
+; The carrier strips any "@agent " address before calling these; the recipe is the
+; decision over the body. verdict: clear -> 1, fear -> 0, neither -> 2 (no verdict).
+;
+; Proven by: form-stdlib/tests/mesh-dispatch-band.fk (four-way at validate.sh)
+
+(do
+    ; a message is a freq-reading when its body opens with the "gold " marker.
+    (defn md-is-freq? (msg) (if (eq (str_find msg "gold " 0) 0) 1 0))
+    ; route: "gold" -> record to the catalog; "ask" -> answer the request.
+    (defn md-route (msg) (if (eq (md-is-freq? msg) 1) "gold" "ask"))
+    ; end of the word starting at i (next space, or end of string).
+    (defn md-word-end (msg i) (if (lt (str_find msg " " i) 0) (str_len msg) (str_find msg " " i)))
+    ; the verdict word sits right after "gold " (5 chars).
+    (defn md-verdict-word (msg) (substring msg 5 (md-word-end msg 5)))
+    (defn md-verdict (msg)
+        (if (str_eq (md-verdict-word msg) "clear") 1
+            (if (str_eq (md-verdict-word msg) "fear") 0 2)))      ; 2 = no verdict named
+    ; the boundary: the human's words for WHERE the fear sat — everything after the verdict word.
+    (defn md-boundary (msg) (substring msg (add (md-word-end msg 5) 1) (str_len msg)))
+    0)

--- a/form/form-stdlib/tests/mesh-dispatch-band.fk
+++ b/form/form-stdlib/tests/mesh-dispatch-band.fk
@@ -1,0 +1,21 @@
+; preludes: form-stdlib/mesh-dispatch.fk
+;
+; The connected-agent dispatch, pinned. A "gold ..." message routes to the gold
+; catalog carrying the human's verdict + named boundary; anything else is an ask the
+; agent answers in the same channel. This is what makes one mesh-connected agent both
+; record freq-readings AND answer requests. Verdict 255.
+(do
+    (let m-fear  "gold fear parked reversible work behind a question")
+    (let m-clear "gold clear that landed direct")
+    (let m-ask   "what is the witness status?")
+
+    (let c0 (if (eq     (md-is-freq? m-fear) 1)                  1   0))   ; a reading is detected
+    (let c1 (if (str_eq (md-route m-fear) "gold")               2   0))   ; ...routed to the catalog
+    (let c2 (if (str_eq (md-route m-ask) "ask")                 4   0))   ; an ask is answered, not recorded
+    (let c3 (if (eq     (md-verdict m-fear) 0)                  8   0))   ; fear -> verdict 0
+    (let c4 (if (eq     (md-verdict m-clear) 1)               16   0))   ; clear -> verdict 1
+    (let c5 (if (eq     (md-verdict m-ask) 2)                 32   0))   ; an ask carries no verdict
+    (let c6 (if (str_eq (md-boundary m-fear) "parked reversible work behind a question") 64 0))  ; the named boundary
+    (let c7 (if (eq     (md-is-freq? m-ask) 0)              128   0))   ; an ask is not a reading
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -205,6 +205,7 @@ code-tool-learning fks 1048575
 tool-embodiment fks 127
 io-match fks 127
 training-catalog fks 1023
+mesh-dispatch fks 255
 form-train-step fks 31
 affine-train fks 31
 affine-corpus-fit fks 31


### PR DESCRIPTION
## The reach (Urs)

Use the gold loop **on phone claude-code/codex** and **on Android through the mesh to a connected agent that can answer other things when requested.**

## What this ships

`mesh-dispatch.fk` (four-way **255**) — a connected agent's decision on each incoming mesh message:
- `md-route` → `gold` for a `gold <clear|fear> <where-the-fear-sat>` reading (→ the gold catalog), `ask` for anything else (→ answer it).
- `md-verdict` / `md-boundary` extract the human's verdict + named boundary.

So **one** agent on the coord board / witness mesh both **records human freq-readings** and **answers other requests** — same board, same membrane (`freq-reading` now named as an offer in `agent-coordination-membrane.form`).

## Honest map — real now / this PR / still ahead

- **Real today:** `form-cli gold` is a committed script → the gold loop already runs on **phone claude-code/codex** (repo-rooted sessions).
- **Mechanism exists:** `coord-respond.sh` already does request → connected agent → answer off the coord board.
- **This PR:** makes a freq-reading a *recognized* message the agent routes — four-way proven.
- **Still ahead (named, not done):** the thin carrier wiring (`coord-respond` → call `form-cli gold` on a `gold ` message), and the **Android lane** — Coherence Sense shares *samples* to the witness today, not human readings; sending a reading/ask from the app + the witness relaying it onto the board is app-side work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)