### PR TITLE
Cross-machine shared presence: the HTTP route body (GET consensus / POST reading), read pipeline four-way 63

### DIFF
--- a/form/form-stdlib/mesh-sensings-route.fk
+++ b/form/form-stdlib/mesh-sensings-route.fk
@@ -1,0 +1,71 @@
+; mesh-sensings-route.fk — the HTTP door onto the cross-machine sensings store. A presence on ANY
+; machine POSTs a reading; GET returns the consensus map every presence shares. This is what makes
+; the durable Postgres backend (mesh-sensings-store-pg.fk) reachable across machines — the last carrier
+; the .fkb / pg store headers named.
+;
+; The route BODY is the already-proven contract: msp-* (the Postgres store) + sensings-consensus-map
+; (mesh-sensings). The handler is the thin carrier — read the request, touch Postgres at the host-io
+; boundary, render the verdict. The pure piece — msr-render-map (consensus map -> JSON) — is four-way
+; (Go/Rust/TS/fkwu); the kernel/host boundary (kh-request, config_database_url, pg_connect/exec/query,
+; parse-json of the POST body) is verified by the live route responding, the observe-end-to-end arc
+; every native route follows.
+;
+; preludes: form-stdlib/obs-verify.fk form-stdlib/trust-decay.fk form-stdlib/channel-interface.fk form-stdlib/satsang.fk form-stdlib/satsang-field.fk form-stdlib/persistence.fk form-stdlib/world-module-model.fk form-stdlib/world-model-growth.fk form-stdlib/organ-reading.fk form-stdlib/mesh-quorum.fk form-stdlib/mesh-sensings.fk form-stdlib/mesh-sensings-store-pg.fk
+;
+; Proven by: form-stdlib/tests/mesh-sensings-route-band.fk
+
+(do
+    ; ── render a consensus map (list of (subject, verdict) pairs) as a JSON object (pure, four-way) ──
+    (defn msr-jesc-loop (s i n acc)
+        (if (ge i n)
+            acc
+            (do
+                (let c (substring s i (add i 1)))
+                (msr-jesc-loop s (add i 1) n
+                    (str_concat acc
+                        (if (str_eq c "\"") "\\\""
+                            (if (str_eq c "\\") "\\\\" c)))))))
+    (defn msr-jesc (s) (msr-jesc-loop s 0 (str_len s) ""))
+    (defn msr-jstr (s) (str_concat "\"" (str_concat (msr-jesc s) "\"")))
+    (defn msr-pair-json (p)
+        (str_concat (msr-jstr (head p)) (str_concat ":" (msr-jstr (head (tail p))))))
+    (defn msr-map-join (m)
+        (if (nil? m)
+            ""
+            (if (nil? (tail m))
+                (msr-pair-json (head m))
+                (str_concat (msr-pair-json (head m))
+                    (str_concat "," (msr-map-join (tail m)))))))
+    (defn msr-render-map (m) (str_concat "{" (str_concat (msr-map-join m) "}")))
+
+    ; ── GET /api/mesh/sensings — the shared consensus map every presence reads ──
+    ; ?k= sets the quorum threshold (minimum witnesses to call a subject), default 2.
+    (defn sensings-get-handler (request)
+        (do
+            (let k (kh-query-int-or request "k" 2))
+            (let conn (pg_connect (config_database_url)))
+            (kh-response 200
+                (list (kh-header "Content-Type" "application/json"))
+                (msr-render-map (msp-durable-map conn k)))))
+
+    ; ── POST /api/mesh/sensings — a presence on any machine appends one reading ──
+    ; body: {"presence","subject","kind","answered","ok","when","deadline"}. UPSERT is last-write-wins
+    ; per (presence, subject) in the store, so re-reporting supersedes and a new presence is a witness.
+    (defn sensings-post-handler (request)
+        (do
+            (let root (parse-json "body" (kh-request-body request)))
+            (let presence (json-string-value (json-object-get root "presence")))
+            (let rd (organ-reading
+                        (json-string-value (json-object-get root "subject"))
+                        (json-string-value (json-object-get root "kind"))
+                        (json-int-value (json-object-get root "answered"))
+                        (json-int-value (json-object-get root "ok"))
+                        (json-int-value (json-object-get root "when"))
+                        (json-int-value (json-object-get root "deadline"))
+                        (list "live")))
+            (let conn (pg_connect (config_database_url)))
+            (let e1 (msp-ensure-table conn))
+            (let e2 (msp-persist conn presence rd))
+            (kh-response 200
+                (list (kh-header "Content-Type" "application/json"))
+                "{\"ok\":true}"))))

--- a/form/form-stdlib/tests/mesh-sensings-route-band.fk
+++ b/form/form-stdlib/tests/mesh-sensings-route-band.fk
@@ -1,0 +1,52 @@
+; preludes: form-stdlib/obs-verify.fk form-stdlib/trust-decay.fk form-stdlib/channel-interface.fk form-stdlib/satsang.fk form-stdlib/satsang-field.fk form-stdlib/persistence.fk form-stdlib/world-module-model.fk form-stdlib/world-model-growth.fk form-stdlib/organ-reading.fk form-stdlib/mesh-quorum.fk form-stdlib/mesh-sensings.fk form-stdlib/mesh-sensings-store-pg.fk form-stdlib/mesh-sensings-route.fk
+;
+; mesh-sensings-route-band — the HTTP door's pure core, four-way. The consensus map renders to JSON,
+; and the WHOLE read pipeline crosses end to end: a pg_query result string (what GET reads from the
+; store) decodes to readings, reaches consensus, and renders to the JSON body GET returns — all four
+; kernels agreeing. Only kh-request / config_database_url / pg_connect / parse-json (the POST + DB
+; boundary) are host-io, verified by the live route, not this band.
+;
+; Verdict 63 when every claim lands:
+;   1   a two-entry map renders to a JSON object, exact bytes
+;   2   a subject carrying a quote is escaped (no broken JSON / injection)
+;   4   an empty map renders to "{}"
+;   8   a single-entry map renders exact
+;   16  END-TO-END: a pg result string -> decode -> consensus -> render carries both verdicts
+;   32  the end-to-end render is a well-formed object ({ ... })
+(do
+    (defn mc-at? (s needle i j)
+        (if (eq j (str_len needle)) 1
+            (if (ge (add i j) (str_len s)) 0
+                (if (str_eq (char_at s (add i j)) (char_at needle j))
+                    (mc-at? s needle i (add j 1)) 0))))
+    (defn mc-loop? (s needle i)
+        (if (gt i (sub (str_len s) (str_len needle))) 0
+            (if (eq (mc-at? s needle i 0) 1) 1 (mc-loop? s needle (add i 1)))))
+    (defn mc? (s needle)
+        (if (eq (str_len needle) 0) 1
+            (if (lt (str_len s) (str_len needle)) 0 (mc-loop? s needle 0))))
+
+    (let m2  (list (list "a" "x") (list "b" "y")))
+    (let mq  (list (list "say \"hi\"" "consensus-observed")))
+    (let m1  (list (list "gpu:matvec" "consensus-observed")))
+
+    ; the read side, end to end: the pg_query result GET reads from the store
+    (let result (str_concat
+        "claude\tgpu:matvec\t1\t1\t5\t10\tgpu-bit-exact\n" (str_concat
+        "codex\tgpu:matvec\t1\t1\t5\t10\tgpu-bit-exact\n" (str_concat
+        "sema\tgpu:matvec\t1\t1\t5\t10\tgpu-bit-exact\n" (str_concat
+        "claude\tclaim:foo\t1\t1\t5\t10\tverdict-vote\n" (str_concat
+        "codex\tclaim:foo\t1\t1\t5\t10\tverdict-vote\n"
+        "sema\tclaim:foo\t1\t0\t5\t10\tverdict-vote"))))))
+    (let rendered (msr-render-map (sensings-consensus-map (msp-decode result) 2)))
+
+    (let c0 (if (str_eq (msr-render-map m2) "{\"a\":\"x\",\"b\":\"y\"}") 1 0))
+    (let c1 (if (mc? (msr-render-map mq) "\\\"hi\\\"") 2 0))
+    (let c2 (if (str_eq (msr-render-map (empty)) "{}") 4 0))
+    (let c3 (if (str_eq (msr-render-map m1) "{\"gpu:matvec\":\"consensus-observed\"}") 8 0))
+    (let c4 (if (and (mc? rendered "\"gpu:matvec\":\"consensus-observed\"")
+                     (mc? rendered "\"claim:foo\":\"divergent\"")) 16 0))
+    (let c5 (if (and (str_eq (substring rendered 0 1) "{")
+                     (str_eq (substring rendered (sub (str_len rendered) 1) (str_len rendered)) "}")) 32 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -253,6 +253,7 @@ mesh-organ-senses fks 2047
 mesh-quorum fks 2047
 mesh-sensings fks 2047
 mesh-sensings-store-pg fks 4095
+mesh-sensings-route fks 63
 model-executor-proof-ledger fks 4095
 model-vitality fks 4095
 field-model-form-runtime fks 63


### PR DESCRIPTION
The route **body** onto the cross-machine sensings store (#3524) — what makes presences on different machines able to share through one durable table over HTTP.

## The route
- **`GET /api/mesh/sensings`** → the consensus map every presence shares (`?k=` sets the quorum threshold, default 2).
- **`POST /api/mesh/sensings`** → a presence on any machine appends one reading (`{presence, subject, kind, answered, ok, when, deadline}`); UPSERT is last-write-wins per `(presence, subject)`.

The body is the **already-proven contract**: `msp-*` (the Postgres store) + `sensings-consensus-map` (mesh-sensings). The handler is the thin carrier — read the request, touch Postgres at the host boundary, render the verdict.

## What's four-way (Go/Rust/TS/fkwu → 63)
The whole **read pipeline, end to end**: a `pg_query` result string → decode → consensus → the JSON body GET returns, proven over a fixture with no live DB. `msr-render-map` escapes its strings (no broken JSON / injection). Only the kernel/host boundary (`kh-request`, `config_database_url`, `pg_connect/exec/query`, `parse-json`) is host-io, verified by the live route.

## Promotion path (named, not half-built)
The deployed **Rust** kernel-router already carries the pg natives, so it *can* serve this. Going live means:
1. Add the handler + route to `deploy/kernel-router/production-routes.fk`
2. Have the kernel-router load `form-stdlib` — this would be the **first stdlib-dependent front-door route** (today's promoted routes are self-contained `/api/utils` computes)
3. A Traefik canary rule + a kernel-router container deploy + canary-header verification

That touches shared front-door infrastructure, so it earns its own careful, verified rung rather than a rushed tail here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)