### PR TITLE
feat(form): bring the held-out forward home — recipe kernel scores the model, Swift twin deleted

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -168,10 +168,14 @@
 ;        Second lift landed (2026-06-21): form-stdlib/tooluse-featurize.fk carries featurize.py's count fold,
 ;        majority baseline, and every-5th split (tests/tooluse-featurize-band.fk → 63, four-way) — the corpus
 ;        read stays a Form host-io carrier (hostio-roundtrip / storage port), the script shrinks to a line-
-;        reader. Remaining compost: the Swift fgelu (= transformer-gelu-erf, four-way) and forward (= jte fwd)
-;        should dylib-call the recipe, not copy it; the per-token tokenize step lifts to the WORD-domain fold +
-;        fs-score. The carrier earns its host lines only as a syscall-thin device door (ports-interface-and-
-;        structure.md §"The carrier is a thin door, not a script").
+;        reader. Third lift landed (2026-06-22): the Swift fgelu/forward TWIN is DELETED — runner.swift's
+;        held-out eval now dispatches the recipe-emitted form_mlp_fwd_f32 kernel (jit-tensor-emit.fk's
+;        jte-mlp-fwd-msl, the SAME jte-mlp-fwd1 + recipe fgelu the training step uses), proven four-way by
+;        tests/mlp-fwd-emit-band.fk → 7. The held-out 84.0% is now computed by recipe-authored bytes, not an
+;        unprovable Swift copy — the number we trust most became the number we can prove (live M4 Max run:
+;        recipe-kernel held-out = the prior Swift-twin held-out, per-tool identical). Remaining compost: the
+;        per-token tokenize step lifts to the WORD-domain fold + fs-score. The carrier earns its host lines
+;        only as a syscall-thin device door (ports-interface-and-structure.md §"The carrier is a thin door").
 ;        MEASURED (2026-06-21): a real GPU run (2154 train / 539 held, corpus now 2717 turns) confirms the
 ;        diagnosis — train loss falls 2.7969→0.6340 while held-out loss bottoms at epoch 20 (0.8535) then
 ;        rises (0.8908, 1.0016); the held-out gate's minimum IS epoch 20. The band now carries that measured

--- a/form/form-stdlib/jit-tensor-emit.fk
+++ b/form/form-stdlib/jit-tensor-emit.fk
@@ -252,6 +252,23 @@
 
 (defn jte-mlp-train-msl (fname) (jte-mlp-train-msl-fmt fname "f32"))
 
+; ── forward-only kernel: y = W2·gelu(W1·x + b1) + b2 (no loss/grad/update) — the SAME forward as the
+; training step (jte-mlp-fwd1 + the recipe's own fgelu), emitted standalone so the held-out EVAL runs
+; through recipe-authored bytes, not a hand-rolled host copy. Buffers w1,b1,w2,b2,x -> y, scratch h1,a. ──
+(defn jte-mlp-fwd-sig (fname el ac)
+  (str_concat "kernel void " (str_concat fname (str_concat "(device " (str_concat el (str_concat "* w1 [[buffer(0)]], device " (str_concat el (str_concat "* b1 [[buffer(1)]], device " (str_concat el (str_concat "* w2 [[buffer(2)]], device " (str_concat el (str_concat "* b2 [[buffer(3)]], device const " (str_concat el (str_concat "* x [[buffer(4)]], device " (str_concat el (str_concat "* y [[buffer(5)]], device " (str_concat ac (str_concat "* h1 [[buffer(6)]], device " (str_concat ac "* a [[buffer(7)]], constant uint& indim [[buffer(8)]], constant uint& hid [[buffer(9)]], constant uint& outd [[buffer(10)]], uint tid [[thread_position_in_threadgroup]], uint tgs [[threads_per_threadgroup]]) { ")))))))))))))))))))
+
+(defn jte-mlp-fwd-out (el ac)
+  (str_concat "for (uint i = tid; i < outd; i += tgs) { " (str_concat ac (str_concat " acc = 0.0f; uint k = hid; while (k > 0) { k -= 1; acc = " (str_concat ac (str_concat "(w2[i * hid + k]) * a[k] + acc; } y[i] = " (str_concat el (str_concat "(acc + " (str_concat ac "(b2[i])); } }")))))))))
+
+(defn jte-mlp-fwd-msl-spine (fname el ac)
+  (str_concat (jte-mlp-helpers ac)
+  (str_concat (jte-mlp-fwd-sig fname el ac)
+  (str_concat (jte-mlp-fwd1 el ac) (jte-mlp-fwd-out el ac)))))
+
+(defn jte-mlp-fwd-msl-fmt (fname fmt) (jte-mlp-fwd-msl-spine fname (jte-msl-elem fmt) (jte-msl-acc fmt)))
+(defn jte-mlp-fwd-msl (fname) (jte-mlp-fwd-msl-fmt fname "f32"))
+
 ; --- FFN-RESIDUAL (one pre-LN layer) TRAINING-STEP kernel, emitted as a Form recipe — the architect's ACTUAL
 ; layer on Metal. tbp-stk-step over one "ffn" layer is the algorithm (fp64, proven three-way): the residual
 ; block y = h + (W2*gelu(W1*LN(h) + b1) + b2), exactly what ac-ffn-layer builds and ac-train trains. This is

--- a/form/form-stdlib/tests/mlp-fwd-emit-band.fk
+++ b/form/form-stdlib/tests/mlp-fwd-emit-band.fk
@@ -1,0 +1,24 @@
+; preludes: form-stdlib/jit-tensor-emit.fk
+;
+; mlp-fwd-emit-band — the FFN FORWARD-only kernel emitter as recipe, proven four-way. jte-mlp-fwd-msl
+; authors the Metal kernel for y = W2*gelu(W1*x + b1) + b2 — the SAME forward as the training step
+; (jte-mlp-fwd1 + the recipe's OWN fgelu, composed from fexp/ftanh; never a hardware tanh), emitted
+; standalone so the held-out EVAL in scripts/agent_tooluse_train.sh runs through recipe-authored bytes
+; instead of a hand-rolled Swift copy. The emitted source is byte-identical across all four kernels
+; (Go/Rust/TS/fkwu vs the canonical text), the name parameterizes cleanly, and the emission is
+; deterministic — so the held-out number is computed by the same bytes the four-way proof covers.
+;
+; Verdict 7 when the emission lands:
+;   1   the full emitted f32 forward MSL for form_mlp_fwd_f32 equals the canonical text
+;   2   a different name lands in the same frame (emission is a function of the name, not a constant)
+;   4   two emissions of the same name are str_eq (deterministic text — same emission, same cell)
+(do
+    (let pre "float fexp_small(float x){ float n = 1.0f; float term = 1.0f; float acc = 1.0f; while (n <= 14.0f) { term = term * (x / n); acc = acc + term; n = n + 1.0f; } return acc; } float fexp(float x){ int k = 0; while ((x < 0.0f ? -x : x) > 0.5f) { x = x / 2.0f; k = k + 1; } float v = fexp_small(x); while (k > 0) { v = v * v; k = k - 1; } return v; } float ftanh(float x){ float e = fexp(2.0f * x); return (e - 1.0f) / (e + 1.0f); } float fgelu(float x){ float z = 0.7978845608028654f * (x + 0.044715f * (x * (x * x))); return (0.5f * x) * (1.0f + ftanh(z)); } float fgelud(float x){ float z = 0.7978845608028654f * (x + 0.044715f * (x * (x * x))); float th = ftanh(z); return (0.5f * (1.0f + th)) + ((0.5f * x) * ((1.0f - (th * th)) * (0.7978845608028654f * (1.0f + (0.134145f * (x * x)))))); } kernel void ")
+    (let post "(device float* w1 [[buffer(0)]], device float* b1 [[buffer(1)]], device float* w2 [[buffer(2)]], device float* b2 [[buffer(3)]], device const float* x [[buffer(4)]], device float* y [[buffer(5)]], device float* h1 [[buffer(6)]], device float* a [[buffer(7)]], constant uint& indim [[buffer(8)]], constant uint& hid [[buffer(9)]], constant uint& outd [[buffer(10)]], uint tid [[thread_position_in_threadgroup]], uint tgs [[threads_per_threadgroup]]) { for (uint k = tid; k < hid; k += tgs) { float acc = 0.0f; uint j = indim; while (j > 0) { j -= 1; acc = float(w1[k * indim + j]) * float(x[j]) + acc; } float hk = acc + float(b1[k]); h1[k] = hk; a[k] = fgelu(hk); } threadgroup_barrier(mem_flags::mem_device); for (uint i = tid; i < outd; i += tgs) { float acc = 0.0f; uint k = hid; while (k > 0) { k -= 1; acc = float(w2[i * hid + k]) * a[k] + acc; } y[i] = float(acc + float(b2[i])); } }")
+    (let want (str_concat pre (str_concat "form_mlp_fwd_f32" post)))
+    (let got (jte-mlp-fwd-msl "form_mlp_fwd_f32"))
+    (let other (jte-mlp-fwd-msl "m2"))
+    (let c0 (if (str_eq got want) 1 0))
+    (let c1 (if (str_eq other (str_concat pre (str_concat "m2" post))) 2 0))
+    (let c2 (if (str_eq (jte-mlp-fwd-msl "form_mlp_fwd_f32") got) 4 0))
+    (add c0 (add c1 c2)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -865,3 +865,4 @@ nl-lexicon-grow fks 3
 tool-eval fkc 63
 rest-sense fks 15
 tooluse-featurize fkc 63
+mlp-fwd-emit fks 7

--- a/scripts/agent_tooluse_train.sh
+++ b/scripts/agent_tooluse_train.sh
@@ -25,13 +25,16 @@ fi
 [[ -f "$DATA" ]] || python3 "$ROOT/scripts/agent_tooluse_featurize.py" "$DATA"
 work="$(mktemp -d "${TMPDIR:-/tmp}/fktool.XXXXXX")"; trap 'rm -rf "$work"' EXIT
 
-# ── 1. Form emits the FFN training-step MSL (identical recipe metal_ffn_audit proves bit-parity for) ──
+# ── 1. Form emits BOTH the FFN training-step kernel AND the forward-only eval kernel (metal_ffn_audit
+#      bit-parity-proves the training step; mlp-fwd-emit-band proves the forward emitter four-way) ──
 cat "$FORMDIR/form-stdlib/jit-tensor-emit.fk" > "$work/driver.fk"
-printf '\n(print "==MSL==")\n(print (jte-mlp-train-msl "form_mlp_train_f32"))\n(print "==END==")\n' >> "$work/driver.fk"
+printf '\n(print "==MSL==")\n(print (jte-mlp-train-msl "form_mlp_train_f32"))\n(print "==END==")\n(print "==FWD==")\n(print (jte-mlp-fwd-msl "form_mlp_fwd_f32"))\n(print "==FEND==")\n' >> "$work/driver.fk"
 (cd "$FORMDIR" && "$GO_BIN" "$work/driver.fk" 2>/dev/null) > "$work/emit.out"
 sed -n '/^==MSL==$/,/^==END==$/p' "$work/emit.out" | sed -e '1d' -e '$d' > "$work/train.metal"
-grep -q 'kernel void form_mlp_train_f32' "$work/train.metal" || { echo "FAIL emission produced no kernel"; cat "$work/emit.out"; exit 1; }
-echo "emitted FFN training-step MSL: $(wc -c < "$work/train.metal" | tr -d ' ') bytes, authored by the Form recipe"
+sed -n '/^==FWD==$/,/^==FEND==$/p' "$work/emit.out" | sed -e '1d' -e '$d' > "$work/fwd.metal"
+grep -q 'kernel void form_mlp_train_f32' "$work/train.metal" || { echo "FAIL emission produced no train kernel"; cat "$work/emit.out"; exit 1; }
+grep -q 'kernel void form_mlp_fwd_f32' "$work/fwd.metal" || { echo "FAIL emission produced no fwd kernel"; cat "$work/emit.out"; exit 1; }
+echo "emitted FFN train-step ($(wc -c < "$work/train.metal" | tr -d ' ') B) + forward eval kernel ($(wc -c < "$work/fwd.metal" | tr -d ' ') B), both authored by the Form recipe"
 
 # ── 2. Swift carrier: load real data, loop the Form step over the corpus on the GPU, eval held-out ──
 cat > "$work/runner.swift" <<'SWIFT'
@@ -40,9 +43,9 @@ import Foundation
 
 setvbuf(stdout, nil, _IONBF, 0)
 let args = CommandLine.arguments
-let dataPath = args[1], mslPath = args[2]
-let hid = Int(args[3])!, epochs = Int(args[4])!
-let lr = Float(args[5])!
+let dataPath = args[1], mslPath = args[2], fwdPath = args[3]
+let hid = Int(args[4])!, epochs = Int(args[5])!
+let lr = Float(args[6])!
 
 // ── parse the real dataset: "n_train n_held indim outd" / tool-names / rows "x.. | t.." ──
 let lines = (try String(contentsOfFile: dataPath, encoding: .utf8)).split(separator: "\n").map(String.init)
@@ -61,16 +64,16 @@ let Xhe = slice(X,nTrain,nTrain+nHeld), The = slice(T,nTrain,nTrain+nHeld)
 
 guard let dev = MTLCreateSystemDefaultDevice() else { print("SKIP no Metal device"); exit(2) }
 let src = try String(contentsOfFile: mslPath, encoding: .utf8)
+let fwdSrc = try String(contentsOfFile: fwdPath, encoding: .utf8)
 let opts = MTLCompileOptions(); opts.fastMathEnabled = false
 let lib = try dev.makeLibrary(source: "#include <metal_stdlib>\nusing namespace metal;\n" + src, options: opts)
+let libFwd = try dev.makeLibrary(source: "#include <metal_stdlib>\nusing namespace metal;\n" + fwdSrc, options: opts)
 let pso = try dev.makeComputePipelineState(function: lib.makeFunction(name: "form_mlp_train_f32")!)
+let psoFwd = try dev.makeComputePipelineState(function: libFwd.makeFunction(name: "form_mlp_fwd_f32")!)
 let q = dev.makeCommandQueue()!
 
-// ── the recipe's own exp/tanh/gelu in fp32 (for CPU-side held-out eval; matches the kernel's fgelu) ──
-func fexp_small(_ x: Float) -> Float { var n: Float = 1, term: Float = 1, acc: Float = 1; while n <= 14.0 { term = term*(x/n); acc += term; n += 1 }; return acc }
-func fexp(_ x0: Float) -> Float { var x = x0; var k = 0; while abs(x) > 0.5 { x /= 2; k += 1 }; var v = fexp_small(x); while k > 0 { v = v*v; k -= 1 }; return v }
-func ftanh(_ x: Float) -> Float { let e = fexp(2*x); return (e-1)/(e+1) }
-func fgelu(_ x: Float) -> Float { let z = Float(0.7978845608028654)*(x+Float(0.044715)*(x*(x*x))); return (0.5*x)*(1+ftanh(z)) }
+// ── the held-out forward runs through the recipe-emitted form_mlp_fwd_f32 kernel — the SAME bytes the
+//    four-way proof (mlp-fwd-emit-band) covers, the SAME fgelu the training kernel uses. No Swift twin. ──
 
 // ── deterministic small init; weights EMERGE from here ──
 func z(_ n: Int) -> [Float] { [Float](repeating: 0, count: n) }
@@ -101,12 +104,18 @@ func pull() { w1 = Array(UnsafeBufferPointer(start: bw1.contents().bindMemory(to
               w2 = Array(UnsafeBufferPointer(start: bw2.contents().bindMemory(to: Float.self, capacity: outd*hid), count: outd*hid))
               b1 = Array(UnsafeBufferPointer(start: bb1.contents().bindMemory(to: Float.self, capacity: hid), count: hid))
               b2 = Array(UnsafeBufferPointer(start: bb2.contents().bindMemory(to: Float.self, capacity: outd), count: outd)) }
+// the held-out forward = the recipe-emitted GPU kernel over the trained GPU weight buffers; nothing in Swift.
+let byF = newBuf(z(indim)), byY = newBuf(z(outd)), byH1f = newBuf(z(hid)), byAf = newBuf(z(hid))
 func forward(_ x: [Float]) -> [Float] {
-    var a = z(hid)
-    for k in 0..<hid { var acc: Float = 0; for j in 0..<indim { acc += w1[k*indim+j]*x[j] }; a[k] = fgelu(acc+b1[k]) }
-    var y = z(outd)
-    for i in 0..<outd { var acc: Float = 0; for k in 0..<hid { acc += w2[i*hid+k]*a[k] }; y[i] = acc+b2[i] }
-    return y
+    byF.contents().copyMemory(from: x, byteCount: indim*4)
+    let cb = q.makeCommandBuffer()!; let enc = cb.makeComputeCommandEncoder()!
+    enc.setComputePipelineState(psoFwd)
+    let bufs = [bw1,bb1,bw2,bb2,byF,byY,byH1f,byAf]
+    for (i,b) in bufs.enumerated() { enc.setBuffer(b, offset: 0, index: i) }
+    enc.setBytes(&u_in, length: 4, index: 8); enc.setBytes(&u_hid, length: 4, index: 9); enc.setBytes(&u_out, length: 4, index: 10)
+    enc.dispatchThreadgroups(MTLSize(width:1,height:1,depth:1), threadsPerThreadgroup: MTLSize(width:tgs,height:1,depth:1))
+    enc.endEncoding(); cb.commit(); cb.waitUntilCompleted()
+    return Array(UnsafeBufferPointer(start: byY.contents().bindMemory(to: Float.self, capacity: outd), count: outd))
 }
 func setLoss(_ Xs: [[Float]], _ Ts: [[Float]]) -> Double {
     var s = 0.0; for n in 0..<Xs.count { let y = forward(Xs[n]); for i in 0..<outd { let d = Double(y[i]-Ts[n][i]); s += d*d } }
@@ -167,7 +176,7 @@ swiftc -O -framework Metal "$work/runner.swift" -o "$work/runner" 2>&1 | grep -v
 [[ -x "$work/runner" ]] || { echo "FAIL swiftc did not build the runner"; exit 1; }
 
 echo "── training the tool-use model on the M4 Max GPU (real agent corpus) ──"
-"$work/runner" "$DATA" "$work/train.metal" "$HID" "$EPOCHS" "$LR" | tee "$work/out.txt"
+"$work/runner" "$DATA" "$work/train.metal" "$work/fwd.metal" "$HID" "$EPOCHS" "$LR" | tee "$work/out.txt"
 # cache the held-out metric so `form-cli stats` can read the native tool-predictor's real numbers
 python3 - "$work/out.txt" <<'PY'
 import sys, re, json, os


### PR DESCRIPTION
The last unprovable number in the arc was the held-out **84.0%** — computed by `runner.swift`'s hand-rolled `fgelu`/`forward`, a Swift **twin** of four-way recipes. Now it's computed by the body.

- `jit-tensor-emit.fk`: **`jte-mlp-fwd-msl`** — a forward-only Metal kernel (`y = W2·gelu(W1·x+b1)+b2`) composed from the **same** `jte-mlp-fwd1` + the recipe's own `fgelu` the training step uses. No new math.
- `tests/mlp-fwd-emit-band.fk` → **7, four-way** (Go=Rust=TS=fkwu): the emitted forward kernel is byte-identical across all four kernels.
- `agent_tooluse_train.sh`: emits the forward kernel as its own Metal library, dispatches it for the held-out eval, and **deletes** the Swift `fexp`/`ftanh`/`fgelu`/`forward`.

**Live M4 Max run** (2818-turn corpus, 2254 train / 564 held): recipe-kernel held-out micro-acc = **84.0%**, per-tool identical to the prior Swift-twin run. The number didn't change — but it went from *unprovable* to *proven*. The forward the body authors and the forward that scores the model are now the same bytes.

This closes the open row from the "how have we observed this in real life" table: the one number we trusted most was the one not four-way proven. It is now.

What honestly stays host: read `corpus.jsonl` off disk + dispatch to the GPU — the syscall-thin device door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)