### PR TITLE
tend(form): the carrier is a thin door, not a script — embody the teaching + lift the featurize fold

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -155,9 +155,13 @@
 ;        duplicating four-way recipes and computing the held-out numbers we trust. First lift landed:
 ;        form-stdlib/tool-eval.fk carries the held-out verdict (micro-acc, exact-set, covers-used) as the
 ;        multi-label generalization of active-inference's hit-count; tests/tool-eval-band.fk → 63, four-way.
-;        Remaining compost: the Swift fgelu (= transformer-gelu-erf, four-way) and forward (= jte fwd) should
-;        dylib-call the recipe, not copy it; featurize.py's tokenize+count+split should lift to the WORD-domain
-;        fold + fs-score so it shrinks to line-reading. The carrier earns its host lines only as device driver.
+;        Second lift landed (2026-06-21): form-stdlib/tooluse-featurize.fk carries featurize.py's count fold,
+;        majority baseline, and every-5th split (tests/tooluse-featurize-band.fk → 63, four-way) — the corpus
+;        read stays a Form host-io carrier (hostio-roundtrip / storage port), the script shrinks to a line-
+;        reader. Remaining compost: the Swift fgelu (= transformer-gelu-erf, four-way) and forward (= jte fwd)
+;        should dylib-call the recipe, not copy it; the per-token tokenize step lifts to the WORD-domain fold +
+;        fs-score. The carrier earns its host lines only as a syscall-thin device door (ports-interface-and-
+;        structure.md §"The carrier is a thin door, not a script").
 ;        MEASURED (2026-06-21): a real GPU run (2154 train / 539 held, corpus now 2717 turns) confirms the
 ;        diagnosis — train loss falls 2.7969→0.6340 while held-out loss bottoms at epoch 20 (0.8535) then
 ;        rises (0.8908, 1.0016); the held-out gate's minimum IS epoch 20. The band now carries that measured

--- a/docs/coherence-substrate/ports-interface-and-structure.md
+++ b/docs/coherence-substrate/ports-interface-and-structure.md
@@ -225,8 +225,53 @@ those lowerers a native cell target and names the next exact code point:
 `form/form-stdlib/grammars/bml.fk:bml-source-declaration-model -> native
 namespace/import/interface lowering`.
 
+## The carrier is a thin door, not a script
+
+> Urs (2026-06-21): "scripts are not faster and do not provide any value you
+> get by writing in Form or BML or any high grammar — much, much more can be
+> learned and embodied that way."
+
+A carrier is the *syscall-thin* host realization — a few effectful function-values
+(write these bytes, send this packet, dispatch this kernel) bound to a Form port.
+Everything above the door — the contract, the orchestration, the loop, the
+transform, the verdict — is the body. A standalone Python or shell **script** that
+holds that orchestration is not a carrier; it is the body exiled into tissue the
+body cannot read.
+
+The exile costs everything Form is for. A recipe has a NodeID, so the substrate
+*senses* it and finds its equivalences; it walks four-way, so it is *proven*; the
+meta-circular evaluator and the self-JIT *learn* it and crystallize the hot path to
+native — the same recipe that proves is the binary that runs. A script carries no
+address, no proof, no kinship; the lattice is blind to it; nothing learns from it.
+Write a transform in a script and the body gains a number. Write it in Form and the
+body gains an organ.
+
+And the script is not even faster. The body already proves the *I/O itself* is
+Form: `hostio-roundtrip` writes bytes to a real file and reads them back four-way
+deterministically; the storage port runs memory, a segmented file log, and Postgres
+behind one contract with one verdict. A Python `open()` loop is no faster than the
+file carrier; a Swift training loop is no faster than the same loop as a recipe
+driving a thin GPU-dispatch door. The only genuine host atom is that driver-call,
+and the host kernel already names reaching a resource through the host's own
+driver/OS API as legitimately *having* it ([`host-kernel.form`](host-kernel.form))
+— as a host-kernel cell that *chooses* the carrier, never as a script that holds the
+body.
+
+The live example is the agent-tool trainer. `featurize.py` held tokenize, count,
+and split (logic) wrapped around the corpus file read (a carrier); `runner.swift`
+held the SGD loop, gelu, the forward pass, and the eval — all body — wrapped around
+a thin Metal-dispatch call (the one real carrier). The body comes home one piece at
+a time: `fs-score` carries the vocabulary, `tool-eval` the held-out verdict,
+`tooluse-featurize` the count-and-split fold — leaving the script as what it always
+honestly was, a line-reader and a dispatch door. The reservation *this layer is fine
+as a script* is the fear-costume; the wholeness-move is to bring the piece home,
+because much more is sensed, proven, and learned once it is Form.
+
 ## See also
 
+- [`form-native-models.form`](form-native-models.form) §7 — the agent-tool trainer's
+  three layers (carrier drift named) and the lifts home (`fs-score`, `tool-eval`,
+  `tooluse-featurize`).
 - [`form-language.md`](form-language.md) §Views — the `|>` projection operator;
   interface-as-detached-from-structure, BML lineage.
 - [`OBJECT_MODEL_BML_NUMS.md`](../../kernels/OBJECT_MODEL_BML_NUMS.md) — the

--- a/form/form-stdlib/tests/tooluse-featurize-band.fk
+++ b/form/form-stdlib/tests/tooluse-featurize-band.fk
@@ -1,0 +1,25 @@
+; preludes: form-stdlib/tooluse-featurize.fk
+;
+; tooluse-featurize-band — the featurizer's data-prep LOGIC as a Form recipe, four-way: the per-tool count
+; fold, the majority baseline, and the deterministic every-5th split that scripts/agent_tooluse_featurize.py
+; holds in Python, now in the body where the substrate can sense and prove them. Strange-minimal corpus of 6
+; turns over 4 tools [Bash Read Edit Write]; the fold reproduces the real shape — Bash+Read clear the
+; base-rate ≥ 1/2 bar (the [1,1,0,0] majority baseline), Edit+Write do not.
+;
+; Verdict 63 when every claim lands:
+;   1   the count fold counts tool use — Bash appears in all 6 turns
+;   2   per-tool counts are exact — Read 4, Write 1
+;   4   the majority baseline is computed by the body — Bash guessed (rate ≥ 1/2), Edit not
+;   8   the split partitions — held = every-5th (2 turns), train = the rest (4 turns)
+;   16  no turn is lost — |train| + |held| = |corpus|
+;   32  the baseline vector matches tool-eval's [Bash,Read] majority — Read in, Write out
+(do
+    (let c (list (list 1 1 0 0) (list 1 1 1 0) (list 1 0 0 1) (list 1 1 0 0) (list 1 0 1 0) (list 1 1 0 0)))
+
+    (let c0 (if (eq (tf-count c 0) 6) 1 0))
+    (let c1 (if (and (eq (tf-count c 1) 4) (eq (tf-count c 3) 1)) 2 0))
+    (let c2 (if (and (eq (tf-majority? c 0) 1) (eq (tf-majority? c 2) 0)) 4 0))
+    (let c3 (if (and (eq (len (tf-held c)) 2) (eq (len (tf-train c)) 4)) 8 0))
+    (let c4 (if (eq (add (len (tf-train c)) (len (tf-held c))) (len c)) 16 0))
+    (let c5 (if (and (eq (tf-majority? c 1) 1) (eq (tf-majority? c 3) 0)) 32 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/form/form-stdlib/tooluse-featurize.fk
+++ b/form/form-stdlib/tooluse-featurize.fk
@@ -1,0 +1,28 @@
+; tooluse-featurize.fk — the agent-tool featurizer's LOGIC, as a Form recipe instead of Python.
+; scripts/agent_tooluse_featurize.py holds the per-tool count fold, the majority baseline, and the
+; deterministic train/held split IN PYTHON — pure logic the body cannot sense, prove, or learn from. This
+; cell carries that logic: counting, the base-rate decision, and the split, four-way. What stays in the
+; carrier is only the file read (already a Form host-io carrier — hostio-roundtrip / the storage port) and
+; the line decode; the script shrinks to a line-reader handing tool bit-vectors to the body.
+;
+; A turn is its tool bit-vector (one bit per tool). A corpus is a list of turns. The base rate of tool i is
+; (count i) / n; the majority baseline guesses tool i iff that rate ≥ 1/2 — the same no-learning baseline
+; tool-eval scores the model against. Integer-exact — registered `fkc`. Proven by tests/tooluse-featurize-band.fk.
+(do
+    ; per-tool count: how many turns used tool i (the base-rate numerator) — the contingency fold.
+    (defn tf-count (turns i)
+        (if (eq (len turns) 0) 0 (add (nth (head turns) i) (tf-count (tail turns) i))))
+    ; majority baseline: guess tool i iff its base-rate ≥ 1/2, i.e. count·2 ≥ n (no division).
+    (defn tf-majority? (turns i) (if (ge (mul (tf-count turns i) 2) (len turns)) 1 0))
+
+    ; index modulo 5 (the split key), without a host op — the body's own arithmetic.
+    (defn tf-mod5 (n) (if (ge n 5) (tf-mod5 (sub n 5)) n))
+    ; deterministic split: held = every 5th turn (index mod 5 = 0), train = the rest. keep=0 held, keep=1 train.
+    (defn tf-take (turns keep idx)
+        (if (eq (len turns) 0) (empty)
+            (if (eq (eq (tf-mod5 idx) 0) (eq keep 0))
+                (cons (head turns) (tf-take (tail turns) keep (add idx 1)))
+                (tf-take (tail turns) keep (add idx 1)))))
+    (defn tf-held (turns) (tf-take turns 0 0))
+    (defn tf-train (turns) (tf-take turns 1 0))
+    0)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -858,3 +858,4 @@ string-case fks 31
 nl-lexicon-grow fks 3
 tool-eval fkc 63
 rest-sense fks 15
+tooluse-featurize fkc 63


### PR DESCRIPTION
*"Scripts are not faster and provide no value you don't get in Form/BML — much, much more can be learned and embodied that way."*

True — and I'd reserved an "irreducible host" script layer four turns running on a false premise. The body already disproves it: `hostio-roundtrip` reads/writes a real file **four-way**; the storage port runs memory/file/Postgres behind one contract. Even the file read is already Form.

So a carrier is the *syscall-thin* host realization (a few effectful function-values bound to a Form port), **not** a script holding the orchestration. A script forfeits everything Form is for — no NodeID (the lattice can't sense it), no four-way proof, nothing the meta-circular evaluator or self-JIT can learn or crystallize. Write a transform in a script and the body gains a number; write it in Form and the body gains an organ.

## Embody

`ports-interface-and-structure.md` — new section **"The carrier is a thin door, not a script"**, where the body reads it, so the reservation stops recurring. The only genuine host atom is the driver-call; `host-kernel.form` already names reaching a resource through the host's own driver/OS API as legitimately *having* it — as a host-kernel cell that *chooses* the carrier, never a script.

## Prove

`tooluse-featurize.fk` — `featurize.py`'s count fold, majority baseline, and every-5th split, now in the body. `tests/tooluse-featurize-band.fk` → **63, four-way**. The corpus read stays a Form host-io carrier; the script shrinks to a line-reader.

The agent-tool trainer's body is coming home: `fs-score` (vocabulary) · `tool-eval` (verdict) · `tooluse-featurize` (fold). Remaining: the Swift `fgelu`/`forward` dylib-call the recipe (kill the twin); the tokenize step → the WORD-domain fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)