### PR TITLE
feat(form): recognition sense — one recipe recognizes place/room/who/what (four-way 63), live on /sense/surface

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 317 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 318 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/form/form-stdlib/recognition.fk
+++ b/form/form-stdlib/recognition.fk
@@ -1,0 +1,56 @@
+; recognition.fk — recognize WHERE / WHICH ROOM / WHO / WHAT by fingerprint.
+;
+; One recipe under almost every sense the node has. WiFi access-point strengths →
+; which PLACE. Echo bounce-times → which ROOM. A face or voice embedding → WHO.
+; A sound or vision spectrum → WHAT (object, animal, word). Every one of these is
+; the SAME act: a reading vector matched against a library of known signatures,
+; returning the nearest label and how sure. The recipe never changes — only the
+; LIBRARY (the DATA) differs per sense. This is core-abstraction-first: place,
+; room, person, animal are not four code paths, they are four libraries through
+; one engine.
+;
+; Recognition is content-addressed nearest-shape (nearest-shape.fk): similarity is
+; a count of agreeing bins, the nearest prototype's label is the recognition, its
+; agreement count is the confidence. Learning is the smallest act — intern one more
+; (label vector) into the library, and the next reading can route to it. The Mac
+; proves the recognizer; the phone receives the SAME cell, verifiable by NodeID.
+;
+; A reading = a feature vector (small-int bins, the quantized fingerprint of a
+; sense). A library = a list of (label vector) prototypes. A recognition rides as
+; a channel (kind label confidence source) — the world-perception surface renders it.
+;
+; Proven by: form-stdlib/tests/recognition-band.fk
+
+(do
+    (defn rec-floor ()
+        (list
+            "place (wifi) / room (echo) / who (face·voice) / what (sound·vision) are one recipe"
+            "only the library differs per sense; the recognizer never forks into special cases"
+            "recognition is content-addressed nearest-shape — confidence is agreeing bins"
+            "learning is interning one more (label vector); the next reading can route to it"
+            "the Mac proves the recognizer, the phone receives the same cell by NodeID"))
+    (defn rec-north-star ()
+        (list
+            "the node knows where it is, which room, who is here, and what it senses — natively"
+            "every modality quantizes to bins then recognizes through one engine"
+            "libraries are learned exemplars, not trained weight-blobs; a new cell is a new prototype"))
+
+    ;; --- the recognition channel: same shape as every other sense ---------
+    (defn rec-channel (kind label confidence source) (list kind label confidence source))
+    (defn rec-kind (c) (nth c 0))
+    (defn rec-label (c) (nth c 1))
+    (defn rec-confidence (c) (nth c 2))
+    (defn rec-source (c) (nth c 3))
+
+    ;; --- recognize: ONE recipe, the library is the only thing that changes -
+    ;; reading: a quantized feature vector. library: a list of (label vector).
+    ;; the recognition is nearest-shape's label; the confidence is its strength.
+    (defn recognize (kind reading library source)
+        (rec-channel kind
+            (ns-label reading library)
+            (ns-strength reading library)
+            source))
+
+    ;; full confidence = every bin of the reading agreed (an exact fingerprint hit).
+    (defn rec-full? (chan reading) (eq (rec-confidence chan) (len reading)))
+)

--- a/form/form-stdlib/tests/recognition-band.fk
+++ b/form/form-stdlib/tests/recognition-band.fk
@@ -1,0 +1,56 @@
+; preludes: form-stdlib/core.fk form-stdlib/nearest-shape.fk form-stdlib/recognition.fk
+;
+; recognition-band — one recipe recognizes place, room, who, and what; only the
+; library changes. The lift made visible: four senses, four libraries, one engine.
+;
+; Verdict 63:
+;   1   floor and north-star are present
+;   2   WiFi fingerprint -> which PLACE  (home)
+;   4   echo bounce-times -> which ROOM  (kitchen)
+;   8   face/voice embedding -> WHO      (aria)
+;   16  sound/vision spectrum -> WHAT    (dog)
+;   32  an exact fingerprint hit carries full confidence (agreeing bins == reading length)
+(do
+    ;; place library — wifi access-point strength bins
+    (defn rec-place-lib ()
+        (list (list "home" (list 5 5 5 5))
+              (list "cafe" (list 1 8 1 8))
+              (list "office" (list 9 1 9 1))))
+    ;; room library — echo bounce-time bins (the room's acoustic signature)
+    (defn rec-room-lib ()
+        (list (list "kitchen" (list 2 7 2 7))
+              (list "hall" (list 9 9 1 1))))
+    ;; who library — face / voice embedding bins
+    (defn rec-who-lib ()
+        (list (list "aria" (list 3 1 4 1))
+              (list "kai" (list 8 8 8 8))))
+    ;; what library — sound / vision spectrum bins
+    (defn rec-what-lib ()
+        (list (list "dog" (list 6 2 6 2))
+              (list "cat" (list 1 1 9 9))
+              (list "bird" (list 7 7 7 1))))
+
+    (defn rec-q-place () (list 5 5 5 5))
+    (defn rec-q-room () (list 2 7 2 7))
+    (defn rec-q-who () (list 3 1 4 1))
+    (defn rec-q-what () (list 6 2 6 2))
+
+    (defn rec-b1 ()
+        (if (gt (len (rec-floor)) 0) (if (gt (len (rec-north-star)) 0) 1 0) 0))
+    (defn rec-b2 ()
+        (if (str_eq (rec-label (recognize "place" (rec-q-place) (rec-place-lib) "wifi")) "home") 2 0))
+    (defn rec-b4 ()
+        (if (str_eq (rec-label (recognize "room" (rec-q-room) (rec-room-lib) "echo")) "kitchen") 4 0))
+    (defn rec-b8 ()
+        (if (str_eq (rec-label (recognize "who" (rec-q-who) (rec-who-lib) "face")) "aria") 8 0))
+    (defn rec-b16 ()
+        (if (str_eq (rec-label (recognize "what" (rec-q-what) (rec-what-lib) "sound")) "dog") 16 0))
+    (defn rec-b32 ()
+        (if (rec-full? (recognize "place" (rec-q-place) (rec-place-lib) "wifi") (rec-q-place)) 32 0))
+
+    (add (rec-b1)
+        (add (rec-b2)
+            (add (rec-b4)
+                (add (rec-b8)
+                    (add (rec-b16) (rec-b32))))))
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -300,6 +300,7 @@ online-accuracy fks 63
 predictor-train fks 63
 prototype-merge fks 127
 provisioning fks 127
+recognition fks 63
 recognition-router fks 127
 recognition-router-compute fks 63
 recognition-router-vision fks 31

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 317
+**Total files**: 318
 
 | File | Purpose |
 |---|---|
@@ -102,10 +102,10 @@
 | [form_cli_distill_receipt.sh](form_cli_distill_receipt.sh) | form_cli_distill_receipt.sh — run the oracle->native distillation on the real |
 | [form_cli_ensure.sh](form_cli_ensure.sh) | form_cli_ensure.sh — ensure the form-cli's oracles are present, DECIDED by Form. |
 | [form_cli_gaps.sh](form_cli_gaps.sh) | form_cli_gaps.sh — the catalog of what is OPEN, walked from the live body. |
+| [form_cli_gold.sh](form_cli_gold.sh) | form_cli_gold.sh — record a human's direct freq-reading into the local GOLD catalog. |
 | [form_cli_guided.sh](form_cli_guided.sh) | form_cli_guided.sh — the trained native model makes the live model better. |
 | [form_cli_judge.sh](form_cli_judge.sh) | form_cli_judge.sh — measure the REASONING lane: how well a native model's answer |
 | [form_cli_learn.sh](form_cli_learn.sh) | form_cli_learn.sh — the continuous-learning loop's body, in ONE motion: grow the tool-use corpus |
-| [form_cli_gold.sh](form_cli_gold.sh) | form_cli_gold.sh — `form-cli gold <clear\|fear> "<where the fear sat>"`: persist a human's direct freq-reading (verdict + named boundary) into the local gold catalog. Carrier-last; the shape is training-catalog.fk tc-gold-named (four-way). The strongest label the freq-check model learns from. |
 | [form_cli_learn_on_session.sh](form_cli_learn_on_session.sh) | form_cli_learn_on_session.sh — the SessionEnd trigger that makes tool-use learning CONTINUOUS. |
 | [form_cli_neural_lm_train.sh](form_cli_neural_lm_train.sh) | form_cli_neural_lm_train.sh — train the Form-native neural LM (neural-lm.fk) on the |
 | [form_cli_preflight.sh](form_cli_preflight.sh) | form_cli_preflight.sh — air-gap readiness check for the form-cli. |

--- a/web/app/sense/_components/PerceptionSurface.tsx
+++ b/web/app/sense/_components/PerceptionSurface.tsx
@@ -20,9 +20,11 @@ import {
   Mic,
   Radio,
   Ruler,
+  ScanSearch,
   Cloud,
 } from "lucide-react";
 import { wpRun, type WpRun } from "@/lib/form-kernel/world-perception-recipe";
+import { recRun } from "@/lib/form-kernel/recognition-recipe";
 
 // Sanitize a string for embedding inside a Form double-quoted literal.
 const q = (s: string) => s.replace(/["()\\]/g, "").trim();
@@ -127,6 +129,22 @@ const TONGUES = [
   { id: "es", label: "Español" },
 ];
 
+// Recognition — one recipe, four libraries. A reading vector (a quantized
+// fingerprint) matched against a library of known signatures. The recipe never
+// changes; only the library differs per sense. Readings here are sample
+// fingerprints, the way the scenes are sample snapshots — the logic is the
+// proven body's (nearest-shape + recognition, four-way 63).
+const REC_SENSES = [
+  { kind: "place", label: "Place", from: "wifi fingerprint", reading: "(list 5 5 5 5)",
+    library: '(list (list "home" (list 5 5 5 5)) (list "cafe" (list 1 8 1 8)) (list "office" (list 9 1 9 1)))' },
+  { kind: "room", label: "Room", from: "echo signature", reading: "(list 2 7 2 7)",
+    library: '(list (list "kitchen" (list 2 7 2 7)) (list "hall" (list 9 9 1 1)))' },
+  { kind: "who", label: "Who", from: "face · voice", reading: "(list 3 1 4 1)",
+    library: '(list (list "aria" (list 3 1 4 1)) (list "kai" (list 8 8 8 8)))' },
+  { kind: "what", label: "What", from: "sound · vision", reading: "(list 6 2 6 2)",
+    library: '(list (list "dog" (list 6 2 6 2)) (list "cat" (list 1 1 9 9)) (list "bird" (list 7 7 7 1)))' },
+] as const;
+
 type Surface = {
   transcript: { text: string; source: string; isHome: boolean; conf: string };
   audibility: Array<{ emitter: string; heard: boolean; strength: number }>;
@@ -212,6 +230,19 @@ export function PerceptionSurface() {
     const tongueOut = wpRun(`(wp-translation-tongue (wp-translate ${chan} "${tongue}"))`).value;
     return { can, tongueOut };
   }, [tongue, transcript]);
+
+  // Recognition — one recipe, four libraries, all walked on the same kernel.
+  const recognized = useMemo(
+    () =>
+      REC_SENSES.map((s) => ({
+        label: s.label,
+        from: s.from,
+        result: recRun(
+          `(rec-label (recognize "${s.kind}" ${s.reading} ${s.library} "${s.from}"))`,
+        ).value,
+      })),
+    [],
+  );
 
   const mm = (v: number) => (v / 1000).toFixed(2);
 
@@ -431,6 +462,26 @@ export function PerceptionSurface() {
             </div>
           </article>
         )}
+
+        {/* Recognized — one recipe, four senses */}
+        <article className="rounded-xl border border-stone-800/50 bg-stone-900/40 p-4">
+          <div className="flex items-center gap-2 text-xs uppercase tracking-[0.18em] text-stone-500">
+            <ScanSearch className="h-3.5 w-3.5 text-green-300/75" aria-hidden="true" />
+            Recognized — one recipe, four senses
+          </div>
+          <div className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1.5">
+            {recognized.map((r) => (
+              <div key={r.label} className="flex items-baseline justify-between gap-2 text-sm">
+                <span className="text-stone-500">{r.label}</span>
+                <span className="font-mono text-stone-200">{r.result}</span>
+              </div>
+            ))}
+          </div>
+          <div className="mt-2 text-xs text-stone-500">
+            place by wifi · room by echo · who by face/voice · what by sound/vision — the same{" "}
+            <code className="text-green-300/70">recognize</code> recipe; only the library differs.
+          </div>
+        </article>
       </div>
     </div>
   );

--- a/web/lib/form-kernel/recognition-recipe.ts
+++ b/web/lib/form-kernel/recognition-recipe.ts
@@ -1,0 +1,161 @@
+// recognition-recipe.ts — the recognize sense, run in-browser on the TS Form kernel.
+//
+// SOURCE OF TRUTH: form/form-stdlib/nearest-shape.fk + form/form-stdlib/recognition.fk
+// (four-way 63). Verbatim recipe TEXT, run as-is on the same kernel that proves the
+// band — not a TypeScript reimplementation. recognition depends on nearest-shape, so
+// both are bundled and wrapped into one (do ...) program with the witness. The web
+// container does not ship form/, so the text lives here; refresh on change.
+import { Frame, Kernel, Trace, walk } from "./vendor/kernel.ts";
+import { readAll } from "./vendor/reader.ts";
+
+export const NEAREST_SHAPE_RECIPE = String.raw`
+; nearest-shape.fk — the body's OWN classifier, built from core primitives: content-addressing as recognition.
+;
+; recognition-router.fk fuses a circle of MODEL readings; shared-sensing.fk fuses a circle of DEVICES.
+; This is the layer underneath both: the recognizer itself. A query arrives as a FEATURE-VECTOR (bins
+; of small integers — a coarse fingerprint of what was sensed). The body has INTERNED a set of
+; PROTOTYPES, each (list label vector): "this shape is a dog, that shape is a cat". Recognition =
+; find the prototype whose vector AGREES with the query in the most positions. SIMILARITY is a COUNT
+; of agreeing bins — no subtraction, no distance metric, no float: just how many positions match. The
+; nearest prototype's label is the recognition; its agreement count is the strength.
+;
+; This is content-addressing as perception. A prototype is a substrate cell; its Blueprint NodeID IS
+; its vector's shape, identical on every kernel — so "nearest by structure" is the same answer on Go,
+; Rust, and TS (validate.sh parity is recognition parity). LEARNING is the smallest possible act:
+; adding a prototype to the set. No weights, no training loop — a new exemplar is a new (list label
+; vector), and the next query can route to it immediately. The classifier the Mac proves is the SAME
+; cell the phone receives, verifiable by NodeID, not an opaque weight-blob.
+;
+; A query = a feature-vector (list of bins, each a small int 0..100). A prototype = (list label vector).
+; A prototype-set = a list of prototypes the body has interned so far.
+;
+; Honest lane: similarity is a COUNT of exact-agreeing bins, not a graded distance — two vectors that
+; are close-but-never-equal score 0, the same as two that are wholly unrelated. That is the right
+; primitive for content-addressed (quantized) features, where bins are already the discretization; it
+; is the wrong primitive for raw continuous signal (quantize first, then recognize). Ties go to the
+; FIRST-interned prototype (oldest exemplar wins) — recognition is stable under replay, not order-random.
+;
+; Proven by: form-stdlib/tests/nearest-shape-band.fk (four-way at validate.sh, incl. fkwu)
+
+(do
+    ; a prototype: (list label feature-vector)
+    (defn ns-label-of (p) (nth p 0))   ; the prototype's label  ("dog", "cat", ...)
+    (defn ns-vec-of   (p) (nth p 1))   ; the prototype's feature-vector
+
+    ; --- SIMILARITY: count of indices where query and prototype agree, walked in lockstep. ---
+    ; no subtraction, no distance — recognition is "how many bins match" (content-addressing).
+    (defn ns-sim (v1 v2)
+        (if (eq (len v1) 0) 0
+            (if (eq (len v2) 0) 0
+                (if (eq (head v1) (head v2))
+                    (add 1 (ns-sim (tail v1) (tail v2)))
+                    (ns-sim (tail v1) (tail v2))))))
+
+    ; --- NEAREST: the prototype whose vector agrees most with the query (most data wins). ---
+    ; mirror rr-select-loop's max walk; ties keep the FIRST-interned prototype (oldest exemplar).
+    (defn ns-best-loop (query prototypes best best-sim)
+        (if (eq (len prototypes) 0) best
+            (if (eq (len best) 0)
+                (ns-best-loop query (tail prototypes)
+                              (head prototypes)
+                              (ns-sim query (ns-vec-of (head prototypes))))
+                (if (gt (ns-sim query (ns-vec-of (head prototypes))) best-sim)
+                    (ns-best-loop query (tail prototypes)
+                                  (head prototypes)
+                                  (ns-sim query (ns-vec-of (head prototypes))))
+                    (ns-best-loop query (tail prototypes) best best-sim)))))
+    (defn ns-nearest (query prototypes) (ns-best-loop query prototypes (empty) 0))
+
+    ; --- RECOGNITION: the nearest prototype's label, and the strength behind it. ---
+    (defn ns-label    (query prototypes) (ns-label-of (ns-nearest query prototypes)))  ; what it is
+    (defn ns-strength (query prototypes) (ns-sim query (ns-vec-of (ns-nearest query prototypes))))  ; how sure
+
+    ; --- LEARNING: interning an exemplar GROWS the set (no training loop). The new prototype is
+    ;     prepended; every older exemplar remains, so the next query can route to the new shape OR
+    ;     any prior one. Adding without forgetting — the smallest possible act of learning. ---
+    (defn ns-learn  (prototypes p)         (cons p prototypes))                     ; admit a prototype cell
+    (defn ns-intern (prototypes label vec) (ns-learn prototypes (list label vec)))  ; build it, then admit it
+
+    0)
+`;
+
+export const RECOGNITION_RECIPE = String.raw`
+; recognition.fk — recognize WHERE / WHICH ROOM / WHO / WHAT by fingerprint.
+;
+; One recipe under almost every sense the node has. WiFi access-point strengths →
+; which PLACE. Echo bounce-times → which ROOM. A face or voice embedding → WHO.
+; A sound or vision spectrum → WHAT (object, animal, word). Every one of these is
+; the SAME act: a reading vector matched against a library of known signatures,
+; returning the nearest label and how sure. The recipe never changes — only the
+; LIBRARY (the DATA) differs per sense. This is core-abstraction-first: place,
+; room, person, animal are not four code paths, they are four libraries through
+; one engine.
+;
+; Recognition is content-addressed nearest-shape (nearest-shape.fk): similarity is
+; a count of agreeing bins, the nearest prototype's label is the recognition, its
+; agreement count is the confidence. Learning is the smallest act — intern one more
+; (label vector) into the library, and the next reading can route to it. The Mac
+; proves the recognizer; the phone receives the SAME cell, verifiable by NodeID.
+;
+; A reading = a feature vector (small-int bins, the quantized fingerprint of a
+; sense). A library = a list of (label vector) prototypes. A recognition rides as
+; a channel (kind label confidence source) — the world-perception surface renders it.
+;
+; Proven by: form-stdlib/tests/recognition-band.fk
+
+(do
+    (defn rec-floor ()
+        (list
+            "place (wifi) / room (echo) / who (face·voice) / what (sound·vision) are one recipe"
+            "only the library differs per sense; the recognizer never forks into special cases"
+            "recognition is content-addressed nearest-shape — confidence is agreeing bins"
+            "learning is interning one more (label vector); the next reading can route to it"
+            "the Mac proves the recognizer, the phone receives the same cell by NodeID"))
+    (defn rec-north-star ()
+        (list
+            "the node knows where it is, which room, who is here, and what it senses — natively"
+            "every modality quantizes to bins then recognizes through one engine"
+            "libraries are learned exemplars, not trained weight-blobs; a new cell is a new prototype"))
+
+    ;; --- the recognition channel: same shape as every other sense ---------
+    (defn rec-channel (kind label confidence source) (list kind label confidence source))
+    (defn rec-kind (c) (nth c 0))
+    (defn rec-label (c) (nth c 1))
+    (defn rec-confidence (c) (nth c 2))
+    (defn rec-source (c) (nth c 3))
+
+    ;; --- recognize: ONE recipe, the library is the only thing that changes -
+    ;; reading: a quantized feature vector. library: a list of (label vector).
+    ;; the recognition is nearest-shape's label; the confidence is its strength.
+    (defn recognize (kind reading library source)
+        (rec-channel kind
+            (ns-label reading library)
+            (ns-strength reading library)
+            source))
+
+    ;; full confidence = every bin of the reading agreed (an exact fingerprint hit).
+    (defn rec-full? (chan reading) (eq (rec-confidence chan) (len reading)))
+)
+`;
+
+// strip the outer (do ... ) wrapper, returning the inner defn forms.
+function innerDefns(recipe: string): string {
+  const after = recipe.slice(recipe.indexOf("(do") + 3);
+  return after.slice(0, after.lastIndexOf(")"));
+}
+
+export type RecRun = { value: string; walks: number; ms: number };
+
+// Walk one witness against nearest-shape + recognition on the in-browser kernel.
+export function recRun(witness: string): RecRun {
+  const program = `(do ${innerDefns(NEAREST_SHAPE_RECIPE)}
+${innerDefns(RECOGNITION_RECIPE)}
+${witness})`;
+  const kernel = new Kernel({ writeStdout: () => {}, writeStderr: () => {} });
+  kernel.trace = new Trace();
+  const start = performance.now();
+  const rendered = kernel.render(walk(kernel, readAll(kernel, program), new Frame(null)));
+  const ms = performance.now() - start;
+  const trace = kernel.trace.toJSON() as { total_walks?: number };
+  return { value: rendered.replace(/^"(.*)"$/s, "$1"), walks: trace.total_walks ?? 0, ms };
+}


### PR DESCRIPTION
## What

Under almost every sense the node has is **one act**: a reading vector matched against a library of known signatures → nearest label + confidence.

- WiFi access-point strengths → which **place**
- echo bounce-times → which **room**
- a face / voice embedding → **who**
- a sound / vision spectrum → **what** (object, animal, word)

The recipe never changes — **only the library (the data) differs per sense.** Place / room / person / animal aren't four code paths; they're four libraries through one engine (core-abstraction-first, the way Urs thinks).

## How

`recognition.fk` is a thin channel wrapper over the existing `nearest-shape.fk` — content-addressed recognition (confidence = count of agreeing bins; learning = intern one more prototype, no weight-blob). It composes, it doesn't fork.

## Proof

Four-way (Go / Rust / TS / fkwu → **63**), registered in `fourth-arm-bands.txt`: one `recognize` call returns place→home, room→kitchen, who→aria, what→dog, plus an exact fingerprint carrying full confidence — **only the library swapped between them.**

## Surfaced live

A **"Recognized — one recipe, four senses"** card on [/sense/surface](https://coherencycoin.com/sense/surface), computed in-browser on the same TS kernel that proves the band. `recognition-recipe.ts` bundles `nearest-shape` + `recognition` **verbatim** (the web container doesn't ship `form/`) — not a TS reimplementation. Verified live: place→home, room→kitchen, who→aria, what→dog; `tsc` → 0 errors; no console errors.

## Honest floor

Readings here are sample fingerprints, the way the scenes are sample snapshots — the *logic* is the body's, proven four-way. Feeding real WiFi/echo/face/sound fingerprints from the phone, and learning libraries from lived exemplars, are the next rungs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)