### PR TITLE
feat(form): sleep-night — fold a night's snore verdicts into the morning readout, four-way (127)

### DIFF
--- a/form/form-stdlib/sleep-night.fk
+++ b/form/form-stdlib/sleep-night.fk
@@ -1,0 +1,39 @@
+; sleep-night.fk — fold a night of per-window snore verdicts (0/1) into the morning readout, IN FORM.
+;
+; The bedside carrier classifies each breath-window with ss-snore? (sleep-sense.fk) into a 0/1 stream
+; across the night. This recipe turns that stream into what a person reads in the morning: how many
+; windows, how many snored, the longest unbroken snore run, how many separate episodes, and the percent
+; of the night spent snoring. Integers only; the input is a 0/1 verdict list — no audio, no words.
+;
+; Proven by: form-stdlib/tests/sleep-night-band.fk (four-way at validate.sh). Builds on the sleep-sense atom.
+
+(do
+    ; total windows in the night
+    (defn sn-total (xs) (len xs))
+
+    ; snore windows = sum of the 0/1 stream (guard at len>=1 so nth 0 never reads empty)
+    (defn sn-snores (xs)
+        (if (ge (len xs) 1) (add (nth xs 0) (sn-snores (tail xs))) 0))
+
+    ; longest unbroken run of snore-windows. Walk carrying (cur run length, best so far).
+    ; On a 1 the current run grows and best rises to meet it; on a 0 the current run resets.
+    (defn sn-run (xs cur best)
+        (if (ge (len xs) 1)
+            (if (eq (nth xs 0) 1)
+                (sn-run (tail xs) (add cur 1) (if (ge (add cur 1) best) (add cur 1) best))
+                (sn-run (tail xs) 0 best))
+            best))
+    (defn sn-longest (xs) (sn-run xs 0 0))
+
+    ; episode count = rising edges: a 1 whose predecessor was 0 (or the night's start).
+    ; Walk carrying prev; count when prev=0 and cur=1.
+    (defn sn-eps (xs prev acc)
+        (if (ge (len xs) 1)
+            (sn-eps (tail xs) (nth xs 0)
+                (if (eq (nth xs 0) 1) (if (eq prev 0) (add acc 1) acc) acc))
+            acc))
+    (defn sn-episodes (xs) (sn-eps xs 0 0))
+
+    ; percent of the night spent snoring = snores*100/total (0 on an empty night, no divide-by-zero)
+    (defn sn-fraction (xs)
+        (if (ge (len xs) 1) (div (mul (sn-snores xs) 100) (len xs)) 0)))

--- a/form/form-stdlib/tests/sleep-night-band.fk
+++ b/form/form-stdlib/tests/sleep-night-band.fk
@@ -1,0 +1,30 @@
+; preludes: form-stdlib/sleep-night.fk
+;
+; sleep-night-band — fold a night of snore verdicts into the morning readout, made falsifiable.
+;
+; A night arrives as a 0/1 stream (1 = that breath-window was a snore). One worked night pins the readout,
+; plus two edge nights pin the boundaries:
+;   night (0 0 1 1 1 0 0 1 0 1 1 0 0 0 1 1 1 1 0 0)  -> 20 windows, 10 snores, longest run 4, 4 episodes, 50%
+;   quiet (0 0 0)                                     -> no run at all (longest 0)
+;   solid (1 1 1)                                     -> one continuous episode, longest run 3
+;
+; Verdict 127 when every claim lands:
+;   1    total counts every window                         (sn-total night == 20)
+;   2    snores sum the 0/1 stream                         (sn-snores night == 10)
+;   4    longest finds the longest unbroken run            (sn-longest night == 4)
+;   8    episodes count separate snore runs                (sn-episodes night == 4)
+;   16   fraction is percent of the night snored           (sn-fraction night == 50)
+;   32   a quiet night has no run                          (sn-longest quiet == 0)
+;   64   a solid run is one episode of full length         (sn-episodes solid == 1, sn-longest solid == 3)
+(do
+    (let night (list 0 0 1 1 1 0 0 1 0 1 1 0 0 0 1 1 1 1 0 0))
+    (let quiet (list 0 0 0))
+    (let solid (list 1 1 1))
+    (let c0 (if (eq (sn-total night) 20) 1 0))
+    (let c1 (if (eq (sn-snores night) 10) 2 0))
+    (let c2 (if (eq (sn-longest night) 4) 4 0))
+    (let c3 (if (eq (sn-episodes night) 4) 8 0))
+    (let c4 (if (eq (sn-fraction night) 50) 16 0))
+    (let c5 (if (eq (sn-longest quiet) 0) 32 0))
+    (let c6 (if (and (eq (sn-episodes solid) 1) (eq (sn-longest solid) 3)) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -505,6 +505,7 @@ speaker-aam-train fks 63
 eer fks 63
 wav-sense fks 63
 sleep-sense fkc 127
+sleep-night fkc 127
 witness-theorem fks 31
 witness-to-co-regulate fks 127
 


### PR DESCRIPTION
## What

`sleep-night.fk` — folds a night of per-window snore verdicts (the 0/1 stream `ss-snore?` emits) into the **morning readout**, four-way proven (Go/Rust/TS/fkwu), verdict **127**.

- `sn-total` — windows in the night
- `sn-snores` — how many snored
- `sn-longest` — longest unbroken snore run
- `sn-episodes` — separate snore episodes (rising edges)
- `sn-fraction` — percent of the night snored

## Proof

```
scripts/fourth-arm-gate.sh sleep-night  ->  PASS-4WAY  sleep-night
```

Anchor nights pin every claim (verdict 127). For illustration, a **synthetic** 20-window verdict list — *not real audio, a hand-written test fixture* — folds to `windows 20 · snored 10 · longest 4 · episodes 4 · percent 50`. Integers only, 0/1 verdicts.

## Honest status

The recipe is proven, but it has **never read a real microphone**. There is no real sleep data behind any number here — the example above is invented. The bedside carrier (real capture → envelope → `ss-snore?` stream) runs on the host and does not exist yet; this PR is only the decision body it would feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)