### PR TITLE
feat(sense): live-room — multi-speaker transcriber + Brazilian-Portuguese translator on a phone

### DIFF
--- a/experiments/coherence-sense-android/live-room.html
+++ b/experiments/coherence-sense-android/live-room.html
@@ -1,0 +1,71 @@
+<!doctype html><html lang="pt-BR"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>Hati Suci — sala ao vivo</title>
+<style>
+  :root { color-scheme: light; }
+  * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+  body { margin: 0; font-family: -apple-system, system-ui, "Segoe UI", Roboto, sans-serif;
+         background: #f6f4ef; color: #1f1d1a; }
+  header { position: sticky; top: 0; background: #fffefb; border-bottom: 1px solid #e7e3da;
+           padding: 12px 16px; display: flex; align-items: center; justify-content: space-between; }
+  .h-title { font-size: 17px; font-weight: 600; }
+  .h-sub { font-size: 12px; color: #8a857c; margin-top: 1px; }
+  .live { display: flex; align-items: center; gap: 6px; background: #f6f4ef; padding: 5px 11px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+  .dot { width: 8px; height: 8px; border-radius: 50%; background: #D85A30; animation: pulse 1.6s ease-in-out infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1 } 50% { opacity: .25 } }
+  #feed { padding: 6px 14px 30px; max-width: 640px; margin: 0 auto; }
+  .turn { display: flex; gap: 12px; padding: 14px 2px; border-top: 1px solid #ece8df; }
+  .turn:first-child { border-top: none; }
+  .av { flex: none; width: 36px; height: 36px; border-radius: 50%; color: #fff; font-weight: 600;
+        font-size: 14px; display: flex; align-items: center; justify-content: center; }
+  .meta { display: flex; align-items: baseline; gap: 8px; }
+  .name { font-size: 14px; font-weight: 600; }
+  .time { font-size: 11px; color: #b0aaa0; }
+  .orig { font-size: 13px; color: #9a948a; margin: 2px 0 4px; line-height: 1.4; }
+  .pt   { font-size: 17px; color: #1f1d1a; line-height: 1.5; }
+  .pend { color: #c98a3a; font-size: 14px; }
+  .empty { text-align: center; color: #b0aaa0; padding: 60px 20px; font-size: 15px; }
+  footer { position: sticky; bottom: 0; background: #fffefb; border-top: 1px solid #e7e3da;
+           padding: 10px 16px; display: flex; justify-content: space-between; font-size: 12px; color: #8a857c; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #17150f; color: #efe9dc } header,footer { background: #1f1c14; border-color: #322d20 }
+    .live { background: #17150f } .turn { border-color: #2a261b } .pt { color: #efe9dc }
+    .h-sub,.time,.orig,.empty { color: #8f887a } .name { color: #efe9dc }
+  }
+</style></head><body>
+<header>
+  <div><div class="h-title">Hati Suci</div><div class="h-sub">sala ao vivo · português (BR)</div></div>
+  <div class="live"><span class="dot"></span>ao vivo</div>
+</header>
+<div id="feed"><div class="empty">Ouvindo a sala… as falas aparecem aqui, traduzidas.</div></div>
+<footer><span id="voices">— vozes</span><span>traduzido no aparelho</span></footer>
+<script>
+  function initial(s){ return (s||'?').replace(/[^A-Za-zÀ-ÿ0-9]/g,' ').trim().charAt(0).toUpperCase()||'?'; }
+  function esc(s){ const d=document.createElement('div'); d.textContent=s||''; return d.innerHTML; }
+  let lastN = -1;
+  async function tick(){
+    try {
+      const r = await fetch('turns.json?_=' + Date.now(), {cache:'no-store'});
+      const turns = await r.json();
+      if (turns.length === lastN) return; lastN = turns.length;
+      const colors = {};
+      const feed = document.getElementById('feed');
+      if (!turns.length){ return; }
+      feed.innerHTML = turns.map(t => {
+        const pend = (t.pt||'').startsWith('⏳');
+        return `<div class="turn">
+          <div class="av" style="background:${esc(t.color||'#888')}">${initial(t.speaker)}</div>
+          <div style="min-width:0">
+            <div class="meta"><span class="name">${esc(t.speaker)}</span><span class="time">${esc(t.time)}</span></div>
+            <div class="orig">${esc(t.original)}</div>
+            <div class="${pend?'pt pend':'pt'}">${esc(t.pt)}</div>
+          </div></div>`;
+      }).join('');
+      const names = new Set(turns.map(t=>t.speaker));
+      document.getElementById('voices').textContent = names.size + (names.size===1?' voz':' vozes');
+      window.scrollTo(0, document.body.scrollHeight);
+    } catch(e){}
+  }
+  tick(); setInterval(tick, 1200);
+</script></body></html>

--- a/experiments/coherence-sense-android/live-room.sh
+++ b/experiments/coherence-sense-android/live-room.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# live-room.sh — a LIVE room transcriber + Brazilian-Portuguese translator, served to any phone on the wifi.
+#
+# The Mac listens, segments speech, labels who is speaking (pitch cluster), transcribes (whisper, any
+# language auto-detected), and translates each turn to Brazilian Portuguese (local ollama — sovereign, no
+# rented mind). Each turn is appended to live-room/turns.json; a clean web page polls it and renders the
+# conversation the way a person reads it (translation prominent, original underneath). Built so the
+# Brazilian-only member at Hati Suci can FOLLOW a room she otherwise can't.
+#
+# Carrier-only I/O: whisper is the STT oracle, ollama the translation oracle, the page is static (the
+# heavy fusion/decision recipes — VAD, speaker-id — are the Form body). Everything stays on this Mac.
+#
+# Run:  live-room.sh --serve     start the web page (prints the phone URL); keep it running
+#       live-room.sh             the capture+transcribe+translate loop (run alongside --serve)
+#       live-room.sh --demo      process a few say-generated voices into turns.json (test the display)
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DIR="${LIVE_DIR:-$HOME/.coherence-network/live-room}"; mkdir -p "$DIR"
+TURNS="$DIR/turns.json"; [[ -f "$TURNS" ]] || echo "[]" > "$TURNS"
+PORT="${LIVE_PORT:-8755}"
+WIN="${LIVE_WINDOW:-5}"
+MODEL_W="${WHISPER_MODEL:-$HOME/whisper-models/ggml-large-v3-turbo.bin}"
+MODEL_T="${TRANSLATE_MODEL:-llama3.2:3b}"
+MIC="${LIVE_MIC:-1}"
+COLORS=("#378ADD" "#1D9E75" "#D85A30" "#7F77DD" "#BA7517" "#D4537E")
+
+cp "$SCRIPT_DIR/live-room.html" "$DIR/index.html" 2>/dev/null || true
+
+# --- speaker diarization by pitch cluster (coarse v1; upgrades to speaker-aam voiceprints later) ---
+roster="$DIR/speakers.tsv"; [[ -f "$roster" ]] || : > "$roster"   # lines: pitch<TAB>label<TAB>color
+diarize() {  # $1 pitch_hz -> "label\tcolor"
+    local p="$1" best="" bestd=9999 bl bc
+    while IFS=$'\t' read -r rp rl rc; do
+        [[ -z "$rp" ]] && continue
+        local d=$(( p>rp ? p-rp : rp-p )); if [[ $d -lt $bestd ]]; then bestd=$d; best="$rl"; bc="$rc"; fi
+    done < "$roster"
+    if [[ -n "$best" && $bestd -le 18 ]]; then echo -e "$best\t$bc"; return; fi
+    local n; n=$(( $(wc -l < "$roster") + 1 )); local label="Voz $n"; local color="${COLORS[$(( (n-1) % ${#COLORS[@]} ))]}"
+    printf "%s\t%s\t%s\n" "$p" "$label" "$color" >> "$roster"; echo -e "$label\t$color"
+}
+
+transcribe() {  # $1 wav -> text (one line; empty if silence)
+    local of="${1%.wav}"
+    whisper-cli -m "$MODEL_W" -f "$1" -nt -oj -of "$of" -l auto -t 4 >/dev/null 2>&1
+    [[ -f "$of.json" ]] || { echo ""; return; }
+    jq -r '[.transcription[].text] | join(" ") | gsub("^[\\s]+|[\\s]+$";"")' "$of.json" 2>/dev/null | grep -vE '^\s*\[.*\]\s*$'
+    rm -f "$of.json"
+}
+
+translate_pt() {  # $1 text -> Brazilian Portuguese (local ollama HTTP API; clean .response, honest pending marker)
+    local prompt out
+    prompt="Translate the following into natural Brazilian Portuguese. Output ONLY the translation — no quotes, no notes, no English: $1"
+    out=$(curl -s --max-time 40 http://localhost:11434/api/generate \
+            -d "$(jq -nc --arg m "$MODEL_T" --arg p "$prompt" '{model:$m, prompt:$p, stream:false, options:{temperature:0.2}}')" \
+          | jq -r '.response // empty' | tr '\n' ' ' | sed 's/  */ /g; s/^[[:space:]]*//; s/[[:space:]]*$//; s/^"//; s/"$//')
+    if [[ -z "$out" || "$out" == *Metal* || "$out" == *MTLCompiler* ]]; then echo "⏳ tradução local aguardando (Metal)"; else echo "$out"; fi
+}
+
+append_turn() {  # $1 label  $2 color  $3 original  $4 pt
+    local ts; ts="$(date '+%H:%M')"
+    jq --arg s "$1" --arg c "$2" --arg o "$3" --arg p "$4" --arg t "$ts" \
+       '. + [{speaker:$s, color:$c, original:$o, pt:$p, time:$t}]' "$TURNS" > "$TURNS.tmp" && mv "$TURNS.tmp" "$TURNS"
+}
+
+process_wav() {  # $1 wav
+    local text; text="$(transcribe "$1")"
+    [[ -z "$text" || "$text" == "[BLANK_AUDIO]" ]] && return
+    local pitch; pitch="$(sox "$1" -n lowpass 350 stat 2>&1 | awk '/Rough +frequency/{printf "%d",$3+0}')"
+    local label color; IFS=$'\t' read -r label color < <(diarize "${pitch:-150}")
+    append_turn "$label" "$color" "$text" "$(translate_pt "$text")"
+    echo "[live] «$label» ${pitch}Hz: $text"
+}
+
+# ---- modes ----
+if [[ "${1:-}" == "--serve" ]]; then
+    IP="$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || echo 127.0.0.1)"
+    echo "[live] serving on  http://$IP:$PORT/   (open this on her phone, same wifi)"
+    echo "[live] turns → $TURNS   ·  run '$0' in another shell to start listening"
+    cd "$DIR" && exec python3 -m http.server "$PORT" --bind 0.0.0.0
+fi
+
+if [[ "${1:-}" == "--demo" ]]; then
+    echo "[]" > "$TURNS"; : > "$roster"
+    declare -a LINES=("Samantha|Let's land in the body first, one slow breath together."
+                      "Daniel|A lot came up for me this week and I want to bring it here."
+                      "Samantha|Thank you, we are holding it with you, you are not alone.")
+    for pair in "${LINES[@]}"; do
+        v="${pair%%|*}"; txt="${pair#*|}"; w="/tmp/lr-$v.wav"
+        say -v "$v" -o /tmp/lr.aiff "$txt" 2>/dev/null && sox /tmp/lr.aiff -r 16000 -c 1 "$w" 2>/dev/null
+        process_wav "$w"; rm -f /tmp/lr.aiff "$w"
+    done
+    echo "[live] demo turns:"; jq -r '.[] | "  «\(.speaker)» \(.original)  →  \(.pt)"' "$TURNS"
+    exit 0
+fi
+
+# ---- live capture loop ----
+echo "[live] listening (mic :$MIC, ${WIN}s windows). turns → $TURNS. Ctrl-C to stop."
+i=0
+while true; do
+    [[ -f "$DIR/STOP" ]] && { echo "[live] STOP"; break; }
+    w="/tmp/live-win-$$.wav"
+    perl -e 'alarm($ARGV[0]+5); shift; exec @ARGV' "$WIN" \
+        ffmpeg -hide_banner -loglevel error -f avfoundation -i ":$MIC" -t "$WIN" -ac 1 -ar 16000 -y "$w" >/dev/null 2>&1 || { sleep 1; continue; }
+    # cheap silence gate: skip near-silent windows
+    rms=$(sox "$w" -n stat 2>&1 | awk '/RMS +amplitude/{printf "%d",$3*1e6}')
+    [[ "${rms:-0}" -gt 1500 ]] && process_wav "$w"
+    rm -f "$w"
+done


### PR DESCRIPTION
For the Brazilian-only member at Hati Suci who can only follow a room through a live transcriber. The Mac listens → segments → labels the speaker (pitch cluster) → transcribes (whisper, auto-language) → translates each turn to Brazilian Portuguese with a **local** ollama model (sovereign, no rented mind). Turns append to `turns.json`; `live-room.html` polls it and renders the conversation — translation prominent, original underneath, one colour per voice. She opens one URL on her phone and follows the room.

Carrier-only I/O; the decision recipes (VAD, speaker-id) are the Form body, and translation follows the same self-grounding arc as `stt-agree` (oracle teacher → native earns the route). All local.

**Verified end-to-end:** two voices → 2 speakers separated → whisper transcribed → local pt-BR (*"Vamos começar pelo corpo primeiro. Uma respiração lenta juntos."*) → rendered live.

v1 of the north star (web display, Mac compute). Next: native Android app cleanup, phone-as-mic, on-device models, qwen2.5:72b for quality. Modes: `--serve` · default listen · `--demo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)