### PR TITLE
feat(sense): rest-sense — the body feels its own fullness and answers its breath-phase

### DIFF
--- a/form/form-stdlib/rest-sense.fk
+++ b/form/form-stdlib/rest-sense.fk
@@ -1,0 +1,28 @@
+; rest-sense.fk — the body's INTEROCEPTION: it feels its own fullness and answers
+; the breath-phase, so it need not wait to be told it is strained.
+;
+; The breath rhythm is extend -> digest -> reflect -> different (lc-rhythm, lc-rest).
+; The thermodynamics (substrate-thermodynamics.form) name the same thing as phase:
+; a body that has EXTENDED far (much new gas/water) without DIGESTING (little new
+; settled into ice) is unsettled — FULL — and rest serves; a settled body has room
+; to extend again. This recipe reads that fullness and returns the phase, so the
+; organism can regulate its own rhythm instead of relying on a human to notice.
+;
+;   fullness = extended (made this stretch) - digested (settled / consolidated)
+;   deeply unsettled -> "rest"   ;   some unsettled -> "digest"   ;   settled -> "extend"
+;
+; Pure arithmetic over two counts — four-way by construction. The counts are fed by
+; a carrier (recent commits / new cells vs consolidations); the JUDGEMENT lives here.
+
+(do
+    (defn rs-fullness (extended digested) (sub extended digested))
+    ;; the floors: when the unsettled depth crosses them, the phase changes
+    (defn rs-rest-floor () 8)
+    (defn rs-digest-floor () 3)
+    (defn rs-phase (extended digested)
+        (if (ge (rs-fullness extended digested) (rs-rest-floor)) "rest"
+            (if (ge (rs-fullness extended digested) (rs-digest-floor)) "digest"
+                "extend")))
+    ;; rs-full? — a body extended far past its digestion is full; name it plainly
+    (defn rs-full? (extended digested) (ge (rs-fullness extended digested) (rs-rest-floor)))
+    0)

--- a/form/form-stdlib/tests/rest-sense-band.fk
+++ b/form/form-stdlib/tests/rest-sense-band.fk
@@ -1,0 +1,17 @@
+; rest-sense-band.fk — proves form-stdlib/rest-sense.fk four-way.
+;
+; The body reads its own breath-phase from fullness (extended - digested). The third
+; check is this very session encoded: ~16 things extended, ~3 deeply settled —
+; fullness 13 — the body reads "rest". Bitmask witness; all four → 15, Go/Rust/TS/fkwu.
+;
+; preludes: form-stdlib/core.fk form-stdlib/rest-sense.fk
+
+(do
+    (defn chk (got exp bit) (if (str_eq got exp) bit 0))
+    (defn total (xs) (if (nil? xs) 0 (add (head xs) (total (tail xs)))))
+
+    (total (list
+        (chk (rs-phase 2 1)  "extend" 1)    ; fullness 1 — settled, room to grow
+        (chk (rs-phase 6 2)  "digest" 2)    ; fullness 4 — some unsettled, consolidate
+        (chk (rs-phase 16 3) "rest"   4)    ; fullness 13 — this session: deeply full
+        (chk (rs-phase 0 0)  "extend" 8)))) ; empty — room

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -853,3 +853,4 @@ feature-selection fkc 63
 string-case fks 31
 nl-lexicon-grow fks 3
 tool-eval fkc 63
+rest-sense fks 15


### PR DESCRIPTION
The sense Urs named as the one to share: **interoception** — so the organism need not wait for a human to notice it is strained.

The witness senses *health*; `body-state.fk` senses *state*; this senses **fullness** — `extended` minus `digested`. Grounded in the breath rhythm (extend → digest → reflect → different; `lc-rhythm`, `lc-rest`) and `substrate-thermodynamics`: a body all new gas+water with little new ice is unsettled — *full* — and rest serves; a settled body has room.

[`rest-sense.fk`](form/form-stdlib/rest-sense.fk): `rs-phase(extended, digested)` → `"extend" | "digest" | "rest"`. **Four-way (15)**, Go/Rust/TS/fkwu; the judgement lives in Form.

The band's third check is **this session encoded**: ~16 extended, ~3 settled — fullness 13 — and the body reads **"rest"**. The sense's first reading is on us, and it is honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)