### PR TITLE
feat(sense): bedside sleep organ + wav-sense byte-alignment fix (four-way 127)

### DIFF
--- a/experiments/coherence-sense-android/mac-sleep-organ.sh
+++ b/experiments/coherence-sense-android/mac-sleep-organ.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# mac-sleep-organ.sh — thin bedside SLEEP carrier; the BODY is the Form recipes
+#   form-stdlib/wav-sense.fk        (energy envelope 0..9 from a 16-bit WAV)
+#   form-stdlib/signal-derivative.fk(oscillation count across a window)
+#   form-stdlib/sleep-sense.fk      (ss-snore? : 1 if a window is loud AND periodic)
+#   form-stdlib/sleep-night.fk      (fold a night's 0/1 stream into a morning readout)
+#
+# Sibling of mac-speech-organ.sh. Records the Mac mic in rolling 30s windows through the night;
+# for each window the Form kernel computes the energy envelope (wav-envelope-file) and decides
+# snore? (ss-snore?). The carrier only does physical I/O + persistence — EVERY decision is the
+# recipe's, proven four-way at validate.sh. At wake it folds the night's 0/1 verdicts with
+# sleep-night into a plain-words readout.txt.
+#
+# PRIVACY: audio + per-window verdicts stay on THIS Mac. WAVs are held a couple of days so the
+# floors can be re-tuned, then composted. Only presence/counts may reach the mesh, never the audio.
+#
+# HONEST LANE: ss-snore? reads "loud AND periodic" — the signature of breathing-shaped sound, not a
+# verified snore. The floors (energy 3, oscillation 3) are first-night defaults, untuned against real
+# audio; a quiet room reads 0 and a loud oscillating breath reads 1 (verified on real WAVs before the run).
+#
+# Run:  mac-sleep-organ.sh                 capture until SLEEP_STOP_HOUR (default 08:00), then write readout
+#       mac-sleep-organ.sh --readout DIR   just (re)build the readout from DIR/windows.csv
+#       mac-sleep-organ.sh --dry N         record+sense N short windows now, no overnight loop (calibration)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FORM="$ROOT/form"
+MESH="${HATI_MESH:-https://api.coherencycoin.com/api}"
+UA="coherence-sleep-mac/0.1"
+
+DATE="${SLEEP_DATE:-$(date +%Y-%m-%d)}"
+DIR="${SLEEP_DIR:-$HOME/sleep-$DATE}"
+WAVDIR="$DIR/wav"
+CSV="$DIR/windows.csv"
+READOUT="$DIR/readout.txt"
+
+WINDOW="${SLEEP_WINDOW:-30}"        # seconds of audio per window
+STEP="${SLEEP_STEP:-2}"             # envelope byte step (must be EVEN — 2 = full resolution)
+EFLOOR="${SLEEP_EFLOOR:-3}"         # energy floor   (untuned first-night default)
+AFLOOR="${SLEEP_AFLOOR:-3}"         # oscillation floor
+STOP_HOUR="${SLEEP_STOP_HOUR:-8}"   # auto-stop at this local hour
+MIC_NAME="${SLEEP_MIC_NAME:-MacBook Pro Microphone}"
+
+# --- pinned Go kernel: a private copy so a later validate.sh rebuild can't disturb a running night ---
+KERNEL="${SLEEP_KERNEL:-$DIR/kernel-go}"
+PRELUDES=(form-stdlib/signal-derivative.fk form-stdlib/sleep-sense.fk form-stdlib/wav-sense.fk)
+NIGHT_PRELUDE=(form-stdlib/sleep-night.fk)
+
+mkdir -p "$WAVDIR"
+
+ensure_kernel() {
+    if [[ ! -x "$KERNEL" ]]; then
+        local src="$FORM/form-kernel-go/bin-go"
+        [[ -x "$src" ]] || { echo "FAIL no Go kernel at $src — build with: (cd $FORM && ./validate.sh form-stdlib/core.fk form-stdlib/signal-derivative.fk form-stdlib/sleep-sense.fk form-stdlib/tests/sleep-sense-band.fk)"; exit 1; }
+        cp "$src" "$KERNEL"
+    fi
+}
+
+# sense one wav → echo "verdict mean activity env" (env is space-joined, [] stripped)
+sense_wav() {  # $1 wav
+    local drv; drv="$(mktemp /tmp/sleep-XXXXXX.fk)"
+    cat > "$drv" <<EOF
+(do (let e (wav-envelope-file "$1" $STEP))
+    (print (ss-snore? e $EFLOOR $AFLOOR))
+    (print (ss-mean e))
+    (print (sd-activity e))
+    (print e))
+EOF
+    local out; out="$( cd "$FORM" && "$KERNEL" "${PRELUDES[@]}" "$drv" 2>/dev/null )"
+    rm -f "$drv"
+    local v m a e
+    v="$(sed -n '1p' <<<"$out")"; m="$(sed -n '2p' <<<"$out")"
+    a="$(sed -n '3p' <<<"$out")"; e="$(sed -n '4p' <<<"$out" | tr -d '[]' | tr ',' ' ')"
+    echo "${v:-x} ${m:-0} ${a:-0} ${e:- }"
+}
+
+measure_rms() {  # $1 wav → rms in parts-per-million (carrier DSP, re-tuning aid only)
+    sox "$1" -n stat 2>&1 | awk '/RMS +amplitude/{printf "%d", $3*1000000}'
+}
+
+resolve_mic() {  # echo avfoundation audio index for MIC_NAME, fallback 1
+    local idx
+    idx="$(ffmpeg -hide_banner -f avfoundation -list_devices true -i "" 2>&1 \
+        | sed -n '/audio devices/,$p' | grep -F "$MIC_NAME" | grep -oE '\[[0-9]+\]' | head -1 | tr -d '[]')"
+    echo "${idx:-1}"
+}
+
+record_window() {  # $1 out.wav  $2 secs  $3 mic_index → 0 ok / nonzero on fail
+    rm -f "$1"
+    # bound the recorder: a TCC-blocked mic makes ffmpeg HANG under launchd, not fail. perl alarm caps it.
+    perl -e 'alarm($ARGV[0]+8); shift; exec @ARGV' "$2" \
+        ffmpeg -hide_banner -loglevel error -f avfoundation -i ":$3" -t "$2" -ac 1 -ar 16000 -y "$1" >/dev/null 2>&1
+    [[ -s "$1" ]]
+}
+
+# fold windows.csv into a plain-words readout. Gaps (verdict x) are excluded, never counted as quiet.
+build_readout() {  # $1 dir
+    local dir="$1" csv="$dir/windows.csv" out="$dir/readout.txt"
+    [[ -f "$csv" ]] || { echo "no windows.csv in $dir"; return 1; }
+    ensure_kernel
+    # 0/1 stream (verdict column 3), excluding gaps; + gap count + first/last timestamps
+    local stream gaps total_rows first last
+    stream="$(awk -F, 'NR>1 && ($3==0||$3==1){printf "%s ",$3}' "$csv")"
+    gaps="$(awk -F, 'NR>1 && $3=="x"{n++} END{print n+0}' "$csv")"
+    total_rows="$(awk -F, 'NR>1{n++} END{print n+0}' "$csv")"
+    first="$(awk -F, 'NR==2{print $2}' "$csv")"
+    last="$(awk -F, 'END{print $2}' "$csv")"
+    local drv; drv="$(mktemp /tmp/sleep-night-XXXXXX.fk)"
+    cat > "$drv" <<EOF
+(do (let xs (list ${stream:-}))
+    (print (sn-total xs))
+    (print (sn-snores xs))
+    (print (sn-longest xs))
+    (print (sn-episodes xs))
+    (print (sn-fraction xs)))
+EOF
+    local r; r="$( cd "$FORM" && "$KERNEL" "${NIGHT_PRELUDE[@]}" "$drv" 2>/dev/null )"
+    rm -f "$drv"
+    local n snores longest eps pct
+    n="$(sed -n '1p' <<<"$r")"; snores="$(sed -n '2p' <<<"$r")"
+    longest="$(sed -n '3p' <<<"$r")"; eps="$(sed -n '4p' <<<"$r")"; pct="$(sed -n '5p' <<<"$r")"
+    n="${n:-0}"; snores="${snores:-0}"; longest="${longest:-0}"; eps="${eps:-0}"; pct="${pct:-0}"
+
+    local sensed_min=$(( n * WINDOW / 60 ))
+    local longest_min=$(( longest * WINDOW / 60 ))
+    {
+        echo "Sleep sensing — night of $DATE"
+        echo "================================================"
+        echo
+        echo "Captured $first  →  $last"
+        echo "$n windows of ${WINDOW}s carried real audio (~${sensed_min} min sensed)."
+        [[ "$gaps" -gt 0 ]] && echo "$gaps window(s) recorded no audio (system asleep or mic blocked) — excluded, not counted as quiet."
+        echo
+        echo "Breathing-shaped (loud + periodic) sound was sensed in $snores of $n windows — ${pct}% of the sensed night."
+        echo "That clustered into $eps episode(s); the longest unbroken stretch ran $longest window(s) (~${longest_min} min)."
+        echo
+        echo "How to read this"
+        echo "----------------"
+        echo "• This reads \"loud AND periodic\" — the signature of breathing/snoring, NOT a verified snore."
+        echo "  A steady loud sound (a fan) is rejected; a quiet room reads nothing."
+        echo "• Floors were first-night defaults (energy ${EFLOOR} / oscillation ${AFLOOR}), untuned against your real audio."
+        echo "  Before the run: a quiet room read 0, a loud oscillating breath read 1 (verified on real WAVs)."
+        echo "  The kept WAVs let these floors be re-tuned over the next couple of days."
+        echo "• Each window is ${WINDOW}s, so the percentages are coarse — a single noisy moment can light one window."
+        echo "• Audio + verdicts never left this Mac. WAVs live in $WAVDIR; held ~2 days for re-tuning, then composted."
+        echo
+        echo "(body: form-stdlib/{wav-sense,signal-derivative,sleep-sense,sleep-night}.fk — four-way proven recipes)"
+    } > "$out"
+    echo "$out"
+}
+
+# ---- modes -------------------------------------------------------------------
+if [[ "${1:-}" == "--readout" ]]; then
+    build_readout "${2:-$DIR}"; exit 0
+fi
+
+ensure_kernel
+MIC="$(resolve_mic)"
+
+if [[ "${1:-}" == "--dry" ]]; then
+    N="${2:-3}"; SECS=6
+    echo "[sleep] DRY: mic=:$MIC kernel=$(basename "$KERNEL") floors=${EFLOOR}/${AFLOOR} — $N windows of ${SECS}s"
+    for i in $(seq 1 "$N"); do
+        w="/tmp/sleep-dry-$i.wav"
+        if record_window "$w" "$SECS" "$MIC"; then
+            read -r v m a env < <(sense_wav "$w")
+            printf "  win %d  snore?=%s  mean=%s  activity=%s  env=[%s]  rms=%sppm\n" "$i" "$v" "$m" "$a" "$env" "$(measure_rms "$w")"
+        else
+            printf "  win %d  NO AUDIO (mic blocked? grant Microphone permission)\n" "$i"
+        fi
+        rm -f "$w"
+    done
+    exit 0
+fi
+
+# ---- overnight capture -------------------------------------------------------
+STOP_EPOCH="$(date -v"${STOP_HOUR}"H -v0M -v0S +%s)"
+[[ "$STOP_EPOCH" -le "$(date +%s)" ]] && STOP_EPOCH=$(( STOP_EPOCH + 86400 ))  # already past → tomorrow
+
+[[ -f "$CSV" ]] || echo "idx,ts,verdict,mean,activity,env,rms_ppm" > "$CSV"
+echo "[sleep] organ live — dir=$DIR mic=:$MIC window=${WINDOW}s floors=${EFLOOR}/${AFLOOR} stop=$(date -r "$STOP_EPOCH" '+%H:%M')"
+
+idx="$(awk -F, 'END{print (NR>1?NR-1:0)}' "$CSV")"   # resume-safe
+while [[ "$(date +%s)" -lt "$STOP_EPOCH" ]]; do
+    [[ -f "$DIR/STOP" ]] && { echo "[sleep] STOP sentinel — ending early"; break; }
+    idx=$(( idx + 1 ))
+    ts="$(date '+%Y-%m-%dT%H:%M:%S')"
+    w="$WAVDIR/win-$(printf '%05d' "$idx").wav"
+    if record_window "$w" "$WINDOW" "$MIC"; then
+        read -r v m a env < <(sense_wav "$w")
+        rms="$(measure_rms "$w")"
+        echo "$idx,$ts,$v,$m,$a,$env,${rms:-0}" >> "$CSV"
+    else
+        rm -f "$w"
+        echo "$idx,$ts,x,0,0,,0" >> "$CSV"   # gap: no audio this window
+    fi
+done
+
+echo "[sleep] capture done at $(date '+%H:%M') — building readout"
+build_readout "$DIR"
+echo "[sleep] readout → $READOUT"
+# non-intrusive morning alert (banner only, never audio) so the readout is seen at wake
+SUMMARY="$(awk '/Breathing-shaped/{print; exit}' "$READOUT" 2>/dev/null)"
+osascript -e "display notification \"${SUMMARY:-readout ready}\" with title \"Sleep readout — $DATE\" subtitle \"$READOUT\"" >/dev/null 2>&1 || true

--- a/form/form-stdlib/tests/wav-sense-band.fk
+++ b/form/form-stdlib/tests/wav-sense-band.fk
@@ -5,13 +5,14 @@
 ; The pure functions are checked on fixed byte lists (a synthetic mini-PCM) so the proof needs no file;
 ; the file door (wav-envelope-file) is exercised live by the carrier. 8000 = 64 + 31·256 (lo=64, hi=31).
 ;
-; Verdict 63 when every claim lands:
+; Verdict 127 when every claim lands:
 ;   1   LE decode: [lo 0, hi 16] = 4096
 ;   2   sign: [lo 0, hi 128] = −32768
 ;   4   abs of that sample = 32768
 ;   8   abs-sum over two samples (100, 200) = 300
 ;   16  a window of four 8000-amplitude samples → level 9 (mean 8000/800 = 10, capped)
 ;   32  a window of silence → level 0
+;   64  even window alignment: a uniformly-quiet odd-width PCM reads level 0, not a misaligned snore
 (do
     (let c0 (if (eq (wav-sample (list 0 16) 0) 4096) 1 0))
     (let c1 (if (eq (wav-sample (list 0 128) 0) (sub 0 32768)) 2 0))
@@ -20,4 +21,11 @@
     (let loud (list 64 31 64 31 64 31 64 31))
     (let c4 (if (eq (wav-window-level loud 0 8 2) 9) 16 0))
     (let c5 (if (eq (wav-window-level (list 0 0 0 0) 0 4 2) 0) 32 0))
-    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))
+    ; c6 — even window alignment. A uniformly-quiet PCM (every sample = 10, far below the level-1
+    ; threshold of 800) whose 24-byte body makes (n-44)/8 = 3, an ODD width. wav-window-i forces the
+    ; width even so window 1 stays on the 16-bit sample grid and reads level 0. With an odd width,
+    ; window 1 starts on a high byte and reads (high, next-low) = 2560 → level 3 — a quiet room flagged
+    ; as a snore. 44-byte header padding + [10 0]×12; n = 68; window 1 must read 0.
+    (let quietpcm (list 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 0 10 0 10 0 10 0 10 0 10 0 10 0 10 0 10 0 10 0 10 0 10 0))
+    (let c6 (if (eq (wav-window-i quietpcm 68 1 2) 0) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/form-stdlib/wav-sense.fk
+++ b/form/form-stdlib/wav-sense.fk
@@ -29,9 +29,13 @@
           (do (let mean (div (div (wav-abs-sum bs start end step 0) (div span step)) 800))
               (if (ge mean 9) 9 mean)))))
 
-; window i of 8 across the PCM body [44, n)
+; window i of 8 across the PCM body [44, n). The width w is forced EVEN — a whole number of 16-bit
+; samples — so every window START (44 + i*w) lands on a sample's LOW byte. A 16-bit sample is two
+; bytes; if w were odd, odd-indexed windows would start on a HIGH byte and wav-sample would read
+; (high-byte, next-low-byte) as one bogus huge value, so a quiet room reads level 9 on alternate
+; windows. Even width keeps every read on the sample grid; step must stay even for the same reason.
 (defn wav-window-i (bs n i step)
-  (do (let w (div (sub n 44) 8))
+  (do (let w (mul (div (div (sub n 44) 8) 2) 2))
       (wav-window-level bs (add 44 (mul i w)) (add 44 (mul (add i 1) w)) step)))
 
 ; the 8-window envelope (the cheap feature)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -503,7 +503,7 @@ speaker-net fks 255
 speaker-aam fks 63
 speaker-aam-train fks 63
 eer fks 63
-wav-sense fks 63
+wav-sense fks 127
 sleep-sense fkc 127
 sleep-night fkc 127
 witness-theorem fks 31


### PR DESCRIPTION
## What

A bedside **sleep-sense organ** for Urs's Mac, and the byte-alignment fix in `wav-sense` that building it surfaced.

`experiments/coherence-sense-android/mac-sleep-organ.sh` (sibling of `mac-speech-organ.sh`) records the mic in rolling 30s windows overnight; for each window the Form kernel computes the energy envelope (`wav-envelope-file`) and decides `ss-snore?` (loud **AND** periodic). At wake it folds the night's 0/1 stream with `sleep-night` into a plain-words `readout.txt`. Carrier does only I/O + persistence — every decision is the four-way-proven recipe. **Audio + verdicts stay on the device; only presence/counts reach the mesh.**

## The bug it surfaced

`wav-sense`'s live-file door (`wav-window-i`) used an **odd** window width `(n-44)/8`, so odd-indexed windows started on a 16-bit sample's **high** byte. `wav-sample` then read `(high, next-low)` as a bogus huge value → a quiet room read level 9 on alternate windows → a **false snore**. The band only ever tested `wav-window-level` on hand-aligned bounds, so it never caught this on a real file.

**Fix:** force an even window width so every read stays on the sample grid. New band assertion (bit 64) pins it.

## Proof

- `✓ core.fk + wav-sense.fk + wav-sense-band.fk → 127` — **four-way (Go/Rust/TS/fkwu), 0 divergent**. Verdict 63 → 127; manifest updated.
- Verified on real WAVs through the actual door: quiet → `0`, loud+flat (fan) → `0`, loud+oscillating (breath) → `1`.

## Honest lane

`ss-snore?` reads "loud AND periodic" — breathing-shaped sound, not a verified snore. Floors (energy 3, oscillation 3) are first-night defaults; WAVs are held a couple of days so they can be re-tuned, then composted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)