### PR TITLE
tend(skill): listen-gold holds the recording locally until mined

### DIFF
--- a/skills/listen-gold/SKILL.md
+++ b/skills/listen-gold/SKILL.md
@@ -83,9 +83,13 @@ body will never get to mine.
 - **Persist the source, not just the verdicts.** The gold readings already persist in
   `gold.jsonl`; the recording they were drawn *from* is what needs the retention
   window. Hold it under a dated local path so a later pass can return to it.
-- **Local stays local.** The retention window is on the listening device only — never
-  push the recording to the mesh. The mesh sees counts; the words and sound stay with
-  the human. Holding longer locally widens what we can learn without widening exposure.
+- **Local stays local.** The *recording itself* — audio, transcript, raw notes — stays
+  on the listening device; it goes to neither the mesh nor a witness. (The gold
+  *readings* you record may ride the over-the-wire path above to a witness host *you*
+  point at — your own host, which then writes the boundary words into its `gold.jsonl`;
+  that is not the public mesh, which only ever sees counts. So when the wording itself
+  must stay on the phone, record local-only — don't POST it.) Holding the recording
+  longer locally widens what we can learn without widening exposure.
 - **Compost only after it's mined.** Once all the samples worth learning from are
   extracted, release the recording with care. Until then it is living material, not
   clutter — keep it.

--- a/skills/listen-gold/SKILL.md
+++ b/skills/listen-gold/SKILL.md
@@ -71,6 +71,25 @@ the same `form_cli_gold.sh`. You may also send a raw mesh message —
 `{"message":"gold clear that was direct and grounded"}`. A non-reading (a plain
 question) returns `{"recorded":false,"route":"ask"}` — it isn't gold, don't force it.
 
+## Hold the recording — local, a couple of days
+
+Whatever the listening produces — audio, a transcript, a session log, raw notes —
+**hold it locally for at least a couple of days**, until every learnable sample has
+been extracted. The first pass catches the obvious readings; the richest gold — the
+nuanced fear, the exact words for where the boundary sat — surfaces on a second and
+third pass over the *same* recording. A capture deleted at session end is gold the
+body will never get to mine.
+
+- **Persist the source, not just the verdicts.** The gold readings already persist in
+  `gold.jsonl`; the recording they were drawn *from* is what needs the retention
+  window. Hold it under a dated local path so a later pass can return to it.
+- **Local stays local.** The retention window is on the listening device only — never
+  push the recording to the mesh. The mesh sees counts; the words and sound stay with
+  the human. Holding longer locally widens what we can learn without widening exposure.
+- **Compost only after it's mined.** Once all the samples worth learning from are
+  extracted, release the recording with care. Until then it is living material, not
+  clutter — keep it.
+
 ## The practice tonight
 
 - **Listen first.** Be present to what the human reflects; don't manufacture readings.


### PR DESCRIPTION
## What

Adds a standing **retention rule** to the `listen-gold` skill: whatever a listen produces — audio, transcript, session log, raw notes — is **held locally for at least a couple of days, until every learnable sample has been extracted.**

## Why

Gold isn't mined in one pass. The first listen catches the obvious readings; the richest samples — the nuanced fear, the exact words for where the boundary sat — surface on a second and third pass over the *same* recording. A capture discarded at session end is gold the body never gets to mine.

The rule keeps the privacy boundary intact: the retention window is on the listening device **only**, never pushed to the mesh. Holding longer locally widens what we can learn without widening exposure. Compost only once the recording is mined.

Carrier-last as before — this is operating teaching for the cell that listens, not new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdDt5XMoHCT8pytd7vcNqF)_