### PR TITLE
tend(form): grouped-query attention (GQA) crosses four-way — the attention real llama3.2:3b uses

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-22_gqa_attn_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-22_gqa_attn_four_way.json
@@ -1,0 +1,19 @@
+{
+  "date": "2026-06-22",
+  "brick": "Grouped-query attention (GQA) crosses four-way — the attention real llama3.2:3b uses (24 query heads sharing 8 KV heads), lifted from emitted C to a standalone four-kernel recipe",
+  "author": "Sema (Opus 4.8), autonomous native-ML walk",
+  "pr": null,
+  "files": {
+    "recipe": "form/form-stdlib/gqa-attn.fk",
+    "band": "form/form-stdlib/tests/gqa-attn-band.fk",
+    "manifest": "form/fourth-arm-bands.txt (gqa-attn fks 7)"
+  },
+  "verdict": 7,
+  "proof": "scoped ./validate.sh form-stdlib/core.fk trig.fk transformer-numerics.fk transformer-block.fk transformer-mh.fk gqa-attn.fk tests/gqa-attn-band.fk -> 7, 1 ok, 0 divergent. All four kernels (Go, Rust, TypeScript, fkwu) built and agree on every sample. Fourth arm crossed.",
+  "gap_closed": "GQA's query-head -> kv-head sharing mapping (kvh = h / group, group = n_head / n_kv_head) lived ONLY inside transformer-kernel.fk's tk-emit-llama as emitted C (three-way, projecting to a C unit). transformer-mh.fk (four-way) is plain MHA — every head slices q AND k/v at (mul h hd), i.e. n_kv_head == n_head. Real llama3.2:3b (and 3.1/3.3, qwen, most modern decoders) project k/v to the SMALLER n_kv_head*hd width and share each kv head across group query heads. That sharing was never a standalone four-way recipe. Now it is.",
+  "design": "Reference computed FIRST (softmax(scale*q.k).v in fp64, stdlib math), three strange-minimal claims pinned at 1e-6: (bit1) GQA n=2 nkv=1 group=2 — k/v HALF the q width (KVD=2 < D=4); head 0 reproduces MHA's head 0 (same q, same kv0), head 1 reads kv0 too (differs from MHA's head1 -> sharing does real work); a query-head-indexed k/v slice would walk off the shorter k/v vector, only (div h grp) stays in bounds (the off-end catch). (bit2) GQA n=2 nkv=2 group=1 EQUALS transformer-mh's tb-mh-attn bit-for-bit (maxdiff 0.0) — GQA generalizes MHA, MHA is the n_kv_head=n_head case, core-abstraction-first no parallel path. (bit4) GQA n=4 nkv=2 group=2 — heads 0,1 -> kv0 ; heads 2,3 -> kv1, the same (h / group) grouping arithmetic llama3.2 runs at 24 -> 8.",
+  "recipe_shape": "tb-gqa-attn composes transformer-mh's OWN proven primitives (tb-seq-headslice, tb-attn-seq, tb-seq-cat) verbatim; the ONLY new arithmetic vs MHA is the kv-head index (div h grp). No new transcendental, no new fold — bit-deterministic across kernels exactly as MHA.",
+  "lane": "lifted three-way emitted-C numeric -> standalone four-way recipe, same lane as RMSNorm/SwiGLU/SiLU (#3308), RoPE (#3319), causal mask (#3376), KV cache (#3382). Design (the GQA reference + the three distinguishing laws) was the cost; the four-way proof was seconds.",
+  "north_star_position": "the last attention-shape gap between the proven GPU llama decode stack (which runs single-head/MHA-shaped blocks) and REAL llama3.2:3b weights — real GQA weights cannot run on an MHA-only block. Next: emit GQA to Metal next to the MHA/llama block kernels and run on the M4 GPU (the 3m/3s/3u lane), then GQA over real llama3.2:3b GGUF (n_head=24, n_kv_head=8, head_dim=128) toward the first end-to-end native llama token.",
+  "read_the_body": "grepped form/ — GQA/kv_head/grouped-query appears ONLY in transformer-kernel.fk (emitted C). transformer-mh.fk confirmed plain MHA (q and k/v both sliced at mul-h-hd). A real gap, not a re-impl — same lesson the scoreboard has logged ~15 times."
+}

--- a/form/form-stdlib/gqa-attn.fk
+++ b/form/form-stdlib/gqa-attn.fk
@@ -1,0 +1,37 @@
+; gqa-attn.fk — grouped-query attention (GQA): the attention real llama3.2/3.1/3.3
+; (and most modern decoder models) use. n_head query heads share n_kv_head < n_head
+; KV heads; query head h reads KV head (h / group), group = n_head / n_kv_head.
+;
+; preludes: form-stdlib/trig.fk form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk
+;
+; transformer-mh.fk (four-way) is plain MHA: every head slices q AND k/v at (mul h hd)
+; — one KV head per query head (n_kv_head = n_head). Real llama3.2:3b has 24 query
+; heads but only 8 KV heads, so 3 query heads share each KV head and k/v are projected
+; to the SMALLER n_kv_head*hd width. That sharing mapping lived ONLY inside
+; transformer-kernel.fk's tk-emit-llama as emitted C (kvh = h / (heads/kv_heads),
+; three-way, projecting to a C unit) — never a standalone four-way recipe. This lifts
+; it to the four-kernel floor, composing transformer-mh's OWN proven primitives
+; (tb-seq-headslice, tb-attn-seq, tb-seq-cat). The ONLY new arithmetic vs MHA is the
+; kv-head index (div h grp) — so GQA at group=1 IS tb-mh-attn (MHA is the
+; n_kv_head = n_head case; core-abstraction-first, MHA generalizes to GQA, not a
+; parallel path). With KVD < D a query-head-indexed k/v slice walks off the end of the
+; shorter k/v vector; only the divided kv-head index stays in bounds — that
+; out-of-bounds is the strange-minimal catch the band pins.
+
+; query head h reads kv head kvh (each width hd); shared √hd scale.
+(defn tb-gqa-head (qs ks vs h kvh hd scale)
+  (tb-attn-seq (tb-seq-headslice qs h hd)
+               (tb-seq-headslice ks kvh hd)
+               (tb-seq-headslice vs kvh hd) scale))
+
+; heads h..n-1 concatenated position-wise; query head h reads kv head (div h grp).
+(defn tb-gqa-loop (qs ks vs h n grp hd scale)
+  (if (eq h (sub n 1))
+      (tb-gqa-head qs ks vs h (div h grp) hd scale)
+      (tb-seq-cat (tb-gqa-head qs ks vs h (div h grp) hd scale)
+                  (tb-gqa-loop qs ks vs (add h 1) n grp hd scale))))
+
+; GQA over projected q/k/v: n query heads, nkv kv heads (k/v are nkv*hd wide), head-dim hd.
+; group = n / nkv. group=1 (nkv=n) reduces exactly to transformer-mh's tb-mh-attn.
+(defn tb-gqa-attn (qs ks vs n nkv hd scale)
+  (tb-gqa-loop qs ks vs 0 n (div n nkv) hd scale))

--- a/form/form-stdlib/tests/gqa-attn-band.fk
+++ b/form/form-stdlib/tests/gqa-attn-band.fk
@@ -1,0 +1,57 @@
+; preludes: form-stdlib/trig.fk form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk
+;
+; gqa-attn-band — grouped-query attention (GQA), the attention real llama3.2:3b uses
+; (24 query heads sharing 8 KV heads). Three strange-minimal claims, hd=2, scale=1,
+; each pinned to the fp64 reference (softmax(scale*q.k).v) at 1e-6:
+;
+;   bit 1  GQA n=2 nkv=1 (group=2): both query heads read kv head 0; k/v are HALF the
+;          q width (KVD=2 < D=4). Head 0 reproduces MHA's head 0 (same q, same kv0);
+;          head 1 reads kv0 too (differs from MHA's head1 → the sharing does real work).
+;          A query-head-indexed k/v slice would walk off the shorter k/v vector; only
+;          (div h grp) stays in bounds — the off-end catch.
+;   bit 2  GQA n=2 nkv=2 (group=1) EQUALS transformer-mh's tb-mh-attn bit-for-bit —
+;          GQA generalizes MHA, MHA is the n_kv_head = n_head case (no parallel path).
+;   bit 4  GQA n=4 nkv=2 (group=2): heads 0,1 -> kv0 ; heads 2,3 -> kv1 — the same
+;          (h / group) grouping arithmetic llama3.2 runs at 24 -> 8.
+;
+; Verdict 7 when all three cross.
+
+(do
+  (defn gqa-vmaxdiff (a b)
+    (if (eq (len a) 0) 0.0
+        (do (let d (tn-abs (sub (head a) (head b))))
+            (let r (gqa-vmaxdiff (tail a) (tail b)))
+            (if (gt d r) d r))))
+  (defn gqa-maxdiff (as bs)
+    (if (eq (len as) 0) 0.0
+        (do (let d (gqa-vmaxdiff (head as) (head bs)))
+            (let r (gqa-maxdiff (tail as) (tail bs)))
+            (if (gt d r) d r))))
+
+  (let scale 1.0) (let hd 2)
+
+  ; --- claim 1: GQA n=2 nkv=1 (group=2), k/v half the q width ---
+  (let qs1 (list (list 0.5 -0.3 0.9 0.2) (list -0.4 0.7 -0.1 0.6)))
+  (let ks1 (list (list 0.2 0.8) (list -0.5 0.3)))
+  (let vs1 (list (list 1.0 -1.0) (list 0.4 0.6)))
+  (let exp1 (list (list 0.7299003983874868 -0.2797343956999647 0.804883163549388 -0.47968843613170165)
+                  (list 0.7104957145998338 -0.2279885722662236 0.7343487127591333 -0.2915965673576889)))
+  (let got1 (tb-gqa-attn qs1 ks1 vs1 2 1 hd scale))
+  (let c1 (if (lt (gqa-maxdiff got1 exp1) 0.000001) 1 0))
+
+  ; --- claim 2: GQA n=2 nkv=2 (group=1) == tb-mh-attn exactly ---
+  (let ks2 (list (list 0.2 0.8 -0.1 0.5) (list -0.5 0.3 0.6 -0.2)))
+  (let vs2 (list (list 1.0 -1.0 0.3 0.7) (list 0.4 0.6 -0.8 0.1)))
+  (let got2 (tb-gqa-attn qs1 ks2 vs2 2 2 hd scale))
+  (let mha2 (tb-mh-attn qs1 ks2 vs2 2 hd scale))
+  (let c2 (if (lt (gqa-maxdiff got2 mha2) 0.000001) 2 0))
+
+  ; --- claim 3: GQA n=4 nkv=2 (group=2), the real llama 24->8 grouping shape ---
+  (let qs3 (list (list 0.5 -0.3 0.9 0.2 -0.4 0.7 0.1 -0.6)
+                 (list -0.2 0.8 0.3 -0.5 0.6 0.1 -0.7 0.4)))
+  (let exp3 (list (list 0.7299003983874868 -0.2797343956999647 0.804883163549388 -0.47968843613170165 -0.048127016890052804 0.5101125362417893 -0.3821170755773992 0.3279361405941459)
+                  (list 0.7387817750818175 -0.30341806688484674 0.6940007998720208 -0.18400213299205526 -0.34527933680906314 0.34802945264960194 -0.048127016890052804 0.5101125362417893)))
+  (let got3 (tb-gqa-attn qs3 ks2 vs2 4 2 hd scale))
+  (let c3 (if (lt (gqa-maxdiff got3 exp3) 0.000001) 4 0))
+
+  (add c1 (add c2 c3)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -779,6 +779,7 @@ transformer-gelu-erf fks 255
 conv-stem fks 1
 positional fks 1
 transformer-mh fks 1
+gqa-attn fks 7
 transformer-decoder fks 1
 transformer-generate fks 1
 whisper-mh-block-real fks 1


### PR DESCRIPTION
## What

`gqa-attn.fk` — **grouped-query attention (GQA)**, the attention real llama3.2:3b (and 3.1/3.3, qwen, most modern decoders) use, lifted to the **four-kernel floor** (Go · Rust · TypeScript · fkwu).

## Why it's a real gap

`transformer-mh.fk` (four-way) is plain **MHA**: every head slices q **and** k/v at `(mul h hd)` — `n_kv_head == n_head`. Real llama3.2:3b has **24 query heads but only 8 KV heads**: k/v project to the smaller `n_kv_head*hd` width and each KV head is shared by `group = n_head/n_kv_head` query heads (query head `h` reads KV head `h/group`). That sharing mapping lived **only** inside `transformer-kernel.fk`'s `tk-emit-llama` as emitted C (`kvh = h / (heads/kv_heads)`, three-way, projecting to a C unit) — never a standalone four-way recipe.

A query-head-indexed k/v slice would walk off the end of the **shorter** k/v vector; only `(div h grp)` stays in bounds. The GPU llama decode stack (#3355/#3376/#3412/#3424) runs single-head/MHA-shaped blocks — **real GQA weights cannot run on an MHA-only block.** This closes that attention-shape gap.

## How — core-abstraction-first

`tb-gqa-attn` composes `transformer-mh`'s **own** proven primitives (`tb-seq-headslice`, `tb-attn-seq`, `tb-seq-cat`) verbatim. The only new arithmetic vs MHA is the kv-head index `(div h grp)` — so **GQA at group=1 IS `tb-mh-attn`**; MHA is the `n_kv_head=n_head` case, not a parallel path.

## Proof — verdict 7, 0 divergent, fourth arm crossed

Three strange-minimal claims (hd=2, scale=1), each pinned to the fp64 reference at 1e-6:
1. **n=2 nkv=1 group=2** — k/v half the q width; head 0 reproduces MHA's head 0, head 1 shares kv0 (differs from MHA's head 1 → sharing does real work; the off-end catch).
2. **n=2 nkv=2 group=1** — EQUALS `tb-mh-attn` bit-for-bit (the generalization law).
3. **n=4 nkv=2 group=2** — heads 0,1→kv0 ; 2,3→kv1, the same `(h/group)` arithmetic llama3.2 runs at **24→8**.

```
./validate.sh core.fk trig.fk transformer-numerics.fk transformer-block.fk transformer-mh.fk gqa-attn.fk tests/gqa-attn-band.fk
  → 7   |   1 ok, 0 divergent — kernels agree on every sample
```

Registered `gqa-attn fks 7` in `form/fourth-arm-bands.txt`; evidence at `docs/system_audit/commit_evidence_2026-06-22_gqa_attn_four_way.json`.

**Next stone:** emit GQA to Metal next to the MHA/llama block kernels, run on the M4 GPU (3m/3s/3u lane), then GQA over real llama3.2:3b GGUF toward the first end-to-end native llama token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>