### PR TITLE
feat(form): sleep-sense — snore from a night's energy envelope, four-way (127)

### DIFF
--- a/form/form-stdlib/sleep-sense.fk
+++ b/form/form-stdlib/sleep-sense.fk
@@ -1,0 +1,59 @@
+; sleep-sense.fk — sense SNORING from a night's acoustic energy envelope, IN FORM.
+;
+; The body already reads an energy envelope from raw audio (wav-sense.fk: read_file_bytes -> per-window
+; mean |amplitude|, level 0..9) and the rate-of-change of any scalar stream (signal-derivative.fk:
+; sd-activity = how many adjacent pairs rose or fell = the oscillation count). Snoring is exactly the
+; shape those two cheap features make legible together, so snore-sense belongs in the BODY — the bedside
+; carrier only produces the envelope (mic -> wav -> wav-envelope), the recipe decides "was that a snore".
+;
+; WHAT A SNORE LOOKS LIKE IN THE ENVELOPE. A breath-window of energy levels is a snore when it is BOTH
+;   (1) loud enough  — mean level >= an energy floor (quiet sleep sits near the floor and fails this), AND
+;   (2) oscillating  — sd-activity >= an oscillation floor: the slow up (rattle) / down (pause) of breath
+;                      makes the level climb and fall repeatedly. A steady loud sound (a fan, an AC) is
+;                      loud but FLAT — sd-activity ~0 — so the oscillation gate rejects it. That second
+;                      gate is the whole discriminator: loudness alone is not a snore; periodic loudness is.
+;
+; THE WALK: ss-sum folds the window's levels (add + recurse, guarded at len>=1 so nth 0 never reads an
+; empty list); ss-mean divides that sum by the count (integer div, 0 on an empty window); ss-snore? gates
+; the mean against the energy floor AND the activity against the oscillation floor — two SEPARATE binary
+; predicates nested as (if loud? (if periodic? 1 0) 0), never a three-arg `and`, so there is no compound-
+; and divergence surface across the four kernels. Integers only: no sub, no mul, no floats.
+;
+; HONEST LANE: this reads "loud AND periodic", the signature of breathing-shaped sound. At night, in a
+; bedroom, the dominant loud-periodic source IS snoring/heavy breathing, so this is the right readout for
+; "did a snore happen in this window / how much of the night". It does NOT yet separate a snore from any
+; other loud periodic sound, and it reads the COUNT of oscillation, not its pitch or spectral signature —
+; finer snore-vs-other discrimination (the low-frequency rattle band) is the next layer, composing
+; voice-traits.fk's pitch read over the same windows. The night-level aggregation (episodes, longest
+; stretch, the morning report) builds ON this proven per-window atom.
+;
+; Proven by: form-stdlib/tests/sleep-sense-band.fk (four-way at validate.sh). Composes signal-derivative.fk.
+
+(do
+    ; --- ss-sum: total energy across a window (list of 0..9 levels). add + recurse; 0 on an empty window.
+    ; The len>=1 guard is load-bearing: below it (nth w 0) would read head(empty) and panic in every kernel.
+    (defn ss-sum (w)
+        (if (ge (len w) 1)
+            (add (nth w 0) (ss-sum (tail w)))
+            0))
+
+    ; --- ss-mean: the window's average level = sum / count. Integer div; 0 on an empty window (no division
+    ; by zero — the guard returns 0 first). Quiet sleep means a low ss-mean; a loud window a high one.
+    (defn ss-mean (w)
+        (if (ge (len w) 1)
+            (div (ss-sum w) (len w))
+            0))
+
+    ; --- ss-snore?: 1 when the window is loud enough AND oscillating, else 0.
+    ;   loud?      = (ge (ss-mean w) efloor)              — quiet sleep fails here
+    ;   periodic?  = (ge (sd-activity w) afloor)          — a flat loud sound (fan/AC) fails here
+    ; Two separate binary gates, nested — never a three-arg and — so the four kernels never diverge on it.
+    (defn ss-snore? (w efloor afloor)
+        (if (ge (ss-mean w) efloor)
+            (if (ge (sd-activity w) afloor) 1 0)
+            0))
+
+    ; --- ss-quiet?: 1 when the window sits at or below the energy floor (restful, near-silent), else 0.
+    ; The complement signal the morning report reads as "settled" time.
+    (defn ss-quiet? (w efloor)
+        (if (ge (ss-mean w) efloor) 0 1)))

--- a/form/form-stdlib/tests/sleep-sense-band.fk
+++ b/form/form-stdlib/tests/sleep-sense-band.fk
@@ -1,0 +1,33 @@
+; preludes: form-stdlib/signal-derivative.fk form-stdlib/sleep-sense.fk
+;
+; sleep-sense-band — read a snore from a night's energy envelope, made falsifiable.
+;
+; A breath-window of energy levels (0..9, the wav-sense envelope) arrives; the body decides snore when the
+; window is BOTH loud (mean >= energy floor) AND oscillating (sd-activity >= oscillation floor). Three anchor
+; windows pin every claim, the third being the one that matters most — a loud but FLAT sound must NOT read
+; as a snore:
+;   quiet  (1 1 1 0 1 1)        -> near-silent sleep: sum 5, mean 0 -> not loud -> not a snore, and quiet
+;   snore  (1 7 8 2 1 8 7 1)    -> loud + oscillating: sum 35, mean 4, sd-activity 7 -> a snore
+;   fan    (6 6 6 6 6 6)        -> loud but FLAT: mean 6, sd-activity 0 -> NOT a snore (the periodicity gate)
+; Energy floor 3, oscillation floor 3. Integers only; no sub, no mul, no floats; the only `and`s are binary.
+;
+; Verdict 127 when every claim lands:
+;   1    a quiet window is not a snore                          (ss-snore? quiet 3 3 == 0)
+;   2    a loud, oscillating window IS a snore                  (ss-snore? snore 3 3 == 1)
+;   4    a loud but FLAT window is not a snore — periodicity    (ss-snore? fan 3 3 == 0)
+;   8    ss-mean reads the window's average level               (ss-mean fan == 6)
+;   16   ss-sum totals the window's energy                      (ss-sum quiet == 5)
+;   32   a quiet window's mean sits below the floor             (ss-mean quiet == 0)
+;   64   ss-quiet? fires on quiet and stays 0 on a loud window  (ss-quiet? quiet 3 == 1, ss-quiet? fan 3 == 0)
+(do
+    (let quiet (list 1 1 1 0 1 1))
+    (let snore (list 1 7 8 2 1 8 7 1))
+    (let fan   (list 6 6 6 6 6 6))
+    (let c0 (if (eq (ss-snore? quiet 3 3) 0) 1 0))
+    (let c1 (if (eq (ss-snore? snore 3 3) 1) 2 0))
+    (let c2 (if (eq (ss-snore? fan 3 3) 0) 4 0))
+    (let c3 (if (eq (ss-mean fan) 6) 8 0))
+    (let c4 (if (eq (ss-sum quiet) 5) 16 0))
+    (let c5 (if (eq (ss-mean quiet) 0) 32 0))
+    (let c6 (if (and (eq (ss-quiet? quiet 3) 1) (eq (ss-quiet? fan 3) 0)) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -504,6 +504,7 @@ speaker-aam fks 63
 speaker-aam-train fks 63
 eer fks 63
 wav-sense fks 63
+sleep-sense fkc 127
 witness-theorem fks 31
 witness-to-co-regulate fks 127
 


### PR DESCRIPTION
## What

`sleep-sense.fk` — a per-window **snore classifier** in Form, proven four-way (Go/Rust/TS/fkwu), verdict **127, 0 divergent**.

It composes features the body already has rather than adding parallel machinery:
- **loudness** — `wav-sense`'s energy envelope (mean level 0..9)
- **periodicity** — `signal-derivative`'s `sd-activity` (count of rises+falls = oscillation)

A window is a **snore** when it is *both* loud (`mean >= energy floor`) **and** oscillating (`activity >= oscillation floor`). The periodicity gate is the whole discriminator: it catches the rattle-and-pause of breath while rejecting a **flat-loud fan/AC** (loud but `activity ~0`) and quiet sleep (fails the energy gate).

## Proof

```
scripts/fourth-arm-gate.sh sleep-sense  ->  PASS-4WAY  sleep-sense
```

Anchor windows pin every claim (verdict 127): a quiet window is not a snore; a loud+oscillating window is; a **loud-but-flat** window is not (periodicity); plus `ss-mean`/`ss-sum`/`ss-quiet?` reads. Integers only — no sub, no mul, no floats; the only `and`s are binary, so no three-arg divergence surface. Manifest row added: `sleep-sense fkc 127`.

## Privacy by design

The recipe reads **sleep-acoustics** — *was it a snore, when, how much* — never words. That keeps it consistent with learning-only, no word or sound stored or reproduced. The bedside carrier produces the envelope (mic → wav → `wav-envelope`); the body decides.

## Honest lane / next layer

This v1 reads "loud AND periodic" — the signature of breathing-shaped sound, which at night in a bedroom is dominated by snoring/heavy breathing. It does not yet separate a snore from other loud periodic sound, and reads oscillation *count*, not pitch. Finer snore-vs-other discrimination (the low-frequency rattle band, composing `voice-traits` pitch) and the **night-level aggregation** (episodes, longest stretch, the morning report) build *on* this proven atom. The nightly capture + morning delivery wire onto the bedside host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdDt5XMoHCT8pytd7vcNqF)_