### PR TITLE
Cross-machine shared presence: Postgres backend beneath the mesh-sensings contract (four-way 4095)

### DIFF
--- a/form/form-stdlib/mesh-sensings-store-pg.fk
+++ b/form/form-stdlib/mesh-sensings-store-pg.fk
@@ -1,0 +1,134 @@
+; mesh-sensings-store-pg.fk — the Postgres backend beneath the mesh-sensings contract: the
+; CROSS-MACHINE sibling of the .fkb store (mesh-sensings-store.fk). The .fkb backend let co-located
+; presences on ONE machine share a body that survives the session; this backend lets presences on
+; DIFFERENT machines append into one durable table and read back the same consensus. Same contract
+; (mesh-sensings.fk), swapped backend — exactly the "store is the contract, the backend swappable
+; beneath it" the .fkb store named as next.
+;
+; What is four-way (Go/Rust/TS/fkwu): the SQL builders AND the whole decode pipeline — a pg_query
+; result string (rows \n-separated, columns \t-separated) parses back into the reading list the
+; consensus consumes, so a band proves decode + consensus with a pure fixture, no live DB. The ONLY
+; host-io is the two boundary calls pg_exec / pg_query — the standing wall (3-kernel), named here,
+; never buried, exactly as the .fkb store named write_form_binary.
+;
+; Identity is (presence, subject): both are the table PRIMARY KEY, so a second presence reporting the
+; same subject is a distinct witness, and one presence re-reporting is last-write-wins via the
+; database's own ON CONFLICT DO UPDATE — the dedup the .fkb store did in-recipe is now the UPSERT.
+;
+; preludes: form-stdlib/obs-verify.fk form-stdlib/trust-decay.fk form-stdlib/channel-interface.fk form-stdlib/satsang.fk form-stdlib/satsang-field.fk form-stdlib/persistence.fk form-stdlib/world-module-model.fk form-stdlib/world-model-growth.fk form-stdlib/organ-reading.fk form-stdlib/mesh-quorum.fk form-stdlib/mesh-sensings.fk
+;
+; Proven by: form-stdlib/tests/mesh-sensings-store-pg-band.fk
+
+(do
+    (defn msp-table () "sensing_readings")
+
+    ; ── SQL string building (pure, four-way) ────────────────────────────
+    ; single-quote escaping, local so this carrier stands alone (agn-esc shape)
+    (defn msp-esc-loop (s i n acc)
+        (if (ge i n)
+            acc
+            (do
+                (let c (substring s i (add i 1)))
+                (msp-esc-loop s (add i 1) n
+                    (str_concat acc (if (str_eq c "'") "''" c))))))
+    (defn msp-esc (s) (msp-esc-loop s 0 (str_len s) ""))
+    (defn msp-quote (s) (str_concat "'" (str_concat (msp-esc s) "'")))
+
+    ; non-negative int -> decimal string (portable, four-way; cls-int-str shape)
+    (defn msp-int-str (n)
+        (if (lt n 10)
+            (substring "0123456789" n (add n 1))
+            (str_concat (msp-int-str (div n 10))
+                        (substring "0123456789" (mod n 10) (add (mod n 10) 1)))))
+
+    (defn msp-join (sep xs)
+        (if (nil? xs)
+            ""
+            (if (nil? (tail xs))
+                (head xs)
+                (str_concat (head xs) (str_concat sep (msp-join sep (tail xs)))))))
+
+    ; CREATE TABLE — presence + subject are the PK, so identity is (presence, subject)
+    (defn msp-ddl-sql ()
+        (msp-join " " (list
+            "CREATE TABLE IF NOT EXISTS"
+            (msp-table)
+            "(presence text not null, subject text not null, answered integer not null, ok integer not null, reading_at bigint not null, deadline bigint not null, kind text not null, primary key (presence, subject))")))
+
+    ; UPSERT one reading — last-write-wins per (presence, subject) is the DB's ON CONFLICT
+    (defn msp-insert-sql (presence rd)
+        (msp-join " " (list
+            (str_concat "INSERT INTO " (str_concat (msp-table)
+                " (presence, subject, answered, ok, reading_at, deadline, kind)"))
+            (str_concat "VALUES (" (str_concat
+                (msp-join ", " (list
+                    (msp-quote presence)
+                    (msp-quote (or-name rd))
+                    (msp-int-str (or-answered rd))
+                    (msp-int-str (or-ok rd))
+                    (msp-int-str (or-when rd))
+                    (msp-int-str (or-deadline rd))
+                    (msp-quote (or-kind rd))))
+                ")"))
+            "ON CONFLICT (presence, subject) DO UPDATE SET"
+            "answered = EXCLUDED.answered, ok = EXCLUDED.ok, reading_at = EXCLUDED.reading_at, deadline = EXCLUDED.deadline, kind = EXCLUDED.kind")))
+
+    ; SELECT all readings — every (presence, subject) is already deduped by the PK
+    (defn msp-select-sql ()
+        (str_concat "SELECT presence, subject, answered, ok, reading_at, deadline, kind FROM "
+            (msp-table)))
+
+    ; ── decode a pg_query result string -> reading list (pure, four-way) ─
+    ; pg_query returns rows \n-separated, columns \t-separated. parse a positive int from a column.
+    (defn msp-str-int-loop (s i n acc)
+        (if (ge i n)
+            acc
+            (msp-str-int-loop s (add i 1) n
+                (add (mul acc 10) (sub (ord (char_at s i)) 48)))))
+    (defn msp-str-int (s) (msp-str-int-loop s 0 (str_len s) 0))
+
+    ; the value of column `wanted` in a \t-separated row (agrp-col shape)
+    (defn msp-col-loop (row wanted current start pos)
+        (if (ge pos (str_len row))
+            (if (eq current wanted) (substring row start (str_len row)) "")
+            (if (str_eq (char_at row pos) "\t")
+                (if (eq current wanted)
+                    (substring row start pos)
+                    (msp-col-loop row wanted (add current 1) (add pos 1) (add pos 1)))
+                (msp-col-loop row wanted current start (add pos 1)))))
+    (defn msp-col (row idx) (msp-col-loop row idx 0 0 0))
+
+    ; split the pg_query result into row-strings (no empty trailing row)
+    (defn msp-split (s pos n start)
+        (if (ge pos n)
+            (if (gt n start) (cons (substring s start n) (empty)) (empty))
+            (if (str_eq (char_at s pos) "\n")
+                (cons (substring s start pos) (msp-split s (add pos 1) n (add pos 1)))
+                (msp-split s (add pos 1) n start))))
+    (defn msp-rows-split (s) (msp-split s 0 (str_len s) 0))
+
+    ; one row -> organ-reading. SELECT order: 0 presence 1 subject 2 answered 3 ok 4 reading_at
+    ; 5 deadline 6 kind. The subject is the reading name; the live payload is now a durable marker.
+    (defn msp-row-reading (row)
+        (organ-reading
+            (msp-col row 1)
+            (msp-col row 6)
+            (msp-str-int (msp-col row 2))
+            (msp-str-int (msp-col row 3))
+            (msp-str-int (msp-col row 4))
+            (msp-str-int (msp-col row 5))
+            (list "durable")))
+    (defn msp-rows-readings (rows)
+        (if (nil? rows)
+            (empty)
+            (cons (msp-row-reading (head rows)) (msp-rows-readings (tail rows)))))
+    (defn msp-decode (result) (msp-rows-readings (msp-rows-split result)))
+
+    ; ── host-io wrappers (pg_exec / pg_query — the standing wall, 3-kernel) ──
+    (defn msp-ensure-table (conn) (do (pg_exec conn (msp-ddl-sql)) conn))
+    (defn msp-persist (conn presence rd) (do (pg_exec conn (msp-insert-sql presence rd)) conn))
+    (defn msp-load (conn) (msp-decode (pg_query conn (msp-select-sql))))
+
+    ; the durable cross-machine consensus — read every presence's persisted readings, quorum each
+    (defn msp-durable-map (conn k) (sensings-consensus-map (msp-load conn) k))
+    (defn msp-durable-consensus (conn name k) (sensings-consensus (msp-load conn) name k)))

--- a/form/form-stdlib/tests/mesh-sensings-store-pg-band.fk
+++ b/form/form-stdlib/tests/mesh-sensings-store-pg-band.fk
@@ -1,0 +1,71 @@
+; preludes: form-stdlib/obs-verify.fk form-stdlib/trust-decay.fk form-stdlib/channel-interface.fk form-stdlib/satsang.fk form-stdlib/satsang-field.fk form-stdlib/persistence.fk form-stdlib/world-module-model.fk form-stdlib/world-model-growth.fk form-stdlib/organ-reading.fk form-stdlib/mesh-quorum.fk form-stdlib/mesh-sensings.fk form-stdlib/mesh-sensings-store-pg.fk
+;
+; mesh-sensings-store-pg-band — the Postgres backend beneath the mesh-sensings contract: presences on
+; DIFFERENT machines append into one durable table and read back the same consensus. The SQL builders
+; AND the whole decode pipeline are four-way — a pg_query result string parses back into readings and
+; runs consensus with no live DB. Only pg_exec / pg_query (the two boundary calls in the carrier) are
+; the host-io wall; this band never touches them, so it crosses four-way.
+;
+; The fixture is a real pg_query result shape: rows \n-separated, columns \t-separated, in the SELECT
+; order (presence, subject, answered, ok, reading_at, deadline, kind). Three machines report
+; gpu:matvec bit-exact; on claim:foo two agree and one dissents.
+;
+; Verdict 4095 when every claim lands:
+;   1     DDL names the table and the (presence, subject) primary key
+;   2     DDL declares all seven columns
+;   4     INSERT escapes a single quote in a value (no injection)
+;   8     INSERT carries the verdict ints and the kind string
+;   16    INSERT is an UPSERT — last-write-wins per (presence, subject)
+;   32    SELECT names the table and the column order the decoder expects
+;   64    a pg_query result string decodes to the right number of readings
+;   128   CROSS-MACHINE: three machines' gpu:matvec readings reach consensus-observed
+;   256   a dissent on claim:foo is divergent (one machine disagrees; resolve, never ship)
+;   512   the consensus map carries one entry per distinct subject
+;   1024  decode fidelity: a reading read back carries the ok flag and subject it was stored with
+;   2048  int round-trips: msp-str-int . msp-int-str is identity (the column codec is honest)
+(do
+    ; string-contains, local to the band (agn-contains? shape) — assertions only, not carrier tissue
+    (defn mc-at? (s needle i j)
+        (if (eq j (str_len needle)) 1
+            (if (ge (add i j) (str_len s)) 0
+                (if (str_eq (char_at s (add i j)) (char_at needle j))
+                    (mc-at? s needle i (add j 1)) 0))))
+    (defn mc-loop? (s needle i)
+        (if (gt i (sub (str_len s) (str_len needle))) 0
+            (if (eq (mc-at? s needle i 0) 1) 1 (mc-loop? s needle (add i 1)))))
+    (defn mc? (s needle)
+        (if (eq (str_len needle) 0) 1
+            (if (lt (str_len s) (str_len needle)) 0 (mc-loop? s needle 0))))
+
+    (let ddl (msp-ddl-sql))
+    (let sel (msp-select-sql))
+    ; a reading whose presence carries a quote, to prove escaping
+    (let rd-q  (organ-reading "gpu:x" "gpu-bit-exact" 1 1 5 10 (list "live")))
+    (let ins   (msp-insert-sql "o'brien" rd-q))
+
+    ; a real pg_query result: three machines on gpu:matvec (all bit-exact), a split on claim:foo
+    (let result (str_concat
+        "claude\tgpu:matvec\t1\t1\t5\t10\tgpu-bit-exact\n" (str_concat
+        "codex\tgpu:matvec\t1\t1\t5\t10\tgpu-bit-exact\n" (str_concat
+        "sema\tgpu:matvec\t1\t1\t5\t10\tgpu-bit-exact\n" (str_concat
+        "claude\tclaim:foo\t1\t1\t5\t10\tverdict-vote\n" (str_concat
+        "codex\tclaim:foo\t1\t1\t5\t10\tverdict-vote\n"
+        "sema\tclaim:foo\t1\t0\t5\t10\tverdict-vote"))))))
+    (let decoded (msp-decode result))
+    (let r5 (nth decoded 5))
+
+    (let c0  (if (and (mc? ddl "sensing_readings") (mc? ddl "primary key (presence, subject)")) 1 0))
+    (let c1  (if (and (mc? ddl "answered integer")
+                      (and (mc? ddl "reading_at bigint") (mc? ddl "kind text"))) 2 0))
+    (let c2  (if (mc? ins "'o''brien'") 4 0))
+    (let c3  (if (and (mc? ins "1, 1, 5, 10,") (mc? ins "'gpu-bit-exact'")) 8 0))
+    (let c4  (if (mc? ins "ON CONFLICT (presence, subject) DO UPDATE") 16 0))
+    (let c5  (if (mc? sel "SELECT presence, subject, answered, ok, reading_at, deadline, kind FROM sensing_readings") 32 0))
+    (let c6  (if (eq (len decoded) 6) 64 0))
+    (let c7  (if (str_eq (sensings-consensus decoded "gpu:matvec" 2) "consensus-observed") 128 0))
+    (let c8  (if (str_eq (sensings-consensus decoded "claim:foo" 2) "divergent") 256 0))
+    (let c9  (if (eq (len (sensings-consensus-map decoded 2)) 2) 512 0))
+    (let c10 (if (and (str_eq (or-name r5) "claim:foo") (eq (or-ok r5) 0)) 1024 0))
+    (let c11 (if (eq (msp-str-int (msp-int-str 80435)) 80435) 2048 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 (add c9 (add c10 c11))))))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -251,6 +251,7 @@ organ-reading fks 255
 mesh-organ-senses fks 2047
 mesh-quorum fks 2047
 mesh-sensings fks 2047
+mesh-sensings-store-pg fks 4095
 model-executor-proof-ledger fks 4095
 model-vitality fks 4095
 field-model-form-runtime fks 63


### PR DESCRIPTION
The next rung toward cross-machine shared presence. The `.fkb` store (#3518) let co-located presences on **one machine** share a body that survives the session. This is the **cross-machine** sibling: presences on different machines UPSERT into one Postgres table and read back the same consensus. Same contract (`mesh-sensings.fk`), swapped backend — the *"store is the contract, backend swappable beneath it"* the `.fkb` store named as next.

## What's four-way (Go/Rust/TS/fkwu)
The SQL builders **and the whole decode pipeline**. `pg_query` returns rows `\n`-separated / columns `\t`-separated; that string parses back into the reading list the consensus consumes — so the band proves **decode + consensus over a pure fixture, no live DB**:

- three machines on `gpu:matvec` reach `consensus-observed`
- a dissent on `claim:foo` is `divergent` (one machine disagrees → resolve, never ship)

The **only** host-io is the two boundary calls `pg_exec` / `pg_query` — the standing wall, named here, never buried, exactly as the `.fkb` store named `write_form_binary`. The band never touches them, so it crosses four-way at **4095**.

## Identity = (presence, subject) = the table PRIMARY KEY
A second presence on the same subject is a distinct witness; one presence re-reporting is **last-write-wins** via `ON CONFLICT DO UPDATE` — the dedup the `.fkb` store did in-recipe is now the database's own UPSERT.

## What this rung is, and isn't
This is the durable cross-machine **backend**, proven. The HTTP route that exposes it (`POST`/`GET`, native Go kernel body, deploy) is the immediately-following motion — it touches the live native router + prod schema + a deploy, so it earns its own focused rung. Named plainly rather than half-built here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)