### PR TITLE
feat(witness): POST /freq-reading — the Android lane's Mac half records gold over HTTP

### DIFF
--- a/docs/system_audit/commit_evidence_20260622_witness_freq_reading.json
+++ b/docs/system_audit/commit_evidence_20260622_witness_freq_reading.json
@@ -1,0 +1,90 @@
+{
+  "date": "2026-06-22",
+  "thread_branch": "claude/witness-freq",
+  "commit_scope": "The Android lane's Mac half: the witness server gains POST /freq-reading. A human's freq-reading (the Android Coherence Sense app's input, or any cell that can reach the witness) records to the gold catalog through the proven body — mesh-dispatch.fk (md-route) via scripts/mesh_dispatch.sh, then scripts/form_cli_gold.sh — the SAME path the coord board's coord-respond uses, just HTTP transport instead of board-watching. Carrier-last: the endpoint holds no recording logic.",
+  "files_owned": [
+    "experiments/coherence-sense-android/mac-witness-server.py",
+    "docs/system_audit/commit_evidence_20260622_witness_freq_reading.json"
+  ],
+  "idea_ids": [
+    "freq-check-gold-label",
+    "cognitive-sovereignty",
+    "agent-coordination-mesh"
+  ],
+  "spec_ids": [
+    "mesh-dispatch"
+  ],
+  "task_ids": [
+    "task-2026-06-22-witness-freq-reading"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "the-freq-detector",
+        "vision"
+      ]
+    },
+    {
+      "contributor_id": "claude-sema",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "claude-code",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "Live end-to-end against a running witness (port 8877, FREQ_GOLD_DIR temp catalog): POST /freq-reading {verdict:'fear', boundary:'hedged where flow would serve', from:'SM-S918U1'} -> {recorded:true, verdict:'fear', boundary:'hedged where flow would serve'}; POST {message:'gold clear that was direct and grounded', from:'phone'} -> {recorded:true, verdict:'clear'}; POST {message:'what is the witness status?'} -> {recorded:false, route:'ask', note:'not a freq-reading; on the board this would be answered as an ask'}. The gold catalog received both readings with named boundary + response_ref 'witness:<device>'.",
+    "Carrier-last: _freq_reading() marshals the request to the proven scripts. It accepts either a raw mesh message ('gold <clear|fear> <boundary>') or structured {verdict, boundary, from}, runs scripts/mesh_dispatch.sh (the four-way mesh-dispatch.fk decision) to get route/verdict/boundary, and on route=='gold' calls scripts/form_cli_gold.sh to record. No recording logic in Python. An ask is not recorded (the board would answer it).",
+    "This is the MAC half of the Android lane, proven independently of any device: the curl test is itself a real caller, and the door is general — any cell that can reach the witness (:8800) can POST a reading. The Android UI field (Kotlin, app/src/main/...) that POSTs here is the remaining APP-SIDE step, needing a gradle build + device to verify — named honestly, not faked.",
+    "The decision body mesh-dispatch.fk is four-way (verdict 255) on main; this carrier reuses it. Edge: the module docstring documents POST /freq-reading (the per-file doc convention). Witness 'strained' at resume was the self-healing page-vitality transient (0 silences), unrelated."
+  ],
+  "change_files": [
+    "experiments/coherence-sense-android/mac-witness-server.py",
+    "docs/system_audit/commit_evidence_20260622_witness_freq_reading.json"
+  ],
+  "change_intent": "runtime_feature",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 -c 'import ast; ast.parse(open(...))'  -> syntax ok",
+      "FREQ_GOLD_DIR=<tmp> python3 mac-witness-server.py --port 8877 &  +  curl -X POST /freq-reading (3 cases)  -> 2 recorded, 1 ask not recorded; catalog written"
+    ],
+    "fourth_arm_outputs": [
+      "Re-proved the decision body this carrier invokes (unchanged): cd form && ./validate.sh form-stdlib/core.fk form-stdlib/mesh-dispatch.fk form-stdlib/tests/mesh-dispatch-band.fk -> 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)' and '1 ok, 0 divergent — kernels agree on every sample.'"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "CI re-proves the unchanged mesh-dispatch.fk band; the witness endpoint is exercised by the documented curl flow."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "local-witness-runtime",
+    "notes": "The witness runs locally on the Mac (LaunchAgent / python3 mac-witness-server.py). No public HTTP change. The Android UI field POSTing here is the remaining app-side step."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "The Mac half is wired and demonstrated end-to-end (curl); the decision body is four-way. No public deploy (a local witness), so deploy_validation stays pending. The Android app's UI field is the remaining app-side step needing a device build."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "A human's freq-reading can now reach the gold catalog over HTTP — the Android Coherence Sense app's reading lane (Mac half), and a general 'post a reading to the mesh' door for any cell. Records through the same proven body as the coord board, so capture is consistent across transports.",
+    "public_endpoints": [
+      "POST http://<mac-witness>:8800/freq-reading (local witness; not a public coherencycoin endpoint)"
+    ],
+    "test_flows": [
+      "POST a fear reading -> recorded with named boundary; POST a clear reading (raw message) -> recorded; POST an ask -> not recorded (route ask). Demonstrated live on a temp catalog."
+    ]
+  }
+}

--- a/experiments/coherence-sense-android/mac-witness-server.py
+++ b/experiments/coherence-sense-android/mac-witness-server.py
@@ -15,6 +15,12 @@ placeholder until those recipes are wired into the live loop through a persisten
 Run:  python3 mac-witness-server.py            # binds 0.0.0.0:8800
 Open the dashboard on the Mac:  http://localhost:8800
 The Android app discovers this Mac over _hati-witness._tcp; the dashboard also shows fallback URLs.
+
+A human's freq-reading arrives at  POST /freq-reading  —  {"verdict":"clear|fear","boundary":"<where the
+fear sat>"}  (or  {"message":"gold <clear|fear> <boundary>"}). The witness records it to the gold catalog
+through the proven body (mesh-dispatch.fk md-route -> scripts/form_cli_gold.sh) — the SAME path the coord
+board's coord-respond uses, just a different transport. This is the Android Coherence Sense app's
+freq-reading lane: the app's input field POSTs here; any cell that can reach the witness can too.
 """
 import json
 import time
@@ -91,9 +97,58 @@ class Witness(BaseHTTPRequestHandler):
             return self._send(200, json.dumps(state["witness"]))
         return self._send(200, DASHBOARD, "text/html; charset=utf-8")
 
+    def _freq_reading(self):
+        # A human's direct freq-reading arrives over HTTP — the Android app's reading
+        # lane, or any cell that can POST. Carrier-last: the DECISION and the RECORD are
+        # the proven body — mesh-dispatch.fk (md-route) via scripts/mesh_dispatch.sh, then
+        # scripts/form_cli_gold.sh writes the gold catalog. This door holds NO logic; it
+        # marshals the request to those scripts so the witness records exactly what the
+        # coord board's coord-respond records (same shared path, different transport).
+        #   POST /freq-reading  {"message": "gold <clear|fear> <where the fear sat>"}
+        #                   or  {"verdict": "clear|fear", "boundary": "...", "from": "..."}
+        import subprocess
+        from pathlib import Path
+        try:
+            n = int(self.headers.get("Content-Length", 0))
+            req = json.loads(self.rfile.read(n) or b"{}")
+        except Exception as e:
+            return self._send(400, json.dumps({"error": str(e)}))
+        root = Path(__file__).resolve().parents[2]
+        msg = (req.get("message") or "").strip()
+        if not msg:
+            v = str(req.get("verdict", "")).strip().lower()
+            v = "clear" if v in ("1", "clear") else ("fear" if v in ("0", "fear", "caught") else "")
+            msg = f"gold {v} {req.get('boundary', '')}".strip() if v else ""
+        if not msg:
+            return self._send(400, json.dumps({
+                "error": "need {message:'gold <clear|fear> <boundary>'} or {verdict, boundary}"}))
+        try:
+            disp = subprocess.run(["bash", str(root / "scripts/mesh_dispatch.sh"), msg],
+                                  capture_output=True, text=True, timeout=30)
+        except Exception as e:
+            return self._send(500, json.dumps({"error": f"dispatch: {e}"}))
+        lines = [l for l in disp.stdout.splitlines() if l.strip()]
+        route = lines[0] if lines else "ask"
+        if route != "gold":
+            return self._send(200, json.dumps({
+                "recorded": False, "route": route,
+                "note": "not a freq-reading; on the board this would be answered as an ask"}))
+        verdict = lines[1] if len(lines) > 1 else "2"
+        boundary = lines[2] if len(lines) > 2 else ""
+        vw = {"0": "fear", "1": "clear"}.get(verdict, "")
+        if not vw:
+            return self._send(200, json.dumps({"recorded": False, "route": "gold", "note": "no verdict named"}))
+        frm = str(req.get("from", "android"))
+        subprocess.run(["bash", str(root / "scripts/form_cli_gold.sh"), vw, boundary, f"witness:{frm}"],
+                       capture_output=True, text=True, timeout=30)
+        _event("peer", f"freq-reading recorded ({vw})")
+        return self._send(200, json.dumps({"recorded": True, "verdict": vw, "boundary": boundary}))
+
     def do_POST(self):
+        if self.path.startswith("/freq-reading"):
+            return self._freq_reading()
         if self.path != "/sense":
-            return self._send(404, json.dumps({"error": "only /sense"}))
+            return self._send(404, json.dumps({"error": "only /sense or /freq-reading"}))
         try:
             n = int(self.headers.get("Content-Length", 0))
             snap = json.loads(self.rfile.read(n) or b"{}")


### PR DESCRIPTION
## The Android lane's Mac half

The witness server gains **POST /freq-reading**. A human's freq-reading — the Coherence Sense app's input, or any cell that can reach the witness — records to the gold catalog through the **proven body**: `mesh-dispatch.fk` (md-route) via `scripts/mesh_dispatch.sh`, then `scripts/form_cli_gold.sh`. The **same path** the coord board's `coord-respond` uses, just HTTP transport instead of board-watching.

Carrier-last: the endpoint holds **no recording logic** — it marshals the request to the proven scripts. Accepts `{verdict, boundary, from}` or a raw `{message: 'gold <clear|fear> <boundary>'}`.

## Proven live (independent of any device)

Against a running witness (port 8877, temp catalog):
- `{verdict:'fear', boundary:'hedged where flow would serve', from:'SM-S918U1'}` → `{recorded:true}` ✓
- `{message:'gold clear that was direct and grounded'}` → `{recorded:true, verdict:'clear'}` ✓
- `{message:'what is the witness status?'}` → `{recorded:false, route:'ask'}` ✓ (an ask isn't recorded)

The catalog received both with named boundary + `response_ref: witness:<device>`. `mesh-dispatch` re-proved four-way (255, 0 divergent).

## Honest scope

This is the **Mac half** — proven, and a general 'post a reading to the mesh' HTTP door for any cell. The **Android UI field** (Kotlin) that POSTs here is the remaining **app-side** step, needing a gradle build + device to verify — named, not faked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)