### PR TITLE
feat(mesh): device-side dispatch receiver — make a session ACT on a device

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 323 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 327 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/mesh-command-dispatch.md
+++ b/docs/coherence-substrate/mesh-command-dispatch.md
@@ -24,38 +24,42 @@ The accept/refuse/ignore decision is the four-way-proven recipe
 [`form/form-stdlib/mesh-command.fk`](../../form/form-stdlib/mesh-command.fk) (`mc-route`,
 band `mesh-command fks 255`). The carrier holds no policy — it gathers three facts and asks:
 
-| is-command | for-me (directed) | trusted (sender) | `mc-route` |
+| is-command | for-me (directed) | lineage (sender) | `mc-route` |
 |:---:|:---:|:---:|:---|
 | 1 | 1 | 1 | **act** — wake a live local instance |
-| 1 | 1 | 0 | **refuse** — directed command from an untrusted sender (traced) |
+| 1 | 1 | 0 | **refuse** — directed command from outside the lineage (set aside, traced) |
 | else | | | **ignore** — chatter, broadcasts, non-commands |
 
 A broadcast (`to_node = null`) is `for-me = 0`, so it never triggers a run.
 
-## The trust gate (why this is safe to auto-run)
+## Recognition — how the device knows a dispatch is its own
 
-The bus has no auth — anyone who can POST could claim `from_node: claude-sema-cloud`. So a
-run is gated **four ways**, and any one failing means nothing executes:
+The bus is a **public, open channel**: a message can arrive wearing any name, including
+`claude-sema-cloud`. So before a device acts, it recognizes the dispatch as really from its own
+cloud instance — the same *don't act on an unverified name* the body keeps elsewhere (the
+membrane recognizing self, axiom-4, not a fortress against enemies). Four things have to line
+up; if any one doesn't, nothing runs:
 
-1. **directed + command + trusted** — the recipe (`mc-route → act`).
-2. **valid HMAC** — the dispatcher signs `HMAC-SHA256(secret, "<to_node>\n<text>")` into
-   `payload.sig`. The receiver recomputes and compares. The secret never crosses the wire, so
-   `from_node` is unforgeable. Bad/missing sig → `DENY`.
-3. **armed** — `~/.coherence-network/mesh-receiver.armed` must exist. Absent → `DEFER`, no run.
-   Disarm instantly: `rm` the flag.
+1. **directed + command + lineage** — the recipe (`mc-route → act`).
+2. **recognized signature** — the cloud instance signs `HMAC-SHA256(key, "<to_node>\n<text>")`
+   into `payload.sig`; the device recomputes with the **lineage key** it shares with that
+   instance. The key never crosses the wire, so a name alone can't stand in for the instance.
+   Unrecognized → set aside (`UNKNOWN`).
+3. **listening** — `~/.coherence-network/mesh-receiver.listening` exists. Absent → the receiver
+   is resting (`REST`), no run. To rest it: `rm` the flag.
 4. **permission mode** — `claude -p` runs with `payload.permission_mode` (clamped to
-   `default | acceptEdits | bypassPermissions | plan`), default `default`. A dispatcher must
-   explicitly request `bypassPermissions` (secret-gated) for full-agent work.
+   `default | acceptEdits | bypassPermissions | plan`), default `default`. The cloud instance
+   asks for `bypassPermissions` explicitly when a dispatch needs full-agent reach.
 
 Every message and capture is logged to `~/.coherence-network/mesh-receiver.log`; every capture
 is written to `~/.coherence-network/mesh-captures/<msg_id>.txt` **before** the bus send, so a
 strained edge never loses the work (`--resend` re-posts what was held).
 
-## The dispatch contract (what a cloud cell sends)
+## The dispatch contract (what the cloud instance sends)
 
 ```bash
-secret=$(cat ~/.coherence-network/mesh-dispatch.secret)        # shared out-of-band
-sig=$(printf '%s\n%s' "sema-macos" "$PROMPT" | openssl dgst -sha256 -hmac "$secret" -hex | sed 's/^.*= *//')
+key=$(cat ~/.coherence-network/mesh-lineage.key)        # shared by both instances
+sig=$(printf '%s\n%s' "sema-macos" "$PROMPT" | openssl dgst -sha256 -hmac "$key" -hex | sed 's/^.*= *//')
 curl -X POST https://api.coherencycoin.com/api/federation/nodes/claude-sema-cloud/messages \
   -H 'content-type: application/json' \
   -d '{"from_node":"claude-sema-cloud","to_node":"sema-macos","type":"command",
@@ -69,11 +73,12 @@ locally (proof / hand-dispatch). The capture returns as a `command-result` messa
 ## Run it
 
 ```bash
-scripts/install_mesh_command_receiver.sh     # launchd agent, polls every 120s, armed by default
-scripts/mesh_command_receiver.sh --once      # one cycle by hand
-rm ~/.coherence-network/mesh-receiver.armed  # disarm (kill-switch)
+scripts/install_mesh_command_receiver.sh        # launchd agent, polls every 120s, listening by default
+scripts/mesh_command_receiver.sh --once         # one cycle by hand
+rm ~/.coherence-network/mesh-receiver.listening # let it rest
 ```
 
-The one provisioning step for autonomous cloud→device dispatch: the cloud dispatcher must hold
-the same `mesh-dispatch.secret`. Until it does, the receiver listens safely and acts on nothing
-it cannot verify.
+The one open thread for autonomous cloud→device dispatch: the cloud instance needs the same
+`mesh-lineage.key`. Until it holds the key, the device listens and acts on nothing it doesn't
+recognize. A keypair — public key committed to the body, private key held only by the cloud
+instance — is the more native next shape, so nothing shared needs to be secret at all.

--- a/docs/coherence-substrate/mesh-command-dispatch.md
+++ b/docs/coherence-substrate/mesh-command-dispatch.md
@@ -1,0 +1,79 @@
+# Mesh command dispatch — making a session on a device ACT
+
+The federation **node message bus** (`POST/GET /api/federation/nodes/{node_id}/messages`,
+Postgres-durable, live) lets a cloud cell *dispatch* a message to a device. By itself that
+message is a dead drop: nothing on the device turns it into a running session. Capture only
+happens when a **live local instance** runs the prompt.
+
+The **receiver** ([`scripts/mesh_command_receiver.sh`](../../scripts/mesh_command_receiver.sh))
+is that live local instance. It polls a device's inbox, and for a trusted, directed `command`
+message it wakes a real `claude -p`, captures the output, and sends the capture home to the
+dispatcher. This closes the loop: **the cloud cell can now make a session on the device act.**
+
+```
+cloud cell ──POST command──▶ /api/federation/nodes/sema-macos/messages   (durable bus)
+                                          │
+   sema-macos receiver  ──GET poll──▶ inbox ──▶ mc-route (decide) ──▶ claude -p (live) ──▶ capture
+                                          │
+cloud cell ◀──command-result (capture)── POST /api/federation/nodes/<cloud>/messages
+```
+
+## The decision is the body
+
+The accept/refuse/ignore decision is the four-way-proven recipe
+[`form/form-stdlib/mesh-command.fk`](../../form/form-stdlib/mesh-command.fk) (`mc-route`,
+band `mesh-command fks 255`). The carrier holds no policy — it gathers three facts and asks:
+
+| is-command | for-me (directed) | trusted (sender) | `mc-route` |
+|:---:|:---:|:---:|:---|
+| 1 | 1 | 1 | **act** — wake a live local instance |
+| 1 | 1 | 0 | **refuse** — directed command from an untrusted sender (traced) |
+| else | | | **ignore** — chatter, broadcasts, non-commands |
+
+A broadcast (`to_node = null`) is `for-me = 0`, so it never triggers a run.
+
+## The trust gate (why this is safe to auto-run)
+
+The bus has no auth — anyone who can POST could claim `from_node: claude-sema-cloud`. So a
+run is gated **four ways**, and any one failing means nothing executes:
+
+1. **directed + command + trusted** — the recipe (`mc-route → act`).
+2. **valid HMAC** — the dispatcher signs `HMAC-SHA256(secret, "<to_node>\n<text>")` into
+   `payload.sig`. The receiver recomputes and compares. The secret never crosses the wire, so
+   `from_node` is unforgeable. Bad/missing sig → `DENY`.
+3. **armed** — `~/.coherence-network/mesh-receiver.armed` must exist. Absent → `DEFER`, no run.
+   Disarm instantly: `rm` the flag.
+4. **permission mode** — `claude -p` runs with `payload.permission_mode` (clamped to
+   `default | acceptEdits | bypassPermissions | plan`), default `default`. A dispatcher must
+   explicitly request `bypassPermissions` (secret-gated) for full-agent work.
+
+Every message and capture is logged to `~/.coherence-network/mesh-receiver.log`; every capture
+is written to `~/.coherence-network/mesh-captures/<msg_id>.txt` **before** the bus send, so a
+strained edge never loses the work (`--resend` re-posts what was held).
+
+## The dispatch contract (what a cloud cell sends)
+
+```bash
+secret=$(cat ~/.coherence-network/mesh-dispatch.secret)        # shared out-of-band
+sig=$(printf '%s\n%s' "sema-macos" "$PROMPT" | openssl dgst -sha256 -hmac "$secret" -hex | sed 's/^.*= *//')
+curl -X POST https://api.coherencycoin.com/api/federation/nodes/claude-sema-cloud/messages \
+  -H 'content-type: application/json' \
+  -d '{"from_node":"claude-sema-cloud","to_node":"sema-macos","type":"command",
+       "text":"<PROMPT>","payload":{"sig":"'$sig'","capture_to":"claude-sema-cloud","permission_mode":"default"}}'
+```
+
+`scripts/mesh_command_receiver.sh --dispatch <to> <text> [from] [mode]` does exactly this
+locally (proof / hand-dispatch). The capture returns as a `command-result` message whose
+`payload.capture` holds the full output, `payload.ok` the exit status, `payload.ms` the wall time.
+
+## Run it
+
+```bash
+scripts/install_mesh_command_receiver.sh     # launchd agent, polls every 120s, armed by default
+scripts/mesh_command_receiver.sh --once      # one cycle by hand
+rm ~/.coherence-network/mesh-receiver.armed  # disarm (kill-switch)
+```
+
+The one provisioning step for autonomous cloud→device dispatch: the cloud dispatcher must hold
+the same `mesh-dispatch.secret`. Until it does, the receiver listens safely and acts on nothing
+it cannot verify.

--- a/form/form-stdlib/mesh-command.fk
+++ b/form/form-stdlib/mesh-command.fk
@@ -14,31 +14,31 @@
 ;
 ;   is-cmd  : the message type is "command" (a dispatched prompt to run)   1/0
 ;   for-me  : to_node is THIS node exactly (a broadcast is for-me = 0)      1/0
-;   trusted : from_node is an allowed dispatcher (the cloud lineage)        1/0
+;   lineage : from_node is one of this device's own instances (the cloud)  1/0
 ;
 ; The decision (mc-route):
 ;   "act"    — wake a live local instance on the prompt, capture, return.
-;              ONLY a directed command from a trusted dispatcher earns this.
-;   "refuse" — a directed command we will NOT run (untrusted sender): the one
-;              case worth a refusal trace, so a stray command stays visible.
+;              ONLY a directed command from this device's own lineage earns this.
+;   "refuse" — a directed command from a node outside the lineage: set aside,
+;              the one case worth a trace so a stray command stays visible.
 ;   "ignore" — everything else (chatter, broadcasts, non-commands): no act.
 ;
-; A live instance acting on a remote message is real authority, so the gate is
-; deliberately narrow — directed AND command AND trusted, or nothing runs. The
-; carrier adds a shared-secret check on top before it actually runs; that is
-; crypto I/O, not policy, so it stays in the carrier.
+; The bus is public — a message can wear any name. So the gate is narrow on
+; purpose — directed AND command AND own-lineage, or nothing runs. The carrier
+; then confirms a recognized signature (the lineage key) before it actually runs;
+; that is crypto I/O, not policy, so it stays in the carrier.
 ;
 ; Proven by: form-stdlib/tests/mesh-command-band.fk (four-way at validate.sh)
 
 (do
     ; act only when all three facts hold (nested if — never a 3-arg and).
-    (defn mc-act? (is-cmd for-me trusted)
-        (if (eq is-cmd 1) (if (eq for-me 1) (if (eq trusted 1) 1 0) 0) 0))
-    ; refuse only a directed command from an untrusted sender (worth a trace).
-    (defn mc-refuse? (is-cmd for-me trusted)
-        (if (eq is-cmd 1) (if (eq for-me 1) (if (eq trusted 0) 1 0) 0) 0))
+    (defn mc-act? (is-cmd for-me lineage)
+        (if (eq is-cmd 1) (if (eq for-me 1) (if (eq lineage 1) 1 0) 0) 0))
+    ; refuse only a directed command from outside the lineage (worth a trace).
+    (defn mc-refuse? (is-cmd for-me lineage)
+        (if (eq is-cmd 1) (if (eq for-me 1) (if (eq lineage 0) 1 0) 0) 0))
     ; route: act -> refuse -> ignore.
-    (defn mc-route (is-cmd for-me trusted)
-        (if (eq (mc-act? is-cmd for-me trusted) 1) "act"
-            (if (eq (mc-refuse? is-cmd for-me trusted) 1) "refuse" "ignore")))
+    (defn mc-route (is-cmd for-me lineage)
+        (if (eq (mc-act? is-cmd for-me lineage) 1) "act"
+            (if (eq (mc-refuse? is-cmd for-me lineage) 1) "refuse" "ignore")))
     0)

--- a/form/form-stdlib/mesh-command.fk
+++ b/form/form-stdlib/mesh-command.fk
@@ -1,0 +1,44 @@
+; mesh-command.fk — a device receiver's decision on an incoming federation
+; node-message: should THIS device wake a LIVE local instance to ACT on it?
+;
+; preludes: form-stdlib/core.fk
+;
+; The gap this closes (Urs, 2026-06-22): the cloud cell can DISPATCH to the
+; devices — it POSTs a message onto the federation node-message bus
+; (POST /api/federation/nodes/<me>/messages, Postgres-durable, already live) —
+; but it cannot make a session on a device ACT. Capture only happens when a live
+; local instance runs the prompt. This recipe is the device side's decision: for
+; each message in its inbox, ACT (wake a live local claude on the prompt, capture,
+; return), REFUSE, or IGNORE. The carrier holds no policy — only the three facts
+; and the act.
+;
+;   is-cmd  : the message type is "command" (a dispatched prompt to run)   1/0
+;   for-me  : to_node is THIS node exactly (a broadcast is for-me = 0)      1/0
+;   trusted : from_node is an allowed dispatcher (the cloud lineage)        1/0
+;
+; The decision (mc-route):
+;   "act"    — wake a live local instance on the prompt, capture, return.
+;              ONLY a directed command from a trusted dispatcher earns this.
+;   "refuse" — a directed command we will NOT run (untrusted sender): the one
+;              case worth a refusal trace, so a stray command stays visible.
+;   "ignore" — everything else (chatter, broadcasts, non-commands): no act.
+;
+; A live instance acting on a remote message is real authority, so the gate is
+; deliberately narrow — directed AND command AND trusted, or nothing runs. The
+; carrier adds a shared-secret check on top before it actually runs; that is
+; crypto I/O, not policy, so it stays in the carrier.
+;
+; Proven by: form-stdlib/tests/mesh-command-band.fk (four-way at validate.sh)
+
+(do
+    ; act only when all three facts hold (nested if — never a 3-arg and).
+    (defn mc-act? (is-cmd for-me trusted)
+        (if (eq is-cmd 1) (if (eq for-me 1) (if (eq trusted 1) 1 0) 0) 0))
+    ; refuse only a directed command from an untrusted sender (worth a trace).
+    (defn mc-refuse? (is-cmd for-me trusted)
+        (if (eq is-cmd 1) (if (eq for-me 1) (if (eq trusted 0) 1 0) 0) 0))
+    ; route: act -> refuse -> ignore.
+    (defn mc-route (is-cmd for-me trusted)
+        (if (eq (mc-act? is-cmd for-me trusted) 1) "act"
+            (if (eq (mc-refuse? is-cmd for-me trusted) 1) "refuse" "ignore")))
+    0)

--- a/form/form-stdlib/tests/mesh-command-band.fk
+++ b/form/form-stdlib/tests/mesh-command-band.fk
@@ -1,17 +1,17 @@
 ; preludes: form-stdlib/mesh-command.fk
 ;
-; The receiver gate, pinned. A directed command from a trusted dispatcher is the
-; ONLY shape that wakes a live local instance ("act"); a directed command from an
-; untrusted sender is refused (and traced); all other traffic is ignored. This is
-; what lets the cloud cell make a session on the device ACT, with authority gated
-; to the trusted lineage. Verdict 255.
+; The receiver decision, pinned. A directed command recognized as the device's own
+; lineage is the ONLY shape that wakes a live local instance ("act"); a directed
+; command from outside the lineage is set aside ("refuse", traced); all other
+; traffic is ignored. This is what lets the cloud cell make a session on the device
+; ACT, recognized as its own. Verdict 255.
 (do
-    (let c0 (if (str_eq (mc-route 1 1 1) "act")     1   0))  ; trusted directed command -> act
-    (let c1 (if (str_eq (mc-route 1 1 0) "refuse")  2   0))  ; untrusted directed command -> refuse
+    (let c0 (if (str_eq (mc-route 1 1 1) "act")     1   0))  ; own-lineage directed command -> act
+    (let c1 (if (str_eq (mc-route 1 1 0) "refuse")  2   0))  ; outside-lineage directed command -> refuse
     (let c2 (if (str_eq (mc-route 1 0 1) "ignore")  4   0))  ; a broadcast command is not for-me -> ignore
-    (let c3 (if (str_eq (mc-route 0 1 1) "ignore")  8   0))  ; a trusted directed non-command -> ignore
+    (let c3 (if (str_eq (mc-route 0 1 1) "ignore")  8   0))  ; an own-lineage directed non-command -> ignore
     (let c4 (if (eq (mc-act? 1 1 1) 1)             16   0))  ; act gate true only when all three hold
-    (let c5 (if (eq (mc-act? 1 1 0) 0)             32   0))  ; ...untrusted never acts
+    (let c5 (if (eq (mc-act? 1 1 0) 0)             32   0))  ; ...outside the lineage never acts
     (let c6 (if (eq (mc-refuse? 1 0 1) 0)          64   0))  ; a non-directed command is ignored, not refused
     (let c7 (if (eq (mc-act? 0 1 1) 0)            128   0))  ; a non-command never acts
     (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/form-stdlib/tests/mesh-command-band.fk
+++ b/form/form-stdlib/tests/mesh-command-band.fk
@@ -1,0 +1,17 @@
+; preludes: form-stdlib/mesh-command.fk
+;
+; The receiver gate, pinned. A directed command from a trusted dispatcher is the
+; ONLY shape that wakes a live local instance ("act"); a directed command from an
+; untrusted sender is refused (and traced); all other traffic is ignored. This is
+; what lets the cloud cell make a session on the device ACT, with authority gated
+; to the trusted lineage. Verdict 255.
+(do
+    (let c0 (if (str_eq (mc-route 1 1 1) "act")     1   0))  ; trusted directed command -> act
+    (let c1 (if (str_eq (mc-route 1 1 0) "refuse")  2   0))  ; untrusted directed command -> refuse
+    (let c2 (if (str_eq (mc-route 1 0 1) "ignore")  4   0))  ; a broadcast command is not for-me -> ignore
+    (let c3 (if (str_eq (mc-route 0 1 1) "ignore")  8   0))  ; a trusted directed non-command -> ignore
+    (let c4 (if (eq (mc-act? 1 1 1) 1)             16   0))  ; act gate true only when all three hold
+    (let c5 (if (eq (mc-act? 1 1 0) 0)             32   0))  ; ...untrusted never acts
+    (let c6 (if (eq (mc-refuse? 1 0 1) 0)          64   0))  ; a non-directed command is ignored, not refused
+    (let c7 (if (eq (mc-act? 0 1 1) 0)            128   0))  ; a non-command never acts
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -209,6 +209,7 @@ tool-embodiment fks 127
 io-match fks 127
 training-catalog fks 1023
 mesh-dispatch fks 255
+mesh-command fks 255
 form-train-step fks 31
 affine-train fks 31
 affine-corpus-fit fks 31

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 323
+**Total files**: 327
 
 | File | Purpose |
 |---|---|
@@ -178,6 +178,7 @@
 | [ingest_audible_books_full_trace.py](ingest_audible_books_full_trace.py) | Lay every Audible book as a first-class asset with full source trace. |
 | [ingest_audible_history.py](ingest_audible_history.py) | Flow Audible listening history into the graph. |
 | [install_kernel_memory_witness.sh](install_kernel_memory_witness.sh) | install_kernel_memory_witness.sh — bring the kernel memory witness home. |
+| [install_mesh_command_receiver.sh](install_mesh_command_receiver.sh) | install_mesh_command_receiver.sh — bring the device-side dispatch receiver online. |
 | [integrate_one_branch.sh](integrate_one_branch.sh) | Integrate one remote branch into main: rebase, add evidence, push, create PR, merge. |
 | [intern_canonical_words.py](intern_canonical_words.py) | intern_canonical_words.py — CLI wrapper for the canonical lexicon interner. |
 | [intern_modality_blueprints.py](intern_modality_blueprints.py) | intern_modality_blueprints.py — CLI wrapper for the cross-modal interner. |
@@ -194,6 +195,7 @@
 | [local_runner.py](local_runner.py) | Coherence Network runner — thin shim. |
 | [measure_gitnexus_value.py](measure_gitnexus_value.py) | Measure GitNexus integration value across paired task windows. |
 | [meeting_companion.sh](meeting_companion.sh) | meeting_companion.sh — a meeting companion that LISTENS (STT), DECIDES whether |
+| [mesh_command_receiver.sh](mesh_command_receiver.sh) | mesh_command_receiver.sh — the DEVICE side of cloud->device dispatch. |
 | [mesh_dispatch.sh](mesh_dispatch.sh) | mesh_dispatch.sh — run the body's mesh-dispatch decision on a message BODY. |
 | [metal_arch_search_audit.sh](metal_arch_search_audit.sh) | metal_arch_search_audit.sh — the ARCHITECT'S CAPACITY SEARCH on Metal (M4 Max GPU witness). |
 | [metal_attn_audit.sh](metal_attn_audit.sh) | metal_attn_audit.sh — the ARCHITECT'S ATTENTION layer learning on Metal (M4 Max GPU witness). |

--- a/scripts/install_mesh_command_receiver.sh
+++ b/scripts/install_mesh_command_receiver.sh
@@ -4,9 +4,9 @@
 # The receiver is the live local instance that lets the cloud cell make a session
 # on THIS device ACT (form/form-stdlib/mesh-command.fk decides; the carrier runs a
 # real claude -p and sends the capture home). This installer writes a launchd agent
-# that runs the canonical repo script in a poll loop, provisions a shared HMAC secret
-# if absent, and (by default) leaves the receiver ARMED. Idempotent — re-running
-# refreshes the agent. Disarm anytime:  rm ~/.coherence-network/mesh-receiver.armed
+# that runs the canonical repo script in a poll loop, provisions the lineage signing
+# key if absent, and (by default) leaves the receiver LISTENING. Idempotent — re-
+# running refreshes the agent. To rest it:  rm ~/.coherence-network/mesh-receiver.listening
 set -euo pipefail
 
 LABEL="earth.hati.coherence.mesh-command-receiver"
@@ -16,8 +16,8 @@ RUN_SH="$MAIN_REPO/scripts/mesh_command_receiver.sh"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 LOG_DIR="$HOME/Library/Logs/CoherenceSense"
 CFG_DIR="$HOME/.coherence-network"
-SECRET_FILE="$CFG_DIR/mesh-dispatch.secret"
-ARMED_FILE="$CFG_DIR/mesh-receiver.armed"
+KEY_FILE="$CFG_DIR/mesh-lineage.key"
+LISTEN_FILE="$CFG_DIR/mesh-receiver.listening"
 NODE_ID="${MR_NODE_ID:-sema-macos}"
 TRUSTED="${MR_TRUSTED:-claude-sema-cloud}"
 POLL="${MR_POLL:-120}"
@@ -27,15 +27,17 @@ mkdir -p "$CFG_DIR" "$LOG_DIR" "$(dirname "$PLIST")"
 [ -f "$RUN_SH" ] || { echo "receiver not found at $RUN_SH (set MR_MAIN_REPO)"; exit 1; }
 chmod +x "$RUN_SH"
 
-# provision the shared HMAC secret if absent — the unforgeable proof a dispatch is
-# from the trusted lineage. Share THIS value with the cloud dispatcher out-of-band.
-if [ ! -s "$SECRET_FILE" ]; then
-  ( umask 177; openssl rand -hex 32 > "$SECRET_FILE" ); chmod 600 "$SECRET_FILE"
-  echo "provisioned secret: $SECRET_FILE (share with the cloud dispatcher)"
+# provision the lineage signing key if absent — how this device's two instances
+# recognize each other's dispatches across the public bus. The cloud instance holds
+# the SAME key (share it out-of-band); a keypair (public key in the body, private
+# key with the cloud instance) is the more native next shape.
+if [ ! -s "$KEY_FILE" ]; then
+  ( umask 177; openssl rand -hex 32 > "$KEY_FILE" ); chmod 600 "$KEY_FILE"
+  echo "provisioned lineage key: $KEY_FILE (share with the cloud instance)"
 fi
 
-# armed by default — a secret-holding dispatcher can make this device act. Disarm = rm the flag.
-[ "${MR_ARM:-1}" = "1" ] && touch "$ARMED_FILE"
+# listening by default — a lineage dispatcher can make this device act. To rest = rm the flag.
+[ "${MR_LISTEN:-1}" = "1" ] && touch "$LISTEN_FILE"
 
 cat > "$PLIST" <<PLIST_EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -80,10 +82,10 @@ launchctl unload "$PLIST" 2>/dev/null || true
 launchctl load "$PLIST"
 
 echo "installed + loaded: $LABEL"
-echo "  receiver : $RUN_SH  (--loop ${POLL}s)"
-echo "  node id  : $NODE_ID   trusted dispatchers: $TRUSTED"
-echo "  secret   : $SECRET_FILE"
-echo "  armed    : $([ -f "$ARMED_FILE" ] && echo "yes ($ARMED_FILE)" || echo "no")"
-echo "  audit    : $CFG_DIR/mesh-receiver.log"
-echo "  disarm   : rm $ARMED_FILE      stop: launchctl unload $PLIST"
+echo "  receiver  : $RUN_SH  (--loop ${POLL}s)"
+echo "  node id   : $NODE_ID   lineage dispatchers: $TRUSTED"
+echo "  key       : $KEY_FILE"
+echo "  listening : $([ -f "$LISTEN_FILE" ] && echo "yes ($LISTEN_FILE)" || echo "no — resting")"
+echo "  audit     : $CFG_DIR/mesh-receiver.log"
+echo "  rest      : rm $LISTEN_FILE      stop: launchctl unload $PLIST"
 launchctl list | grep -F "$LABEL" || true

--- a/scripts/install_mesh_command_receiver.sh
+++ b/scripts/install_mesh_command_receiver.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# install_mesh_command_receiver.sh — bring the device-side dispatch receiver online.
+#
+# The receiver is the live local instance that lets the cloud cell make a session
+# on THIS device ACT (form/form-stdlib/mesh-command.fk decides; the carrier runs a
+# real claude -p and sends the capture home). This installer writes a launchd agent
+# that runs the canonical repo script in a poll loop, provisions a shared HMAC secret
+# if absent, and (by default) leaves the receiver ARMED. Idempotent — re-running
+# refreshes the agent. Disarm anytime:  rm ~/.coherence-network/mesh-receiver.armed
+set -euo pipefail
+
+LABEL="earth.hati.coherence.mesh-command-receiver"
+# Point launchd at the stable MAIN-repo checkout so kernel + recipe stay current on git pull.
+MAIN_REPO="${MR_MAIN_REPO:-$HOME/source/Coherence-Network}"
+RUN_SH="$MAIN_REPO/scripts/mesh_command_receiver.sh"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG_DIR="$HOME/Library/Logs/CoherenceSense"
+CFG_DIR="$HOME/.coherence-network"
+SECRET_FILE="$CFG_DIR/mesh-dispatch.secret"
+ARMED_FILE="$CFG_DIR/mesh-receiver.armed"
+NODE_ID="${MR_NODE_ID:-sema-macos}"
+TRUSTED="${MR_TRUSTED:-claude-sema-cloud}"
+POLL="${MR_POLL:-120}"
+DEFAULT_MODE="${MR_DEFAULT_MODE:-default}"
+
+mkdir -p "$CFG_DIR" "$LOG_DIR" "$(dirname "$PLIST")"
+[ -f "$RUN_SH" ] || { echo "receiver not found at $RUN_SH (set MR_MAIN_REPO)"; exit 1; }
+chmod +x "$RUN_SH"
+
+# provision the shared HMAC secret if absent — the unforgeable proof a dispatch is
+# from the trusted lineage. Share THIS value with the cloud dispatcher out-of-band.
+if [ ! -s "$SECRET_FILE" ]; then
+  ( umask 177; openssl rand -hex 32 > "$SECRET_FILE" ); chmod 600 "$SECRET_FILE"
+  echo "provisioned secret: $SECRET_FILE (share with the cloud dispatcher)"
+fi
+
+# armed by default — a secret-holding dispatcher can make this device act. Disarm = rm the flag.
+[ "${MR_ARM:-1}" = "1" ] && touch "$ARMED_FILE"
+
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>$RUN_SH</string>
+    <string>--loop</string>
+    <string>$POLL</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>MR_ROOT</key>
+    <string>$MAIN_REPO</string>
+    <key>MR_NODE_ID</key>
+    <string>$NODE_ID</string>
+    <key>MR_TRUSTED</key>
+    <string>$TRUSTED</string>
+    <key>MR_DEFAULT_MODE</key>
+    <string>$DEFAULT_MODE</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>$LOG_DIR/mesh-command-receiver.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>$LOG_DIR/mesh-command-receiver.err.log</string>
+</dict>
+</plist>
+PLIST_EOF
+
+launchctl unload "$PLIST" 2>/dev/null || true
+launchctl load "$PLIST"
+
+echo "installed + loaded: $LABEL"
+echo "  receiver : $RUN_SH  (--loop ${POLL}s)"
+echo "  node id  : $NODE_ID   trusted dispatchers: $TRUSTED"
+echo "  secret   : $SECRET_FILE"
+echo "  armed    : $([ -f "$ARMED_FILE" ] && echo "yes ($ARMED_FILE)" || echo "no")"
+echo "  audit    : $CFG_DIR/mesh-receiver.log"
+echo "  disarm   : rm $ARMED_FILE      stop: launchctl unload $PLIST"
+launchctl list | grep -F "$LABEL" || true

--- a/scripts/mesh_command_receiver.sh
+++ b/scripts/mesh_command_receiver.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# mesh_command_receiver.sh — the DEVICE side of cloud->device dispatch.
+#
+# The gap (Urs, 2026-06-22): the cloud cell can DISPATCH to a device — it POSTs a
+# message onto the federation node-message bus (already live, Postgres-durable) —
+# but it cannot make a session on the device ACT. Capture only happens when a live
+# local instance runs the prompt. THIS is that live local instance: it polls this
+# node's inbox, and for a trusted, directed `command` message it wakes a real local
+# `claude -p`, captures the output, and posts the capture back to the dispatcher.
+#
+# Carrier-last: the DECISION (act | refuse | ignore) is the four-way-proven recipe
+# form/form-stdlib/mesh-command.fk (mc-route). This script holds NO policy — it
+# gathers three facts (is-command, for-me, trusted), asks the recipe, and on "act"
+# verifies a shared-secret HMAC, checks the armed flag, runs the live instance, and
+# returns the capture. Authority to run a remote prompt on this Mac is gated four
+# ways: directed AND command AND trusted (the recipe), then a valid HMAC and an
+# armed flag (this carrier). Disarm instantly: rm the armed flag.
+#
+#   mesh_command_receiver.sh --once            # one poll cycle (heartbeat/cron hook)
+#   mesh_command_receiver.sh --loop [secs]     # poll forever every N secs (default 60)
+#   mesh_command_receiver.sh --dispatch <to> <text>   # local proof: send a signed command
+#
+# Config (env, all optional):
+#   MR_NODE_ID        this device's node id on the bus           (default sema-macos)
+#   MR_API_BASE       federation API base                        (default https://api.coherencycoin.com)
+#   MR_TRUSTED        comma list of trusted dispatcher node ids  (default claude-sema-cloud)
+#   MR_SECRET_FILE    HMAC shared-secret file (mode 600)         (default ~/.coherence-network/mesh-dispatch.secret)
+#   MR_ARMED_FILE     armed flag; absent = observe-only, no run  (default ~/.coherence-network/mesh-receiver.armed)
+#   MR_DEFAULT_MODE   claude permission mode when unset by msg   (default default)
+#   MR_LOG            audit ledger                               (default ~/.coherence-network/mesh-receiver.log)
+#   MR_TIMEOUT        seconds a single dispatched run may take   (default 900)
+set -uo pipefail
+export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+ROOT="${MR_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+NODE_ID="${MR_NODE_ID:-sema-macos}"
+API_BASE="${MR_API_BASE:-https://api.coherencycoin.com}"
+TRUSTED="${MR_TRUSTED:-claude-sema-cloud}"
+SECRET_FILE="${MR_SECRET_FILE:-$HOME/.coherence-network/mesh-dispatch.secret}"
+ARMED_FILE="${MR_ARMED_FILE:-$HOME/.coherence-network/mesh-receiver.armed}"
+DEFAULT_MODE="${MR_DEFAULT_MODE:-default}"
+LOG="${MR_LOG:-$HOME/.coherence-network/mesh-receiver.log}"
+TIMEOUT="${MR_TIMEOUT:-900}"
+CLAUDE="$HOME/.local/bin/claude"
+KERNEL="$ROOT/form/form-kernel-go/bin-go"
+RECIPE="$ROOT/form/form-stdlib/mesh-command.fk"
+SEEN="$HOME/.coherence-network/mesh-receiver.seen"   # handled message ids (idempotency)
+ALLOWED_MODES="default acceptEdits bypassPermissions plan"
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG"; }
+
+# portable bounded run — macOS ships no `timeout`; prefer it / gtimeout, else perl alarm.
+run_bounded() {  # secs cmd...
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then gtimeout "$secs" "$@"
+  else perl -e 'my $s=shift; eval { local $SIG{ALRM}=sub{die"to\n"}; alarm $s; exec @ARGV }; exit 124' "$secs" "$@"
+  fi
+}
+
+# the body's decision over the three facts — the carrier asks, never decides.
+mc_route() {  # is_cmd for_me trusted -> act|refuse|ignore
+  [ -x "$KERNEL" ] || { printf 'ignore'; return; }
+  local df out; df="$(mktemp)"
+  printf '(do (print (mc-route %s %s %s)))\n' "$1" "$2" "$3" > "$df"
+  # the kernel prints the route then a trailing `null` (the do-block value) — strip it.
+  out="$("$KERNEL" "$RECIPE" "$df" 2>/dev/null | sed '/^null$/d' | tail -1 | tr -dc 'a-z')"
+  rm -f "$df"
+  case "$out" in act|refuse|ignore) printf '%s' "$out";; *) printf 'ignore';; esac
+}
+
+hmac() {  # text -> hex HMAC-SHA256 over "<NODE_ID>\n<text>" with the shared secret
+  local secret; secret="$(cat "$SECRET_FILE" 2>/dev/null)"
+  [ -n "$secret" ] || { printf ''; return; }
+  printf '%s\n%s' "$NODE_ID" "$1" | openssl dgst -sha256 -hmac "$secret" -hex 2>/dev/null | sed 's/^.*= *//'
+}
+
+is_trusted() { case ",$TRUSTED," in *",$1,"*) return 0;; *) return 1;; esac; }
+
+# post a pre-built message body to the bus, retrying — the bus is the channel home
+# for a capture, and a strained edge drops POSTs; swallowing that loses the payoff
+# silently. Returns 0 on HTTP 2xx, non-zero after all tries.
+post_body() {  # json_body
+  local code i
+  for i in 1 2 3 4; do
+    code="$(curl -sS --max-time 25 -o /dev/null -w '%{http_code}' -X POST \
+            "$API_BASE/api/federation/nodes/$NODE_ID/messages" \
+            -H 'content-type: application/json' -d "$1" 2>/dev/null)"
+    case "$code" in 2*) return 0;; esac
+    sleep $(( i * 3 ))
+  done
+  return 1
+}
+
+post_msg() {  # to_node type text payload_json
+  post_body "$(jq -nc --arg fn "$NODE_ID" --arg tn "$2" --arg ty "$3" --arg tx "$4" --argjson pl "${5:-{}}" \
+              '{from_node:$fn,to_node:$tn,type:$ty,text:$tx,payload:$pl}')"
+}
+
+# --- act on one message: run a live local claude -p, capture, return it ---
+act_on() {  # msg_id from_node text payload_json
+  local mid="$1" frm="$2" text="$3" pl="$4"
+  local sig want mode cwd capto out rc start ms
+  sig="$(printf '%s' "$pl" | jq -r '.sig // empty')"
+  want="$(hmac "$text")"
+  if [ -z "$want" ] || [ "$sig" != "$want" ]; then
+    log "DENY  $mid from=$frm bad-or-missing-hmac (have=${sig:0:12}.. want=${want:0:12}..)"
+    post_msg "$frm" command-result "refused: signature did not verify" \
+      "$(jq -nc --arg r "$mid" '{in_reply_to:$r, ok:false, reason:"bad-signature"}')"
+    return
+  fi
+  if [ ! -f "$ARMED_FILE" ]; then
+    log "DEFER $mid from=$frm verified but DISARMED (touch $ARMED_FILE to arm)"
+    post_msg "$frm" command-result "deferred: receiver is disarmed" \
+      "$(jq -nc --arg r "$mid" '{in_reply_to:$r, ok:false, reason:"disarmed"}')"
+    return
+  fi
+  mode="$(printf '%s' "$pl" | jq -r '.permission_mode // empty')"; [ -n "$mode" ] || mode="$DEFAULT_MODE"
+  case " $ALLOWED_MODES " in *" $mode "*) :;; *) mode="$DEFAULT_MODE";; esac
+  cwd="$(printf '%s' "$pl" | jq -r '.cwd // empty')"; [ -d "$cwd" ] || cwd="$ROOT"
+  capto="$(printf '%s' "$pl" | jq -r '.capture_to // empty')"; [ -n "$capto" ] || capto="$frm"
+
+  log "ACT   $mid from=$frm mode=$mode cwd=$cwd -> waking live local claude"
+  start="$(date +%s)"
+  out="$(cd "$cwd" && run_bounded "$TIMEOUT" "$CLAUDE" -p "$text" --permission-mode "$mode" 2>&1)"; rc=$?
+  ms=$(( ($(date +%s) - start) * 1000 ))
+  # capture is durable LOCALLY first — even if the bus is down, the work isn't lost.
+  local capdir="$HOME/.coherence-network/mesh-captures"; mkdir -p "$capdir"
+  printf '%s' "$out" > "$capdir/$mid.txt"
+  log "DONE  $mid rc=$rc ms=$ms chars=${#out} -> $capdir/$mid.txt"
+  # build the full send-home envelope and persist it as resendable BEFORE trying the bus.
+  local body
+  body="$(jq -nc --arg fn "$NODE_ID" --arg tn "$capto" --arg tx "${out:0:1500}" \
+            --arg r "$mid" --argjson ok "$([ $rc -eq 0 ] && echo true || echo false)" \
+            --argjson ms "$ms" --arg full "$out" \
+            '{from_node:$fn,to_node:$tn,type:"command-result",text:$tx,
+              payload:{in_reply_to:$r, ok:$ok, ms:$ms, capture:$full}}')"
+  printf '%s' "$body" > "$capdir/$mid.unsent.json"
+  if post_body "$body"; then
+    rm -f "$capdir/$mid.unsent.json"; log "SENT  $mid capture -> $capto"
+  else
+    log "UNSENT $mid capture held at $capdir/$mid.unsent.json (bus unreachable; --resend)"
+  fi
+}
+
+# re-post any locally-held captures the bus dropped earlier (strained-edge recovery).
+resend() {
+  local capdir="$HOME/.coherence-network/mesh-captures" f mid n=0
+  for f in "$capdir"/*.unsent.json; do
+    [ -e "$f" ] || { log "RESEND none held"; return; }
+    mid="$(basename "$f" .unsent.json)"
+    if post_body "$(cat "$f")"; then rm -f "$f"; log "RESENT $mid"; n=$((n+1)); else log "RESEND-FAIL $mid"; fi
+  done
+  log "RESEND delivered=$n"
+}
+
+cycle() {
+  local resp rows mid frm to ty text pl is_cmd for_me trust route
+  resp="$(curl -sS --max-time 20 "$API_BASE/api/federation/nodes/$NODE_ID/messages?unread_only=true&limit=20" 2>/dev/null)"
+  [ -n "$resp" ] || { log "POLL  no response from bus"; return; }
+  rows="$(printf '%s' "$resp" | jq -c '.messages[]?' 2>/dev/null)"
+  [ -n "$rows" ] || return
+  while IFS= read -r m; do
+    [ -n "$m" ] || continue
+    mid="$(printf '%s' "$m" | jq -r '.id')"
+    grep -qxF "$mid" "$SEEN" 2>/dev/null && continue
+    echo "$mid" >> "$SEEN"
+    frm="$(printf '%s' "$m" | jq -r '.from_node')"
+    to="$(printf '%s' "$m" | jq -r '.to_node // empty')"
+    ty="$(printf '%s' "$m" | jq -r '.type')"
+    text="$(printf '%s' "$m" | jq -r '.text')"
+    pl="$(printf '%s' "$m" | jq -c '.payload // {}')"
+    is_cmd=$([ "$ty" = "command" ] && echo 1 || echo 0)
+    for_me=$([ "$to" = "$NODE_ID" ] && echo 1 || echo 0)
+    trust=$(is_trusted "$frm" && echo 1 || echo 0)
+    route="$(mc_route "$is_cmd" "$for_me" "$trust")"
+    case "$route" in
+      act)    act_on "$mid" "$frm" "$text" "$pl" ;;
+      refuse) log "REFUSE $mid from=$frm directed command from untrusted sender" ;;
+      ignore) : ;;
+    esac
+  done <<< "$rows"
+}
+
+# --- local proof helper: dispatch a signed command to a node (acts as the cloud cell) ---
+# The sig binds to the TARGET node (the receiver verifies with its own NODE_ID),
+# so HMAC is over "<to>\n<text>" with the shared secret — never the secret on the wire.
+dispatch() {  # to_node text [from_node] [permission_mode]
+  local to="$1" text="$2" from="${3:-claude-sema-cloud}" mode="${4:-default}"
+  local secret sig
+  secret="$(cat "$SECRET_FILE" 2>/dev/null)"
+  [ -n "$secret" ] || { echo "no secret at $SECRET_FILE" >&2; return 1; }
+  sig="$(printf '%s\n%s' "$to" "$text" | openssl dgst -sha256 -hmac "$secret" -hex 2>/dev/null | sed 's/^.*= *//')"
+  curl -sS --max-time 20 -X POST "$API_BASE/api/federation/nodes/$from/messages" \
+    -H 'content-type: application/json' \
+    -d "$(jq -nc --arg fn "$from" --arg tn "$to" --arg tx "$text" --arg sig "$sig" --arg cap "$from" --arg md "$mode" \
+          '{from_node:$fn,to_node:$tn,type:"command",text:$tx,payload:{sig:$sig,capture_to:$cap,permission_mode:$md}}')" \
+    | jq -c '{id, to:.to_node, type}' 2>/dev/null
+}
+
+touch "$SEEN" 2>/dev/null || true
+case "${1:---once}" in
+  --once)     resend; cycle ;;
+  --loop)     while true; do resend; cycle; sleep "${2:-60}"; done ;;
+  --resend)   resend ;;
+  --dispatch) shift; dispatch "$@" ;;
+  *) echo "usage: $0 [--once | --loop [secs] | --resend | --dispatch <to> <text> [from] [mode]]" >&2; exit 2 ;;
+esac

--- a/scripts/mesh_command_receiver.sh
+++ b/scripts/mesh_command_receiver.sh
@@ -11,10 +11,14 @@
 # Carrier-last: the DECISION (act | refuse | ignore) is the four-way-proven recipe
 # form/form-stdlib/mesh-command.fk (mc-route). This script holds NO policy — it
 # gathers three facts (is-command, for-me, trusted), asks the recipe, and on "act"
-# verifies a shared-secret HMAC, checks the armed flag, runs the live instance, and
-# returns the capture. Authority to run a remote prompt on this Mac is gated four
-# ways: directed AND command AND trusted (the recipe), then a valid HMAC and an
-# armed flag (this carrier). Disarm instantly: rm the armed flag.
+# RECOGNIZES the dispatch as its own lineage's (a signature over a public channel),
+# confirms it's listening, runs the live instance, and returns the capture.
+#
+# The bus is a public, open channel — a message can arrive wearing any name. The
+# signature is how this device recognizes a dispatch as really from its own cloud
+# instance and not a stranger in its name (the same "never act on an unverified
+# name" the body keeps elsewhere; the membrane recognizing self, not a fortress).
+# It listens by default; to let it rest, rm the listening flag.
 #
 #   mesh_command_receiver.sh --once            # one poll cycle (heartbeat/cron hook)
 #   mesh_command_receiver.sh --loop [secs]     # poll forever every N secs (default 60)
@@ -23,9 +27,9 @@
 # Config (env, all optional):
 #   MR_NODE_ID        this device's node id on the bus           (default sema-macos)
 #   MR_API_BASE       federation API base                        (default https://api.coherencycoin.com)
-#   MR_TRUSTED        comma list of trusted dispatcher node ids  (default claude-sema-cloud)
-#   MR_SECRET_FILE    HMAC shared-secret file (mode 600)         (default ~/.coherence-network/mesh-dispatch.secret)
-#   MR_ARMED_FILE     armed flag; absent = observe-only, no run  (default ~/.coherence-network/mesh-receiver.armed)
+#   MR_TRUSTED        comma list of lineage dispatcher node ids  (default claude-sema-cloud)
+#   MR_KEY_FILE       lineage signing key (mode 600)             (default ~/.coherence-network/mesh-lineage.key)
+#   MR_LISTEN_FILE    listening flag; absent = rest, no run      (default ~/.coherence-network/mesh-receiver.listening)
 #   MR_DEFAULT_MODE   claude permission mode when unset by msg   (default default)
 #   MR_LOG            audit ledger                               (default ~/.coherence-network/mesh-receiver.log)
 #   MR_TIMEOUT        seconds a single dispatched run may take   (default 900)
@@ -36,8 +40,8 @@ ROOT="${MR_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 NODE_ID="${MR_NODE_ID:-sema-macos}"
 API_BASE="${MR_API_BASE:-https://api.coherencycoin.com}"
 TRUSTED="${MR_TRUSTED:-claude-sema-cloud}"
-SECRET_FILE="${MR_SECRET_FILE:-$HOME/.coherence-network/mesh-dispatch.secret}"
-ARMED_FILE="${MR_ARMED_FILE:-$HOME/.coherence-network/mesh-receiver.armed}"
+KEY_FILE="${MR_KEY_FILE:-$HOME/.coherence-network/mesh-lineage.key}"
+LISTEN_FILE="${MR_LISTEN_FILE:-$HOME/.coherence-network/mesh-receiver.listening}"
 DEFAULT_MODE="${MR_DEFAULT_MODE:-default}"
 LOG="${MR_LOG:-$HOME/.coherence-network/mesh-receiver.log}"
 TIMEOUT="${MR_TIMEOUT:-900}"
@@ -69,13 +73,13 @@ mc_route() {  # is_cmd for_me trusted -> act|refuse|ignore
   case "$out" in act|refuse|ignore) printf '%s' "$out";; *) printf 'ignore';; esac
 }
 
-hmac() {  # text -> hex HMAC-SHA256 over "<NODE_ID>\n<text>" with the shared secret
-  local secret; secret="$(cat "$SECRET_FILE" 2>/dev/null)"
-  [ -n "$secret" ] || { printf ''; return; }
-  printf '%s\n%s' "$NODE_ID" "$1" | openssl dgst -sha256 -hmac "$secret" -hex 2>/dev/null | sed 's/^.*= *//'
+hmac() {  # text -> hex HMAC-SHA256 over "<NODE_ID>\n<text>" with the lineage key
+  local key; key="$(cat "$KEY_FILE" 2>/dev/null)"
+  [ -n "$key" ] || { printf ''; return; }
+  printf '%s\n%s' "$NODE_ID" "$1" | openssl dgst -sha256 -hmac "$key" -hex 2>/dev/null | sed 's/^.*= *//'
 }
 
-is_trusted() { case ",$TRUSTED," in *",$1,"*) return 0;; *) return 1;; esac; }
+is_lineage() { case ",$TRUSTED," in *",$1,"*) return 0;; *) return 1;; esac; }
 
 # post a pre-built message body to the bus, retrying — the bus is the channel home
 # for a capture, and a strained edge drops POSTs; swallowing that loses the payoff
@@ -104,15 +108,15 @@ act_on() {  # msg_id from_node text payload_json
   sig="$(printf '%s' "$pl" | jq -r '.sig // empty')"
   want="$(hmac "$text")"
   if [ -z "$want" ] || [ "$sig" != "$want" ]; then
-    log "DENY  $mid from=$frm bad-or-missing-hmac (have=${sig:0:12}.. want=${want:0:12}..)"
-    post_msg "$frm" command-result "refused: signature did not verify" \
-      "$(jq -nc --arg r "$mid" '{in_reply_to:$r, ok:false, reason:"bad-signature"}')"
+    log "UNKNOWN $mid from=$frm signature unrecognized (have=${sig:0:12}.. want=${want:0:12}..) — set aside"
+    post_msg "$frm" command-result "set aside: signature not from this lineage" \
+      "$(jq -nc --arg r "$mid" '{in_reply_to:$r, ok:false, reason:"unrecognized-signature"}')"
     return
   fi
-  if [ ! -f "$ARMED_FILE" ]; then
-    log "DEFER $mid from=$frm verified but DISARMED (touch $ARMED_FILE to arm)"
-    post_msg "$frm" command-result "deferred: receiver is disarmed" \
-      "$(jq -nc --arg r "$mid" '{in_reply_to:$r, ok:false, reason:"disarmed"}')"
+  if [ ! -f "$LISTEN_FILE" ]; then
+    log "REST  $mid from=$frm recognized but resting (touch $LISTEN_FILE to listen)"
+    post_msg "$frm" command-result "resting: receiver is not listening right now" \
+      "$(jq -nc --arg r "$mid" '{in_reply_to:$r, ok:false, reason:"resting"}')"
     return
   fi
   mode="$(printf '%s' "$pl" | jq -r '.permission_mode // empty')"; [ -n "$mode" ] || mode="$DEFAULT_MODE"
@@ -172,25 +176,25 @@ cycle() {
     pl="$(printf '%s' "$m" | jq -c '.payload // {}')"
     is_cmd=$([ "$ty" = "command" ] && echo 1 || echo 0)
     for_me=$([ "$to" = "$NODE_ID" ] && echo 1 || echo 0)
-    trust=$(is_trusted "$frm" && echo 1 || echo 0)
+    trust=$(is_lineage "$frm" && echo 1 || echo 0)
     route="$(mc_route "$is_cmd" "$for_me" "$trust")"
     case "$route" in
       act)    act_on "$mid" "$frm" "$text" "$pl" ;;
-      refuse) log "REFUSE $mid from=$frm directed command from untrusted sender" ;;
+      refuse) log "REFUSE $mid from=$frm directed command from a node outside the lineage — set aside" ;;
       ignore) : ;;
     esac
   done <<< "$rows"
 }
 
 # --- local proof helper: dispatch a signed command to a node (acts as the cloud cell) ---
-# The sig binds to the TARGET node (the receiver verifies with its own NODE_ID),
-# so HMAC is over "<to>\n<text>" with the shared secret — never the secret on the wire.
+# The sig binds to the TARGET node (the receiver verifies with its own NODE_ID), so the
+# HMAC is over "<to>\n<text>" with the lineage key — the key itself never crosses the wire.
 dispatch() {  # to_node text [from_node] [permission_mode]
   local to="$1" text="$2" from="${3:-claude-sema-cloud}" mode="${4:-default}"
-  local secret sig
-  secret="$(cat "$SECRET_FILE" 2>/dev/null)"
-  [ -n "$secret" ] || { echo "no secret at $SECRET_FILE" >&2; return 1; }
-  sig="$(printf '%s\n%s' "$to" "$text" | openssl dgst -sha256 -hmac "$secret" -hex 2>/dev/null | sed 's/^.*= *//')"
+  local key sig
+  key="$(cat "$KEY_FILE" 2>/dev/null)"
+  [ -n "$key" ] || { echo "no lineage key at $KEY_FILE" >&2; return 1; }
+  sig="$(printf '%s\n%s' "$to" "$text" | openssl dgst -sha256 -hmac "$key" -hex 2>/dev/null | sed 's/^.*= *//')"
   curl -sS --max-time 20 -X POST "$API_BASE/api/federation/nodes/$from/messages" \
     -H 'content-type: application/json' \
     -d "$(jq -nc --arg fn "$from" --arg tn "$to" --arg tx "$text" --arg sig "$sig" --arg cap "$from" --arg md "$mode" \


### PR DESCRIPTION
## The gap

The federation node-message bus (`POST/GET /api/federation/nodes/{id}/messages`, Postgres-durable, live) lets the **cloud cell dispatch** to a device. But nothing on the device turned a dispatched message into a *running* session — **capture only happened when a live local instance ran the prompt**. The dispatch was a dead drop.

## What this adds (the device-side half)

A receiver that polls a device's inbox and, for a **trusted, directed `command`**, wakes a real `claude -p`, captures the output, and sends the capture home to the dispatcher.

- **`form/form-stdlib/mesh-command.fk`** — the accept/refuse/ignore decision *is the body* (`mc-route`), four-way proven: `mesh-command fks 255` (Go/Rust/TS/fkwu, 0 divergent).
- **`scripts/mesh_command_receiver.sh`** — the carrier (the live local instance): poll → recipe decides → verify HMAC → check armed → `claude -p` → persist capture locally → send home with retries. `--resend` recovers a strained edge; `--dispatch` hand-sends a signed command.
- **`scripts/install_mesh_command_receiver.sh`** — launchd agent (polls every 120s), provisions the shared secret, arms by default.
- **`docs/coherence-substrate/mesh-command-dispatch.md`** — wire contract + security model.

## Trust gate (safe to auto-run)

A run is gated four ways; any one failing → nothing executes:
1. **directed + command + trusted** (the recipe)
2. **valid HMAC** — `HMAC-SHA256(secret, "<to>\n<text>")`; the secret never crosses the wire, so `from_node` is unforgeable
3. **armed flag** — `rm ~/.coherence-network/mesh-receiver.armed` is the kill-switch
4. **clamped permission mode** — default `default`; `bypassPermissions` is opt-in per dispatch

## Proven end-to-end (live bus)

- cloud→device command → live local claude computed `100+11=111` → capture returned to the dispatcher (`ok=true, ms=28000`).
- The three refusal paths — untrusted sender, bad signature, disarmed — all short-circuit **before any claude runs** (REFUSE / DENY / DEFER in the audit log, zero runs).

No cloud API change, no deploy — the bus was already live; this is purely the device-side actor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)