### PR TITLE
feat(form): accel-breath — read a night's breathing from phone motion, fully in Form (127)

### DIFF
--- a/form/form-stdlib/accel-breath-file.fk
+++ b/form/form-stdlib/accel-breath-file.fk
@@ -1,0 +1,48 @@
+; preludes: form-stdlib/line-grammar.fk form-stdlib/breath-rhythm.fk form-stdlib/accel-breath.fk
+;
+; accel-breath-file.fk — the Form-native reader that closes the awk gap: it READS an accelerometer csv
+; ("epoch,timestamp,x,y,z" rows, signed 2-decimal g), PARSES the x/y/z columns to centi-g integers, and
+; runs accel-breath's analysis — so reading the breath from a file is Form end to end, not a bash pipeline.
+; The only thing left to the carrier is windowing which recent lines to look at (genuine I/O); every parse
+; and every judgment lives here. Values like "-0.01" become -1 (centi-g); a header or short row is skipped.
+
+(do
+    ; --- parse a signed fixed-point string to centi-g int: "-0.01" -> -1, "0.00" -> 0, "1.50" -> 150 ---
+    (defn abf-neg? (s) (if (ge (str_len s) 1) (str_eq (substring s 0 1) "-") 0))
+    (defn abf-mag (s)                              ; |value| in centi-g from the unsigned string
+        (do (let parts (split-on s "."))
+            (let ip (str_to_int (head parts)))
+            (let frac (if (ge (len parts) 2) (nth parts 1) "0"))
+            (let fp (str_to_int frac))
+            ; scale the fraction to exactly 2 places (2 digits -> *1, 1 digit -> *10, 0 -> *0)
+            (let fl (str_len frac))
+            (let fscaled (if (ge fl 2) fp (if (eq fl 1) (mul fp 10) 0)))
+            (add (mul ip 100) fscaled)))
+    (defn abf-centi (s)
+        (do (let body (if (abf-neg? s) (substring s 1 (str_len s)) s))
+            (let m (abf-mag body))
+            (if (abf-neg? s) (sub 0 m) m)))
+
+    ; --- extract column k (0=epoch 1=ts 2=x 3=y 4=z) from each well-formed row as a centi-g list ---
+    (defn abf-col (rows k)
+        (if (eq (len rows) 0) (list)
+            (do (let cells (split-on (head rows) ","))
+                (if (ge (len cells) 5)
+                    (cons (abf-centi (nth cells k)) (abf-col (tail rows) k))
+                    (abf-col (tail rows) k)))))
+
+    ; --- drop a header row if the first cell isn't numeric-looking (starts with a digit or '-') ---
+    (defn abf-digit? (c) (if (str_eq c "-") 1 (if (ge (str_len c) 1) (ge (str_to_int c) 1) 0)))
+    (defn abf-first-cell (line) (head (split-on line ",")))
+    (defn abf-rows (path)
+        (do (let lines (split-on (read_file path) "\n"))
+            (if (eq (len lines) 0) (list)
+                (if (abf-digit? (substring (abf-first-cell (head lines)) 0 1)) lines (tail lines)))))
+
+    ; --- the full read: (dominant-axis  motion  rate  confidence) over the file's rows ---
+    (defn abf-read (path lo hi spm)
+        (do (let rows (abf-rows path))
+            (let ax (abf-col rows 2)) (let ay (abf-col rows 3)) (let az (abf-col rows 4))
+            (list (ab-dominant ax ay az) (ab-motion ax ay az)
+                  (ab-rate ax ay az lo hi spm) (ab-confidence ax ay az lo hi))))
+    0)

--- a/form/form-stdlib/accel-breath.fk
+++ b/form/form-stdlib/accel-breath.fk
@@ -1,0 +1,35 @@
+; preludes: form-stdlib/breath-rhythm.fk
+;
+; accel-breath.fk — read a night's breathing from 3-axis phone-accelerometer motion, fully in Form.
+; A phone resting on a sleeping chest sees the breath as a slow oscillation on ONE axis (whichever way
+; the chest lifts under it); the other two carry less of it. This recipe is the WHOLE decision the bash
+; carrier used to make in awk: pick that axis by motion energy (integer variance), then read its
+; respiratory rate via breath-rhythm's autocorrelation. Samples are signed scaled integers (milli-g);
+; a phone flat on a desk has near-zero variance on every axis — no breath to read, and the recipe says so.
+;
+; The division of labor this restores: the carrier only READS the csv columns and scales to int (thin
+; I/O); every judgment — which axis is breathing, how much motion, what rate — is a Form recipe, four-way.
+
+(do
+    ; --- motion energy of one axis: integer variance (mean squared deviation from the axis mean) ---
+    (defn ab-sqdev (xs mean)
+        (if (ge (len xs) 1)
+            (add (mul (sub (nth xs 0) mean) (sub (nth xs 0) mean)) (ab-sqdev (tail xs) mean))
+            0))
+    (defn ab-var (xs) (if (ge (len xs) 1) (div (ab-sqdev xs (br-mean xs)) (len xs)) 0))
+
+    ; --- the axis (0=x 1=y 2=z) carrying the most motion = the breathing axis ---
+    (defn ab-dominant (ax ay az)
+        (do (let vx (ab-var ax)) (let vy (ab-var ay)) (let vz (ab-var az))
+            (if (ge vx vy) (if (ge vx vz) 0 2) (if (ge vy vz) 1 2))))
+    (defn ab-axis (ax ay az k) (if (eq k 0) ax (if (eq k 1) ay az)))
+    (defn ab-pick (ax ay az) (ab-axis ax ay az (ab-dominant ax ay az)))
+
+    ; --- overall motion level = variance of the dominant axis (0 = a perfectly still phone) ---
+    (defn ab-motion (ax ay az) (ab-var (ab-pick ax ay az)))
+
+    ; --- respiratory rate + confidence from the dominant axis (breath-rhythm autocorrelation) ---
+    ;   lo/hi = lag window (samples), spm = samples*60 (e.g. 5Hz -> 300): rate = spm / peak-lag
+    (defn ab-rate (ax ay az lo hi spm) (br-rate (ab-pick ax ay az) lo hi spm))
+    (defn ab-confidence (ax ay az lo hi) (br-confidence (ab-pick ax ay az) lo hi))
+    0)

--- a/form/form-stdlib/tests/accel-breath-band.fk
+++ b/form/form-stdlib/tests/accel-breath-band.fk
@@ -1,0 +1,29 @@
+; preludes: form-stdlib/breath-rhythm.fk form-stdlib/accel-breath.fk
+;
+; accel-breath-band — reading breath from 3-axis motion, made falsifiable. The Y axis carries a period-20
+; square oscillation (10 up, 10 down, ×3 = 60 samples) — at 5Hz that is one breath every 4s = 15/min; X and
+; Z are flat. The recipe must pick Y, measure its motion, and recover 15 breaths/min — and a perfectly
+; still phone (all axes zero) must read motion 0, the honest floor that says "no breath here."
+;   1   the breathing axis is found (Y, index 1)          (ab-dominant == 1)
+;   2   its motion energy is the wave's variance          (ab-var Y == 100)
+;   4   a flat axis has zero motion                        (ab-var X == 0)
+;   8   the respiratory rate is recovered                  (ab-rate == 15)
+;   16  the rhythm carries real confidence                 (ab-confidence == 66)
+;   32  overall motion = the dominant axis's variance      (ab-motion == 100)
+;   64  a still phone reads no breath                       (ab-motion of all-zero == 0)
+(do
+    (defn abb-rep (v n) (if (eq n 0) (list) (cons v (abb-rep v (sub n 1)))))
+    (defn abb-cat (a b) (if (eq (len a) 0) b (cons (head a) (abb-cat (tail a) b))))
+    (let wave (abb-cat (abb-rep 10 10) (abb-rep -10 10)))
+    (let ay (abb-cat wave (abb-cat wave wave)))
+    (let ax (abb-rep 1 60))
+    (let az (abb-rep -2 60))
+    (let zero (abb-rep 0 60))
+    (let c0 (if (eq (ab-dominant ax ay az) 1) 1 0))
+    (let c1 (if (eq (ab-var ay) 100) 2 0))
+    (let c2 (if (eq (ab-var ax) 0) 4 0))
+    (let c3 (if (eq (ab-rate ax ay az 10 30 300) 15) 8 0))
+    (let c4 (if (eq (ab-confidence ax ay az 10 30) 66) 16 0))
+    (let c5 (if (eq (ab-motion ax ay az) 100) 32 0))
+    (let c6 (if (eq (ab-motion zero zero zero) 0) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -532,6 +532,7 @@ sleep-night fkc 127
 sleep-classify fks 127
 sleep-report fks 127
 breath-rhythm fks 127
+accel-breath fks 127
 stt-agree fks 127
 wer-align fks 127
 voice-diarize fks 127


### PR DESCRIPTION
The breath/motion analysis the bedside carrier used to do in **awk**, lifted into the body.

**accel-breath.fk** (four-way, 127) — picks the breathing axis by motion energy (integer variance), reads its respiratory rate via breath-rhythm's autocorrelation. A still phone reads motion 0 / no breath, the honest floor.

**accel-breath-file.fk** — the Form-native CSV reader: `read_file` → parse the signed 2-decimal x/y/z columns to centi-g ints → analyze. Reading breath from a file is now Form end to end; the carrier shrinks to windowing recent lines (genuine I/O). Uses `read_file` (host-io) so it's the 3-kernel reader carrier, exactly like `wav-envelope-file` beside the four-way `wav-sense` core.

Verified live: on tonight's capture it correctly read phone-handling as high-motion / low-confidence (not breathing) — the recipe working, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)