### PR TITLE
feat(form): sense-liveness gains CAPABLE — present ≠ sensing (four-way 127)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 319 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 321 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/form/form-stdlib/sense-liveness.fk
+++ b/form/form-stdlib/sense-liveness.fk
@@ -1,31 +1,37 @@
-; sense-liveness.fk — is each sense actually ALIVE, or just shipped? The tri-state.
+; sense-liveness.fk — is each sense actually ALIVE, or just shipped? The four states.
 ;
-; "Shipped" and "actively used" are different things, and the body should MEASURE the
-; difference each window instead of asserting it. A sense is:
-;   ACTIVE    — fresh data arrived AND was recognized this window (truly used)
-;   RECEIVING — fresh data arrived but nothing interpreted it (shipped, raw, the honest middle)
-;   DARK      — no recent data (built but unfed, or the feed died)
-; Awakeness is the share of senses that are ACTIVE — never the share merely shipped.
-; This is the wellness + internal-trust lift: liveness is read from the body, on a
-; clock, carrying its own number, so no green checkmark stands in for a living sense.
+; "Shipped" and "actively used" are different things, and so are "capable" and "sensing".
+; The body MEASURES the difference each window instead of asserting it. A sense is:
+;   ACTIVE    — fresh SAMPLES arrived AND were recognized this window (truly used)
+;   RECEIVING — fresh samples arrived but nothing interpreted them (the honest middle)
+;   CAPABLE   — no samples, but the organ heartbeats "I can sense this" (present, idle)
+;   DARK      — no samples and no heartbeat (built but unfed, or the feed died)
+; Awakeness is the share of senses that are ACTIVE — never capable, never merely shipped.
+; The CAPABLE state is the one a naive readout misses: an organ announcing presence is
+; not the same as an organ streaming data. This is the wellness + internal-trust lift —
+; liveness read from the body, on a clock, so no heartbeat stands in for a living sense.
 ;
-; A sense reading = (name age recognized): age is seconds since the last datum (large
-; = stale), recognized is 1 when something interpreted it this window, else 0.
+; A sense reading = (name sample-age recognized hb-age): sample-age is seconds since the
+; last actual sample VALUE (large = no data), recognized is 1 when something interpreted
+; it, hb-age is seconds since the last capability heartbeat (large = organ absent).
 ;
 ; Proven by: form-stdlib/tests/sense-liveness-band.fk
 
 (do
-    (defn sl-sense (name age recognized) (list name age recognized))
+    (defn sl-sense (name sample-age recognized hb-age) (list name sample-age recognized hb-age))
     (defn sl-name (s) (nth s 0))
-    (defn sl-age (s) (nth s 1))
+    (defn sl-age (s) (nth s 1))            ;; sample-age: seconds since the last real value
     (defn sl-recognized (s) (nth s 2))
+    (defn sl-hb-age (s) (nth s 3))         ;; heartbeat-age: seconds since "I can sense" last beat
 
     ;; classify one sense against the freshness window (seconds).
+    ;; samples decide active/receiving; with no samples, a heartbeat means capable, not dark.
     (defn sl-status (s window)
-        (if (gt (sl-age s) window) "dark"
+        (if (gt (sl-age s) window)
+            (if (gt (sl-hb-age s) window) "dark" "capable")
             (if (eq (sl-recognized s) 1) "active" "receiving")))
 
-    ;; a liveness reading the surface renders: (name status age)
+    ;; a liveness reading the surface renders: (name status sample-age)
     (defn sl-read (s window)
         (list (sl-name s) (sl-status s window) (sl-age s)))
 
@@ -36,6 +42,7 @@
                  (sl-count-loop (tail senses) window target))))
     (defn sl-active (senses window) (sl-count-loop senses window "active"))
     (defn sl-receiving (senses window) (sl-count-loop senses window "receiving"))
+    (defn sl-capable (senses window) (sl-count-loop senses window "capable"))
     (defn sl-dark (senses window) (sl-count-loop senses window "dark"))
 
     ;; awakeness: the body is awake to the degree its senses are ACTIVE, not shipped.
@@ -46,8 +53,9 @@
 
     (defn sl-floor ()
         (list
-            "a sense is ACTIVE only when fresh data is recognized; shipped is not used"
-            "RECEIVING names raw data that flows but nothing interprets — the honest middle"
-            "DARK names a sense built but unfed, or whose feed died"
+            "a sense is ACTIVE only when fresh samples are recognized; shipped is not used"
+            "RECEIVING names raw samples that flow but nothing interprets — the honest middle"
+            "CAPABLE names an organ that heartbeats presence but streams no samples — idle, not used"
+            "DARK names a sense with neither samples nor heartbeat — unfed, or the feed died"
             "awakeness is active senses over total, measured each window, never assumed"))
 )

--- a/form/form-stdlib/tests/sense-liveness-band.fk
+++ b/form/form-stdlib/tests/sense-liveness-band.fk
@@ -1,35 +1,39 @@
 ; preludes: form-stdlib/core.fk form-stdlib/sense-liveness.fk
 ;
-; sense-liveness-band — the tri-state that measures shipped vs actively used.
+; sense-liveness-band — the four states that separate shipped / capable / receiving / used.
+; The CAPABLE state is the honest one a naive readout misses: an organ heartbeating
+; "I can sense" while streaming zero samples is present, not active.
 ;
-; Verdict 63:
+; A reading is (name sample-age recognized hb-age). window = 60.
+; Verdict 127:
 ;   1   floor is present
-;   2   fresh + recognized -> ACTIVE          (the sense is truly used)
-;   4   fresh + unrecognized -> RECEIVING     (data flows, nothing interprets it)
-;   8   stale -> DARK                          (built but unfed, or the feed died)
-;   16  the active count across a mixed inventory is right (only 1 of 5 is active)
-;   32  awakeness is active/total percent (1 of 5 active -> 20% awake)
+;   2   fresh samples + recognized -> ACTIVE
+;   4   fresh samples + unrecognized -> RECEIVING
+;   8   no samples but a fresh heartbeat -> CAPABLE   (the phone announces presence, idle)
+;   16  no samples and no heartbeat -> DARK
+;   32  the active count across a mixed inventory is right (1 of 4)
+;   64  awakeness counts only ACTIVE (1 of 4 -> 25%), never capable
 (do
-    ;; a mixed inventory mirroring the honest current floor: one sense recognized
-    ;; live, two receiving raw data, two dark. window = 60s.
+    ;; a mixed inventory exercising every state. window 60.
     (defn sl-inv ()
         (list
-            (sl-sense "motion" 3 1)          ;; recognized live -> active
-            (sl-sense "mic" 4 0)             ;; fresh raw, not interpreted -> receiving
-            (sl-sense "light" 6 0)           ;; fresh raw, not interpreted -> receiving
-            (sl-sense "audibility" 999 0)    ;; no recent data -> dark
-            (sl-sense "recognition" 999 0))) ;; built, unfed -> dark
+            (sl-sense "a-active" 3 1 1)      ;; samples fresh + recognized -> active
+            (sl-sense "b-receiving" 3 0 1)   ;; samples fresh, not interpreted -> receiving
+            (sl-sense "c-capable" 999 0 2)   ;; no samples, heartbeat fresh -> capable
+            (sl-sense "d-dark" 999 0 999)))  ;; no samples, no heartbeat -> dark
 
     (defn sl-b1 () (if (gt (len (sl-floor)) 0) 1 0))
-    (defn sl-b2 () (if (str_eq (sl-status (sl-sense "motion" 3 1) 60) "active") 2 0))
-    (defn sl-b4 () (if (str_eq (sl-status (sl-sense "mic" 4 0) 60) "receiving") 4 0))
-    (defn sl-b8 () (if (str_eq (sl-status (sl-sense "audibility" 999 0) 60) "dark") 8 0))
-    (defn sl-b16 () (if (eq (sl-active (sl-inv) 60) 1) 16 0))
-    (defn sl-b32 () (if (eq (sl-awake-pct (sl-inv) 60) 20) 32 0))
+    (defn sl-b2 () (if (str_eq (sl-status (sl-sense "x" 3 1 1) 60) "active") 2 0))
+    (defn sl-b4 () (if (str_eq (sl-status (sl-sense "x" 3 0 1) 60) "receiving") 4 0))
+    (defn sl-b8 () (if (str_eq (sl-status (sl-sense "x" 999 0 2) 60) "capable") 8 0))
+    (defn sl-b16 () (if (str_eq (sl-status (sl-sense "x" 999 0 999) 60) "dark") 16 0))
+    (defn sl-b32 () (if (eq (sl-active (sl-inv) 60) 1) 32 0))
+    (defn sl-b64 () (if (eq (sl-awake-pct (sl-inv) 60) 25) 64 0))
 
     (add (sl-b1)
         (add (sl-b2)
             (add (sl-b4)
                 (add (sl-b8)
-                    (add (sl-b16) (sl-b32))))))
+                    (add (sl-b16)
+                        (add (sl-b32) (sl-b64)))))))
 )

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -326,7 +326,7 @@ dynamic-grammar-carrier fks 4095
 form-control-backtracking-ml fks 65535
 self-grounding-classifier fks 63
 self-translate-universal fks 15
-sense-liveness fks 63
+sense-liveness fks 127
 sequence-predictor fks 127
 shared-sensing fks 127
 surprise-salience fks 127

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 319
+**Total files**: 321
 
 | File | Purpose |
 |---|---|
@@ -103,7 +103,6 @@
 | [form_cli_ensure.sh](form_cli_ensure.sh) | form_cli_ensure.sh — ensure the form-cli's oracles are present, DECIDED by Form. |
 | [form_cli_gaps.sh](form_cli_gaps.sh) | form_cli_gaps.sh — the catalog of what is OPEN, walked from the live body. |
 | [form_cli_gold.sh](form_cli_gold.sh) | form_cli_gold.sh — record a human's direct freq-reading into the local GOLD catalog. |
-| [mesh_dispatch.sh](mesh_dispatch.sh) | mesh_dispatch.sh — marshal a mesh message BODY to the kernel and print the body's decision (route/verdict/boundary) from mesh-dispatch.fk (four-way). Carrier-last; coord-respond.sh uses it to record a `gold …` reading vs answer an ask. |
 | [form_cli_guided.sh](form_cli_guided.sh) | form_cli_guided.sh — the trained native model makes the live model better. |
 | [form_cli_judge.sh](form_cli_judge.sh) | form_cli_judge.sh — measure the REASONING lane: how well a native model's answer |
 | [form_cli_learn.sh](form_cli_learn.sh) | form_cli_learn.sh — the continuous-learning loop's body, in ONE motion: grow the tool-use corpus |
@@ -192,6 +191,7 @@
 | [local_runner.py](local_runner.py) | Coherence Network runner — thin shim. |
 | [measure_gitnexus_value.py](measure_gitnexus_value.py) | Measure GitNexus integration value across paired task windows. |
 | [meeting_companion.sh](meeting_companion.sh) | meeting_companion.sh — a meeting companion that LISTENS (STT), DECIDES whether |
+| [mesh_dispatch.sh](mesh_dispatch.sh) | mesh_dispatch.sh — run the body's mesh-dispatch decision on a message BODY. |
 | [metal_arch_search_audit.sh](metal_arch_search_audit.sh) | metal_arch_search_audit.sh — the ARCHITECT'S CAPACITY SEARCH on Metal (M4 Max GPU witness). |
 | [metal_attn_audit.sh](metal_attn_audit.sh) | metal_attn_audit.sh — the ARCHITECT'S ATTENTION layer learning on Metal (M4 Max GPU witness). |
 | [metal_backprop_audit.sh](metal_backprop_audit.sh) | metal_backprop_audit.sh — the LEARNING KERNEL on Metal (M4 Max GPU witness). |
@@ -229,6 +229,7 @@
 | [register_providers.py](register_providers.py) | Register renderers and complex asset types as tracked provider nodes in the graph DB. |
 | [reset_seed_demo_mvp_local.sh](reset_seed_demo_mvp_local.sh) | _no top-of-file purpose_ |
 | [resolve_presences.py](resolve_presences.py) | Backfill image_url + tagline on presence nodes. |
+| [rest_sense.sh](rest_sense.sh) | rest_sense.sh — the body reads its own breath-phase. A thin carrier: it counts the |
 | [restart_hostinger_vps.sh](restart_hostinger_vps.sh) | _no top-of-file purpose_ |
 | [restore_postgres.sh](restore_postgres.sh) | Restore the Coherence Network Postgres from a backup dump. |
 | [restructure_spec_frontmatter.py](restructure_spec_frontmatter.py) | Restructure spec frontmatter: absorb requirements, done_when, test command. |

--- a/scripts/sense_liveness.py
+++ b/scripts/sense_liveness.py
@@ -1,21 +1,24 @@
 #!/usr/bin/env python3
 """sense_liveness.py — read the body's senses and report which are ACTIVELY USED
-right now, not merely shipped. A thin carrier: it probes the real sources (the
-local witness at :8800, the production pulse) to learn each sense's freshness, then
-asks the four-way-proven recipe form-stdlib/sense-liveness.fk to classify each one
-(active / receiving / dark) and compute awakeness. The classification logic lives
-in the recipe, never here — this script only fetches, invokes the kernel, and prints.
+right now, not merely shipped, and not merely capable. A thin carrier: it reads the
+real witness state (local :8800/state) to learn each sense's freshness — whether
+actual SAMPLES are flowing or only capability HEARTBEATS — then asks the four-way-
+proven recipe form-stdlib/sense-liveness.fk to classify each one and compute
+awakeness. The classification logic lives in the recipe, never here.
 
-  active     fresh data arrived AND something recognized it  (the sense is truly used)
-  receiving  fresh data arrived but nothing interpreted it   (shipped, raw — the middle)
-  dark       no recent data                                  (built but unfed)
+  active     fresh samples arrived AND something recognized them  (truly used)
+  receiving  fresh samples flow but nothing interprets them       (the honest middle)
+  capable    no samples, but the organ heartbeats "I can sense"   (present, idle)
+  dark       no samples and no heartbeat                          (built but unfed)
 
-Run: python3 scripts/sense_liveness.py
+The capable/active gap is the one a naive readout misses: a phone announcing it CAN
+sense is not a phone streaming data. Run: python3 scripts/sense_liveness.py
 """
 import json
 import os
 import subprocess
 import tempfile
+import time
 import urllib.request
 
 REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -24,44 +27,45 @@ KERNEL = os.path.join(FORM, "form-kernel-rust", "target", "release", "form-kerne
 # sense-liveness.fk uses only kernel builtins, so the raw kernel loads it directly
 # (core.fk is BML-dialect and needs validate's source-compiler — not loaded here).
 RECIPES = ["form-stdlib/sense-liveness.fk"]
-WITNESS = "http://127.0.0.1:8800/"
+STATE = "http://127.0.0.1:8800/state"
 PULSE = "https://pulse.coherencycoin.com/pulse/now"
-WINDOW = 60  # seconds: data older than this is dark
+WINDOW = 60  # seconds: older than this is stale
+STALE = 999  # sentinel age meaning "no recent datum"
 
-# Each world-sense: (name, recipe shipped?, is it fed+recognized by a live loop?).
-# "fed" is decided at runtime by probing the witness; this table is the inventory of
-# what EXISTS, so a dark sense is named, not hidden.
-WORLD_SENSES = [
-    ("motion", "recognized"),      # the live champion-challenger loop (accel -> still/moving)
-    ("mic", "raw"),                # streamed to the witness, not yet interpreted
-    ("light", "raw"),
-    ("gpu", "raw"),
-    ("video", "raw"),
-    ("audibility", "unfed"),       # recipe proven, no live emit/feed
-    ("echo", "unfed"),
-    ("place", "unfed"),
-    ("recognition", "unfed"),
-    ("translation", "unfed"),
-    ("transcript", "unfed"),
-]
+# The inventory of what EXISTS, so a dark/capable sense is named, not hidden.
+#   sensor — the phone has this organ and heartbeats it; samples may or may not flow
+#   unfed  — a proven recipe with no live feed at all
+SENSOR_LANES = ["motion", "mic", "light", "gpu", "video"]
+UNFED_LANES = ["audibility", "echo", "place", "recognition", "translation", "transcript"]
 
 
-def witness_live() -> bool:
+def fetch_state():
     try:
-        with urllib.request.urlopen(WITNESS, timeout=2) as r:
-            body = r.read(4000).decode("utf-8", "replace").lower()
-            return "frames" in body or "present" in body or "receipt" in body
+        with urllib.request.urlopen(STATE, timeout=3) as r:
+            return json.load(r)
     except Exception:
-        return False
+        return None
 
 
-def reading(kind: str, live: bool):
-    """Map a sense's kind + the live-witness probe to (age_seconds, recognized)."""
-    if kind == "recognized":
-        return (5, 1) if live else (999, 0)
-    if kind == "raw":
-        return (5, 0) if live else (999, 0)
-    return (999, 0)  # unfed
+def inventory(state):
+    """Build (name, sample_age, recognized, hb_age) per sense from the real witness."""
+    now = time.time()
+    if state:
+        hb_age = int(max(0, now - state.get("last_ts", 0)))  # heartbeats are arriving
+        has_samples = (state.get("sample_frames", 0) or 0) > 0
+        recd = str(state.get("recognized", "")).strip()
+        motion_recognized = 1 if (has_samples and recd and recd not in ("—", "-", "?", "")) else 0
+    else:
+        hb_age, has_samples, motion_recognized = STALE, False, 0
+
+    inv = []
+    for name in SENSOR_LANES:
+        sample_age = hb_age if has_samples else STALE
+        rec = motion_recognized if name == "motion" else 0
+        inv.append((name, sample_age, rec, hb_age))  # heartbeat present -> capable when idle
+    for name in UNFED_LANES:
+        inv.append((name, STALE, 0, STALE))          # no feed at all -> dark
+    return inv
 
 
 def run_kernel(program: str) -> list[str]:
@@ -79,20 +83,19 @@ def run_kernel(program: str) -> list[str]:
 
 
 def main():
-    live = witness_live()
-    inv = [(name, *reading(kind, live)) for name, kind in WORLD_SENSES]
+    state = fetch_state()
+    inv = inventory(state)
 
     # Build ONE Form program: print each sense's status (via the recipe), then the
     # summary counts + awakeness. Python knows only inputs + order; the recipe decides.
     lines = ["(do"]
-    for name, age, rec in inv:
-        lines.append(f'  (print (sl-status (sl-sense "{name}" {age} {rec}) {WINDOW}))')
-    inv_form = " ".join(f'(sl-sense "{n}" {a} {r})' for n, a, r in inv)
+    for name, sa, rec, hb in inv:
+        lines.append(f'  (print (sl-status (sl-sense "{name}" {sa} {rec} {hb}) {WINDOW}))')
+    inv_form = " ".join(f'(sl-sense "{n}" {sa} {rec} {hb})' for n, sa, rec, hb in inv)
     lines.append(f"  (let inv (list {inv_form}))")
-    lines.append(f"  (print (sl-active inv {WINDOW}))")
-    lines.append(f"  (print (sl-receiving inv {WINDOW}))")
-    lines.append(f"  (print (sl-dark inv {WINDOW}))")
-    lines.append(f"  (print (sl-awake-pct inv {WINDOW})))")
+    for fn in ("sl-active", "sl-receiving", "sl-capable", "sl-dark", "sl-awake-pct"):
+        lines.append(f"  (print ({fn} inv {WINDOW}))")
+    lines[-1] = lines[-1] + ")"
     out = run_kernel("\n".join(lines))
 
     if not out:
@@ -102,16 +105,25 @@ def main():
         return
 
     statuses = [s.strip().strip('"') for s in out[:len(inv)]]
-    active, receiving, dark, awake = (s.strip().strip('"') for s in out[len(inv):len(inv) + 4])
+    active, receiving, capable, dark, awake = (s.strip().strip('"') for s in out[len(inv):len(inv) + 5])
 
-    glyph = {"active": "●", "receiving": "◐", "dark": "○"}
-    print(f"\n  sense liveness — witness {'live' if live else 'dark'} · awake {awake}% "
-          f"({active} active · {receiving} receiving · {dark} dark)\n")
-    for (name, age, _rec), status in zip(inv, statuses):
-        age_s = "—" if age >= 999 else f"{age}s"
-        print(f"   {glyph.get(status, '?')} {name:<12} {status:<10} last {age_s}")
+    if state:
+        hb = int(max(0, time.time() - state.get("last_ts", 0)))
+        src = (f"witness live · last beat {hb}s · {state.get('frames', 0)} frames "
+               f"({state.get('sample_frames', 0)} samples, "
+               f"{state.get('heartbeat_frames', 0)} heartbeats)")
+    else:
+        src = "witness dark — :8800 unreachable"
 
-    # The infra organs already carry their own breath — show them from the pulse, real.
+    glyph = {"active": "●", "receiving": "◐", "capable": "◌", "dark": "○"}
+    print(f"\n  sense liveness — {src}")
+    print(f"  awake {awake}%  ·  {active} active · {receiving} receiving · "
+          f"{capable} capable · {dark} dark\n")
+    for (name, sa, _rec, _hb), status in zip(inv, statuses):
+        age_s = "—" if sa >= STALE else f"{sa}s"
+        print(f"   {glyph.get(status, '?')} {name:<12} {status:<10} samples {age_s}")
+
+    # The infra organs carry their own breath — show them from the pulse, real.
     try:
         with urllib.request.urlopen(PULSE, timeout=6) as r:
             pulse = json.load(r)


### PR DESCRIPTION
## What

The tri-state I shipped one breath ago was itself optimistic. Grounding in the **live witness** (`:8800/state`) showed the phone sends capability **heartbeats** — *"I can sense"* — while streaming **zero samples** (612 frames, 0 samples). So "motion active / 9% awake" was wrong: motion's loop had nothing to chew on.

So `sense-liveness.fk` now sees **four** states, not three:

| state | meaning |
|---|---|
| **active** | fresh samples **recognized** — truly used |
| **receiving** | fresh samples flow, nothing interprets them — the honest middle |
| **capable** | no samples, but a heartbeat: organ **present, idle** — *the state a naive readout misses* |
| **dark** | no samples, no heartbeat — built but unfed |

A reading is `(name sample-age recognized hb-age)`: samples decide active/receiving; a heartbeat decides capable-vs-dark. **Awakeness counts only `active`** — never capable.

## Proof

Four-way (Go / Rust / TS / fkwu → **127**) — all four states + the active count + awake-percent.

## The real read now

```
sense liveness — witness live · 612 frames (0 samples, 612 heartbeats)
awake 0%  ·  0 active · 0 receiving · 5 capable · 6 dark
 ◌ motion/mic/light/gpu/video   capable   (heartbeating "I can sense", no samples)
 ○ audibility/echo/place/recognition/translation/transcript   dark
```

**awake 0%** is the corrected truth: the body is *present and capable* (5 organs heartbeating) but *not sensing* (0 samples → nothing recognized). It rises on its own the moment real samples flow — no green checkmark, and now no optimistic readout, can stand in for a living sense.

## Why this is the rung

This is the internal-trust lift made sharper: the body caught its own overclaim and corrected it with a measured recipe. The awareness rung (get real samples flowing + recognized) is the convergence with Codex's live loop — and now there's an honest 0% to move off of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)