### PR TITLE
feat(form): wer-align + voice-diarize — order-aware WER + diarization decision, four-way (127)

### DIFF
--- a/form/form-stdlib/tests/voice-diarize-band.fk
+++ b/form/form-stdlib/tests/voice-diarize-band.fk
@@ -1,0 +1,27 @@
+; preludes: form-stdlib/voice-traits.fk form-stdlib/feature-vector.fk form-stdlib/nearest-shape.fk form-stdlib/voice-diarize.fk
+;
+; voice-diarize-band — the diarization decision made falsifiable. Two speakers enrolled: Voz1 (low pitch,
+; calm) at vec [0 1 0], Voz2 (high pitch, animated) at vec [2 3 2]. Similarity is matching-dimension count
+; (ns-sim, 0..3), so an exact match scores 3 and the enrollment floor is 3. The decisive claim is c6: a
+; voice that matches NO prototype well (a new mid-register voice, strength 1) is enrolled rather than
+; mislabelled — the roster grows 2 -> 3.
+;   1   a known low/calm voice is labelled Voz1                  (vd-label == "Voz1")
+;   2   that match is a full 3/3 similarity                      (vd-strength == 3)
+;   4   a known high/animated voice is labelled Voz2            (vd-label == "Voz2")
+;   8   a new mid voice matches weakly                           (vd-strength == 1)
+;   16  the known voice clears the enrollment floor              (vd-known? @floor 3)
+;   32  the new voice is enrolled under its new label            (vd-route -> "Voz3")
+;   64  enrollment grows the roster 2 -> 3                       (len roster' == 3)
+(do
+    (let v1 (vd-features 120 (list 2 2 3 2)))
+    (let v2 (vd-features 220 (list 1 5 2 7)))
+    (let roster (list (list "Voz1" v1) (list "Voz2" v2)))
+    (let rNew (vd-route roster 175 (list 3 3 3 3) 3 "Voz3"))
+    (let c0 (if (str_eq (vd-label roster 125 (list 2 2 2 3)) "Voz1") 1 0))
+    (let c1 (if (eq (vd-strength roster 125 (list 2 2 2 3)) 3) 2 0))
+    (let c2 (if (str_eq (vd-label roster 215 (list 2 6 1 8)) "Voz2") 4 0))
+    (let c3 (if (eq (vd-strength roster 175 (list 3 3 3 3)) 1) 8 0))
+    (let c4 (if (vd-known? roster 125 (list 2 2 2 3) 3) 16 0))
+    (let c5 (if (str_eq (vd-spoke-of rNew) "Voz3") 32 0))
+    (let c6 (if (eq (len (vd-roster-of rNew)) 3) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/form-stdlib/tests/wer-align-band.fk
+++ b/form/form-stdlib/tests/wer-align-band.fk
@@ -1,0 +1,30 @@
+; preludes: form-stdlib/wer-align.fk
+;
+; wer-align-band — word-sequence-aligned WER, made falsifiable. The reference is "we are the iris"; five
+; hypotheses pin the edit distance and the WER percent, the second being the one that matters most — a
+; word SWAP that set-overlap (stt-agree) scores a perfect 100, but which costs 2 edits = 50% WER:
+;   identical (we are the iris)        -> dist 0,  wer 0
+;   swap      (we the are iris)        -> dist 2,  wer 50   <- order error set-overlap is blind to
+;   sub       (we are an iris)         -> dist 1,  wer 25
+;   delete    (we are iris)            -> dist 1
+;   insert    (we are the big iris)    -> dist 1
+;   empty hyp ()                       -> dist 4 (all four ref words inserted)
+;
+; Verdict 127 when every claim lands:
+;   1    an identical read costs 0 edits                        (wa-distance == 0)
+;   2    a word swap costs 2 edits — order is seen              (wa-distance swap == 2)
+;   4    the swap is 50% WER (set-overlap would say 0% error)   (wa-wer100 swap == 50)
+;   8    a substitution costs 1 edit                            (wa-distance sub == 1)
+;   16   a deletion costs 1 edit                                (wa-distance del == 1)
+;   32   an insertion costs 1 edit                              (wa-distance ins == 1)
+;   64   an empty hypothesis costs len(ref) insertions          (wa-distance empty == 4)
+(do
+    (let ref (list "we" "are" "the" "iris"))
+    (let c0 (if (eq (wa-distance (list "we" "are" "the" "iris") ref) 0) 1 0))
+    (let c1 (if (eq (wa-distance (list "we" "the" "are" "iris") ref) 2) 2 0))
+    (let c2 (if (eq (wa-wer100  (list "we" "the" "are" "iris") ref) 50) 4 0))
+    (let c3 (if (eq (wa-distance (list "we" "are" "an" "iris") ref) 1) 8 0))
+    (let c4 (if (eq (wa-distance (list "we" "are" "iris") ref) 1) 16 0))
+    (let c5 (if (eq (wa-distance (list "we" "are" "the" "big" "iris") ref) 1) 32 0))
+    (let c6 (if (eq (wa-distance (list) ref) 4) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/form-stdlib/voice-diarize.fk
+++ b/form/form-stdlib/voice-diarize.fk
@@ -1,0 +1,46 @@
+; preludes: form-stdlib/voice-traits.fk form-stdlib/feature-vector.fk form-stdlib/nearest-shape.fk
+;
+; voice-diarize.fk — the diarization DECISION as a content-addressed nearest-shape classifier, lifted out
+; of bash. live-room.sh's diarize() bucketed pitch in shell ("if f0 < 150 then Voz1 elif ..."): an opaque,
+; non-shareable ladder of magic numbers. This is that decision as Form — a speaker ROSTER (a list of
+; (label, feature-vector) prototype cells), nearest-shape to pick who is speaking, and enrollment when the
+; nearest match is too weak to trust. The roster is a NodeID-bearing cell: a speaker model the phone can
+; receive, not a private speakers.tsv.
+;
+; THE FEATURE. A speaker's voice-print here is three coordinates the body already proves:
+;   speaker-band(f0)            voice-traits.fk : 0 low / 1 mid / 2 high pitch register
+;   fv-bin(f0, 110 150 190 230) feature-vector.fk : finer pitch bin 0..4 (within-register detail)
+;   fv-bin(arousal(windows),..) feature-vector.fk : delivery dynamics bin 0..2 (calm vs animated)
+; Pitch dominates (two coordinates) because it separates speakers most; arousal adds within-speaker spread
+; so a calm and an animated turn from the same voice still land nearest their own prototype.
+;
+; THE DECISION. vd-route is the whole of diarize() in one recipe:
+;   known (nearest prototype's similarity >= floor)  -> keep the roster, return its label
+;   new   (nearest too weak)                          -> intern a fresh prototype, return the new label
+; It returns (roster', label) so the caller threads the (possibly grown) roster to the next turn — the
+; enrollment is part of the same content-addressed structure, never a side-effect in bash.
+;
+; Proven by: form-stdlib/tests/voice-diarize-band.fk (four-way at validate.sh, incl. fkwu).
+
+(do
+    ; --- a voice-print: (register, pitch-bin, arousal-bin) over the existing proven traits ---
+    (defn vd-features (f0 windows)
+        (list (speaker-band f0)
+              (fv-bin f0 (list 110 150 190 230))
+              (fv-bin (arousal windows) (list 2 5))))
+
+    ; --- who is this, and how sure, against the roster ---
+    (defn vd-label    (roster f0 windows) (ns-label    (vd-features f0 windows) roster))
+    (defn vd-strength (roster f0 windows) (ns-strength (vd-features f0 windows) roster))
+    (defn vd-known?   (roster f0 windows floor) (ge (vd-strength roster f0 windows) floor))
+
+    ; --- the diarization route: keep + label a known voice, or enroll a new one. Returns (roster', label). ---
+    (defn vd-route (roster f0 windows floor newlabel)
+        (if (vd-known? roster f0 windows floor)
+            (list roster (vd-label roster f0 windows))
+            (list (ns-intern roster newlabel (vd-features f0 windows)) newlabel)))
+
+    ; --- conveniences for the carrier: pull the threaded roster / chosen label back out of a route ---
+    (defn vd-roster-of (route) (nth route 0))
+    (defn vd-spoke-of  (route) (nth route 1))
+    0)

--- a/form/form-stdlib/wer-align.fk
+++ b/form/form-stdlib/wer-align.fk
@@ -1,0 +1,56 @@
+; wer-align.fk — word-sequence-aligned WER by rolling-row Levenshtein: the ORDER-AWARE refinement of
+; stt-agree.fk's set-overlap. stt-agree scores word OVERLAP — "we the are iris" scores a perfect 100
+; against "we are the iris" because every word is present and a set cannot see order. WER does see it:
+; aligning the two sequences costs 2 edits = 50%. This recipe is that alignment — the true word-level
+; Levenshtein the stt-agree header named as "the next recipe."
+;
+; THE METRIC. Unit-cost edit distance over two word lists, compared by str_eq (the content-addressed
+; equality the four kernels agree on) = S + D + I. WER100 = dist*100 / len(ref), an integer (0 on an
+; empty reference). Lower is better — the inverse polarity of sa-accuracy, by design: WER is an ERROR rate.
+;
+; THE DP. A two-row rolling Levenshtein (only the previous row and the row being built are ever live, so
+; memory is O(len ref), tractable for long transcripts). Each cell D[i][j] = min of three moves:
+;   up   = D[i-1][j]   + 1   (delete the hyp word)
+;   left = D[i][j-1]   + 1   (insert the ref word)
+;   diag = D[i-1][j-1] + cost(hyp_i, ref_j)   (match if equal, else substitute)
+; The previous row is walked so its head = D[i-1][j-1] (diag) and head(tail) = D[i-1][j] (up); the new
+; row is built reversed with cheap cons and closed by wa-rev. Integers only; no floats; min via gt.
+;
+; HONEST LANE. This is the exact edit distance and its WER percent; it does not yet split S/D/I (that is a
+; tuple-carrying variant) — the number is what the STT/translation eval gates on. Compared to set-overlap
+; (stt-agree): WER catches reordering and repetition that overlap is blind to; overlap catches presence WER
+; over-penalizes. Use both — agreement for "are the words there", WER for "in the right order".
+;
+; Proven by: form-stdlib/tests/wer-align-band.fk (four-way at validate.sh, incl. fkwu).
+
+(do
+    (defn wa-mn2 (a b) (if (gt b a) a b))                 ; min of two (a<b via b>a; no lt dependency)
+    (defn wa-mn3 (a b c) (wa-mn2 a (wa-mn2 b c)))
+    (defn wa-cost (h r) (if (str_eq h r) 0 1))            ; 0 on a matching word, 1 on a substitution
+    (defn wa-rev (xs acc) (if (eq (len xs) 0) acc (wa-rev (tail xs) (cons (head xs) acc))))
+    (defn wa-iota (k n) (if (gt k n) (list) (cons k (wa-iota (add k 1) n))))  ; row 0 = (0 1 .. m)
+    (defn wa-last (xs) (if (eq (len xs) 1) (head xs) (wa-last (tail xs))))    ; D[n][m] = last cell
+
+    ; --- build one DP row across the ref columns. prev-rest head = D[i-1][j-1] (diag), head(tail) = up;
+    ;     left = D[i][j-1] carried; acc the row built in reverse. ---
+    (defn wa-row-loop (h ref-rest prev-rest left acc)
+        (if (eq (len ref-rest) 0)
+            acc
+            (do (let diag (head prev-rest))
+                (let up (head (tail prev-rest)))
+                (let cell (wa-mn3 (add up 1) (add left 1) (add diag (wa-cost h (head ref-rest)))))
+                (wa-row-loop h (tail ref-rest) (tail prev-rest) cell (cons cell acc)))))
+    (defn wa-row (h ref i prev-row)
+        (wa-rev (wa-row-loop h ref prev-row i (cons i (list))) (list)))   ; D[i][0] = i (i deletions)
+
+    (defn wa-rows (hyp ref prev-row i)
+        (if (eq (len hyp) 0) prev-row
+            (wa-rows (tail hyp) ref (wa-row (head hyp) ref i prev-row) (add i 1))))
+
+    ; --- edit distance (S+D+I) between hyp and ref word lists ---
+    (defn wa-distance (hyp ref) (wa-last (wa-rows hyp ref (wa-iota 0 (len ref)) 1)))
+
+    ; --- WER as an integer percent: dist*100 / len(ref); 0 when the reference is empty ---
+    (defn wa-wer100 (hyp ref)
+        (if (ge (len ref) 1) (div (mul (wa-distance hyp ref) 100) (len ref)) 0))
+    0)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -533,6 +533,8 @@ sleep-classify fks 127
 sleep-report fks 127
 breath-rhythm fks 127
 stt-agree fks 127
+wer-align fks 127
+voice-diarize fks 127
 witness-theorem fks 31
 witness-to-co-regulate fks 127
 


### PR DESCRIPTION
Two Form recipes from the frontier fan-out, each four-way (127).

**wer-align** — word-sequence-aligned WER (rolling-row Levenshtein over word lists by `str_eq`). The order-aware refinement of `stt-agree`'s set-overlap: a word swap scores a blind 100 on overlap but costs 2 edits = 50% WER. The shared measurement instrument for the native STT eval and the semantic-translation acceptance gate.

**voice-diarize** — the diarization decision lifted out of `live-room.sh`'s bash pitch-ladder into a content-addressed nearest-shape classifier over (register, pitch-bin, arousal-bin); composes only already-four-way cells. A weak nearest match enrolls a new speaker rather than mislabelling; the roster is a shareable speaker model, not an opaque tsv.

Proven: Go/Rust/TS/fkwu → 127 (`wer-align-band`, `voice-diarize-band`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)