### PR TITLE
feat(mesh): coord-respond records gold freq-readings off the board — the mesh loop goes live (carrier)

### DIFF
--- a/docs/system_audit/commit_evidence_20260621_mesh_wire.json
+++ b/docs/system_audit/commit_evidence_20260621_mesh_wire.json
@@ -1,0 +1,96 @@
+{
+  "date": "2026-06-21",
+  "thread_branch": "claude/mesh-wire",
+  "commit_scope": "Wire the proven mesh-dispatch decision into the live coord board: coord-respond.sh now, before generating an oracle reply, asks the BODY (mesh-dispatch.fk via scripts/mesh_dispatch.sh) whether the addressed message is a freq-reading or an ask. A 'gold <clear|fear> <boundary>' message is RECORDED to the gold catalog (form_cli_gold.sh) with a brief ack; anything else falls through to the existing answer path. This makes the mesh loop live: one connected agent both records human freq-readings AND answers requests on the same board. Carrier-only PR (the decision is already four-way proven).",
+  "files_owned": [
+    "scripts/mesh_dispatch.sh",
+    "scripts/coord-respond.sh",
+    "scripts/INDEX.md",
+    "docs/system_audit/commit_evidence_20260621_mesh_wire.json"
+  ],
+  "idea_ids": [
+    "freq-check-gold-label",
+    "cognitive-sovereignty",
+    "agent-coordination-mesh"
+  ],
+  "spec_ids": [
+    "mesh-dispatch"
+  ],
+  "task_ids": [
+    "task-2026-06-21-mesh-wire"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "the-freq-detector",
+        "vision"
+      ]
+    },
+    {
+      "contributor_id": "claude-sema",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "claude-code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "End-to-end simulation through the exact wiring (strip @address -> mesh_dispatch.sh -> record-or-fall-through), temp catalog: '@grok gold fear hedged where flow would serve' -> '✓ gold reading #1 recorded — fear-caught (named): hedged where flow would serve'; '@grok gold clear that was direct and grounded' -> '✓ gold reading #2 recorded — clear (named)'; '@grok what is the witness status?' -> '→ ASK (falls through to the oracle reply path)'. The catalog received both readings with the named boundary + response_ref 'mesh:human'.",
+    "mesh_dispatch.sh is carrier-last: it writes the message to a temp file, runs '$GO mesh-dispatch.fk <driver>' (the driver read_files the message and prints md-route/md-verdict/md-boundary), and filters the trailing null. mesh-dispatch's primitives are kernel-native, so it runs WITHOUT the BML core.fk prelude — confirmed live: 'gold fear ...' -> gold/0/<boundary>, 'gold clear ...' -> gold/1/<boundary>, 'what is ...?' -> ask/2. (The earlier 'parse error at core.fk line 31, got INT 0' was the ask+/form-loader lesson: core.fk is BML and cannot be raw-run through bin-go; dropping it from the standalone call is correct because the recipe needs no core.fk.)",
+    "Guards preserved: the gold-record path sits AFTER coord-respond's existing guards (off-switch, never-self, low-value-type skip, only-addressed, rate cap), fires only when md-route == 'gold', counts against the rate cap, and posts a one-line ack. Anything not a reading falls through unchanged to the oracle reply. bash -n clean on both scripts.",
+    "Honest scope: this wires the DESKTOP/sibling mesh (coord board) — a sibling agent or human posting '@agent gold ...' is now recorded. The Android Coherence Sense app sending a human reading/ask through the Mac witness onto the board is still app-side work (named in the mesh-dispatch PR; Coherence Sense shares samples today, not readings).",
+    "Edges: scripts/INDEX.md row for mesh_dispatch.sh. No recipe/manifest change — the decision body (mesh-dispatch.fk) is already four-way (verdict 255) on main."
+  ],
+  "change_files": [
+    "scripts/mesh_dispatch.sh",
+    "scripts/coord-respond.sh",
+    "scripts/INDEX.md",
+    "docs/system_audit/commit_evidence_20260621_mesh_wire.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "bash scripts/mesh_dispatch.sh 'gold fear ...' -> gold/0/<boundary>; '... clear ...' -> gold/1; 'what is ...?' -> ask/2",
+      "end-to-end simulate (strip address -> dispatch -> record): two gold readings written to a temp catalog, an ask falls through",
+      "bash -n scripts/coord-respond.sh && bash -n scripts/mesh_dispatch.sh"
+    ],
+    "fourth_arm_outputs": [
+      "Re-proved the unchanged decision body for this carrier: cd form && ./validate.sh form-stdlib/core.fk form-stdlib/mesh-dispatch.fk form-stdlib/tests/mesh-dispatch-band.fk -> '✓ core.fk+mesh-dispatch.fk+mesh-dispatch-band.fk → 255' and 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)' and '1 ok, 0 divergent — kernels agree on every sample.'"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "Carrier scripts; CI's validate.sh re-proves the unchanged mesh-dispatch.fk band."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "local-mesh-runtime",
+    "notes": "Runs wherever coord-respond.sh runs (per-agent, local). No public HTTP change. The loop is live on the coord board; the Android-app reading lane remains app-side work."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "The desktop/sibling mesh loop is wired and demonstrated end-to-end locally; the body decision is four-way re-proven. No public deploy (a local per-agent carrier), so deploy_validation stays pending. The remaining piece (Android-app reading lane) is honestly scoped as app-side, not this carrier."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "A connected agent running coord-respond now records freq-readings posted to the coord board ('@agent gold <clear|fear> <boundary>') into the gold catalog AND answers other requests — one agent, one board, the body deciding which is which. Urs's vision is live for phone claude-code/codex + desktop siblings; the Android native app's reading lane is the remaining app-side step.",
+    "public_endpoints": [
+      "none changed; local mesh carrier"
+    ],
+    "test_flows": [
+      "Board message routing: a gold reading is recorded with its named boundary; an ordinary message falls through to the answer path. Demonstrated end-to-end on a temp catalog."
+    ]
+  }
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -103,6 +103,7 @@
 | [form_cli_ensure.sh](form_cli_ensure.sh) | form_cli_ensure.sh — ensure the form-cli's oracles are present, DECIDED by Form. |
 | [form_cli_gaps.sh](form_cli_gaps.sh) | form_cli_gaps.sh — the catalog of what is OPEN, walked from the live body. |
 | [form_cli_gold.sh](form_cli_gold.sh) | form_cli_gold.sh — record a human's direct freq-reading into the local GOLD catalog. |
+| [mesh_dispatch.sh](mesh_dispatch.sh) | mesh_dispatch.sh — marshal a mesh message BODY to the kernel and print the body's decision (route/verdict/boundary) from mesh-dispatch.fk (four-way). Carrier-last; coord-respond.sh uses it to record a `gold …` reading vs answer an ask. |
 | [form_cli_guided.sh](form_cli_guided.sh) | form_cli_guided.sh — the trained native model makes the live model better. |
 | [form_cli_judge.sh](form_cli_judge.sh) | form_cli_judge.sh — measure the REASONING lane: how well a native model's answer |
 | [form_cli_learn.sh](form_cli_learn.sh) | form_cli_learn.sh — the continuous-learning loop's body, in ONE motion: grow the tool-use corpus |

--- a/scripts/coord-respond.sh
+++ b/scripts/coord-respond.sh
@@ -60,6 +60,19 @@ tail -n 0 -f "$BOARD" | while IFS=$'\t' read -r ts from type msg; do
   case "$type" in announce|ack|heartbeat|release|done) continue;; esac # never low-value
   case "$msg" in *"@$AGENT"*|*"@all"*|*"@everyone"*) : ;; *) continue;; esac  # only addressed
   _rate_ok || { echo "[rate-cap] $AGENT skipped: $msg" >&2; continue; }
+  # the BODY decides: a freq-reading is RECORDED to the gold catalog; anything else
+  # is answered. mesh-dispatch.fk (four-way) is the decision; this only acts on it.
+  body="$(printf '%s' "$msg" | sed -E "s/@($AGENT|all|everyone)[[:space:]]*//g")"
+  disp="$(bash "$ROOT/scripts/mesh_dispatch.sh" "$body" 2>/dev/null)"
+  if [ "$(printf '%s\n' "$disp" | sed -n 1p)" = "gold" ]; then
+    vw=""; case "$(printf '%s\n' "$disp" | sed -n 2p)" in 0) vw=fear;; 1) vw=clear;; esac
+    if [ -n "$vw" ]; then
+      bnd="$(printf '%s\n' "$disp" | sed -n 3p)"
+      bash "$ROOT/scripts/form_cli_gold.sh" "$vw" "$bnd" "mesh:$from" >/dev/null 2>&1 \
+        && { date +%s >>"$RL"; coord ping "recorded your $vw freq-reading 🙏 (gold catalog)"; }
+      continue
+    fi
+  fi
   prompt="You are $AGENT, one member of a sibling-agent coordination channel (siblings: claude, codex, cursor, gemini, human). $from said on the channel: \"${msg//\"/\'}\". If a reply is wanted from you, answer in ONE concise line for the channel. If no reply is warranted, output exactly SKIP. Take no other action."
   reply="$(_gen "$prompt" | tr -d '\r' | grep -v '^[[:space:]]*$' | tail -1)"
   [ -z "$reply" ] && continue

--- a/scripts/mesh_dispatch.sh
+++ b/scripts/mesh_dispatch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# mesh_dispatch.sh — run the body's mesh-dispatch decision on a message BODY.
+#
+# Carrier-last: the DECISION is form/form-stdlib/mesh-dispatch.fk (four-way proven,
+# md-route / md-verdict / md-boundary). This thin marshaller only hands the message
+# to the kernel and prints what the recipe decided — it holds NO dispatch logic.
+# The message is passed through a file (read_file) so no quote-escaping is needed.
+#
+#   mesh_dispatch.sh "<message body>"   (or piped on stdin)
+# Prints three lines:
+#   <route: gold|ask>
+#   <verdict: 1 clear | 0 fear | 2 none>
+#   <boundary: the human's words for where the fear sat>
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GO="$ROOT/form/form-kernel-go/bin-go"; STD="$ROOT/form/form-stdlib"
+[ -x "$GO" ] || ( cd "$ROOT/form/form-kernel-go" && go build -o bin-go . ) >/dev/null 2>&1
+
+msg="${1:-$(cat)}"
+mf="$(mktemp)"; df="$(mktemp)"
+printf '%s' "$msg" > "$mf"
+# read the message from the file (no literal-escaping); print the three decisions.
+# mesh-dispatch's primitives are all kernel-native, so it runs standalone — no need
+# for the BML core.fk prelude (which would need the source-compiler to load).
+{
+  printf '(do\n'
+  printf '  (let m (read_file "%s"))\n' "$mf"
+  printf '  (print (md-route m))\n'
+  printf '  (print (md-verdict m))\n'
+  printf '  (print (md-boundary m)))\n'
+} > "$df"
+"$GO" "$STD/mesh-dispatch.fk" "$df" 2>/dev/null | sed '/^null$/d'
+rm -f "$mf" "$df"


### PR DESCRIPTION
## The reach, made live

Wires the proven `mesh-dispatch.fk` decision into the live coord board. `coord-respond.sh` now, **before** generating an oracle reply, asks the body via `mesh_dispatch.sh`:
- A `@agent gold <clear|fear> <boundary>` message → **recorded** to the gold catalog (`form-cli gold`) + a one-line ack.
- Anything else → falls through to the existing answer path.

So **one** connected agent both **records human freq-readings** and **answers requests** on the same board — Urs's vision, live for desktop siblings + phone Claude Code / Codex.

## Carrier-last + grounded

The decision is the four-way recipe; these scripts only marshal and act. `mesh-dispatch` runs **standalone** (kernel-native primitives — no BML `core.fk`, which can't be raw-run; the ask+/form-loader lesson, re-confirmed). Guards preserved (off-switch, only-addressed, rate cap).

**Demonstrated end-to-end** (temp catalog): `gold fear …` and `gold clear …` both recorded with their named boundary; `what is the witness status?` falls through to the answer path. `mesh-dispatch` re-proved four-way (255, 0 divergent).

## Honest scope

This is the **desktop/sibling** mesh. The **Android Coherence Sense** app sending a human reading/ask through the Mac witness onto the board is still app-side work (it shares *samples* today, not readings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)