### PR TITLE
feat(speaker-aam-train): the AAM trainer four-way — gap 9(a), gradient + SGD with finite-diff proof

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -206,11 +206,14 @@
 ;        with the segment-trial generator + bootstrap CI in eer-measure.sh). The post-EER panel (Grok+Cursor,
 ;        2026-06-21) RE-ORDERED the rungs against the measured floor: untrained features don't verify (best
 ;        EER .380, mean-only), so feature tuning is low ROI — the unlock is the TRAINED embedder, now. Ordered:
-;        (a) the AAM TRAINER on the native asm lane (gap 1's emit→compile→exec) — chain the margin gradient
-;        (softmax−onehot through cos(θ+m)) into W + embedding updates (the one new piece beyond loss.fk's
-;        backward), trained WITH (b) augmentation from day one (random 2-4s multi-crops per recording +
-;        MUSAN/RIR/speed + in-batch hard-negative mining — turns 26×1 into many samples/speaker); these two
-;        are now ONE step, ahead of feature work. (c) score normalization (z-norm / AS-norm vs an impostor
+;        (a) the AAM TRAINER — the gradient + SGD recipe is SHIPPED four-way (speaker-aam-train, verdict 31):
+;        the margin gradient (softmax−onehot chained through cos(θ+m) and the cosine-wrt-W derivative) into W
+;        updates, proven by a finite-difference gradient check (analytic = numeric < 1%) + descent + the
+;        target cosine rising, and robust at the alignment singularity (√(1−c²) floored: aligned → zero
+;        gradient, no NaN). The one new piece beyond loss.fk's backward, done. What REMAINS in (a): run it on
+;        the native asm lane (gap 1's emit→compile→exec) for corpus-scale speed; trained WITH (b) augmentation
+;        from day one (random 2-4s multi-crops per recording + MUSAN/RIR/speed + in-batch hard-negative mining
+;        — turns 26×1 into many samples/speaker); these two are now ONE step, ahead of feature work. (c) score normalization (z-norm / AS-norm vs an impostor
 ;        cohort) folded into eer.fk — may beat architecture tweaks on small trials, and it's what production
 ;        verification uses. (d) attentive stats pooling (LEARNED mean+std weights) + per-utterance CMVN feeding
 ;        the AAM head — NOT raw mean+std (std is nuisance untrained) and NOT global CMVN. (e) shallow dilated

--- a/experiments/rune-galdr/CHALLENGERS.md
+++ b/experiments/rune-galdr/CHALLENGERS.md
@@ -223,3 +223,20 @@ the only identity carrier untrained, leaving ~std-only.
 
 Floor re-ordered accordingly (`form-native-models.form` gap 9). The metric now produces stable,
 panel-validated numbers — design improvement is a loop the body runs.
+
+## Walk: gap 9(a) — the AAM TRAINER, four-way
+
+`speaker-aam-train.fk` (`speaker-aam-train` band, **PASS-4WAY, verdict 31**) closes the backward loop on
+the AAM head — the one new piece beyond `loss.fk`'s `softmax−onehot` backward:
+- the margin gradient chains `softmax−onehot` → through `cos(θ+m)` (the `s·(cosm + sinm·c/√(1−c²))` factor)
+  → through the cosine-wrt-`W` derivative `(x̂ − cosθ·ŵ)/‖W‖`, giving the SGD update that pulls the target
+  row toward `x̂` and pushes impostor rows away — the angular-margin attraction, in Form.
+- proven four-way by a **finite-difference gradient check** (analytic gradient = numeric within 1%), plus
+  descent (one step lowers the loss; eight lower it further) and the target cosine rising.
+- robust at the alignment singularity: `√(1−c²)` is floored, so a perfectly-aligned target gives a *zero*
+  gradient (already there — no pull) instead of a NaN/hang. (Caught via the band: a parallel-`W` fixture
+  hit `√0` → `div` → `Inf` → `tn-exp(Inf)` infinite halving loop; fixed in the recipe + the fixture.)
+
+The objective (speaker-aam) and now its trainer are both four-way. What remains in 9(a): run it at corpus
+scale on the native asm lane + augmentation (9b) — the same recipe that proves four-way is the one that
+crystallizes and trains native.

--- a/form/form-stdlib/speaker-aam-train.fk
+++ b/form/form-stdlib/speaker-aam-train.fk
@@ -1,0 +1,56 @@
+; speaker-aam-train.fk — the AAM-Softmax TRAINER: backward pass + SGD, FLOAT.
+;
+; preludes: form-stdlib/transformer-numerics.fk form-stdlib/loss.fk form-stdlib/speaker-aam.fk
+;
+; speaker-aam.fk gave the forward objective; this closes the loop. loss.fk's softmax-CE backward is
+; softmax(logits) − onehot(y) at the logits — so no new gradient NODE is needed, only the chain DOWN
+; through the AAM geometry to the weights:
+;   dL/dlogit_j = p_j − [j=y]                                  (softmax − onehot)
+;   dlogit_j/dcosθ_j = s            (j≠y)                       (plain scale)
+;                    = s·(cosm + sinm·cosθ_y/√(1−cos²θ_y))  (j=y) (the angular-margin chain)
+;   dcosθ_j/dW_j = (x̂ − cosθ_j·ŵ_j)/‖W_j‖                       (gradient of a cosine wrt the un-normalized W)
+; The weight update is W_j ← W_j − lr·(p_j−[j=y])·factor_j·(x̂ − cosθ_j·ŵ_j)/‖W_j‖. Moving W_y toward x̂
+; raises the target cosine; moving impostor rows away lowers theirs — exactly the angular-margin pull.
+; All fp64. Proven by tests/speaker-aam-train-band.fk (finite-difference gradient check + descent).
+
+(do
+    ; --- softmax-CE gradient on logits: p − onehot(y) ---
+    (defn aat-dec-at (xs i)
+        (if (eq (len xs) 0) (empty)
+            (cons (if (eq i 0) (sub (head xs) 1.0) (head xs)) (aat-dec-at (tail xs) (sub i 1)))))
+    (defn aat-logit-grad (logits y) (aat-dec-at (tn-softmax logits) y))
+
+    ; --- vector helpers + norm ---
+    (defn aat-vsub (a b) (if (eq (len a) 0) (empty) (cons (sub (head a) (head b)) (aat-vsub (tail a) (tail b)))))
+    (defn aat-norm (v) (tn-sqrt (aam-dot v v)))
+
+    ; --- the target's margin chain factor s·(cosm + sinm·cosθ/√(1−cos²θ)); non-target is just s.
+    ;     √(1−c²) is singular at c=±1 (perfect alignment); a tiny floor keeps it finite — and there the
+    ;     direction (x̂−c·ŵ) is the zero vector anyway, so factor·0 = 0: no pull when already aligned. ---
+    (defn aat-tfactor (c cosm sinm s) (mul s (add cosm (mul sinm (div c (tn-sqrt (add (sub 1.0 (mul c c)) 0.000001)))))))
+
+    ; --- gradient for one row j: (p_j−[j=y]) · factor_j · (x̂ − cosθ_j·ŵ_j)/‖W_j‖ ---
+    (defn aat-rowgrad (wj xhat gj i y s cosm sinm)
+        (do (let nw (aat-norm wj))
+            (let what (aam-scale wj (div 1.0 nw)))
+            (let c (aam-dot what xhat))
+            (let dir (aam-scale (aat-vsub xhat (aam-scale what c)) (div 1.0 nw)))
+            (let f (if (eq i y) (aat-tfactor c cosm sinm s) s))
+            (aam-scale dir (mul gj f))))
+    (defn aat-gradW-rows (W xhat g i y s cosm sinm)
+        (if (eq (len W) 0) (empty)
+            (cons (aat-rowgrad (head W) xhat (head g) i y s cosm sinm)
+                  (aat-gradW-rows (tail W) xhat (tail g) (add i 1) y s cosm sinm))))
+    (defn aat-gradW (W x y s cosm sinm)
+        (do (let xhat (aam-l2norm x))
+            (let g (aat-logit-grad (aam-logits W x y s cosm sinm) y))
+            (aat-gradW-rows W xhat g 0 y s cosm sinm)))
+
+    ; --- SGD step over all rows: W_j ← W_j − lr·gradW_j ---
+    (defn aat-vstep (w gw lr) (if (eq (len w) 0) (empty) (cons (sub (head w) (mul lr (head gw))) (aat-vstep (tail w) (tail gw) lr))))
+    (defn aat-step-rows (W gW lr) (if (eq (len W) 0) (empty) (cons (aat-vstep (head W) (head gW) lr) (aat-step-rows (tail W) (tail gW) lr))))
+    (defn aat-step (W x y s cosm sinm lr) (aat-step-rows W (aat-gradW W x y s cosm sinm) lr))
+
+    ; --- train n steps on one sample (fold over a corpus to extend) ---
+    (defn aat-train1 (W x y s cosm sinm lr n)
+        (if (eq n 0) W (aat-train1 (aat-step W x y s cosm sinm lr) x y s cosm sinm lr (sub n 1)))))

--- a/form/form-stdlib/tests/speaker-aam-train-band.fk
+++ b/form/form-stdlib/tests/speaker-aam-train-band.fk
@@ -1,0 +1,39 @@
+; preludes: form-stdlib/transformer-numerics.fk form-stdlib/loss.fk form-stdlib/speaker-aam.fk form-stdlib/speaker-aam-train.fk
+;
+; speaker-aam-train-band — the AAM-Softmax trainer is correct (gradient) and works (descent), four-way.
+;
+; Fixture: x=[3,4]; W_0=[1,4] (target, cosθ_0≈0.92 — NOT aligned, so the target cosine has room to rise
+; and the cosine-gradient is non-singular), W_1=[4,−3] (cosθ_1=0.0); y=0, s=4, margin (0.95, 0.3122).
+;
+; Verdict 31 when every claim lands:
+;   1   the logit gradient sums to 0          (Σ(softmax − onehot) = 0 — a probability simplex move)
+;   2   one SGD step REDUCES the loss          (descent)
+;   4   the step raises the TARGET cosine      (W_0 pulled toward x̂ — the angular-margin attraction)
+;   8   more steps reduce the loss further     (loss after 8 steps < after 1)
+;   16  analytic grad MATCHES finite-difference (the gold gradient check on W_0[0]: rel err < 1%)
+(do
+    (defn at-i (x) (round (mul x 1000000.0)))
+    (let x (list 3.0 4.0))
+    (let W (list (list 1.0 4.0) (list 4.0 -3.0)))
+    (let s 4.0) (let cm 0.95) (let sm 0.3122)
+    (let lg   (aat-logit-grad (aam-logits W x 0 s cm sm) 0))
+    (let l0   (aam-loss W x 0 s cm sm))
+    (let W1   (aat-step W x 0 s cm sm 0.1))
+    (let l1   (aam-loss W1 x 0 s cm sm))
+    (let c0   (head (aam-cosines W  (aam-l2norm x))))
+    (let c1   (head (aam-cosines W1 (aam-l2norm x))))
+    (let W8   (aat-train1 W x 0 s cm sm 0.1 8))
+    (let l8   (aam-loss W8 x 0 s cm sm))
+    (let eps  0.0001)
+    (let r0   (head W))
+    (let Wp   (cons (cons (add (head r0) eps) (tail r0)) (tail W)))
+    (let Wm   (cons (cons (sub (head r0) eps) (tail r0)) (tail W)))
+    (let numg (div (sub (aam-loss Wp x 0 s cm sm) (aam-loss Wm x 0 s cm sm)) (mul 2.0 eps)))
+    (let anag (head (head (aat-gradW W x 0 s cm sm))))
+    (let rel  (div (tn-abs (sub numg anag)) (add (tn-abs anag) 0.0001)))
+    (let k0 (mul 1  (if (eq (at-i (tn-sum lg)) 0) 1 0)))
+    (let k1 (mul 2  (if (gt l0 l1) 1 0)))
+    (let k2 (mul 4  (if (gt c1 c0) 1 0)))
+    (let k3 (mul 8  (if (gt l1 l8) 1 0)))
+    (let k4 (mul 16 (if (lt rel 0.01) 1 0)))
+    (add k0 (add k1 (add k2 (add k3 k4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -501,6 +501,7 @@ speaker-lin fks 1023
 speaker-proj fks 255
 speaker-net fks 255
 speaker-aam fks 63
+speaker-aam-train fks 31
 eer fks 63
 wav-sense fks 63
 witness-theorem fks 31


### PR DESCRIPTION
Walk **gap 9(a)**: the AAM-Softmax trainer (backward + SGD), proven four-way.

[`speaker-aam-train.fk`](form/form-stdlib/speaker-aam-train.fk) (`speaker-aam-train` band, **PASS-4WAY, verdict 31**) — the one new piece beyond `loss.fk`'s `softmax−onehot` backward:
- the margin gradient chains `softmax−onehot` → `cos(θ+m)` factor `s·(cosm + sinm·c/√(1−c²))` → the cosine-wrt-W derivative `(x̂−cosθ·ŵ)/‖W‖` → the SGD update that pulls the target row toward x̂ and pushes impostors away (angular-margin attraction, in Form).
- proven by a **finite-difference gradient check** (analytic = numeric < 1%) + descent (1 step lowers loss, 8 lower further) + target cosine rising.
- **robust at the alignment singularity**: `√(1−c²)` floored → a perfectly-aligned target gives a *zero* gradient (no pull) instead of NaN. Caught via the band: a parallel-W fixture hit `√0` → `div` → `Inf` → `tn-exp(Inf)` infinite halving loop (a hang); fixed in recipe + fixture.

Objective + trainer now both four-way. Remaining in 9(a): the native asm lane + augmentation (9b). Floor + CHALLENGERS.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)