### PR TITLE
feat(tokenizer): llama3 pre-tokenization crosses four-way — the algorithmic gap to the first native LLAMA token

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-22_llama3_pretokenize_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-22_llama3_pretokenize_four_way.json
@@ -1,0 +1,49 @@
+{
+  "evidence_id": "commit_evidence_2026-06-22_llama3_pretokenize_four_way",
+  "date": "2026-06-22",
+  "author": "Sema (Opus 4.8, autonomous native-ML walk)",
+  "title": "Llama 3 (tiktoken-style) regex pre-tokenization crosses four-way — the one algorithmic gap between the proven GPU llama decode stack and the first end-to-end native LLAMA token",
+  "claim": "llama3-pretokenize.fk implements Llama 3's fixed pre-tokenization pat_str as a Form recipe; it crosses four-way (Go/Rust/TS/fkwu) at verdict 255 with 0 divergent.",
+  "north_star_position": "The whole llama inference floor is four-way AND on the M4 GPU: load path (q4k/q6k/f16 dequant), every llama numeric (RMSNorm/RoPE/SwiGLU/SiLU), both block-forward kernels, the KV-cached decode step, and the multi-layer depth stack all run on silicon bit-identical to recompute (#3355/#3376/#3408/#3412/#3423/#3424). The WHISPER tokenizer is four-way end-to-end (tokenize #3550). But the GPU decode stack is LLAMA, and llama3's tokenizer differs from whisper's in exactly ONE algorithmic piece: the pre-tokenization pat_str. The byte->symbol map is the SAME byte-level bytes_to_unicode (#3503); the merge core is the SAME lowest-rank-first BPE (#3447; tiktoken's _byte_pair_merge is lowest-rank-first too) — only the rank TABLE (DATA) and this splitter differ. This brick closes that algorithmic gap.",
+  "band": {
+    "file": "form/form-stdlib/tests/llama3-pretokenize-band.fk",
+    "recipe": "form/form-stdlib/llama3-pretokenize.fk",
+    "verdict": 255,
+    "fourth_arm": "four-way (fkwu + pre-flattened tables)",
+    "divergent": 0,
+    "validate_cmd": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/llama3-pretokenize.fk form-stdlib/tests/llama3-pretokenize-band.fk",
+    "manifest_row": "llama3-pretokenize fks 255"
+  },
+  "pat_str": "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\nA-Za-z0-9]?[A-Za-z]+|[0-9]{1,3}| ?[^\\sA-Za-z0-9]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
+  "four_distinguishing_laws_vs_gpt2": [
+    "CASE-INSENSITIVE contractions (?i:): 'DON\\'T' -> ['DON',''T'] — llama3 splits the UPPERCASE 'T; GPT-2's lowercase-only 't would not. (band bit 2)",
+    "DIGITS group 1-3 [0-9]{1,3}: '1234' -> ['123','4']; GPT-2's ` ?\\p{N}+` gives ['1234']. (band bit 4)",
+    "WORD leading char is ANY non-newline non-alnum, not just a space [^\\r\\nA-Za-z0-9]?\\p{L}+: '_word' -> ['_word']; GPT-2's ` ?\\p{L}+` gives ['_','word']. (band bit 8)",
+    "DIGITS take NO leading space (no ` ?` on the digit alt): ' 42' -> [' ','42']; GPT-2's ` ?\\p{N}+` gives [' 42']. This also forces the ws run==1 path (one space before a non-space) that GPT-2's space-absorption never reaches. (band bit 16)"
+  ],
+  "band_claims": {
+    "bit1": "' tokenizer' -> [' tokenizer'] (anchor / space absorbed into word by the leading-char rule)",
+    "bit2": "'DON\\'T' -> ['DON',''T'] (case-insensitive contraction)",
+    "bit4": "'1234' -> ['123','4'] (digit grouping 1-3)",
+    "bit8": "'_word' -> ['_word'] (leading non-alnum char absorbed into word)",
+    "bit16": "' 42' -> [' ','42'] (digits no leading space + ws run==1)",
+    "bit32": "'a   b' -> ['a','  ',' b'] (internal whitespace \\s+(?!\\S), shared load-bearing law)",
+    "bit64": "'a\\nb' -> ['a','\\n','b'] (newline rule \\s*[\\r\\n]+ — the l3-lastnl cut)",
+    "bit128": "'DON\\'T 1234' -> ['DON',''T',' ','123','4'] (composite: three distinguishing laws in scan order)"
+  },
+  "reference": {
+    "method": "Python `re` with the ASCII-reduced llama3 pat_str (\\p{L}->[A-Za-z], \\p{N}->[0-9]). Every band fixture AND a wider edge-case set (newline runs ' \\n ', '  \\n'; rule-d trailing newlines 'hi!\\n\\n'; '12345'->['123','45']; '@home'; 'It\\'s') confirmed bit-identical to the recipe model BEFORE authoring.",
+    "result": "0 mismatches on all fixtures."
+  },
+  "lane": "NEW-recipe brick on the critical path. Design (the regex-as-left-to-right-scan model, the four distinguishing laws + their reference cross-check, the ws run==1 / newline-cut edge cases, the strange-minimal fixtures) was the cost; the four-way proof was seconds. Modeled closely on pretokenize.fk (#3542, the GPT-2 splitter) with the four llama3 deltas. READ-THE-BODY (15th time): grepped form/ first — confirmed no llama3/tiktoken pretokenizer existed (the 'llama' grep hits are all the numerics/block files); a real gap, exactly the one #3550's own receipt named.",
+  "gotchas": [
+    "Verified the `\\n` escape survives four-way INCLUDING fkwu's pre-flattener with a throwaway probe band (str_len('a\\nb')==3, ord(char_at,1)==10, verdict 7, fourth arm four-way) BEFORE relying on it for the newline rule-(e) band bit — don't assume the flattener handles every escape.",
+    "The GPT-2 ws end trick `(if (ge j n) j (sub j 1))` is WRONG for llama3: GPT-2's ` ?` absorption means it never hits a single whitespace char before a non-space, but llama3 digits take no leading space, so ' 42' reaches the ws handler with one space and must emit it (not collapse to a zero-length token / infinite loop). l3-ws-end adds the run-length guard."
+  ],
+  "named_next_stones": [
+    "Intern the llama3 byte->symbol vocab + the tiktoken merge-rank table as Form DATA (the last carrier-DATA pieces of the llama tokenizer).",
+    "Compose the whole llama text->ids tokenizer (llama3-pretokenize + byte-to-symbol #3503 + lowest-rank-first BPE #3447 over the llama rank table) into one `tokenize-llama` recipe, the llama analog of tokenize.fk #3550.",
+    "Wire the FULL generation loop: tokenize-llama -> multi-layer KV-cached decode stack on the M4 GPU (#3423/#3424) -> greedy argmax (#3402) over real llama3.2:3b GGUF weights (load path already Form-native four-way) — the first end-to-end native LLAMA token."
+  ],
+  "receipt_of": "form/form-stdlib/llama3-pretokenize.fk + form/form-stdlib/tests/llama3-pretokenize-band.fk + the fourth-arm-bands.txt row"
+}

--- a/form/form-stdlib/llama3-pretokenize.fk
+++ b/form/form-stdlib/llama3-pretokenize.fk
@@ -1,0 +1,128 @@
+; llama3-pretokenize.fk — Llama 3 (tiktoken-style) regex pre-tokenization (word splitting), as a Form recipe.
+;
+; preludes: (none beyond the kernel — pure string/int/list recursion)
+;
+; The whisper/GPT-2 tokenizer front-end is four-way (pretokenize.fk #3542, byte-to-symbol.fk #3503,
+; bpe-tokenizer.fk #3447, tokenize.fk #3550). But the GPU decode stack the body now runs on the M4
+; (#3424/#3412 multi-layer KV-cached llama decode) is LLAMA — and llama3's tokenizer differs from
+; whisper's in exactly ONE algorithmic piece: the pre-tokenization `pat_str`. The byte→symbol map is the
+; SAME byte-level bytes_to_unicode (#3503), and the merge core is the SAME lowest-rank-first BPE (#3447;
+; tiktoken's _byte_pair_merge is lowest-rank-first too) — only the rank TABLE (DATA) and this splitter
+; differ. So this recipe is the one algorithmic gap between the proven GPU llama decode and the first
+; end-to-end native LLAMA token.
+;
+; Llama 3's fixed pattern (Meta tokenizer.py), `\p{L}`→[A-Za-z], `\p{N}`→[0-9] over the ASCII byte domain:
+;
+;   (?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\nA-Za-z0-9]?[A-Za-z]+|[0-9]{1,3}| ?[^\sA-Za-z0-9]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+
+;
+; Four differences from GPT-2's ` 's|'t|...| ?\p{L}+| ?\p{N}+| ?[^\s...]+|\s+(?!\S)|\s+` — each a real law:
+;   (1) CASE-INSENSITIVE contractions `(?i:)` — "DON'T" splits 'T too, not just lowercase 't.
+;   (2) DIGITS group 1-3 `[0-9]{1,3}` (not ` ?\p{N}+`) — "1234" → "123","4", and NO leading space on digits.
+;   (3) WORD leading char `[^\r\nA-Za-z0-9]?\p{L}+` (not ` ?\p{L}+`) — ANY non-newline non-alnum char (not
+;       only a space) is absorbed before a word: "_word" → ["_word"], "@home" → ["@home"], " tok" → [" tok"].
+;   (4) NEWLINES `\s*[\r\n]+` and other-run `[^\s...]+[\r\n]*` get explicit handling — a ws run that ends in
+;       a newline is cut after the LAST newline; a punct run absorbs trailing newlines.
+;
+; A regex IS a recipe (a char-class state machine): the alternation, tried left-to-right at each position,
+; becomes a left-to-right scan — at i take the FIRST matching alternative, emit that substring, continue
+; from its end. Confirmed bit-identical to Python `re` (ASCII-reduced pattern) on every fixture before
+; authoring. All char_at/ord/str_concat/str_len — the four-way string subset; no floats (no e-notation
+; risk), no host I/O, small tables. Feeds byte-to-symbol.fk → bpe-tokenizer.fk for the llama text→ids path.
+
+(do
+  ; --- character classes by ord ---
+  (defn l3-ws? (c)
+    (do (let o (ord c))
+        (if (if (eq o 32) 1 (if (eq o 9) 1 (if (eq o 10) 1 (if (eq o 11) 1 (if (eq o 12) 1 (if (eq o 13) 1 0)))))) 1 0)))
+  (defn l3-letter? (c)
+    (do (let o (ord c))
+        (if (if (ge o 65) (le o 90) 0) 1 (if (if (ge o 97) (le o 122) 0) 1 0))))
+  (defn l3-digit? (c)
+    (do (let o (ord c)) (if (if (ge o 48) (le o 57) 0) 1 0)))
+  (defn l3-crlf? (c)
+    (do (let o (ord c)) (if (if (eq o 10) 1 (if (eq o 13) 1 0)) 1 0)))
+  ; `[^\r\nA-Za-z0-9]` — the optional leading char of a word: NOT cr/lf, NOT letter, NOT digit (space ok).
+  (defn l3-lead? (c)
+    (if (eq (l3-crlf? c) 1) 0 (if (eq (l3-letter? c) 1) 0 (if (eq (l3-digit? c) 1) 0 1))))
+  ; `[^\sA-Za-z0-9]` — the "other" (punct/symbol) class: NOT whitespace, NOT letter, NOT digit.
+  (defn l3-other? (c)
+    (if (eq (l3-ws? c) 1) 0 (if (eq (l3-letter? c) 1) 0 (if (eq (l3-digit? c) 1) 0 1))))
+
+  ; first index >= k where the class predicate fails (or n) — the maximal run end.
+  (defn l3-run (s n k pred)
+    (if (ge k n) n
+        (if (eq (pred (char_at s k)) 1) (l3-run s n (add k 1) pred) k)))
+
+  ; `[0-9]{1,3}` — take up to 3 digits from k (c = count so far). Greedy, max 3.
+  (defn l3-dig3 (s n k c)
+    (if (ge c 3) k
+        (if (ge k n) k
+            (if (eq (l3-digit? (char_at s k)) 1) (l3-dig3 s n (add k 1) (add c 1)) k))))
+
+  ; case-insensitive ord equality against a lowercase/uppercase pair.
+  (defn l3-eqi (o lo hi) (if (eq o lo) 1 (if (eq o hi) 1 0)))
+
+  ; s[i]=="'" → contraction length INCLUDING the quote (2 for 's/'t/'m/'d, 3 for 're/'ve/'ll), case-
+  ; insensitive (the (?i:) flag — llama3 splits 'T/'RE/'LL too), else 0.
+  (defn l3-contract-len (s n i)
+    (if (ge (add i 1) n) 0
+        (do (let a (ord (char_at s (add i 1))))
+            (if (if (l3-eqi a 115 83) 1 (if (l3-eqi a 116 84) 1 (if (l3-eqi a 109 77) 1 (if (l3-eqi a 100 68) 1 0)))) 2
+                (if (ge (add i 2) n) 0
+                    (do (let b (ord (char_at s (add i 2))))
+                        (if (if (and (l3-eqi a 114 82) (l3-eqi b 101 69)) 1
+                                (if (and (l3-eqi a 118 86) (l3-eqi b 101 69)) 1
+                                    (if (and (l3-eqi a 108 76) (l3-eqi b 108 76)) 1 0)))
+                            3 0)))))))
+
+  ; ` ?[^\sA-Za-z0-9]+[\r\n]*` body from p — the "other" run then a trailing run of newlines.
+  (defn l3-other-end (s n p)
+    (do (let e (l3-run s n p l3-other?)) (l3-run s n e l3-crlf?)))
+
+  ; last index of a \r\n char in [i,j), or (sub i 1) sentinel when none.
+  (defn l3-lastnl (s k j acc)
+    (if (ge k j) acc
+        (do (let o (ord (char_at s k)))
+            (l3-lastnl s (add k 1) j (if (if (eq o 10) 1 (if (eq o 13) 1 0)) k acc)))))
+
+  ; whitespace at i: rule (e) `\s*[\r\n]+` cuts a ws run after its LAST newline; otherwise rule
+  ; (f) `\s+(?!\S)` leaves the last ws of an internal run (len>=2), rule (g) `\s+` emits a single
+  ; ws or a trailing run whole. (GPT-2 never hits the run==1 case — its ` ?` absorbs leading spaces;
+  ; llama3 digits do NOT, so " 42" reaches here with one space and must emit it, not collapse to empty.)
+  (defn l3-ws-end (s n i)
+    (do (let j (l3-run s n i l3-ws?))
+        (let lastnl (l3-lastnl s i j (sub i 1)))
+        (if (ge lastnl i) (add lastnl 1)
+            (if (ge j n) j
+                (if (ge (sub j i) 2) (sub j 1) j)))))
+
+  ; end index (exclusive) of the pre-token starting at i — the alternation, in order.
+  (defn l3-end (s n i)
+    (do (let c (char_at s i)) (let o (ord c))
+        (let cl (if (eq o 39) (l3-contract-len s n i) 0))
+        (if (gt cl 0) (add i cl)
+            ; `[^\r\nA-Za-z0-9]?\p{L}+` — bare word, or one leading non-alnum char then letters.
+            (if (eq (l3-letter? c) 1) (l3-run s n (add i 1) l3-letter?)
+                (if (if (eq (l3-lead? c) 1) (if (lt (add i 1) n) (l3-letter? (char_at s (add i 1))) 0) 0)
+                    (l3-run s n (add i 2) l3-letter?)
+                    ; `[0-9]{1,3}` — NO leading space on digits.
+                    (if (eq (l3-digit? c) 1) (l3-dig3 s n i 0)
+                        ; ` ?[^\sA-Za-z0-9]+[\r\n]*` — other run (optionally one leading space) + trailing newlines.
+                        (if (eq (l3-other? c) 1) (l3-other-end s n i)
+                            (if (if (eq o 32) (if (lt (add i 1) n) (l3-other? (char_at s (add i 1))) 0) 0)
+                                (l3-other-end s n (add i 1))
+                                ; `\s*[\r\n]+ | \s+(?!\S) | \s+`
+                                (l3-ws-end s n i)))))))))
+
+  ; substring s[i..e) by char accumulation (char_at returns a one-char string).
+  (defn l3-sub (s i e)
+    (if (ge i e) "" (str_concat (char_at s i) (l3-sub s (add i 1) e))))
+
+  ; scan: emit the pre-token at i, continue from its end.
+  (defn l3-plist (s n i)
+    (if (ge i n) (list)
+        (do (let e (l3-end s n i)) (cons (l3-sub s i e) (l3-plist s n e)))))
+
+  ; the entry: text -> list of llama3 pre-token substrings (in order).
+  (defn llama3-pretokenize (s) (l3-plist s (str_len s) 0))
+  0)

--- a/form/form-stdlib/tests/llama3-pretokenize-band.fk
+++ b/form/form-stdlib/tests/llama3-pretokenize-band.fk
@@ -1,0 +1,51 @@
+; preludes: form-stdlib/core.fk form-stdlib/llama3-pretokenize.fk
+;
+; llama3-pretokenize-band — Llama 3 (tiktoken-style) regex pre-tokenization on the four-kernel floor.
+; The whisper/GPT-2 tokenizer front-end is four-way (pretokenize #3542, byte-to-symbol #3503, bpe #3447,
+; tokenize #3550) — but the GPU decode stack the body runs on the M4 (#3424/#3412 multi-layer KV-cached
+; llama decode) is LLAMA, and llama3's tokenizer differs in exactly ONE algorithmic piece: this
+; pre-tokenization `pat_str`. The byte→symbol map and lowest-rank-first BPE merge are SHARED with whisper;
+; only the rank table (DATA) and this splitter differ. So this is the one algorithmic gap between the
+; proven GPU llama decode and the first end-to-end native LLAMA token.
+;
+; The proof is the splitting LAWS — the four that DISTINGUISH llama3 from GPT-2, plus the shared
+; load-bearing ones — each confirmed bit-identical to Python `re` (ASCII-reduced llama3 pat_str) before
+; authoring:
+;
+;   bit 1   — ANCHOR / leading-char word: " tokenizer" -> [" tokenizer"]. The space is absorbed into the
+;             word by `[^\r\nA-Za-z0-9]?\p{L}+`; this is the exact string the llama path must tokenize.
+;   bit 2   — CASE-INSENSITIVE contraction `(?i:)`: "DON'T" -> ["DON","'T"]. llama3 splits the UPPERCASE
+;             'T; GPT-2's lowercase-only `'t` would NOT. DISTINGUISHING LAW #1.
+;   bit 4   — DIGITS group 1-3 `[0-9]{1,3}`: "1234" -> ["123","4"]. GPT-2's ` ?\p{N}+` gives ["1234"].
+;             DISTINGUISHING LAW #2.
+;   bit 8   — WORD leading char is ANY non-newline non-alnum, not just a space: "_word" -> ["_word"].
+;             GPT-2's ` ?\p{L}+` gives ["_","word"]. DISTINGUISHING LAW #3.
+;   bit 16  — DIGITS take NO leading space (no ` ?` on `[0-9]{1,3}`): " 42" -> [" ","42"]. GPT-2's
+;             ` ?\p{N}+` gives [" 42"]. DISTINGUISHING LAW #4 — and it forces the ws run==1 path (one space
+;             before a non-space): llama3 emits the lone space, where GPT-2's ` ?` absorption never hits it.
+;   bit 32  — INTERNAL whitespace `\s+(?!\S)`: "a   b" -> ["a","  "," b"] — a run of 3 spaces leaves its
+;             LAST space to lead the next word (shared with GPT-2; the load-bearing lookahead law).
+;   bit 64  — NEWLINE rule `\s*[\r\n]+`: "a\nb" -> ["a","\n","b"] — a ws run is cut after its last newline,
+;             llama3's explicit newline handling (the `l3-lastnl` cut).
+;   bit 128 — the COMPOSITE real anchor: "DON'T 1234" -> ["DON","'T"," ","123","4"] — ties the
+;             case-insensitive contraction, the lone-space-before-digits, and the 1-3 digit grouping in one
+;             string: three distinguishing laws firing together in left-to-right scan order.
+;
+; Pure string/int/list recursion — no host I/O, no floats (no e-notation risk), small tables — the
+; fourth-friendly subset. Verdict 255 when the llama3 splitter lands four-way.
+(do
+  (defn strs-eq (a b)
+    (if (eq (len a) 0) (if (eq (len b) 0) 1 0)
+        (if (eq (len b) 0) 0
+            (if (str_eq (head a) (head b)) (strs-eq (tail a) (tail b)) 0))))
+
+  (let c0 (if (eq (strs-eq (llama3-pretokenize " tokenizer") (list " tokenizer")) 1) 1 0))
+  (let c1 (if (eq (strs-eq (llama3-pretokenize "DON'T") (list "DON" "'T")) 1) 2 0))
+  (let c2 (if (eq (strs-eq (llama3-pretokenize "1234") (list "123" "4")) 1) 4 0))
+  (let c3 (if (eq (strs-eq (llama3-pretokenize "_word") (list "_word")) 1) 8 0))
+  (let c4 (if (eq (strs-eq (llama3-pretokenize " 42") (list " " "42")) 1) 16 0))
+  (let c5 (if (eq (strs-eq (llama3-pretokenize "a   b") (list "a" "  " " b")) 1) 32 0))
+  (let c6 (if (eq (strs-eq (llama3-pretokenize "a\nb") (list "a" "\n" "b")) 1) 64 0))
+  (let c7 (if (eq (strs-eq (llama3-pretokenize "DON'T 1234") (list "DON" "'T" " " "123" "4")) 1) 128 0))
+
+  (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -240,6 +240,7 @@ text-tokenize fks 31
 bpe-tokenizer fks 31
 byte-to-symbol fks 255
 pretokenize fks 255
+llama3-pretokenize fks 255
 tokenize fks 31
 form-cli-judge fks 127
 obs-verify fks 31


### PR DESCRIPTION
## What

`llama3-pretokenize.fk` implements **Llama 3's (tiktoken-style) fixed pre-tokenization `pat_str`** as a Form recipe — four-way (Go/Rust/TS/fkwu) at **verdict 255, 0 divergent**.

## Why this stone

The whole llama inference floor is four-way **and on the M4 GPU**: load path (q4k/q6k/f16 dequant), every numeric (RMSNorm/RoPE/SwiGLU/SiLU), both block-forward kernels, the KV-cached decode step, the multi-layer depth stack — all on silicon bit-identical to recompute. The **whisper** tokenizer is four-way end-to-end (`tokenize` #3550). But the GPU decode stack is **LLAMA**, and llama3's tokenizer differs from whisper's in exactly **one algorithmic piece: this pre-tokenization `pat_str`**. The byte→symbol map is the SAME byte-level `bytes_to_unicode` (#3503); the merge core is the SAME lowest-rank-first BPE (#3447; tiktoken's `_byte_pair_merge` is lowest-rank-first too) — only the rank *table* (DATA) and this splitter differ. This brick closes that gap — the named blocker from #3550's own receipt.

## The four laws that distinguish llama3 from GPT-2

Each reference-pinned against Python `re` (ASCII-reduced pat_str) before authoring:

| law | llama3 | GPT-2 |
|---|---|---|
| case-insensitive contractions `(?i:)` | `DON'T` → `DON`,`'T` | would not split `'T` |
| digits group 1-3 `[0-9]{1,3}` | `1234` → `123`,`4` | `1234` |
| any non-newline non-alnum absorbed before a word | `_word` → `_word` | `_`,`word` |
| digits take no leading space | ` 42` → ` `,`42` | ` 42` |

## Proof

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/llama3-pretokenize.fk form-stdlib/tests/llama3-pretokenize-band.fk
# ✓ → 255   fourth arm: four-way   1 ok, 0 divergent
```

Band = 8 strange-minimal claims (255), incl. the composite anchor `DON'T 1234` → `DON`,`'T`,` `,`123`,`4` and the newline rule `\s*[\r\n]+`. Pure string/int/list recursion — no host I/O, no floats — the fourth-friendly subset. Manifest row `llama3-pretokenize fks 255` added next to its tokenizer siblings.

## Next stones

Intern the llama3 vocab + tiktoken merge-rank tables as Form DATA; compose `tokenize-llama` (this + #3503 + #3447); wire the full generation loop over real llama3.2:3b GGUF on the M4 GPU — the first end-to-end native LLAMA token.

Receipt: `docs/system_audit/commit_evidence_2026-06-22_llama3_pretokenize_four_way.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)