### PR TITLE
tend(form): backtrack-search — the one generic choice/fail/stop/backtrack kernel, four-way

### DIFF
--- a/form/form-stdlib/backtrack-search.fk
+++ b/form/form-stdlib/backtrack-search.fk
@@ -1,0 +1,40 @@
+; backtrack-search.fk — the ONE generic depth-first backtracking search: choice / fail / stop /
+; backtrack as a single recursive engine. The hypothesis-tree search (auto-ml / auto-research), the
+; PEG parser, provider-routing-with-fallback, and a proof search are all THIS engine with a different
+; choice-space supplied as DATA — exactly as arch-search.fk is the ONE architecture searcher over a
+; candidate list. Here the canonical instance is SUBSET-SUM: does some subset of `items` sum to
+; `target`? It is the smallest expression that forces all four primitives to fire at once.
+;
+;   CHOICE     — at each item, two branches: include it, or exclude it.
+;   FAIL       — a partial sum past the target is a dead branch: prune, do not descend.
+;   STOP       — items exhausted with the sum exactly on target: a solution, return 1.
+;   BACKTRACK  — when the include-branch fails, fall back to the exclude-branch (and back up the tree).
+;
+; The four seams (the include/exclude choice, the overshoot fail-predicate, the exact-on-exhaust stop,
+; the fall-back-to-the-other backtrack) are where a different domain plugs a different rule. The next
+; breath lifts them to pluggable goal data so the parser / router / proof-search drop on directly,
+; each getting branch-choice-order.fk's learned ordering for free. Proven four-way by
+; tests/backtrack-search-band.fk (Go=Rust=TS=fkwu).
+;
+; preludes: form-stdlib/core.fk
+(do
+    ; bts-go — depth-first over `items`, carrying the partial sum `sofar`. Returns 1 if some choice of
+    ; the remaining items lands the total exactly on `target`, else 0.
+    (defn bts-go (items target sofar)
+        (if (gt sofar target)
+            0                                              ; FAIL — overshoot: prune this whole branch.
+            (if (eq (len items) 0)
+                (if (eq sofar target) 1 0)                 ; STOP — exhausted: 1 iff exactly on target.
+                (do
+                    (let it (head items))
+                    (let rest (tail items))
+                    ; CHOICE — try INCLUDING `it` first ...
+                    (let included (bts-go rest target (add sofar it)))
+                    (if (eq included 1)
+                        1
+                        ; ... BACKTRACK — the include-branch died; fall back to EXCLUDING `it`.
+                        (bts-go rest target sofar))))))
+
+    ; the door — search from an empty running sum.
+    (defn bts-find? (items target) (bts-go items target 0))
+    0)

--- a/form/form-stdlib/tests/backtrack-search-band.fk
+++ b/form/form-stdlib/tests/backtrack-search-band.fk
@@ -1,0 +1,22 @@
+; preludes: form-stdlib/core.fk form-stdlib/backtrack-search.fk
+;
+; backtrack-search-band — the generic choice / fail / stop / backtrack kernel, four-way, on the
+; smallest subset-sum witnesses that each force ONE primitive to carry the result.
+;
+; Verdict 31 when every claim lands:
+;   1   BACKTRACK: {3,2,4} target 6 -> 1. The greedy include-3 path dead-ends (3+2+4=9, 3+4=7, 3+2=5);
+;       only excluding 3 and taking {2,4}=6 succeeds — the answer lives past deep backtracking.
+;   2   EXHAUST: {3,2,4} target 8 -> 0. No subset sums to 8; the whole tree is walked and the honest
+;       answer is "no" (reachable sums are 0,2,3,4,5,6,7,9).
+;   4   PRUNE: {5,5} target 3 -> 0 (every include overshoots and is pruned) AND target 10 -> 1 (prune
+;       does not false-negative the real solution 5+5).
+;   8   STOP base case: {} target 0 -> 1 (the empty subset sums to 0) AND {} target 7 -> 0.
+;   16  single hit through prune: {3,2,4} target 4 -> 1 (just {4}; the 3- and 2-first paths overshoot
+;       and prune).
+(do
+    (let c1  (if (eq (bts-find? (list 3 2 4) 6) 1) 1 0))
+    (let c2  (if (eq (bts-find? (list 3 2 4) 8) 0) 2 0))
+    (let c4  (if (and (eq (bts-find? (list 5 5) 3) 0) (eq (bts-find? (list 5 5) 10) 1)) 4 0))
+    (let c8  (if (and (eq (bts-find? (empty) 0) 1) (eq (bts-find? (empty) 7) 0)) 8 0))
+    (let c16 (if (eq (bts-find? (list 3 2 4) 4) 1) 16 0))
+    (add c1 (add c2 (add c4 (add c8 c16)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -191,6 +191,7 @@ active-inference fks 127
 indirect-call-runtime-probe fks 7
 higher-order-fn-arg fks 1111
 branch-choice-order fks 511
+backtrack-search fkc 31
 channel-interface fks 127
 organ-sense fks 11230
 organ-offer fks 63


### PR DESCRIPTION
## What

The generic **choice / fail / stop / backtrack** search kernel, as one recursive engine — embodied from a conversation that walked Microsoft's Arbor paper → our substrate trees → the backtracking primitive floor → the metabolic self-improvement loop.

`form-control-backtracking-ml.fk` only *named* the floor (`match · fail · cut · stop · choice · …`) as a checklist; the combinators lived entangled inside the grammar/parse path. This is the first **standalone generic engine** consuming that floor, following the `arch-search.fk` precedent: concrete engine, search-space supplied as **DATA**, never higher-order.

Canonical instance: **subset-sum** — the smallest expression that forces all four primitives at once.
- **CHOICE** — include / exclude each item
- **FAIL** — partial sum past target → prune the branch
- **STOP** — items exhausted exactly on target → solution
- **BACKTRACK** — include-branch dead → fall back to exclude

## Why it matters

The hypothesis-tree search (auto-ml / auto-research), the PEG parser, provider-routing-with-fallback, and a proof search are all *this one engine* with a different choice-space. The next breath lifts the four seams to pluggable goal data so each drops on directly — and inherits `branch-choice-order.fk`'s learned ordering for free.

## Proof

- `form-stdlib/backtrack-search.fk` + `tests/backtrack-search-band.fk` → **verdict 31**
- manifest row `backtrack-search fkc 31`
- **Go = Rust = TS = fkwu four-way** via `validate.sh` (`fourth arm: 1 band(s) four-way`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)