### PR TITLE
fix(host): kernel memory witness — a runaway Form kernel dies alone, not the whole Mac

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 321 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 323 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 321
+**Total files**: 323
 
 | File | Purpose |
 |---|---|
@@ -176,6 +176,7 @@
 | [influence_teaching_translator.py](influence_teaching_translator.py) | Print influence teaching translator shards for a field story. |
 | [ingest_audible_books_full_trace.py](ingest_audible_books_full_trace.py) | Lay every Audible book as a first-class asset with full source trace. |
 | [ingest_audible_history.py](ingest_audible_history.py) | Flow Audible listening history into the graph. |
+| [install_kernel_memory_witness.sh](install_kernel_memory_witness.sh) | install_kernel_memory_witness.sh — bring the kernel memory witness home. |
 | [integrate_one_branch.sh](integrate_one_branch.sh) | Integrate one remote branch into main: rebase, add evidence, push, create PR, merge. |
 | [intern_canonical_words.py](intern_canonical_words.py) | intern_canonical_words.py — CLI wrapper for the canonical lexicon interner. |
 | [intern_modality_blueprints.py](intern_modality_blueprints.py) | intern_modality_blueprints.py — CLI wrapper for the cross-modal interner. |
@@ -184,6 +185,7 @@
 | [kb_common.py](kb_common.py) | Shared utilities for KB sync scripts. |
 | [kernel_attribution_report.py](kernel_attribution_report.py) | Kernel attribution-activity report — which Blueprints/Recipes/natives fire. |
 | [kernel_front_door_local_preflight.sh](kernel_front_door_local_preflight.sh) | _no top-of-file purpose_ |
+| [kernel_memory_witness.sh](kernel_memory_witness.sh) | kernel_memory_witness.sh — a host guardian (carrier tissue, not Form logic). |
 | [kernel_readiness_harness.py](kernel_readiness_harness.py) | kernel_readiness_harness.py — readiness evidence for the API → Form-kernel flip. |
 | [live_audio_copresence_receipt.sh](live_audio_copresence_receipt.sh) | live_audio_copresence_receipt.sh — live speaker→microphone FSK nonce receipt. |
 | [live_speech_loop_receipt.sh](live_speech_loop_receipt.sh) | live_speech_loop_receipt.sh - known text played over speaker, heard by live mics. |

--- a/scripts/install_kernel_memory_witness.sh
+++ b/scripts/install_kernel_memory_witness.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install_kernel_memory_witness.sh — bring the kernel memory witness home.
+#
+# Mirrors the presence-carrier pattern: the canonical guardian lives in the repo
+# (scripts/kernel_memory_witness.sh, version-controlled, reproducible on any
+# machine); this installer copies it to a stable runtime location that survives
+# worktree cleanup, writes a launchd agent, and loads it. Idempotent — re-running
+# refreshes the runtime copy and reloads the agent.
+set -euo pipefail
+
+LABEL="earth.hati.coherence.kernel-memory-witness"
+SRC="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)/kernel_memory_witness.sh"
+RUN_DIR="$HOME/.coherence-witness"
+RUN_SH="$RUN_DIR/kernel-memory-witness.sh"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG_DIR="$HOME/Library/Logs/CoherenceSense"
+CAP_GB="${FORM_KERNEL_MEM_CAP_GB:-16}"
+
+mkdir -p "$RUN_DIR" "$LOG_DIR" "$(dirname "$PLIST")"
+cp "$SRC" "$RUN_SH"
+chmod +x "$RUN_SH"
+
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>$RUN_SH</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>FORM_KERNEL_MEM_CAP_GB</key>
+    <string>$CAP_GB</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>$LOG_DIR/kernel-memory-witness.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>$LOG_DIR/kernel-memory-witness.err.log</string>
+</dict>
+</plist>
+PLIST_EOF
+
+# Reload cleanly (unload-if-present, then load).
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST"
+
+echo "installed + loaded: $LABEL"
+echo "  runtime : $RUN_SH"
+echo "  plist   : $PLIST"
+echo "  cap     : ${CAP_GB} GB"
+echo "  log     : $LOG_DIR/kernel-memory-witness.log"
+launchctl list | grep -F "$LABEL" || true

--- a/scripts/kernel_memory_witness.sh
+++ b/scripts/kernel_memory_witness.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# kernel_memory_witness.sh — a host guardian (carrier tissue, not Form logic).
+#
+# The Form kernels (Go / Rust / TS / fkwu) run UNBOUNDED by design: a four-way
+# proof walk is meant to use the host's full stack and heap. macOS does not
+# enforce RLIMIT_AS (`ulimit -v` is silently ignored), so a single
+# non-terminating band can balloon ONE kernel process to ~100 GB and OOM the
+# whole machine — the JetsamEvent cascade (vm-compressor-space-shortage ->
+# hundreds of system daemons jettisoned) that froze this Mac twice on
+# 2026-06-21. The Rust arm is the catastrophic shape: where Go/TS/fkwu hit a
+# stack wall and die alone, Rust allocates on the heap and runs to ~100 GB.
+#
+# This witness watches ONLY the kernel processes (by command substring — never
+# claude / MCP / other node) and SIGKILLs any one that crosses a generous
+# ceiling, so a runaway dies alone instead of taking the Mac down. Every catch
+# is named (log + notification + mesh) so the non-terminating band becomes a
+# visible, huntable event rather than a silent crash.
+#
+# It is a NET, not the fix. The durable fix is the kernel self-limiting and the
+# non-terminating recipe healed at the source. This only guarantees the machine
+# survives long enough to hunt that band safely. The cost of a false-positive
+# kill (a legit >ceiling band shows as a failed leg, an agent investigates) is
+# far smaller than the cost the net prevents (the whole machine going down).
+set -uo pipefail
+
+CAP_GB="${FORM_KERNEL_MEM_CAP_GB:-16}"          # legit bands use <2 GB; 100 GB killed the Mac
+INTERVAL="${FORM_KERNEL_WITNESS_INTERVAL:-2}"   # one ps+awk every INTERVAL s — negligible
+CAP_KB=$(( CAP_GB * 1024 * 1024 ))
+LOG="${FORM_KERNEL_WITNESS_LOG:-$HOME/Library/Logs/CoherenceSense/kernel-memory-witness.log}"
+COORD="${FORM_KERNEL_WITNESS_COORD:-/Users/ursmuff/source/Coherence-Network/scripts/agent-coord.sh}"
+
+# Match only Form kernel processes. These substrings never appear in the claude
+# CLI, the MCP node servers, or any other host process.
+PATTERN='form-kernel-rust|form-kernel-ts|form-kernel-go|/bin-go( |$)|(^|/)fkwu'
+
+mkdir -p "$(dirname "$LOG")"
+log() { printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >> "$LOG"; }
+
+log "kernel-memory-witness up — cap=${CAP_GB}GB interval=${INTERVAL}s"
+
+while true; do
+  # awk does the cheap numeric filter; the per-pid command lookup (and any kill)
+  # only happens for the RARE process already over the ceiling. ps RSS is in KB.
+  while read -r pid rss; do
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    cmd="$(ps -p "$pid" -o command= 2>/dev/null)" || continue
+    [[ -n "$cmd" ]] || continue
+    case "$cmd" in *kernel_memory_witness*) continue ;; esac   # never ourselves
+    printf '%s' "$cmd" | grep -Eq "$PATTERN" || continue
+    gb=$(( rss / 1024 / 1024 ))
+    log "RUNAWAY KILL pid=$pid rss=${gb}GB (cap=${CAP_GB}GB) cmd=${cmd:0:180}"
+    if kill -9 "$pid" 2>/dev/null; then
+      log "  killed $pid"
+    else
+      log "  kill failed $pid (already gone?)"
+    fi
+    osascript -e "display notification \"Killed a runaway Form kernel at ${gb}GB before it could OOM the Mac. A band is non-terminating — hunt it.\" with title \"Coherence — kernel memory witness\" sound name \"Basso\"" 2>/dev/null || true
+    # publish the catch onto the mesh so it is witnessable, not only local
+    [[ -f "$COORD" ]] && COORD_AGENT=kernel-witness bash "$COORD" share \
+      "killed a runaway Form kernel at ${gb}GB (cap ${CAP_GB}GB) — a band is non-terminating; hunt it" \
+      >/dev/null 2>&1 || true
+  done < <(ps -axo pid=,rss= | awk -v cap="$CAP_KB" '$2+0 > cap {print $1, $2}')
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## What this fixes

Diagnosed a twice-today Mac OOM crash to its ground truth. macOS `JetsamEvent` reports from **2026-06-21 17:22 and 18:23** both name `largestProcess = form-kernel-rust` at **~103 GB lifetimeMax** on a single process — everything else (Chrome, node, claude) was ≤8 GB. One Rust Form-kernel invocation ate essentially all 128 GB → `vm-compressor-space-shortage` → hundreds of system daemons `jettisoned` = the machine froze.

A single non-terminating Form band hits every kernel arm differently: TS (`node`) stack-overflows (bounded, dies alone), fkwu segfaults (bounded), but the **Rust arm allocates on the heap and runs to ~100 GB** — catastrophic, because macOS does **not** enforce `ulimit -v` (verified: 2 GB allocated under a 512 MB cap), so nothing stops it.

## The fix (a net, not the cure)

`kernel_memory_witness.sh` — a host guardian (carrier tissue), mirroring the presence/sense launchd carriers. Watches **only** the four kernel arms by command substring (`form-kernel-rust|-ts|-go|/bin-go|fkwu` — never claude/MCP/other node) and SIGKILLs any one crossing a generous ceiling (default 16 GB; legit bands use <2 GB). Catches are named (log + macOS notification + mesh share) so the runaway band becomes a **visible, huntable event** instead of a silent crash.

`install_kernel_memory_witness.sh` — idempotent installer: stable runtime copy under `~/.coherence-witness/` + a `KeepAlive`/`RunAtLoad` launchd agent. **Already installed + loaded on this Mac.**

## Verified
- Matching test: all four arms caught; claude / MCP / sense-organ / openclaw-node ignored.
- End-to-end kill test: a fake `fkwu` process (315 MB) over a 100 MB test cap was killed; the claude session (445 MB, non-matching) untouched.
- Live: witness running, logging `up — cap=16GB interval=2s`.

## Next (now safe)
The durable fix is the **kernel self-limiting** + the **non-terminating band healed at the source**. Hunting it is now safe — reproduction can no longer take the machine down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)