### PR TITLE
tend(form): the real llama3.2 decoder block in Form — llama3 RoPE + GQA (causal & non-causal), four-way

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-23_llama3_rope_and_gqa_block_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-23_llama3_rope_and_gqa_block_four_way.json
@@ -1,15 +1,18 @@
 {
   "date": "2026-06-23",
-  "brick": "llama3-rope + llama-gqa-block (2x)",
-  "title": "the REAL llama3.2 block comes home — GQA attention + llama3 RoPE (rope_theta 500000 + piecewise wavelength scaling) cross four-way as standalone Form recipes, composed into a GQA-shaped llama decoder block",
+  "brick": "llama3-rope + llama-gqa-block + llama-gqa-block-causal (3x), + tb-take unification",
+  "title": "the REAL llama3.2 decoder block comes home — GQA attention (non-causal AND causal) + llama3 RoPE (rope_theta 500000 + piecewise wavelength scaling) cross four-way as standalone Form recipes, composed into a GQA-shaped llama decoder block",
   "north_star_track": "real local llama3.2:3b inference natively — the fused hati-translator block (24 query heads / 8 KV heads, head_dim 128, rope_theta 500000, rope_scaling llama3) running as proven recipe DATA, not emitted C",
   "what": "Two numerics separated the proven single-head, base-10000 llama block (lblk-block, #3365, four-way 4095) from the block the real Llama-3.2-3B fused checkpoint runs. GQA was lifted in #3577 (tb-gqa-attn, four-way 7). This arc lifts the SECOND and composes both. (1) llama3 RoPE: rope.fk only ever had base 10000 with no scaling; the real model uses rope_theta=500000 AND rope_scaling type 'llama3' (factor 32, low_freq_factor 1, high_freq_factor 4, original_max_position_embeddings 8192). Each default inv_freq f = base^(-hd/HD) is reshaped by where its wavelength 2pi/f sits — long-wavelength (low-freq) components are divided by factor (one rotation spans a longer context), short-wavelength (high-freq) untouched, medium interpolated smoothly. base theta + the scaling factors are now recipe DATA (a rope-cfg list), never smuggled constants. This lived ONLY inside transformer-kernel.fk's tk-emit-llama as emitted C (powf(10000.0,...), three-way, and it had NO llama3 scaling at all — even the theta was wrong). Lifted to rope-l3-scale / rope-freq-theta / rope-scaled, composing trig.fk's already-four-way fpow/fsin/fcos and sharing rope-rot-pair with the default `rope` — `rope` is now the (base 10000, no-scaling) special case, not a parallel path. (2) llama-gqa-block.fk composes tb-gqa-attn + rope-scaled + llama-block.fk's own RMSNorm/proj/SwiGLU walks into lgqa-block, parameterized by (n_q, n_kv, HD, rope-cfg). lblk-block is the (n_q=n_kv=1, base-10000) special case. No new arithmetic in either file.",
   "files": {
     "rope_recipe": "form/form-stdlib/rope.fk (rope-freq-theta, rope-l3-smooth, rope-l3-scale, rope-cfg/-llama3, rope-freq-cfg, rope-angle-cfg, rope-scaled)",
-    "block_recipe": "form/form-stdlib/llama-gqa-block.fk (lgqa-rope-seq, lgqa-attn-sub, lgqa-attn-block, lgqa-block)",
+    "gqa_recipe": "form/form-stdlib/gqa-attn.fk (tb-gqa-attn-causal, tb-gqa-head-causal, tb-gqa-loop-causal added beside the non-causal tb-gqa-attn from #3577)",
+    "block_recipe": "form/form-stdlib/llama-gqa-block.fk (lgqa-rope-seq, lgqa-attn-sub/-block, lgqa-block, and the causal lgqa-attn-sub-causal/-block-causal, lgqa-block-causal)",
     "rope_band": "form/form-stdlib/tests/llama3-rope-band.fk",
     "block_band": "form/form-stdlib/tests/llama-gqa-block-band.fk",
-    "manifest_rows": ["llama3-rope fks 255", "llama-gqa-block fks 31"]
+    "block_causal_band": "form/form-stdlib/tests/llama-gqa-block-causal-band.fk",
+    "tb_take_unification": "form/form-stdlib/transformer-mh.fk (removed the duplicate (n xs) tb-take; tb-vslice now uses transformer-block.fk's (xs n)) + form/form-stdlib/transformer-decoder.fk (tb-attn-causal-acc call sites switched to the (xs n) order) — one tb-take, no prelude-order shadowing",
+    "manifest_rows": ["llama3-rope fks 255", "llama-gqa-block fks 31", "llama-gqa-block-causal fks 15"]
   },
   "proof": {
     "llama3_rope": {
@@ -24,7 +27,14 @@
       "fourth_arm": "1 band four-way (fkwu + pre-flattened tables)",
       "divergent": 0
     },
-    "kernels": "Go, Rust, TypeScript, fkwu — agree on every sample, both bands"
+    "llama_gqa_block_causal": {
+      "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/transformer-numerics.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk form-stdlib/tests/llama-gqa-block-causal-band.fk",
+      "verdict": 15,
+      "fourth_arm": "1 band four-way (fkwu + pre-flattened tables)",
+      "divergent": 0
+    },
+    "tb_take_regression_set": "re-proved four-way after the unification (0 divergent each): gqa-attn 7, transformer-mh 1, transformer-decoder 1, transformer-generate 1, transformer-generate-cached 1, whisper-mh-block-real 1, transformer-gelu-erf 255, sampling 2047 — the change is behavior-preserving (same take logic, unified arg order)",
+    "kernels": "Go, Rust, TypeScript, fkwu — agree on every sample, all bands"
   },
   "fixtures": "llama3-rope: hand-picked inv_freq f per claim so each scaling branch is pure arithmetic (bit-exact across kernels); theta-base and end-to-end rotation pinned to libm fp64 (fpow/fsin/fcos) at 1e-6. llama-gqa-block: the llama-block-band fixture (S=2, d=4, HD=4) for the single-head claims; the same 4x4 weights re-read as 2 heads of width 2 (HD=2) for GQA sharing. At HD=4 under base 500000 the hd=2 pair lands in the MEDIUM scaling branch, so the d=4 block genuinely exercises the llama3 scaling.",
   "claims": {
@@ -44,11 +54,17 @@
       "4": "lgqa-block(n_q=1,n_kv=1,HD=4, cfg-llama3) y[1][2] -> 1648171 (last token, post-SwiGLU)",
       "8": "lgqa-block(n_q=2,n_kv=1,HD=2, cfg-llama3) y[0][0] -> 1424802 (GQA: 2 query heads share KV head 0)",
       "16": "lgqa-block(n_q=2,n_kv=2,HD=2, cfg-llama3) y[0][0] -> 1248836 (per-head; != shared ⇒ the (h/group) grouping propagates through the whole block, not just attention)"
+    },
+    "llama-gqa-block-causal (15)": {
+      "1": "lgqa-block-causal(n_q=1,n_kv=1,HD=4, cfg base 10000) == lblk-block-causal (#3365, 4095), bit-for-bit — single-head base-10000 is the special case of the causal block too",
+      "2": "lgqa-block-causal(cfg-llama3) y[0][0] -> 1893731 — the published four-way causal token-0 value (causal-attention-band / kv-llama-block-band). At position 0 RoPE is the identity (angle 0), so theta is irrelevant for token 0; AND 1893731 != non-causal 1116075 ⇒ the causal mask is real",
+      "4": "lgqa-block-causal(cfg-llama3) last token == lgqa-block(cfg-llama3) last token, bit-for-bit — no over-masking (the last query's causal prefix is the whole sequence)",
+      "8": "lgqa-block-causal(n_q=2,n_kv=1,HD=2) last[1][0] != lgqa-block-causal(n_q=2,n_kv=2,HD=2) last[1][0] — GQA grouping is real in the causal block"
     }
   },
   "lesson": "Read-the-body first: the task framed GQA as undone, but #3577 had just lifted it (tb-gqa-attn four-way 7) — the body's own attestation (the manifest row + commit) redirected the work to the genuine gap, llama3 RoPE. The scaling-branch claims are bit-exact (hand-picked inv_freq makes the piecewise pure arithmetic — no transcendental, no 1e-6 fuzz, identical across all four kernels), with continuity at both boundaries proven by exact equality (s=0 ⇒ f/factor, s=1 ⇒ f). The composition claim of strongest worth is the GENERALIZATION law: lgqa-block at (n_q=n_kv=1, base 10000) equals the already-four-way lblk-block bit-for-bit, so the new recipe inherits a KNOWN-correct value rather than only self-consistency — core-abstraction-first made visible, the single-head block is the special case, not a parallel path. A d=4 block exercises the medium scaling because base 500000 pushes the hd=2 pair's wavelength into [2048, 8192] — strange-minimal coverage without a full-width fixture.",
+  "surfaced_and_fixed": "composing GQA + the causal mask was the first band to co-prelude transformer-mh AND use transformer-block's causal attention, which surfaced a LATENT collision: tb-take was defined twice with SWAPPED arg order ((xs n) in transformer-block.fk, (n xs) in transformer-mh.fk), each silently relying on prelude order. The non-causal path never calls tb-take, so it never bit. Fixed at the source — one tb-take (transformer-block's (xs n)); transformer-mh's tb-vslice and transformer-decoder's causal-take switched to it. Behavior-preserving, the whole transformer-mh/decoder/whisper band set re-proved four-way. Pre-existing-is-disease: the band that surfaced it owned the fix rather than working around with a parallel path.",
   "named_next_stones": [
-    "the causal GQA block: tb-gqa-attn-causal (tb-attn-seq-causal is already four-way 511) + lgqa-block-causal — the autoregressive decoder shape, mechanical from here",
     "KV-cached GQA decode: thread lgqa over the kv-cache (kv-llama-block.fk pattern) at GQA shape — k/v cached at the narrower n_kv*HD width",
     "wire the proven pieces at REAL width: lgqa-block stacked across the 28 Llama-3.2-3B blocks (hidden 3072, n_q 24, n_kv 8, HD 128, rope-cfg-llama3) over the GGUF weights already Form-native dequant — the buffer bridge / emit->compile->exec lane, then the end-to-end transcript the whisper stack still lacks",
     "drop tk-emit-llama's hardcoded powf(10000.0,...) RoPE — the emitted-C path now has a four-way recipe (rope-scaled) and a real-theta cfg to mirror"

--- a/docs/system_audit/commit_evidence_2026-06-23_llama3_rope_and_gqa_block_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-23_llama3_rope_and_gqa_block_four_way.json
@@ -1,0 +1,56 @@
+{
+  "date": "2026-06-23",
+  "brick": "llama3-rope + llama-gqa-block (2x)",
+  "title": "the REAL llama3.2 block comes home — GQA attention + llama3 RoPE (rope_theta 500000 + piecewise wavelength scaling) cross four-way as standalone Form recipes, composed into a GQA-shaped llama decoder block",
+  "north_star_track": "real local llama3.2:3b inference natively — the fused hati-translator block (24 query heads / 8 KV heads, head_dim 128, rope_theta 500000, rope_scaling llama3) running as proven recipe DATA, not emitted C",
+  "what": "Two numerics separated the proven single-head, base-10000 llama block (lblk-block, #3365, four-way 4095) from the block the real Llama-3.2-3B fused checkpoint runs. GQA was lifted in #3577 (tb-gqa-attn, four-way 7). This arc lifts the SECOND and composes both. (1) llama3 RoPE: rope.fk only ever had base 10000 with no scaling; the real model uses rope_theta=500000 AND rope_scaling type 'llama3' (factor 32, low_freq_factor 1, high_freq_factor 4, original_max_position_embeddings 8192). Each default inv_freq f = base^(-hd/HD) is reshaped by where its wavelength 2pi/f sits — long-wavelength (low-freq) components are divided by factor (one rotation spans a longer context), short-wavelength (high-freq) untouched, medium interpolated smoothly. base theta + the scaling factors are now recipe DATA (a rope-cfg list), never smuggled constants. This lived ONLY inside transformer-kernel.fk's tk-emit-llama as emitted C (powf(10000.0,...), three-way, and it had NO llama3 scaling at all — even the theta was wrong). Lifted to rope-l3-scale / rope-freq-theta / rope-scaled, composing trig.fk's already-four-way fpow/fsin/fcos and sharing rope-rot-pair with the default `rope` — `rope` is now the (base 10000, no-scaling) special case, not a parallel path. (2) llama-gqa-block.fk composes tb-gqa-attn + rope-scaled + llama-block.fk's own RMSNorm/proj/SwiGLU walks into lgqa-block, parameterized by (n_q, n_kv, HD, rope-cfg). lblk-block is the (n_q=n_kv=1, base-10000) special case. No new arithmetic in either file.",
+  "files": {
+    "rope_recipe": "form/form-stdlib/rope.fk (rope-freq-theta, rope-l3-smooth, rope-l3-scale, rope-cfg/-llama3, rope-freq-cfg, rope-angle-cfg, rope-scaled)",
+    "block_recipe": "form/form-stdlib/llama-gqa-block.fk (lgqa-rope-seq, lgqa-attn-sub, lgqa-attn-block, lgqa-block)",
+    "rope_band": "form/form-stdlib/tests/llama3-rope-band.fk",
+    "block_band": "form/form-stdlib/tests/llama-gqa-block-band.fk",
+    "manifest_rows": ["llama3-rope fks 255", "llama-gqa-block fks 31"]
+  },
+  "proof": {
+    "llama3_rope": {
+      "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/rope.fk form-stdlib/tests/llama3-rope-band.fk",
+      "verdict": 255,
+      "fourth_arm": "1 band four-way (fkwu + pre-flattened tables)",
+      "divergent": 0
+    },
+    "llama_gqa_block": {
+      "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/transformer-numerics.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk form-stdlib/tests/llama-gqa-block-band.fk",
+      "verdict": 31,
+      "fourth_arm": "1 band four-way (fkwu + pre-flattened tables)",
+      "divergent": 0
+    },
+    "kernels": "Go, Rust, TypeScript, fkwu — agree on every sample, both bands"
+  },
+  "fixtures": "llama3-rope: hand-picked inv_freq f per claim so each scaling branch is pure arithmetic (bit-exact across kernels); theta-base and end-to-end rotation pinned to libm fp64 (fpow/fsin/fcos) at 1e-6. llama-gqa-block: the llama-block-band fixture (S=2, d=4, HD=4) for the single-head claims; the same 4x4 weights re-read as 2 heads of width 2 (HD=2) for GQA sharing. At HD=4 under base 500000 the hd=2 pair lands in the MEDIUM scaling branch, so the d=4 block genuinely exercises the llama3 scaling.",
+  "claims": {
+    "llama3-rope (255)": {
+      "1": "high-freq (wavelen 628 < orig/high-f 2048) -> f UNCHANGED (f=0.01 returns 0.01 exactly)",
+      "2": "low-freq (wavelen 62831 > orig/low-f 8192) -> f / factor (f=1e-4 returns f/32 exactly)",
+      "4": "medium joins LOW continuously: at wavelen = orig/low-f, s=0 ⇒ f/32 (bit-exact)",
+      "8": "medium joins HIGH continuously: at wavelen = orig/high-f, s=1 ⇒ f (bit-exact)",
+      "16": "medium INTERIOR real value: f=0.0011 (wavelen 5712) -> 0.000188598... (x1e9 = 188598, pure arithmetic, bit-exact)",
+      "32": "rope_theta is DATA: base 500000, hd=2, HD=4 -> inv_freq 0.0014142... (x1e6 = 1414, != base-10000's 0.01)",
+      "64": "end-to-end rotation: base 500000, HD=4, pos=1, the hd=2 (MEDIUM-scaled) pair -> 999570 (x1e6) — slower than base-10000's 989950",
+      "128": "generalization: rope-scaled with the (base 10000, no-scaling) cfg == the default `rope`, bit-for-bit — the default is the special case"
+    },
+    "llama-gqa-block (31)": {
+      "1": "lgqa-block(n_q=1,n_kv=1,HD=4, cfg base 10000 no-scaling) == lblk-block (#3365, 4095), bit-for-bit — single-head base-10000 is the special case; inherits lblk-block's libm pins",
+      "2": "lgqa-block(n_q=1,n_kv=1,HD=4, cfg-llama3) y[0][0] -> 1116075 (theta 500000 + medium scaling; != lblk's 1115890 ⇒ scaling does real work end-to-end)",
+      "4": "lgqa-block(n_q=1,n_kv=1,HD=4, cfg-llama3) y[1][2] -> 1648171 (last token, post-SwiGLU)",
+      "8": "lgqa-block(n_q=2,n_kv=1,HD=2, cfg-llama3) y[0][0] -> 1424802 (GQA: 2 query heads share KV head 0)",
+      "16": "lgqa-block(n_q=2,n_kv=2,HD=2, cfg-llama3) y[0][0] -> 1248836 (per-head; != shared ⇒ the (h/group) grouping propagates through the whole block, not just attention)"
+    }
+  },
+  "lesson": "Read-the-body first: the task framed GQA as undone, but #3577 had just lifted it (tb-gqa-attn four-way 7) — the body's own attestation (the manifest row + commit) redirected the work to the genuine gap, llama3 RoPE. The scaling-branch claims are bit-exact (hand-picked inv_freq makes the piecewise pure arithmetic — no transcendental, no 1e-6 fuzz, identical across all four kernels), with continuity at both boundaries proven by exact equality (s=0 ⇒ f/factor, s=1 ⇒ f). The composition claim of strongest worth is the GENERALIZATION law: lgqa-block at (n_q=n_kv=1, base 10000) equals the already-four-way lblk-block bit-for-bit, so the new recipe inherits a KNOWN-correct value rather than only self-consistency — core-abstraction-first made visible, the single-head block is the special case, not a parallel path. A d=4 block exercises the medium scaling because base 500000 pushes the hd=2 pair's wavelength into [2048, 8192] — strange-minimal coverage without a full-width fixture.",
+  "named_next_stones": [
+    "the causal GQA block: tb-gqa-attn-causal (tb-attn-seq-causal is already four-way 511) + lgqa-block-causal — the autoregressive decoder shape, mechanical from here",
+    "KV-cached GQA decode: thread lgqa over the kv-cache (kv-llama-block.fk pattern) at GQA shape — k/v cached at the narrower n_kv*HD width",
+    "wire the proven pieces at REAL width: lgqa-block stacked across the 28 Llama-3.2-3B blocks (hidden 3072, n_q 24, n_kv 8, HD 128, rope-cfg-llama3) over the GGUF weights already Form-native dequant — the buffer bridge / emit->compile->exec lane, then the end-to-end transcript the whisper stack still lacks",
+    "drop tk-emit-llama's hardcoded powf(10000.0,...) RoPE — the emitted-C path now has a four-way recipe (rope-scaled) and a real-theta cfg to mirror"
+  ]
+}

--- a/form/form-stdlib/gqa-attn.fk
+++ b/form/form-stdlib/gqa-attn.fk
@@ -35,3 +35,22 @@
 ; group = n / nkv. group=1 (nkv=n) reduces exactly to transformer-mh's tb-mh-attn.
 (defn tb-gqa-attn (qs ks vs n nkv hd scale)
   (tb-gqa-loop qs ks vs 0 n (div n nkv) hd scale))
+
+; --- causal GQA: the autoregressive decoder mask, per head. Query position i in
+;     head h attends only to keys/values 0..i of its shared KV head (tb-attn-seq-causal,
+;     transformer-block.fk, four-way 511). Identical to tb-gqa-attn but each head's
+;     attention is masked — the only change is tb-attn-seq → tb-attn-seq-causal, no new
+;     arithmetic. At the last position the prefix is the whole sequence, so the last
+;     token is bit-identical to non-causal GQA; earlier tokens differ (they no longer
+;     see the future). This is the block the generation loop steps. ---
+(defn tb-gqa-head-causal (qs ks vs h kvh hd scale)
+  (tb-attn-seq-causal (tb-seq-headslice qs h hd)
+                      (tb-seq-headslice ks kvh hd)
+                      (tb-seq-headslice vs kvh hd) scale))
+(defn tb-gqa-loop-causal (qs ks vs h n grp hd scale)
+  (if (eq h (sub n 1))
+      (tb-gqa-head-causal qs ks vs h (div h grp) hd scale)
+      (tb-seq-cat (tb-gqa-head-causal qs ks vs h (div h grp) hd scale)
+                  (tb-gqa-loop-causal qs ks vs (add h 1) n grp hd scale))))
+(defn tb-gqa-attn-causal (qs ks vs n nkv hd scale)
+  (tb-gqa-loop-causal qs ks vs 0 n (div n nkv) hd scale))

--- a/form/form-stdlib/llama-gqa-block.fk
+++ b/form/form-stdlib/llama-gqa-block.fk
@@ -1,0 +1,52 @@
+; llama-gqa-block.fk — the REAL llama3.2 decoder block as proven Form: GQA
+; attention (n_q query heads sharing n_kv < n_q KV heads) + llama3 RoPE
+; (rope_theta 500000 + piecewise scaling) + RMSNorm + SwiGLU, composed from
+; recipes that are ALREADY four-way. This is the block the fused hati-translator
+; (Llama-3.2-3B: hidden 3072, 24 query heads, 8 KV heads, head_dim 128,
+; rope_theta 500000, rope_scaling "llama3") actually runs.
+;
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/transformer-numerics.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk
+;
+; lblk-block (llama-block.fk, four-way 4095) is SINGLE-head, full MHA, base-10000
+; RoPE. Two numerics separate it from a real llama3 block, and BOTH are now
+; standalone four-way recipes this file only composes — no new arithmetic:
+;   GQA      tb-gqa-attn (gqa-attn.fk, four-way 7): query head h reads KV head
+;            (h / (n_q/n_kv)); group=1 (n_kv=n_q) reduces exactly to MHA.
+;   theta    rope-scaled (rope.fk, four-way via llama3-rope-band): rope_theta
+;   RoPE     base + the piecewise wavelength scaling, carried as a rope-cfg.
+; lblk-block is the (n_q=n_kv=1, cfg base 10000 no-scaling) special case of
+; lgqa-block — core-abstraction-first, no parallel path. Weights stay arguments
+; (lists of rows): the block is recipe DATA, a layer stack a SEQUENCE of calls.
+; fp64 lane; non-causal (matching lblk-block / tb-gqa-attn — the causal GQA mask
+; is the mechanical next step, tb-attn-seq-causal already four-way). Position =
+; absolute token index. Proven four-way against the libm fp64 reference by
+; tests/llama-gqa-block-band.fk.
+;
+;   n1 = RMSNorm1(x)
+;   q  = RoPE_cfg(Wq·n1)  [n_q·HD wide]   k = RoPE_cfg(Wk·n1) [n_kv·HD]   v = Wv·n1 [n_kv·HD]
+;   h  = x + Wo·GQA(q, k, v, n_q, n_kv, HD, scale)            (bias-free proj, residual)
+;   n2 = RMSNorm2(h)
+;   y  = h + Wdown·SwiGLU(Wgate·n2, Wup·n2)
+
+; --- RoPE each token's projected vector by its absolute position under cfg c (HD per head) ---
+; The full projected vector is n_head·HD wide; rope-scaled walks it pairwise with
+; (mod i HD), so the rotation resets every head — applying RoPE to the whole
+; vector then head-slicing is identical to slicing then RoPE per head.
+(defn lgqa-rope-seq-i (xs i HD c)
+  (if (eq (len xs) 0) (empty)
+      (cons (rope-scaled (head xs) i HD c) (lgqa-rope-seq-i (tail xs) (add i 1) HD c))))
+(defn lgqa-rope-seq (xs HD c) (lgqa-rope-seq-i xs 0 HD c))
+
+; --- GQA attention sub-block: RMSNorm → q/k/v proj → RoPE(q),RoPE(k) → GQA → Wo → +residual ---
+; reuses llama-block.fk's lblk-proj-seq (bias-free projection) and lblk-rms-seq.
+(defn lgqa-attn-sub (n1 wq wk wv wo scale n_q n_kv HD c)
+  (lblk-proj-seq wo
+    (tb-gqa-attn (lgqa-rope-seq (lblk-proj-seq wq n1) HD c)
+                 (lgqa-rope-seq (lblk-proj-seq wk n1) HD c)
+                 (lblk-proj-seq wv n1) n_q n_kv HD scale)))
+(defn lgqa-attn-block (xs g1 eps wq wk wv wo scale n_q n_kv HD c)
+  (tb-add-seq xs (lgqa-attn-sub (lblk-rms-seq xs g1 eps) wq wk wv wo scale n_q n_kv HD c)))
+
+; --- the whole GQA llama block (FFN sub-block is lblk-ffn-block from llama-block.fk) ---
+(defn lgqa-block (xs g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd)
+  (lblk-ffn-block (lgqa-attn-block xs g1 eps wq wk wv wo scale n_q n_kv HD c) g2 eps wg wu wd))

--- a/form/form-stdlib/llama-gqa-block.fk
+++ b/form/form-stdlib/llama-gqa-block.fk
@@ -50,3 +50,19 @@
 ; --- the whole GQA llama block (FFN sub-block is lblk-ffn-block from llama-block.fk) ---
 (defn lgqa-block (xs g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd)
   (lblk-ffn-block (lgqa-attn-block xs g1 eps wq wk wv wo scale n_q n_kv HD c) g2 eps wg wu wd))
+
+; --- the causal GQA llama block: the REAL autoregressive decoder. Identical to
+;     lgqa-block but each token attends only to itself and the tokens before it
+;     (tb-gqa-attn-causal). At the last token the prefix is the whole sequence, so the
+;     last position is bit-identical to lgqa-block; earlier tokens differ. This is the
+;     block the generation loop steps — and the (n_q=n_kv=1, base-10000) special case is
+;     lblk-block-causal (llama-block.fk, four-way 4095). ---
+(defn lgqa-attn-sub-causal (n1 wq wk wv wo scale n_q n_kv HD c)
+  (lblk-proj-seq wo
+    (tb-gqa-attn-causal (lgqa-rope-seq (lblk-proj-seq wq n1) HD c)
+                        (lgqa-rope-seq (lblk-proj-seq wk n1) HD c)
+                        (lblk-proj-seq wv n1) n_q n_kv HD scale)))
+(defn lgqa-attn-block-causal (xs g1 eps wq wk wv wo scale n_q n_kv HD c)
+  (tb-add-seq xs (lgqa-attn-sub-causal (lblk-rms-seq xs g1 eps) wq wk wv wo scale n_q n_kv HD c)))
+(defn lgqa-block-causal (xs g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd)
+  (lblk-ffn-block (lgqa-attn-block-causal xs g1 eps wq wk wv wo scale n_q n_kv HD c) g2 eps wg wu wd))

--- a/form/form-stdlib/rope.fk
+++ b/form/form-stdlib/rope.fk
@@ -15,7 +15,8 @@
 ; the recipe DEFINES the reduction order so every kernel computes the same bits. Conformance
 ; pinned to libm cos/sin/pow at 1e-6 in the band.
 
-; --- base θ frequency: base^(−hd/HD), base = 10000 (the llama rope_theta) ---
+; --- base θ frequency: base^(−hd/HD), base = 10000 (the default / llama-2
+;     rope_theta; a real llama3 block uses rope_theta 500000 + scaling, below) ---
 (defn rope-base () 10000.0)
 (defn rope-freq (hd HD) (fpow (rope-base) (div (mul -1.0 hd) (mul HD 1.0))))
 ; per-pair rotation angle at position pos for head-dim offset hd
@@ -38,3 +39,78 @@
                 (cons (head (tail r))
                       (rope-walk (tail (tail xs)) (add i 2) pos HD))))))
 (defn rope (xs pos HD) (rope-walk xs 0 pos HD))
+
+; ============================================================================
+; llama3 RoPE — rope_theta base + piecewise-wavelength frequency scaling.
+; ============================================================================
+; The `rope` above is base 10000 with NO scaling: the short-context whisper /
+; llama-2 shape. A REAL llama3.2/3.1/3.3 block uses rope_theta = 500000 (a much
+; larger base, so frequencies are far slower) AND rope_scaling type "llama3":
+; each default inv_freq f = base^(−hd/HD) is reshaped by where its wavelength
+; 2π/f sits relative to the original training context window —
+;   long-wavelength (low-freq)  components are divided by `factor` so one
+;     rotation spans a longer context (NTK-by-parts extension);
+;   short-wavelength (high-freq) components are left untouched;
+;   medium components interpolate smoothly between the two.
+; base θ, the scaling `factor`, the low/high frequency factors and the original
+; context length are recipe DATA (a cfg list) — never smuggled constants. This
+; is the LAST piece (with GQA, gqa-attn.fk) separating the proven llama block
+; from the fused hati-translator (Llama-3.2-3B: rope_theta 500000, factor 32,
+; low 1, high 4, orig_ctx 8192). `rope` is the (base 10000, no-scaling) special
+; case of `rope-scaled` — the SAME rotation kernel (rope-rot-pair), only the
+; frequency derivation differs. Reference: HF transformers
+; _compute_llama3_parameters. Proven four-way against a libm fp64 reference by
+; tests/llama3-rope-band.fk.
+
+; default inv_freq for head-dim offset hd at an arbitrary base θ (rope_theta)
+(defn rope-freq-theta (base hd HD) (fpow (mul base 1.0) (div (mul -1.0 hd) (mul HD 1.0))))
+
+; smooth interpolation factor s for a medium-frequency f (orig context, low/high factors).
+;   s = (orig/wavelen − low-f) / (high-f − low-f),  wavelen = 2π/f
+; s = 0 at wavelen = orig/low-f (the low boundary), s = 1 at wavelen = orig/high-f (high).
+(defn rope-l3-smooth (f orig low-f high-f)
+  (div (sub (div (mul orig 1.0) (div (TAU) f)) (mul low-f 1.0))
+       (sub (mul high-f 1.0) (mul low-f 1.0))))
+
+; piecewise llama3 scaling of one default inv_freq f → the scaled inv_freq.
+;   wavelen >  orig/low-f   → f / factor          (low freq: stretch over longer ctx)
+;   wavelen <  orig/high-f  → f                    (high freq: untouched)
+;   else (medium)           → f·((1−s)/factor + s)
+; The medium branch joins continuously: at wavelen = orig/low-f, s = 0 ⇒ f/factor;
+; at wavelen = orig/high-f, s = 1 ⇒ f. (Bit-exact at both boundaries since
+; 1/factor·f and f are exact when factor divides cleanly.)
+(defn rope-l3-scale (f factor low-f high-f orig)
+  (do (let wavelen (div (TAU) f))
+      (if (gt wavelen (div (mul orig 1.0) (mul low-f 1.0))) (div f (mul factor 1.0))
+      (if (lt wavelen (div (mul orig 1.0) (mul high-f 1.0))) f
+          (do (let s (rope-l3-smooth f orig low-f high-f))
+              (mul f (add (div (sub 1.0 s) (mul factor 1.0)) s)))))))
+
+; --- a rope cfg bundles the scaling DATA: (base factor low-f high-f orig) ---
+(defn rope-cfg (base factor low-f high-f orig) (list base factor low-f high-f orig))
+(defn rope-cfg-base   (c) (nth c 0))
+(defn rope-cfg-factor (c) (nth c 1))
+(defn rope-cfg-lowf   (c) (nth c 2))
+(defn rope-cfg-highf  (c) (nth c 3))
+(defn rope-cfg-orig   (c) (nth c 4))
+; the real llama3 default — rope_theta 500000, factor 32, low 1, high 4, orig_ctx 8192
+(defn rope-cfg-llama3 () (rope-cfg 500000.0 32.0 1.0 4.0 8192.0))
+
+; llama3-scaled inv_freq for head-dim offset hd under cfg c
+(defn rope-freq-cfg (c hd HD)
+  (rope-l3-scale (rope-freq-theta (rope-cfg-base c) hd HD)
+                 (rope-cfg-factor c) (rope-cfg-lowf c) (rope-cfg-highf c) (rope-cfg-orig c)))
+
+; per-pair rotation angle at position pos for head-dim offset hd under cfg c
+(defn rope-angle-cfg (pos hd HD c) (mul (mul pos 1.0) (rope-freq-cfg c hd HD)))
+
+; walk a vector pairwise applying the cfg-scaled rotation (shares rope-rot-pair with `rope`)
+(defn rope-walk-cfg (xs i pos HD c)
+  (if (eq (len xs) 0) (empty)
+      (do (let q0 (head xs))
+          (let q1 (head (tail xs)))
+          (let r (rope-rot-pair q0 q1 (rope-angle-cfg pos (mod i HD) HD c)))
+          (cons (head r)
+                (cons (head (tail r))
+                      (rope-walk-cfg (tail (tail xs)) (add i 2) pos HD c))))))
+(defn rope-scaled (xs pos HD c) (rope-walk-cfg xs 0 pos HD c))

--- a/form/form-stdlib/tests/llama-gqa-block-band.fk
+++ b/form/form-stdlib/tests/llama-gqa-block-band.fk
@@ -1,0 +1,78 @@
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/transformer-numerics.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk
+;
+; llama-gqa-block-band — the REAL llama3.2 decoder block (GQA attention + llama3
+; RoPE rope_theta 500000 + scaling + RMSNorm + SwiGLU), lifted to the four-kernel
+; floor. lgqa-block (llama-gqa-block.fk) composes ONLY already-four-way recipes:
+; tb-gqa-attn (gqa-attn.fk, 7), rope-scaled (rope.fk, llama3-rope-band 255), and
+; llama-block.fk's proven walks (lblk-rms-seq/lblk-proj-seq/lblk-ffn-block, 4095).
+; Nothing re-derived. The two strange-minimal shapes pin the whole composition:
+;
+;   GENERALIZATION (no parallel path): lblk-block is the single-head, base-10000,
+;   no-scaling special case of lgqa-block. At n_q=n_kv=1 GQA reduces to MHA, and at
+;   HD=4 the (base 10000) cfg is inert (every pair high-freq) ⇒ lgqa-block equals
+;   lblk-block (four-way 4095) BIT-FOR-BIT. This claim inherits lblk-block's own
+;   libm pins — c0 is a known-correct value, not just self-consistency.
+;
+;   THE REAL BLOCK: under the llama3 cfg (rope_theta 500000), the hd=2 pair lands
+;   in the MEDIUM scaling branch, so the block output DIFFERS from base-10000
+;   (1116075 ≠ lblk's 1115890) — theta + scaling do real work end-to-end. Pinned
+;   to the libm fp64 reference at 1e-6 (same conformance as llama-block-band).
+;
+;   GQA SHARING: at n_q=2 sharing one KV head (n_kv=1) gives a DIFFERENT block
+;   output than per-head (n_kv=2) — the (h / group) grouping llama runs at 24→8
+;   propagates through the full block, not just the attention core.
+;
+; Fixture: the llama-block-band fixture (S=2, d=4, HD=4) for the single-head
+; claims; the same weights re-read as 2 heads of width 2 (HD=2) for GQA sharing.
+;
+; Verdict 31 when the GQA llama block lands four-way:
+;   1     lgqa-block(n_q=1,n_kv=1,HD=4, cfg base 10000 no-scaling) == lblk-block, bit-for-bit
+;   2     lgqa-block(n_q=1,n_kv=1,HD=4, cfg-llama3) y[0][0] → 1116075  (theta+medium-scaling; ≠ lblk's 1115890)
+;   4     lgqa-block(n_q=1,n_kv=1,HD=4, cfg-llama3) y[1][2] → 1648171  (last token, post-SwiGLU)
+;   8     lgqa-block(n_q=2,n_kv=1,HD=2, cfg-llama3) y[0][0] → 1424802  (GQA: 2 query heads share KV head 0)
+;   16    lgqa-block(n_q=2,n_kv=2,HD=2, cfg-llama3) y[0][0] → 1248836  (per-head; ≠ shared ⇒ grouping is real)
+(do
+    (defn g-vmaxdiff (a b)
+      (if (eq (len a) 0) 0.0
+          (do (let d (tn-abs (sub (head a) (head b))))
+              (let r (g-vmaxdiff (tail a) (tail b)))
+              (if (gt d r) d r))))
+    (defn g-maxdiff (as bs)
+      (if (eq (len as) 0) 0.0
+          (do (let d (g-vmaxdiff (head as) (head bs)))
+              (let r (g-maxdiff (tail as) (tail bs)))
+              (if (gt d r) d r))))
+
+    ; --- the llama-block-band fixture (S=2 tokens, d=4, HD=4, scale=1/√4) ---
+    (let x  (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75)))
+    (let g1 (list 0.9 1.1 1.0 0.95))   (let g2 (list 1.05 0.95 1.0 0.9))
+    (let wq (list (list 0.5 -0.25 0.1 0.3) (list 0.2 0.4 -0.3 0.1) (list -0.1 0.2 0.5 -0.2) (list 0.3 0.0 -0.15 0.25)))
+    (let wk (list (list 0.2 0.4 -0.3 0.1) (list 0.3 -0.2 0.25 0.5) (list 0.1 0.15 -0.05 0.2) (list -0.25 0.3 0.4 -0.1)))
+    (let wv (list (list 0.3 -0.2 0.25 0.5) (list 0.6 0.1 -0.2 0.4) (list 0.05 -0.1 0.3 0.2) (list 0.15 0.35 -0.25 0.1)))
+    (let wo (list (list 0.6 0.1 -0.2 0.4) (list -0.2 0.4 0.3 0.1) (list 0.25 -0.15 0.5 0.05) (list 0.1 0.2 -0.3 0.45)))
+    (let wg (list (list 0.5 -0.3 0.2 0.1) (list 0.2 0.7 -0.4 0.3) (list -0.1 0.25 0.4 -0.2) (list 0.3 0.1 -0.15 0.5)))
+    (let wu (list (list 0.25 -0.15 0.3 0.05) (list 0.1 0.4 -0.2 0.15) (list 0.35 0.2 -0.1 0.25) (list -0.2 0.3 0.15 0.4)))
+    (let wd (list (list 0.4 -0.2 0.3 0.1) (list 0.15 0.5 -0.25 0.2) (list -0.3 0.1 0.45 -0.15) (list 0.2 -0.1 0.35 0.3)))
+    (let eps 0.00001)
+    (let cfg10 (rope-cfg 10000.0 32.0 1.0 4.0 8192.0))
+    (let cfgl3 (rope-cfg-llama3))
+
+    ; --- claim 1: single-head, base 10000, no-scaling == lblk-block (bit-for-bit) ---
+    (let sc4 (div 1.0 (tn-sqrt 4.0)))
+    (let g1h (lgqa-block x g1 eps wq wk wv wo sc4 1 1 4 cfg10 g2 wg wu wd))
+    (let blk (lblk-block x g1 eps wq wk wv wo sc4 4 g2 wg wu wd))
+    (let c0 (if (eq (g-maxdiff g1h blk) 0.0) 1 0))
+
+    ; --- claims 2,4: the real llama3 block (rope_theta 500000 + medium scaling) ---
+    (let yl3 (lgqa-block x g1 eps wq wk wv wo sc4 1 1 4 cfgl3 g2 wg wu wd))
+    (let c1 (if (eq (round (mul (nth (nth yl3 0) 0) 1000000.0)) 1116075) 2 0))
+    (let c2 (if (eq (round (mul (nth (nth yl3 1) 2) 1000000.0)) 1648171) 4 0))
+
+    ; --- claims 8,16: GQA sharing through the whole block (n_q=2, HD=2) ---
+    (let sc2 (div 1.0 (tn-sqrt 2.0)))
+    (let shr (lgqa-block x g1 eps wq wk wv wo sc2 2 1 2 cfgl3 g2 wg wu wd))
+    (let phd (lgqa-block x g1 eps wq wk wv wo sc2 2 2 2 cfgl3 g2 wg wu wd))
+    (let c3 (if (eq (round (mul (nth (nth shr 0) 0) 1000000.0)) 1424802) 8 0))
+    (let c4 (if (eq (round (mul (nth (nth phd 0) 0) 1000000.0)) 1248836) 16 0))
+
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/form-stdlib/tests/llama-gqa-block-causal-band.fk
+++ b/form/form-stdlib/tests/llama-gqa-block-causal-band.fk
@@ -1,0 +1,77 @@
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/transformer-numerics.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk
+;
+; llama-gqa-block-causal-band — the REAL autoregressive llama3.2 decoder block:
+; GQA attention with the causal mask + llama3 RoPE (rope_theta 500000 + scaling) +
+; RMSNorm + SwiGLU, lifted to the four-kernel floor. lgqa-block-causal composes
+; tb-gqa-attn-causal (gqa-attn.fk — tb-attn-seq-causal, four-way 511) with the same
+; theta-RoPE / RMSNorm / SwiGLU as the non-causal block. No new arithmetic; the only
+; change vs lgqa-block is the per-head causal mask. Strange-minimal claims:
+;
+;   GENERALIZATION: lblk-block-causal (llama-block.fk, four-way 4095) is the
+;   single-head, base-10000 special case of lgqa-block-causal — bit-for-bit.
+;
+;   CAUSALITY IS REAL, AND DOESN'T OVER-MASK: at the last token the causal prefix is
+;   the whole sequence, so the last token is bit-identical to the non-causal block;
+;   token 0 DIFFERS from non-causal (the mask removed the future it had mixed in).
+;   A clean cross-check: at position 0 RoPE is the identity (angle 0), so theta is
+;   irrelevant for token 0 — the causal cfg-llama3 token-0 output equals the published
+;   four-way causal value 1893731 (causal-attention-band / kv-llama-block-band), the
+;   same number base-10000 produces.
+;
+;   GQA SHARING propagates through the causal block: sharing one KV head (n_kv=1) gives
+;   a different last-token output than per-head (n_kv=2).
+;
+; Fixture: the llama-block-band fixture (S=2, d=4, HD=4); the same 4x4 weights re-read
+; as 2 heads of width 2 (HD=2) for GQA sharing.
+;
+; Verdict 15 when the causal GQA llama block lands four-way:
+;   1   lgqa-block-causal(n_q=1,n_kv=1,HD=4, cfg base 10000) == lblk-block-causal, bit-for-bit
+;   2   lgqa-block-causal(n_q=1,n_kv=1,HD=4, cfg-llama3) y[0][0] -> 1893731  (causal token 0 = published four-way value; pos-0 RoPE identity; != non-causal 1116075 -> mask is real)
+;   4   lgqa-block-causal(cfg-llama3) last token == lgqa-block(cfg-llama3) last token, bit-for-bit  (no over-masking)
+;   8   lgqa-block-causal(n_q=2,n_kv=1,HD=2) last[1][0] != lgqa-block-causal(n_q=2,n_kv=2,HD=2) last[1][0]  (GQA grouping is real in the causal block)
+(do
+    (defn gc-vmaxdiff (a b)
+      (if (eq (len a) 0) 0.0
+          (do (let d (tn-abs (sub (head a) (head b))))
+              (let r (gc-vmaxdiff (tail a) (tail b)))
+              (if (gt d r) d r))))
+    (defn gc-maxdiff (as bs)
+      (if (eq (len as) 0) 0.0
+          (do (let d (gc-vmaxdiff (head as) (head bs)))
+              (let r (gc-maxdiff (tail as) (tail bs)))
+              (if (gt d r) d r))))
+
+    ; --- the llama-block-band fixture (S=2 tokens, d=4, HD=4) ---
+    (let x  (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75)))
+    (let g1 (list 0.9 1.1 1.0 0.95))   (let g2 (list 1.05 0.95 1.0 0.9))
+    (let wq (list (list 0.5 -0.25 0.1 0.3) (list 0.2 0.4 -0.3 0.1) (list -0.1 0.2 0.5 -0.2) (list 0.3 0.0 -0.15 0.25)))
+    (let wk (list (list 0.2 0.4 -0.3 0.1) (list 0.3 -0.2 0.25 0.5) (list 0.1 0.15 -0.05 0.2) (list -0.25 0.3 0.4 -0.1)))
+    (let wv (list (list 0.3 -0.2 0.25 0.5) (list 0.6 0.1 -0.2 0.4) (list 0.05 -0.1 0.3 0.2) (list 0.15 0.35 -0.25 0.1)))
+    (let wo (list (list 0.6 0.1 -0.2 0.4) (list -0.2 0.4 0.3 0.1) (list 0.25 -0.15 0.5 0.05) (list 0.1 0.2 -0.3 0.45)))
+    (let wg (list (list 0.5 -0.3 0.2 0.1) (list 0.2 0.7 -0.4 0.3) (list -0.1 0.25 0.4 -0.2) (list 0.3 0.1 -0.15 0.5)))
+    (let wu (list (list 0.25 -0.15 0.3 0.05) (list 0.1 0.4 -0.2 0.15) (list 0.35 0.2 -0.1 0.25) (list -0.2 0.3 0.15 0.4)))
+    (let wd (list (list 0.4 -0.2 0.3 0.1) (list 0.15 0.5 -0.25 0.2) (list -0.3 0.1 0.45 -0.15) (list 0.2 -0.1 0.35 0.3)))
+    (let eps 0.00001)
+    (let cfg10 (rope-cfg 10000.0 32.0 1.0 4.0 8192.0))
+    (let cfgl3 (rope-cfg-llama3))
+
+    ; --- claim 1: single-head base-10000 causal == lblk-block-causal (bit-for-bit) ---
+    (let sc4 (div 1.0 (tn-sqrt 4.0)))
+    (let g1c (lgqa-block-causal x g1 eps wq wk wv wo sc4 1 1 4 cfg10 g2 wg wu wd))
+    (let blc (lblk-block-causal x g1 eps wq wk wv wo sc4 4 g2 wg wu wd))
+    (let c0 (if (eq (gc-maxdiff g1c blc) 0.0) 1 0))
+
+    ; --- claims 2,4: causal cfg-llama3 — token 0 (mask real), last token (no over-masking) ---
+    (let yc (lgqa-block-causal x g1 eps wq wk wv wo sc4 1 1 4 cfgl3 g2 wg wu wd))
+    (let yn (lgqa-block        x g1 eps wq wk wv wo sc4 1 1 4 cfgl3 g2 wg wu wd))
+    (let c1 (if (eq (round (mul (nth (nth yc 0) 0) 1000000.0)) 1893731) 2 0))
+    (let c2 (if (eq (gc-vmaxdiff (nth yc 1) (nth yn 1)) 0.0) 4 0))
+
+    ; --- claim 8: GQA sharing through the causal block (n_q=2, HD=2) ---
+    (let sc2 (div 1.0 (tn-sqrt 2.0)))
+    (let shr (lgqa-block-causal x g1 eps wq wk wv wo sc2 2 1 2 cfgl3 g2 wg wu wd))
+    (let phd (lgqa-block-causal x g1 eps wq wk wv wo sc2 2 2 2 cfgl3 g2 wg wu wd))
+    (let c3 (if (eq (round (mul (nth (nth shr 1) 0) 1000000.0))
+                    (round (mul (nth (nth phd 1) 0) 1000000.0))) 0 8))
+
+    (add c0 (add c1 (add c2 c3))))

--- a/form/form-stdlib/tests/llama3-rope-band.fk
+++ b/form/form-stdlib/tests/llama3-rope-band.fk
@@ -1,0 +1,54 @@
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/rope.fk
+;
+; llama3-rope-band — llama3 RoPE frequency scaling + rope_theta as a Form recipe,
+; lifted to the four-kernel floor. A real llama3.2:3b block uses rope_theta=500000
+; (not 10000) and rope_scaling type "llama3" (factor 32, low_freq_factor 1,
+; high_freq_factor 4, original_max_position_embeddings 8192): each default inv_freq
+; f = base^(−hd/HD) is reshaped by where its wavelength 2π/f sits — low-freq ÷ factor,
+; high-freq untouched, medium interpolated. Until now this lived ONLY inside
+; transformer-kernel.fk's tk-emit-llama as emitted C (powf(10000.0,...), three-way,
+; NO scaling at all). This proves the standalone recipe (rope.fk: rope-l3-scale /
+; rope-freq-theta / rope-scaled) — base θ + the scaling factors are recipe DATA.
+;
+; The scaling-branch claims feed hand-picked inv_freq f so the math is pure
+; arithmetic (bit-exact across kernels, no transcendental); the end-to-end rotation
+; and theta-base claims are libm fp64 references (fpow/fsin/fcos) at 1e-6, the same
+; conformance rope-band pins. Reference: HF transformers _compute_llama3_parameters.
+;
+; Verdict 255 when every claim lands:
+;   1     high-freq (wavelen 628 < 2048) → f UNCHANGED (f=0.01 returns 0.01 exactly)
+;   2     low-freq  (wavelen 62831 > 8192) → f ÷ factor (f=1e-4 returns f/32 exactly)
+;   4     medium joins LOW continuously: at wavelen = orig/low-f, s=0 ⇒ f/32 (bit-exact)
+;   8     medium joins HIGH continuously: at wavelen = orig/high-f, s=1 ⇒ f (bit-exact)
+;   16    medium INTERIOR real value: f=0.0011 (wavelen 5712) → 0.000188598… (×1e9 = 188598)
+;   32    rope_theta is DATA: base 500000, hd=2, HD=4 → inv_freq 0.0014142… (×1e6 = 1414, ≠ 10000's 0.01)
+;   64    end-to-end rotation: base 500000, HD=4, pos=1, the hd=2 (MEDIUM-scaled) pair → 999570 (×1e6)
+;   128   generalization: rope-scaled with the (base 10000, no-scaling) cfg == the default `rope`, bit-for-bit
+(do
+    ; --- bit-exact equality of two equal-length float vectors (for the generalization law) ---
+    (defn r3-veq (a b)
+      (if (eq (len a) 0) 1
+          (if (eq (head a) (head b)) (r3-veq (tail a) (tail b)) 0)))
+
+    ; --- scaling branches (pure arithmetic on a hand-picked inv_freq f → bit-exact) ---
+    (let c0 (if (eq (rope-l3-scale 0.01   32.0 1.0 4.0 8192.0) 0.01) 1 0))
+    (let c1 (if (eq (rope-l3-scale 0.0001 32.0 1.0 4.0 8192.0) (div 0.0001 32.0)) 2 0))
+    (let c2 (if (eq (rope-l3-scale (div (TAU) 8192.0) 32.0 1.0 4.0 8192.0)
+                    (div (div (TAU) 8192.0) 32.0)) 4 0))
+    (let c3 (if (eq (rope-l3-scale (div (TAU) 2048.0) 32.0 1.0 4.0 8192.0)
+                    (div (TAU) 2048.0)) 8 0))
+    (let c4 (if (eq (round (mul (rope-l3-scale 0.0011 32.0 1.0 4.0 8192.0) 1000000000.0)) 188598) 16 0))
+
+    ; --- rope_theta as data, and the full scaled rotation end-to-end (libm pins, 1e-6) ---
+    (let c5 (if (eq (round (mul (rope-freq-theta 500000.0 2 4) 1000000.0)) 1414) 32 0))
+    (let rl3 (rope-scaled (list 1.0 0.0 1.0 1.0) 1 4 (rope-cfg-llama3)))
+    (let c6 (if (eq (round (mul (nth rl3 2) 1000000.0)) 999570) 64 0))
+
+    ; --- generalization: the default `rope` IS rope-scaled at (base 10000, no-scaling) ---
+    ; at HD=4 every pair is high-frequency, so the scaling is inert and the cfg path
+    ; reproduces `rope` bit-for-bit — the default is the special case, not a parallel path.
+    (let v (list 1.0 0.0 1.0 1.0))
+    (let g10 (rope-cfg 10000.0 32.0 1.0 4.0 8192.0))
+    (let c7 (if (eq (r3-veq (rope-scaled v 2 4 g10) (rope v 2 4)) 1) 128 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/form-stdlib/transformer-decoder.fk
+++ b/form/form-stdlib/transformer-decoder.fk
@@ -17,7 +17,7 @@
 ; query at position i attends ONLY to keys/values 0..i (whisper's causal decoder mask).
 (defn tb-attn-causal-acc (qs ks vs scale i)
   (if (eq (len qs) 0) (empty)
-      (cons (tb-attend-one (head qs) (tb-take (add i 1) ks) (tb-take (add i 1) vs) scale)
+      (cons (tb-attend-one (head qs) (tb-take ks (add i 1)) (tb-take vs (add i 1)) scale)
             (tb-attn-causal-acc (tail qs) ks vs scale (add i 1)))))
 (defn tb-attn-causal-seq (qs ks vs scale) (tb-attn-causal-acc qs ks vs scale 0))
 

--- a/form/form-stdlib/transformer-mh.fk
+++ b/form/form-stdlib/transformer-mh.fk
@@ -16,9 +16,11 @@
 ; calls folded over the layer list (tb-enc-stack) — the dynamic-recipe advantage.
 
 ; --- vector slicing (monomorphic, fourth-arm-safe) ---
+; tb-take is transformer-block.fk's (xs n) — preluded above; we DON'T redefine it
+; here (a second (n xs) definition would shadow it and silently break any band that
+; co-preludes transformer-block's causal attention, which calls (tb-take ks i)).
 (defn tb-drop (n xs) (if (eq n 0) xs (tb-drop (sub n 1) (tail xs))))
-(defn tb-take (n xs) (if (eq n 0) (empty) (cons (head xs) (tb-take (sub n 1) (tail xs)))))
-(defn tb-vslice (xs start vlen) (tb-take vlen (tb-drop start xs)))
+(defn tb-vslice (xs start vlen) (tb-take (tb-drop start xs) vlen))
 (defn tb-cat (a b) (if (eq (len a) 0) b (cons (head a) (tb-cat (tail a) b))))
 
 ; extract head h (width hd) from every position-vector of a sequence.

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -784,6 +784,7 @@ positional fks 1
 transformer-mh fks 1
 gqa-attn fks 7
 llama-gqa-block fks 31
+llama-gqa-block-causal fks 15
 transformer-decoder fks 1
 transformer-generate fks 1
 whisper-mh-block-real fks 1

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -449,6 +449,7 @@ neural-lm fks 31
 neural-lm-real fks 7
 llama-numerics fks 4095
 rope fks 4095
+llama3-rope fks 255
 llama-block fks 4095
 causal-attention fks 511
 geometric-learning fks 8388607
@@ -782,6 +783,7 @@ conv-stem fks 1
 positional fks 1
 transformer-mh fks 1
 gqa-attn fks 7
+llama-gqa-block fks 31
 transformer-decoder fks 1
 transformer-generate fks 1
 whisper-mh-block-real fks 1


### PR DESCRIPTION
## What

Two numerics separated the proven single-head, base-10000 llama block (`lblk-block`, four-way 4095) from the block the real **Llama-3.2-3B** fused checkpoint (the hati-translator) runs. GQA attention was lifted in #3577 (`tb-gqa-attn`, four-way 7). This PR lifts the **second** — llama3 RoPE — and **composes both into the real decoder block, causal and non-causal**. No new arithmetic; only composition of already-four-way recipes.

### 1. llama3 RoPE + `rope_theta` (`form/form-stdlib/rope.fk`)
`rope.fk` only ever had base 10000 with no scaling. The real model uses `rope_theta=500000` **and** `rope_scaling` type `"llama3"` (factor 32, low 1, high 4, orig_ctx 8192): each default `inv_freq f = base^(−hd/HD)` is reshaped by where its wavelength `2π/f` sits — low-freq ÷ factor, high-freq untouched, medium interpolated. **base θ + the scaling factors are now recipe DATA** (`rope-cfg`), never smuggled constants. Previously this lived **only** inside `tk-emit-llama` as emitted C (`powf(10000.0,...)`, three-way, *no* scaling at all). Lifted to `rope-l3-scale`/`rope-freq-theta`/`rope-scaled`, sharing `rope-rot-pair` — **`rope` is now the (base 10000, no-scaling) special case, not a parallel path.**

### 2. GQA-shaped llama decoder block (`form/form-stdlib/llama-gqa-block.fk`, `gqa-attn.fk`)
`lgqa-block` / `lgqa-block-causal` compose `tb-gqa-attn`(`-causal`) + `rope-scaled` + `llama-block.fk`'s own RMSNorm/proj/SwiGLU, parameterized by `(n_q, n_kv, HD, rope-cfg)`. `lblk-block`(`-causal`) is the `(n_q=n_kv=1, base-10000)` special case. The causal variant is the real autoregressive decoder shape (over the already-four-way `tb-attn-seq-causal`, 511).

### 3. Unify the duplicate `tb-take` it surfaced
Composing GQA + the causal mask was the first band to co-prelude `transformer-mh` **and** use `transformer-block`'s causal attention — surfacing a **latent collision**: `tb-take` was defined twice with **swapped arg order** (`xs n` in `transformer-block.fk`, `n xs` in `transformer-mh.fk`), each silently relying on prelude order. The non-causal path never calls `tb-take`, so it never bit. Fixed at the source — **one `tb-take`** (`xs n`); `transformer-mh`'s `tb-vslice` and `transformer-decoder`'s causal-take switched to it. Behavior-preserving.

## Proof — every band four-way (Go = Rust = TS = fkwu, 0 divergent)

| band | verdict | what it pins |
|------|---------|--------------|
| `llama3-rope` | **255** | every scaling branch bit-exact; boundary continuity (s=0⇒f/factor, s=1⇒f); theta-base + end-to-end rotation libm-pinned 1e-6; default `rope` is the special case |
| `llama-gqa-block` | **31** | single-head base-10000 == `lblk-block` bit-for-bit (inherits its libm pins); cfg-llama3 block libm-pinned, **differs** because the hd=2 pair hits the *medium* branch; GQA sharing changes whole-block output |
| `llama-gqa-block-causal` | **15** | == `lblk-block-causal` bit-for-bit; causal token-0 == published **1893731** (pos-0 RoPE identity, theta-irrelevant) and ≠ non-causal ⇒ mask is real; causal-last == non-causal-last bit-for-bit (no over-masking); GQA sharing real in the causal block |

**`tb-take` regression set** (re-proved four-way, 0 divergent each): `gqa-attn` 7, `transformer-mh` 1, `transformer-decoder` 1, `transformer-generate` 1, `transformer-generate-cached` 1, `whisper-mh-block-real` 1, `transformer-gelu-erf` 255, `sampling` 2047.

A `d=4` block exercises the medium scaling because base 500000 pushes the hd=2 pair's wavelength into `[2048, 8192]` — strange-minimal coverage without a full-width fixture.

## Files
- `form/form-stdlib/rope.fk` — llama3 scaling + theta (M)
- `form/form-stdlib/gqa-attn.fk` — `tb-gqa-attn-causal` (M)
- `form/form-stdlib/llama-gqa-block.fk` — the GQA llama block, causal + non-causal (new)
- `form/form-stdlib/transformer-mh.fk`, `transformer-decoder.fk` — `tb-take` unification (M)
- `form/form-stdlib/tests/{llama3-rope,llama-gqa-block,llama-gqa-block-causal}-band.fk` (new)
- `form/fourth-arm-bands.txt` — three manifest rows (M)
- `docs/system_audit/commit_evidence_2026-06-23_llama3_rope_and_gqa_block_four_way.json` (new)

## Named next stones
- KV-cached GQA decode (k/v cached at the narrower n_kv·HD width) → multi-layer decode
- wire the proven pieces at real width (28 blocks, hidden 3072, n_q 24, n_kv 8, HD 128) over the GGUF weights → the end-to-end transcript
- drop `tk-emit-llama`'s hardcoded `powf(10000.0,...)` — there's now a four-way recipe + real-theta cfg to mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)