### PR TITLE
fix(form-cli): run/do session log appends via stdin — last /tmp leak gone, Android-clean

### DIFF
--- a/form/form-stdlib/form-native-run.fk
+++ b/form/form-stdlib/form-native-run.fk
@@ -131,8 +131,9 @@
 (defn fnr-recent ()
     (host-exec "tail -c 1500 $HOME/.coherence-network/form-cli-sessions.log 2>/dev/null"))
 (defn fnr-persist (transcript)
-    (do (host-write "/tmp/fnr_session.txt" transcript)
-        (host-exec "cat /tmp/fnr_session.txt >> $HOME/.coherence-network/form-cli-sessions.log; printf '\\n=== /turn ===\\n' >> $HOME/.coherence-network/form-cli-sessions.log")))
+    ; pipe the transcript to the appending shell via stdin (host-exec's 2nd arg) —
+    ; no /tmp hop, so this persists on Android too, where /tmp does not exist.
+    (host-exec "cat >> $HOME/.coherence-network/form-cli-sessions.log; printf '\\n=== /turn ===\\n' >> $HOME/.coherence-network/form-cli-sessions.log" transcript))
 
 ; tiered entry WITH memory: prepend recent session context, run local-first+escalating, persist the run
 ; (the persisted transcript is both cross-turn memory AND a training corpus of real agent work).


### PR DESCRIPTION
`fnr-persist` wrote the transcript to `/tmp/fnr_session.txt` then `cat`'d it into the durable `$HOME` log — the **last `/tmp` dependency in the `form-cli run`/`do` lane**, broken on Android where `/tmp` doesn't exist. Now the transcript pipes straight to the appending shell via `host-exec`'s stdin arg (`cat >> $LOG; printf sep >> $LOG`). No `/tmp` hop.

With the oracle call already filesystem-free + subscription-only ([#3510](https://github.com/seeker71/Coherence-Network/pull/3510), [#3529](https://github.com/seeker71/Coherence-Network/pull/3529)), the whole run/do lane now needs **no writable temp dir at all** — it persists on Android.

## Verified
- No `/tmp/fnr_session.txt` is created; the transcript still reaches the durable log.
- `form-native-run` stays **63** four-way (host-io, outside the band witness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)