### PR TITLE
feat(form): lift the held-out eval out of Swift into the body — kill the duplicate metrics

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -148,6 +148,16 @@
 ;        the derived (token,tool) pairs can feed fcp-boost-pair (form-cli-predict, four-way) or the FFN input.
 ;        North star (sweep w5ype51k7: spec-only-form): the WORD domain / NodeID-as-embedding — features given
 ;        by structure, no vocabulary at all. The derived scorer is the honest step toward it, not ahead of it.
+;        CARRIER DRIFT NAMED (2026-06-21): the training scripts hold THREE layers — (1) irreducible host
+;        (read corpus.jsonl off disk, Metal compile + GPU dispatch — the silicon device driver, allowed per
+;        host-kernel.form); (2) already-Form (jte-mlp-train-msl, fs-score); (3) logic TRAPPED in the carrier
+;        — runner.swift re-implements gelu (fgelu), the FFN forward, and the multi-label eval IN SWIFT,
+;        duplicating four-way recipes and computing the held-out numbers we trust. First lift landed:
+;        form-stdlib/tool-eval.fk carries the held-out verdict (micro-acc, exact-set, covers-used) as the
+;        multi-label generalization of active-inference's hit-count; tests/tool-eval-band.fk → 63, four-way.
+;        Remaining compost: the Swift fgelu (= transformer-gelu-erf, four-way) and forward (= jte fwd) should
+;        dylib-call the recipe, not copy it; featurize.py's tokenize+count+split should lift to the WORD-domain
+;        fold + fs-score so it shrinks to line-reading. The carrier earns its host lines only as device driver.
 ;        MEASURED (2026-06-21): a real GPU run (2154 train / 539 held, corpus now 2717 turns) confirms the
 ;        diagnosis — train loss falls 2.7969→0.6340 while held-out loss bottoms at epoch 20 (0.8535) then
 ;        rises (0.8908, 1.0016); the held-out gate's minimum IS epoch 20. The band now carries that measured

--- a/form/form-stdlib/tests/tool-eval-band.fk
+++ b/form/form-stdlib/tests/tool-eval-band.fk
@@ -1,0 +1,30 @@
+; preludes: form-stdlib/tool-eval.fk
+;
+; tool-eval-band — the held-out eval as a Form recipe, four-way: the same multi-label verdict (micro-acc,
+; exact-set, covers-used) that runner.swift hand-rolls, now in the body. Strange-minimal held set of 3 turns
+; over the 8 tools, mirroring the real structure: the majority baseline predicts [Bash,Read] (the only tools
+; with base-rate ≥ 0.5) on every turn; the model predicts each turn's true tool set. The verdict reproduces
+; the real run's direction — the model beats the majority baseline on all three metrics.
+;
+; Verdict 63 when every claim lands:
+;   1   micro hit-count counts matching bits — the baseline misses Edit on turn 1 (7/8 bits)
+;   2   exact-set match — the model's exact prediction scores 1, the baseline's 0
+;   4   covers-used — the model covers every used tool; the baseline (no Edit) does not
+;   8   MICRO: the model beats the baseline on total matching bits (24 vs 20)
+;   16  EXACT-SET: the model beats the baseline (3 vs 0)
+;   32  COVERS-USED: the model beats the baseline (3 vs 0)
+(do
+    (let t1 (list 1 1 1 0 0 0 0 0))   ; turn 1 used Bash,Read,Edit
+    (let t2 (list 1 0 0 1 0 0 0 0))   ; turn 2 used Bash,Write
+    (let t3 (list 1 1 0 0 1 0 0 0))   ; turn 3 used Bash,Read,StructuredOutput
+    (let bp (list 1 1 0 0 0 0 0 0))   ; majority baseline: Bash+Read, every turn
+    (let model (list (list t1 t1) (list t2 t2) (list t3 t3)))   ; the model predicts each turn's true set
+    (let base  (list (list bp t1) (list bp t2) (list bp t3)))   ; the baseline always guesses the majority
+
+    (let c0 (if (eq (te-bit-hits bp t1) 7) 1 0))
+    (let c1 (if (and (eq (te-exact? t1 t1) 1) (eq (te-exact? bp t1) 0)) 2 0))
+    (let c2 (if (and (eq (te-covers? t1 t1) 1) (eq (te-covers? bp t1) 0)) 4 0))
+    (let c3 (if (gt (te-hits-sum model) (te-hits-sum base)) 8 0))
+    (let c4 (if (gt (te-exact-sum model) (te-exact-sum base)) 16 0))
+    (let c5 (if (gt (te-cover-sum model) (te-cover-sum base)) 32 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/form/form-stdlib/tool-eval.fk
+++ b/form/form-stdlib/tool-eval.fk
@@ -1,0 +1,34 @@
+; tool-eval.fk — the agent-tool model's HELD-OUT EVAL, as a Form recipe instead of a Swift hand-roll.
+; scripts/agent_tooluse_train.sh's runner.swift RE-IMPLEMENTS the multi-label metrics (micro-accuracy,
+; exact-set match, covers-used, per-tool) in Swift — duplicate logic that computes the very held-out numbers
+; we trust. This cell is that verdict in the body: pure counting, the multi-label generalization of
+; active-inference's hit-count (ai-hit?/ai-hit-count over a run). The carrier shrinks to: run the forward on
+; the GPU (the device driver) → hand (prediction, target) bit-vectors here; the body computes the verdict.
+;
+; A prediction p and target t are tool bit-vectors (8 tools: Bash Read Edit Write StructuredOutput Agent
+; ToolSearch WebSearch). A held example is (list p t). The metrics are integer numerators (the rate is the
+; numerator over n·outd or n — kept integer so the verdict is exact and four-way, no division).
+; Proven by tests/tool-eval-band.fk (four-way). Integer-exact — registered `fkc`.
+(do
+    (defn te-p (e) (head e))                     ; the model's predicted bit-vector for an example
+    (defn te-t (e) (head (tail e)))              ; the true tool bit-vector
+
+    ; micro hit-count: matching tool bits in one example (the multi-label ai-hit-count).
+    (defn te-bit-hits (p t)
+        (if (eq (len p) 0) 0
+            (add (if (eq (head p) (head t)) 1 0) (te-bit-hits (tail p) (tail t)))))
+    ; exact-set match: every bit agrees.
+    (defn te-exact? (p t) (if (eq (te-bit-hits p t) (len p)) 1 0))
+    ; covers-used: every USED tool (t_i=1) was predicted (p_i=1) — the recall floor (a miss = uncovered).
+    (defn te-covers? (p t)
+        (if (eq (len t) 0) 1
+            (if (and (eq (head t) 1) (eq (head p) 0)) 0 (te-covers? (tail p) (tail t)))))
+
+    ; fold the three verdicts over a held set (list of (p t) examples) — the numerators the carrier reports.
+    (defn te-hits-sum (ex)
+        (if (eq (len ex) 0) 0 (add (te-bit-hits (te-p (head ex)) (te-t (head ex))) (te-hits-sum (tail ex)))))
+    (defn te-exact-sum (ex)
+        (if (eq (len ex) 0) 0 (add (te-exact? (te-p (head ex)) (te-t (head ex))) (te-exact-sum (tail ex)))))
+    (defn te-cover-sum (ex)
+        (if (eq (len ex) 0) 0 (add (te-covers? (te-p (head ex)) (te-t (head ex))) (te-cover-sum (tail ex)))))
+    0)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -847,3 +847,4 @@ continued-learning fks 63
 feature-selection fkc 63
 string-case fks 31
 nl-lexicon-grow fks 3
+tool-eval fkc 63


### PR DESCRIPTION
*"More python and shell scripts, why?"* — because the carrier was written to get a number fast and **duplicated the body** to do it.

`runner.swift` (embedded in `agent_tooluse_train.sh`) re-implements **gelu** (`fgelu`), the **FFN forward pass**, *and* the **multi-label eval metrics** in Swift — and that Swift copy is what computes the held-out 84.8% we've been trusting. Two implementations of the same math.

## The three layers the scripts actually contain

| layer | what | verdict |
|---|---|---|
| irreducible host | read `corpus.jsonl` off disk; Metal compile + GPU dispatch | **stays host** — the silicon device driver (`host-kernel.form` allow-presence) |
| already-Form | `jte-mlp-train-msl` (the SGD step), `fs-score` (the vocabulary) | invoked, not duplicated |
| **trapped logic** | Swift `fgelu` / `forward` / `eval`; `featurize.py` tokenize+count+split | **drift — lift to Form** |

## First lift

`tool-eval.fk` carries the held-out **verdict** (micro-accuracy, exact-set match, covers-used) in the body — pure counting, the multi-label generalization of `active-inference`'s `ai-hit-count`. The carrier shrinks to: run the forward on the GPU (the device driver) → hand `(prediction, target)` bit-vectors to the recipe; the body computes the verdict.

`tests/tool-eval-band.fk` → 63, four-way (Go/Rust/TS/fkwu): micro hit-count, exact-set, covers-used, and the model-beats-baseline verdict on all three. Integer-exact.

## Remaining compost (named, not waved)

- the Swift `fgelu` = `transformer-gelu-erf` (four-way) and `forward` = `jte` fwd should **dylib-call the recipe, not copy it**;
- `featurize.py`'s tokenize+count+split should lift to the WORD-domain fold + `fs-score` so it shrinks to line-reading.

The carrier earns its host lines only as a device driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)