### PR TITLE
[codex] expose pulse strain details

### DIFF
--- a/docs/system_audit/commit_evidence_20260622_pulse_strain_detail.json
+++ b/docs/system_audit/commit_evidence_20260622_pulse_strain_detail.json
@@ -1,0 +1,93 @@
+{
+  "date": "2026-06-22",
+  "thread_branch": "codex/witness-strain-calibration-20260622",
+  "commit_scope": "Expose successful strain details in the pulse current-state API so slow and fallback organs name their reason instead of returning null detail.",
+  "files_owned": [
+    "pulse/pulse_app/main.py",
+    "pulse/tests/test_main.py",
+    "scripts/validate_commit_evidence.py",
+    "docs/system_audit/commit_evidence_20260622_pulse_strain_detail.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "python3 -m pytest pulse/tests -q",
+      "python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence"
+    ],
+    "summary": "Pulse package tests passed: 78 passed. The evidence validator now treats pulse/ as production runtime tissue, and the branch evidence validates against the full diff. The new regression test confirms an ok=True slow sample returns status=strained with its detail visible in /pulse/now."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "summary": "Pending PR checks after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "curl -sS --max-time 10 https://pulse.coherencycoin.com/pulse/now | jq '{overall, organs: [.organs[] | select(.status != \"breathing\") | {name,status,latency_ms,detail,last_sample_at}], silences: .ongoing_silences}'"
+    ],
+    "summary": "Pre-change live witness was strained with web and API endpoint strain but returned detail=null for successful slow samples. Public deploy verification remains pending."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI and deploy validation are pending."
+  },
+  "idea_ids": [
+    "agent-pipeline"
+  ],
+  "spec_ids": [
+    "pulse-silence-boundary-repair"
+  ],
+  "task_ids": [
+    "witness-strain-calibration-20260622"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "witness-priority"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5-codex",
+    "model": "gpt-5-codex",
+    "session": "witness-strain-calibration-20260622"
+  },
+  "evidence_refs": [
+    "live witness before change: overall=strained; web latency 4691ms detail=null; endpoint_ideas latency 1643ms detail=null; endpoint_vitality latency 1654ms detail=null",
+    "python3 -m pytest pulse/tests -q -> 78 passed",
+    "scripts/validate_commit_evidence.py runtime prefixes include pulse/ so pulse service changes are classified as runtime changes"
+  ],
+  "change_files": [
+    "pulse/pulse_app/main.py",
+    "pulse/tests/test_main.py",
+    "scripts/validate_commit_evidence.py",
+    "docs/system_audit/commit_evidence_20260622_pulse_strain_detail.json"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "GET /pulse/now exposes detail for ok=True strained samples, so live slow/fallback organs name their reason instead of showing detail=null.",
+    "public_endpoints": [
+      "GET https://pulse.coherencycoin.com/pulse/now"
+    ],
+    "test_flows": [
+      "Local route-level regression: store an ok=True web sample with detail='slow: 4691ms > 2000ms threshold'; pulse_now returns web.status='strained' and web.detail with the same slow reason."
+    ],
+    "pending_reason": "Public endpoint verification waits for PR merge and Hostinger deploy."
+  }
+}

--- a/pulse/pulse_app/main.py
+++ b/pulse/pulse_app/main.py
@@ -164,6 +164,12 @@ async def pulse_now() -> PulseNow:
             if age > 3 * INTERVAL:
                 status = "unknown"
 
+        visible_detail = (
+            last.detail
+            if last is not None and status in {"strained", "silent"}
+            else None
+        )
+
         statuses.append(status)
         organ_now.append(
             OrganNow(
@@ -173,7 +179,7 @@ async def pulse_now() -> PulseNow:
                 status=status,  # type: ignore[arg-type]
                 latency_ms=last.latency_ms if last else None,
                 last_sample_at=last.ts if last else None,
-                detail=last.detail if last and not last.ok else None,
+                detail=visible_detail,
             )
         )
 

--- a/pulse/tests/test_main.py
+++ b/pulse/tests/test_main.py
@@ -92,3 +92,29 @@ async def test_pulse_now_keeps_open_silence_strained_without_reentry_evidence(tm
     assert response.overall == "strained"
     assert len(response.ongoing_silences) == 1
     assert response.ongoing_silences[0].organ == "api"
+
+
+@pytest.mark.asyncio
+async def test_pulse_now_exposes_successful_strain_detail(tmp_path):
+    store = Store(str(tmp_path / "pulse.db"))
+    now = datetime.now(timezone.utc)
+    detail = "slow: 4691ms > 2000ms threshold"
+    store.insert_sample(
+        Sample(
+            ts=iso_utc(now),
+            organ="web",
+            ok=True,
+            latency_ms=4691,
+            detail=detail,
+        )
+    )
+
+    app.state.store = store
+    app.state.started_at = now - timedelta(minutes=10)
+
+    response = await pulse_now()
+
+    web = next(organ for organ in response.organs if organ.name == "web")
+    assert response.overall == "strained"
+    assert web.status == "strained"
+    assert web.detail == detail

--- a/scripts/validate_commit_evidence.py
+++ b/scripts/validate_commit_evidence.py
@@ -24,6 +24,7 @@ RUNTIME_PATH_PREFIXES = (
     "deploy/front-door/",
     "deploy/kernel-router/",
     "Dockerfile.kernel-router",
+    "pulse/",
 )
 REQUIRED_TOP_LEVEL = {
     "date",


### PR DESCRIPTION
## What changed

- `GET /pulse/now` now returns `detail` for strained successful samples, not only failed samples.
- Added a regression test for an `ok=True` slow sample returning `status=strained` with its slow reason visible.
- Added `pulse/` to the commit-evidence runtime path classifier so pulse service changes validate as runtime changes.
- Added commit evidence for this witness strain detail fix.

## Why

The live witness was reporting strained organs with `detail=null`, including slow web/API samples. That made the current-state pulse truthful at the status level but not diagnostic enough for a human or deploy script to understand the strain.

## Validation

- `make prompt-guide`
- `make wellness`
- `python3 -m pytest pulse/tests -q` -> 78 passed
- `python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
- `git diff --check origin/main...HEAD`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`

## Notes

Pre-change live witness observation: `overall=strained`; `web`, `endpoint_ideas`, and `endpoint_vitality` were strained while returning `detail=null`. After deploy, the same class of successful strain should include the stored slow/fallback detail.