### PR TITLE
feat(form): world-build — the fifth cross-cell interface (offer cells into a shared commons, content-addressed, consent-gated), four-way

### DIFF
--- a/form/form-stdlib/tests/world-build-band.fk
+++ b/form/form-stdlib/tests/world-build-band.fk
@@ -1,0 +1,38 @@
+; world-build-band.fk — establishes, four-way, the world-building interface:
+; cells offer cells into a shared commons; content-addressing holds each shape
+; once; the offer law gates entry; the commons is the union of what cells offer.
+;
+; The world accepts invitations and offers. One cell offers a recipe, then the
+; same content again (dedup), then a new one; a cell reaches with a mode the world
+; does NOT accept (held out); a second cell's world is merged into the commons
+; (a shape offered by both is counted once). The witness packs every fact.
+;
+; preludes: form-stdlib/core.fk form-stdlib/channel-interface.fk form-stdlib/world-build.fk
+
+(do
+    ; the world's accepting interface — it honors invitations and offers
+    (let accepting (list (m-invite) (m-offer)))
+
+    ; cell A offers recipe "r-add" -> enters
+    (let w1 (world-offer (world-empty) (m-offer) accepting "r-add"))
+    ; cell B offers the SAME content "r-add" -> content-addressed dedup, size stays 1
+    (let w2 (world-offer w1 (m-offer) accepting "r-add"))
+    ; cell B offers a new recipe "r-mul" -> enters, size 2
+    (let w3 (world-offer w2 (m-offer) accepting "r-mul"))
+    ; cell C reaches to push "r-leak" through m-project, which the world does NOT
+    ; accept -> held out (the commons never takes the un-offered)
+    (let w4 (world-offer w3 (m-project) accepting "r-leak"))
+
+    ; a second cell's world, offered independently, then MERGED into the commons
+    (let other (world-offer (world-offer (world-empty) (m-offer) accepting "r-mul")
+                            (m-offer) accepting "r-sub"))
+    (let commons (world-merge w4 other))
+
+    ; w4 = {r-add, r-mul} -> 2 (dedup held, leak held out)
+    (let s-w4 (world-size w4))
+    ; commons = {r-add, r-mul, r-sub} -> 3 (r-mul offered by both, counted once)
+    (let s-commons (world-size commons))
+    ; the leak was held out of the commons
+    (let held (if (world-has? w4 "r-leak") 0 1))
+    ; 2 + 3*10 + 1*100 = 132
+    (add s-w4 (add (mul s-commons 10) (mul held 100))))

--- a/form/form-stdlib/world-build.fk
+++ b/form/form-stdlib/world-build.fk
@@ -1,0 +1,43 @@
+; world-build.fk — the world-building interface: cells offer cells/recipes into a
+; shared commons; content-addressing holds each shape once; the offer/consent law
+; gates entry. The last of the five cross-cell interfaces — sense / ask / share /
+; learn / BUILD — and the generalization of co-learning's cl-merge from exemplars
+; to ANY content-addressed cell: the shared world IS the content-addressed union
+; of what cells offer, each shape held once, honored or held.
+;
+; A contribution is named by its content-address (its content-hash id); two cells
+; offering the same content carry the same id, so the union dedups for free — same
+; law as recipe sharing (form-gen.fk: same source -> same NodeID) and federated
+; learning (co-learning.fk: same exemplar -> one merkle NodeID).
+;
+; preludes: form-stdlib/core.fk form-stdlib/channel-interface.fk
+
+(do
+    (defn world-empty () (empty))
+
+    ; content-addressed membership: is this content (by its address) already here?
+    (defn world-has? (w id)
+        (if (nil? w) false
+            (if (str_eq (head w) id) true (world-has? (tail w) id))))
+
+    ; OFFER content into the world through the offer/consent law: it enters iff the
+    ; contributor's mode is honored by the world's accepting interface; honored +
+    ; new -> added; honored + already present -> unchanged (content-addressed
+    ; dedup); not honored -> unchanged (the commons never takes the un-offered).
+    (defn world-offer (w action accepting id)
+        (if (ci-honors? action accepting)
+            (if (world-has? w id) w (cons id w))
+            w))
+
+    ; MERGE two worlds into their content-addressed union (dedup for free).
+    ; cl-merge generalized from exemplars to any cell: the commons is the union of
+    ; what every cell has offered, each shape counted once.
+    (defn world-merge-into (acc b)
+        (if (nil? b) acc
+            (world-merge-into
+                (if (world-has? acc (head b)) acc (cons (head b) acc))
+                (tail b))))
+    (defn world-merge (a b) (world-merge-into a b))
+
+    (defn world-size (w) (len w))
+    0)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -190,6 +190,7 @@ higher-order-fn-arg fks 1111
 branch-choice-order fks 511
 channel-interface fks 127
 organ-sense fks 11230
+world-build fks 132
 channel-flow fks 8388607
 channel-loopback fks 255
 guidance-channel fks 1111111


### PR DESCRIPTION
## What

The **fifth and final** cross-cell/cross-organ interface — completing **sense / ask / share / learn / BUILD**, all now law over the one consent vocabulary ([`channel-interface.fk`](form/form-stdlib/channel-interface.fk)).

[`world-build.fk`](form/form-stdlib/world-build.fk) generalizes co-learning's `cl-merge` (exemplars) to **any content-addressed cell**: the shared world *is* the content-addressed union of what cells offer, each shape held once, honored or held.

```
world-offer (w action accepting id)   enter iff the offer law honors it;
                                      honored+new → added; honored+present →
                                      unchanged (content-addressed dedup);
                                      not honored → unchanged
world-merge (a b)                     content-addressed union of two worlds
```

## Proof — `world-build-band.fk` (`fks 132`, four-way)

- a recipe offered **twice** enters **once** (content-addressed dedup)
- a recipe pushed through a mode the world does **not accept** is **held out** (consent)
- two cells' worlds **merge to the union**, a shape offered by both counted once

`2 + 3·10 + 1·100 = 132`, Go/Rust/TS/fkwu agree.

## The whole

The five interfaces share **one law and one carrier**: *offer X through a mode → the other honors what's offered → content-addressing carries identity.*

| interface | recipe |
|---|---|
| sense | `organ-sense` |
| ask | `form-cli ask` + `(ask ?site ?question)` |
| share | the gen conductor (`form-gen.fk`) |
| learn | `co-learning` (`cl-merge`) |
| **build** | **`world-build`** (this PR) |

The lattice is not a store *under* the world; it **is** the co-built world.

🤖 Generated with [Claude Code](https://claude.com/claude-code)