### PR TITLE
feat(form-cli): all oracle lanes are agent-CLI-only — strip ANTHROPIC_API_KEY everywhere

### DIFF
--- a/form/form-stdlib/form-cli-ask-plus.fk
+++ b/form/form-stdlib/form-cli-ask-plus.fk
@@ -86,7 +86,7 @@ section [form.bml] {
     ; about a clean environment. (env -u UNSETS it — ANTHROPIC_API_KEY= would leave an
     ; empty key that still wins precedence and fails auth.)
     def fcap-escalate(remote, question) {
-        host-exec(str_concat("env -u ANTHROPIC_API_KEY ", remote), question);
+        host-exec(str_concat("env -u ANTHROPIC_API_KEY ", str_concat(remote, " 2>/dev/null")), question);
     }
 
     ; ── pack THIS turn's outcome: the live trust row (from the four-way-proven

--- a/form/form-stdlib/form-native-run.fk
+++ b/form/form-stdlib/form-native-run.fk
@@ -32,11 +32,15 @@
 (defn fnr-sys ()
     "You are form-cli, a coding agent. Tools (reply with ONE line of JSON to use one): {\"name\":\"bash\",\"arguments\":{\"cmd\":\"...\"}} | {\"name\":\"read_file\",\"arguments\":{\"path\":\"...\"}} | {\"name\":\"write_file\",\"arguments\":{\"path\":\"...\",\"content\":\"...\"}} | {\"name\":\"edit\",\"arguments\":{\"path\":\"...\",\"find\":\"...\",\"replace\":\"...\"}} | {\"name\":\"search\",\"arguments\":{\"pattern\":\"...\"}} | {\"name\":\"glob\",\"arguments\":{\"pattern\":\"*.fk\"}}. After each tool you receive an OBSERVATION. When the task is done, reply with your final answer as plain text (no JSON).\n\n")
 
-; ── call the oracle: write the prompt to a file, exec `oracle < file` ──
+; ── call the oracle: pipe the prompt to its stdin, AGENT-CLI-ONLY ──
+; The prompt goes to the oracle's stdin in memory (host-exec's 2nd arg) — no temp
+; file, no writable /tmp, so this runs unchanged on Android too. The oracle runs with
+; ANTHROPIC_API_KEY stripped (env -u): the remote is an agent CLI on its flat-rate
+; subscription login, NEVER a metered API key — a stray key in the environment can't
+; silently bill per-token. (env -u UNSETS it; ANTHROPIC_API_KEY= would leave an empty
+; key that still wins precedence and fails auth.) Same law as ask+'s fcap-escalate.
 (defn fnr-oracle (oracle prompt)
-    (do
-        (host-write "/tmp/fnr_prompt.txt" prompt)
-        (host-exec (str_concat oracle " < /tmp/fnr_prompt.txt 2>/dev/null"))))
+    (host-exec (str_concat "env -u ANTHROPIC_API_KEY " (str_concat oracle " 2>/dev/null")) prompt))
 
 ; ── structured edit: replace the FIRST occurrence of `find` with `repl` in s (pure Form, four-way) ──
 (defn fnr-replace (s find repl)

--- a/scripts/form_cli_self_review.sh
+++ b/scripts/form_cli_self_review.sh
@@ -54,8 +54,9 @@ while IFS=$'\t' read -r task agent; do
     # 2. INTERNAL review (a local judge)
     jf="$(mktemp)"; judge_prompt "$agent" "$ans" > "$jf"
     is="$(score_of "$($INNER < "$jf" 2>/dev/null)")"; is="${is:-0}"; [[ "$is" -gt 100 ]] && is=100
-    # 3. ORACLE review (Claude via the CLI) — the SAME answer
-    os="$(score_of "$($ORACLE < "$jf" 2>/dev/null)")"; os="${os:-0}"; [[ "$os" -gt 100 ]] && os=100
+    # 3. ORACLE review (the agent CLI on its subscription login) — the SAME answer.
+    # env -u ANTHROPIC_API_KEY: subscription-only, a stray key can't silently meter.
+    os="$(score_of "$(env -u ANTHROPIC_API_KEY $ORACLE < "$jf" 2>/dev/null)")"; os="${os:-0}"; [[ "$os" -gt 100 ]] && os=100
     rm -f "$jf"
     INNER_SCORES="$INNER_SCORES $is"; ORACLE_SCORES="$ORACLE_SCORES $os"
     printf "  %2d  inner=%3s  oracle=%3s  gap=%3s  task: %s\n" "$i" "$is" "$os" "$(( is>os ? is-os : os-is ))" "$(printf '%s' "$task" | head -c 48)"


### PR DESCRIPTION
**We use only agent CLIs on their flat-rate subscription login — never an API key** (not in the subscription, per-token cost too high). ask+ already enforced this in the body ([#3517](https://github.com/seeker71/Coherence-Network/pull/3517)); this carries the same law to **every remaining oracle lane**, so a stray `ANTHROPIC_API_KEY` in the environment can't silently make any of them bill metered.

| Lane | Before | After |
|------|--------|-------|
| `form-cli run`/`do` + tiered tier-3 (`fnr-oracle`) | `oracle < /tmp/fnr_prompt.txt` | `env -u ANTHROPIC_API_KEY <oracle> 2>/dev/null`, prompt piped to **stdin in memory** |
| self-review (`form_cli_self_review.sh`) | `$ORACLE < $jf` | `env -u ANTHROPIC_API_KEY $ORACLE < $jf` |
| ask+ (`fcap-escalate`) | key stripped, but `2>/dev/null` dropped in the stdin switch | `2>/dev/null` restored (stderr can't leak into the answer via `CombinedOutput`) |

`fnr-oracle` gets **three wins in one rewrite**: subscription-only (key stripped), no `/tmp` file (runs on Android), stderr still suppressed. The `env -u` form *unsets* the key — `ANTHROPIC_API_KEY=` would leave an empty key that still wins precedence and fails auth.

The two recipe lanes (`fnr-oracle`, `fcap-escalate`) keep the guard inline rather than in a shared prelude cell: a shared cell would pull a new prelude into `form-native-run.fk`'s four-way band (`fks 63`) for a one-line string — more band risk than vitality. The law is named identically at each site.

## Verified — with a leak control

Every lane tested with `ANTHROPIC_API_KEY` set in the parent:
- each oracle subprocess sees it **empty** (stripped), while **bare `printenv` sees the value** — so the empty result is a real strip, not a hidden crash (the "empty output is a crash" trap, ruled out).
- `run/do` also pipes the prompt to stdin (`cat` echoes it — no file).
- ask+ still returns a clean answer.
- `form-native-run` stays **63** four-way (guard is host-io, outside the band witness); `form-cli-ask` **16383** unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)