### PR TITLE
fix(test): realign native-mutation-gate assertions to current compose wording

### DIFF
--- a/api/tests/test_native_mutation_public_gate.py
+++ b/api/tests/test_native_mutation_public_gate.py
@@ -248,8 +248,8 @@ def test_deploy_exposes_bounded_no_header_native_mutation_flip():
     assert "Header(`X-Form-Native-Preview`,`1`)" in compose
     assert "coherence-api-kernel-public-gate-canary.priority" in compose
     assert "loadbalancer.server.port: \"8080\"" in compose
-    assert "bounded no-header mutation paths match this" in compose
-    assert "Unlisted ordinary requests keep matching api:8000" in compose
+    assert "bounded no-header mutation paths match" in compose
+    assert "requests keep matching api:8000" in compose
     assert "X-Form-Python-Fallback is the explicit" in compose
     assert "coherence-api-kernel-ideas-create-native-default.rule" in compose
     assert "Method(`POST`) && Path(`/api/ideas`)" in compose


### PR DESCRIPTION
## main is red — stale deploy-gate test, realigned

`test_deploy_exposes_bounded_no_header_native_mutation_flip` was failing on `main` (and blocking every PR's `validate-thread-process`). Two **doc-comment** substring assertions in `test_native_mutation_public_gate.py` drifted from `deploy/kernel-router/docker-compose.kernel-router.yml` after the kernel public-gate routing was **intentionally reworded** (`73df119` "Restore kernel public gate routing", `b2f6d34` #3565):

- `"...mutation paths match this"` → compose now says `"...match the kernel-router service directly"`
- `"Unlisted ordinary requests keep matching api:8000"` → compose now reads `Unlisted` / `requests keep matching api:8000` (reworded **and** line-wrapped, so the old phrase isn't contiguous)

The **functional** routing-rule assertions (Traefik rules, `X-Form-Native-*` headers, priorities, ports, `api:8000` upstream) all still match — only two prose comments moved. Realigned both to the current **stable, contiguous** substrings, preserving each guard's intent without re-binding to volatile sentence tails. Audited all 25 `in compose` assertions → **0 remaining drift**.

Not a behavior change — aligning a stale guard to the body it guards. Discovered while CI-validating the field-relay PR (#3575); this is the pre-existing breakage that was blocking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcMKs4fjCCP8zDmk7j5htv)_