### PR TITLE
feat(form-cli): ask+ escalation is subscription-only — strip ANTHROPIC_API_KEY in the body

### DIFF
--- a/form/form-stdlib/form-cli-ask-plus.fk
+++ b/form/form-stdlib/form-cli-ask-plus.fk
@@ -77,8 +77,16 @@ section [form.bml] {
     ; so nothing touches the filesystem: no temp file, no writable /tmp, no shell
     ; re-parsing the question's content. The same recipe escalates on macOS, Termux,
     ; and a bare Android device where there is no writable temp dir at all.
+    ;
+    ; SUBSCRIPTION-ONLY, enforced in the body: the remote runs with ANTHROPIC_API_KEY
+    ; stripped (env -u), so a stray key in the environment can never silently meter the
+    ; call — `claude -p` falls back to its flat-rate subscription login, the only oracle
+    ; cost this body pays (the borrowed-oracle-dividend). This is the router's "no
+    ; metered API" law made true at the carrier boundary, for every caller, not a hope
+    ; about a clean environment. (env -u UNSETS it — ANTHROPIC_API_KEY= would leave an
+    ; empty key that still wins precedence and fails auth.)
     def fcap-escalate(remote, question) {
-        host-exec(remote, question);
+        host-exec(str_concat("env -u ANTHROPIC_API_KEY ", remote), question);
     }
 
     ; ── pack THIS turn's outcome: the live trust row (from the four-way-proven


### PR DESCRIPTION
**We don't use API keys** — they aren't in the subscription and the per-token cost is too high. The router already forbids a metered LLM API ("no metered LLM REST API exists in this body"), and every oracle lane defaults to `claude -p` (the flat-rate subscription CLI).

But there's **one silent way a key sneaks in**: a stray exported `ANTHROPIC_API_KEY` makes `claude -p` prefer the metered key over the subscription login (the documented #1 auth trap) — billing per-token without a word.

`fcap-escalate` now runs the remote oracle with the key stripped — `env -u ANTHROPIC_API_KEY <remote>` — so the **subscription login is the only credential it can use**. Enforced in the **body** (the recipe), for every caller, not a hope about a clean environment. (`env -u` *unsets* it; `ANTHROPIC_API_KEY=` would leave an empty key that still wins precedence and fails auth — so the unset form is the correct one.)

## Verified

- With `ANTHROPIC_API_KEY` set in the parent, the escalation subprocess sees it **empty** (`printenv` returns nothing) — the metered key never reaches the oracle.
- Escalation still functions on the subscription path.
- Also audited: **no oracle lane in the body references an API key** (`form_cli_ask.sh`, `form-cli-ask-plus.fk`, the tiered/self-review/native-run lanes) — every default remote is `claude -p`.
- `form-cli-ask` four-way **16383** unchanged (the gate is untouched; this is the host-io carrier).

Follow-up flagged: the sibling oracle lanes (`form_cli_tiered.sh`, `form_cli_self_review.sh`, `form_native_run.sh`) should get the same key-strip guard, lifted to one shared place rather than copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)