### PR TITLE
feat(android): the phone-native Form kernel runs on-device — recognition without the Mac

### DIFF
--- a/docs/coherence-substrate/kernel-on-android.form
+++ b/docs/coherence-substrate/kernel-on-android.form
@@ -7,9 +7,12 @@
 ;   how validate.sh's three-way parity becomes cross-DEVICE parity, and the lanes kept clean —
 ;   what is standard Android practice (MEASURED) vs what is untested for THIS kernel (carrier-work).
 ;
-;   The thing NOT to overclaim: nobody has run the Coherence Form kernel on a phone yet. Every
-;   "standard Android practice" claim below is a real, documented path. Every "for our kernel"
-;   claim is a build that has not been done. The honesty is in keeping those two apart.
+;   UPDATE 2026-06-23: the Rust Form kernel now RUNS on a phone. Coherence Sense loads
+;   libform_kernel_rust.so over JNI and reproduces the proven signal-derivative band verdict 127
+;   IN-PROCESS on a Galaxy S23 Ultra, plus live accel still/moving — no Mac (PATH A below, MEASURED).
+;   What is STILL not done stays named: the Go/TS arms on a phone, on-device three-way parity, the
+;   native Form->asm JIT on ARM, and the GPU (Vulkan) lane. The honesty is now in keeping
+;   built-and-run-on-hardware apart from documented-but-not-yet-built.
 ;
 ; ── WHAT IS ALREADY TRUE (the ground this stands on) ── [MEASURED — in the body]
 ;   form/validate.sh proves three kernels identical: form/form-kernel-rust, form-kernel-go,
@@ -68,14 +71,24 @@
 ;       sd-moving? and ns-label recognize correctly across the C boundary. Both artifacts (bin + cdylib)
 ;       are file-checked AND symbol-checked by build-android.sh. The real gotcha was the toolchain, not the
 ;       code: a Homebrew rustc has no cross-std, so the rustup toolchain (aarch64 std) must be FIRST in PATH.
+;   WHAT IS NOW DONE FOR THIS KERNEL  [MEASURED 2026-06-23 — run on a Galaxy S23 Ultra]:
+;     - The WIRING is complete and run on hardware. build-android.sh builds the cdylib with
+;       --features cabi (now exporting BOTH form_eval AND the JNI-named
+;       Java_com_coherence_sense_FormKernel_eval over the SAME run_source) and drops the .so into
+;       app/src/main/jniLibs/arm64-v8a + refreshes the bundled recipe assets. FormKernel.kt binds it
+;       via System.loadLibrary + external fun eval(src); MainActivity runs the proven signal-derivative
+;       recipe IN-PROCESS — a launch self-test reproduces the four-way band verdict 127 ON THE PHONE
+;       (adb logcat -s FormKernel), and a live tick recognizes accel still-vs-moving through the same
+;       recipe. The phone recognizes WITHOUT the Mac. (Coherence Sense; both build scripts now invoke
+;       build-android.sh before gradle so the published/CI APK ships the kernel.)
 ;   WHAT IS STILL UNTESTED FOR THIS KERNEL  [carrier-work — not done]:
-;     - The .so exists + exports the entry; what remains is WIRING, not engine: a thin Kotlin JNI shim
-;       (external fun formEval(src): String), the .so in jniLibs/arm64-v8a, the recipes bundled as assets,
-;       and a device/emulator to actually run a recipe on ARM hardware (host-ctypes proves the symbol, not
-;       the phone runtime). On-device three-way (all three kernels on one phone) still UNRUN.
-;     - A separate core-axiom receipt .so has now been packaged into the APK and verified by entry hash,
-;       but it is not wired into Kotlin/JNI yet and has not run from the installed app process.
-;     - Actually RUNNING a recipe on an Android device/emulator is unverified — there is no device here yet.
+;     - On-device THREE-way (the Go .aar AND a TS-on-JS-engine alongside the Rust .so, all agreeing on
+;       one phone) still UNRUN — only the Rust arm runs on-device so far.
+;     - The native Form->asm JIT crystallization on ARM (the form-elf -> loadable .so -> dlopen lane,
+;       the Android twin of the Mac recipe-dylib+codesign path) is NOT built: the on-device kernel runs
+;       as the tree-walker, not crystallized native.
+;     - A separate core-axiom receipt .so was packaged into an APK and entry-hash-verified earlier; it
+;       is superseded as the live path by FormKernel above (which IS JNI-wired and runs from the app).
 ;
 ;
 ; ── PATH B: GO -> ANDROID via gomobile ──  [the kernel already serving BML route bodies]
@@ -209,16 +222,17 @@
 ;
 ; ── THE HONEST PATH (what to build, in order) ──
 ;   1. the shared-sensing circle + cross-grounding         [SHIPPED: shared-sensing.fk -> 127, 3-way]
-;   2. ONE kernel built for ARM as an app-loadable lib:    [DONE for Rust — A built + symbol-verified]
-;        A. form-kernel-rust as cdylib via cargo-ndk + extern "C" form_eval  [MEASURED 2026-06-09: .so
-;           exports form_eval/form_eval_free, ARM aarch64; build-android.sh]. The JNI declaration
-;           (external fun formEval(src): String) is the remaining thin shim, OR
+;   2. ONE kernel built for ARM as an app-loadable lib:    [DONE + RUN for Rust — on-device 2026-06-23]
+;        A. form-kernel-rust as cdylib via cargo-ndk, exporting extern "C" form_eval AND JNI
+;           Java_com_coherence_sense_FormKernel_eval  [MEASURED: build-android.sh builds + drops the .so
+;           into jniLibs; FormKernel.kt binds it; the phone reproduces band verdict 127 in-process], OR
 ;        B. form-kernel-go via gomobile bind behind a total, panic-free shim, OR
 ;        C. form-kernel-ts bundled onto QuickJS/Hermes in the NDK layer.
-;   3. ONE sensor port wired across the FFI boundary:       [carrier-work]
-;        accelerometer via NDK Sensor API, OR microphone via AAudio — whichever the first satsang
-;        needs — interned as a cell, handed to the proven recipe. (The phone already reads accel in
-;        the coherence-sense app via Kotlin SensorManager; the FFI step is handing that to formEval.)
+;   3. ONE sensor port wired across the FFI boundary:       [DONE for accel 2026-06-23 — Kotlin->JNI path]
+;        the coherence-sense app reads accel via Kotlin SensorManager, folds a coarse-int window, and
+;        hands it to FormKernel.eval running signal-derivative (sd-moving?) in-process — accel -> kernel
+;        -> still/moving, on-device, no Mac. (A native NDK Sensor API / AAudio C path is the deeper
+;        floor; the Kotlin->JNI crossing proves the shape today. Microphone via AAudio remains carrier-work.)
 ;   4. cell-sync transport device<->device                 [build — named in shared-sensing.form §3]
 ;   5. the live two-device satsang on real hardware         [build — the payoff]
 ;

--- a/experiments/coherence-sense-android/README.md
+++ b/experiments/coherence-sense-android/README.md
@@ -23,12 +23,16 @@ the senses are held until then.
   is a weak **non-parametric memorizer** (~81% vs ~96% SOTA; "model" = the whole dataset). The "small model
   matches SOTA" prize needs a *parametric* model (integer `mul` + quantized inference) — see the benchmark.
   The carrier only marshals integers in and reads the label out; the recognition is Form, via the kernel.
-- **v1 — phone-native kernel (cdylib BUILT):** *autonomy.* The kernel itself runs **on the phone**.
-  `form/form-kernel-rust/build-android.sh` now emits `libform_kernel_rust.so` — an ARM aarch64 shared
-  object exporting `form_eval` (the same `run_source` evaluator, behind the `cabi` feature), verified
-  via `ctypes` to recognize across the C boundary. What remains is a thin Kotlin JNI shim
-  (`external fun formEval(src): String`), the `.so` in `jniLibs/arm64-v8a`, and the recipes bundled
-  as assets — then the phone recognizes **without the Mac**.
+- **v1 — phone-native kernel (LIVE, verified on-device):** *autonomy.* The kernel runs **on the phone**,
+  no Mac. `form/form-kernel-rust/build-android.sh` emits `libform_kernel_rust.so` (ARM aarch64) with
+  `--features cabi` — the same `run_source` evaluator the CLI runs, exporting both the C-ABI `form_eval`
+  AND the JNI-named `Java_com_coherence_sense_FormKernel_eval`. `FormKernel.kt` binds it via
+  `System.loadLibrary` + `external fun eval(src)`; `build-android.sh` drops the `.so` into
+  `jniLibs/arm64-v8a` and refreshes the bundled recipe assets. On launch the app runs the proven
+  `signal-derivative` recipe in-process — a self-test reproduces the four-way band verdict **127**
+  (Go=Rust=TS=fkwu) **on the phone**, and a live tick recognizes still-vs-moving from the accelerometer
+  through the same recipe. Verified on a Galaxy S23 Ultra (`adb logcat -s FormKernel`). The phone
+  recognizes **without the Mac**.
 
 So every verb you'd want is live today: senses, share, sync, AND recognition/prediction/learning-signal —
 through the kernel, not in Python.

--- a/experiments/coherence-sense-android/app/src/main/assets/recipes/signal-derivative-band.fk
+++ b/experiments/coherence-sense-android/app/src/main/assets/recipes/signal-derivative-band.fk
@@ -1,0 +1,37 @@
+; preludes: form-stdlib/signal-derivative.fk
+;
+; signal-derivative-band — read the rate of change of a sample window, made falsifiable.
+;
+; A window of ordered scalars arrives; the body counts how many adjacent pairs ROSE and FELL, sums them
+; into an activity (the derivative-magnitude), and gates that against a floor to call motion. Two anchor
+; windows pin every claim:
+;   (1 1 1 1)  -> a flat, still window: 0 rises, 0 falls, activity 0, NOT moving at floor 1
+;   (1 5 2 8)  -> a moved window, pairs (1,5) up, (5,2) down, (2,8) up: 2 rises, 1 fall, activity 3
+; plus two edge windows that pin the boundaries:
+;   (7)        -> a single sample: no adjacent pair exists, activity 0 (the length>=2 guard, the strangest
+;                 edge — without the guard (nth s 1) is head(empty) and the kernel panics)
+;   (1 2 3)    -> a strictly rising window: 2 rises, 0 falls (rises and falls separate direction cleanly;
+;                 falls must stay 0 on pure ascent)
+; No sub, no floats, no compound and anywhere — every count is add + recursion, the gate is one binary ge.
+;
+; Verdict 127 when every claim lands:
+;   1   a flat window has zero activity — stillness is the floor   (sd-activity (1 1 1 1) == 0)
+;   2   rises counts only the up-steps                             (sd-rises (1 5 2 8) == 2)
+;   4   falls counts only the down-steps                          (sd-falls (1 5 2 8) == 1)
+;   8   activity is rises + falls, the total change               (sd-activity (1 5 2 8) == 3)
+;   16  the gate fires above the floor AND stays 0 below it        (sd-moving? (1 5 2 8) 2 == 1, and (1 1 1 1) 1 == 0)
+;   32  a single sample has no pair — the guard holds, no panic    (sd-activity (7) == 0)
+;   64  a pure-rising window is all rises, zero falls             (sd-rises (1 2 3) == 2, and sd-falls (1 2 3) == 0)
+(do
+    (let still   (list 1 1 1 1))
+    (let moved   (list 1 5 2 8))
+    (let one     (list 7))
+    (let ascent  (list 1 2 3))
+    (let c0 (if (eq (sd-activity still) 0) 1 0))
+    (let c1 (if (eq (sd-rises moved) 2) 2 0))
+    (let c2 (if (eq (sd-falls moved) 1) 4 0))
+    (let c3 (if (eq (sd-activity moved) 3) 8 0))
+    (let c4 (if (and (eq (sd-moving? moved 2) 1) (eq (sd-moving? still 1) 0)) 16 0))
+    (let c5 (if (eq (sd-activity one) 0) 32 0))
+    (let c6 (if (and (eq (sd-rises ascent) 2) (eq (sd-falls ascent) 0)) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/experiments/coherence-sense-android/app/src/main/assets/recipes/signal-derivative.fk
+++ b/experiments/coherence-sense-android/app/src/main/assets/recipes/signal-derivative.fk
@@ -1,0 +1,68 @@
+; signal-derivative.fk — the RATE OF CHANGE of a sensor signal across a window, so motion/onset can be seen.
+;
+; A still phone reads ~0 derivative; a moved one spikes. The window is a list of samples (accelerometer
+; magnitude, light level, a counter — any ordered scalar stream). The "derivative" here is not a numeric
+; slope: Form has no sub, so "the difference between two adjacent samples" cannot be a number. What CAN be
+; read without subtraction is the DIRECTION of each adjacent step plus a COUNT of how many steps went each
+; way. So the rate of change becomes: how many adjacent pairs ROSE, how many FELL, and the TOTAL number of
+; changes (rises + falls). Stillness is the floor — a flat window (1 1 1 1) has zero rises, zero falls, zero
+; activity. The more the signal jitters, the higher the activity count climbs. That count IS the derivative-
+; magnitude the body can act on: gate it against a floor and you have a motion/onset detector.
+;
+; THE WALK: recurse over the window, at each step comparing the SECOND sample (nth s 1) against the FIRST
+; (nth s 0) — the adjacent pair at the head — then recurse on (tail s), which slides the window forward by
+; one so the next call's head/second are the next adjacent pair. A pair exists only when the window still
+; holds at least two samples, so every walk GUARDS with (ge (len s) 2) and returns 0 below it: a one-sample
+; or empty window has no pairs, no direction, no change. This guard is load-bearing, not defensive — without
+; it (nth s 1) on a single-element list is head(tail(s)) = head(empty), which panics in every kernel. The
+; guard is the honest statement that a derivative needs two points.
+;
+; NO sub, NO floats, NO three-arg and: every count is an integer accumulated with add + recursion; the gate
+; is a single binary (ge activity floor); direction is one binary comparison (gt) per pair. The recipe never
+; nests a compound and at all — each predicate is one comparison — so there is no third-argument divergence
+; surface to begin with (Go/Rust drop a third and-arg, TS folds it; this body simply never writes one).
+;
+; HONEST LANE: this reads the COUNT of direction changes, not their SIZE. A window that ticks 1->2->1->2
+; (activity 3) and a window that slams 1->1000->1->1000 (also activity 3) are indistinguishable here — both
+; moved three times. That is the correct readout for "did it move / how busy was the window", and the wrong
+; readout for "how hard did it move"; magnitude lives in a different recipe. Flat-but-noisy and violent-but-
+; rare can collide; the floor (sd-moving?) only asks "did the window change at least k times", never "by how
+; much". Equal adjacent samples (a plateau, 5 5) count as NEITHER a rise nor a fall — held, not moving — so a
+; staircase that pauses reads its pauses as stillness, which is honest: no change is no change.
+;
+; Proven by: form-stdlib/tests/signal-derivative-band.fk (three-way at validate.sh)
+
+(do
+    ; --- RISES: count adjacent pairs where the LATER sample is greater (the signal stepped up). ---
+    ; Walk the window; a pair exists only at length >= 2. At each step compare the second sample against
+    ; the first (the adjacent pair at the head): if it rose, add 1, then slide forward by tail and recurse.
+    ; Below two samples there is no pair, so the count is 0 — the base case that also stops (nth s 1) from
+    ; ever reaching head(empty).
+    (defn sd-rises (s)
+        (if (ge (len s) 2)
+            (if (gt (nth s 1) (nth s 0))
+                (add 1 (sd-rises (tail s)))
+                (sd-rises (tail s)))
+            0))
+
+    ; --- FALLS: count adjacent pairs where the LATER sample is smaller (the signal stepped down). ---
+    ; Mirror of sd-rises with the comparison flipped: (gt (nth s 0) (nth s 1)) reads "the first is greater
+    ; than the second", i.e. the later sample fell. Same length>=2 guard, same tail-slide recursion.
+    (defn sd-falls (s)
+        (if (ge (len s) 2)
+            (if (gt (nth s 0) (nth s 1))
+                (add 1 (sd-falls (tail s)))
+                (sd-falls (tail s)))
+            0))
+
+    ; --- ACTIVITY: total adjacent changes = rises + falls. Stillness (no step in either direction) is 0. ---
+    ; This is the derivative-magnitude the body acts on: a flat window is 0, a busy one climbs with every
+    ; step that actually moved. Plateaus (equal adjacent samples) are counted by neither half, so they add 0.
+    (defn sd-activity (s) (add (sd-rises s) (sd-falls s)))
+
+    ; --- MOVING?: 1 when the window changed at least `floor` times, else 0 — the motion/onset gate. ---
+    ; One binary comparison: does the activity count clear the floor? Below it the window is treated as still
+    ; (settled or merely jittering under the threshold); at or above it the body calls the window in motion.
+    (defn sd-moving? (s floor) (if (ge (sd-activity s) floor) 1 0))
+
+    0)

--- a/experiments/coherence-sense-android/app/src/main/java/com/coherence/sense/FormKernel.kt
+++ b/experiments/coherence-sense-android/app/src/main/java/com/coherence/sense/FormKernel.kt
@@ -1,0 +1,67 @@
+package com.coherence.sense
+
+import android.content.Context
+
+// FormKernel — the phone-native door to the Form body. The SAME `run_source`
+// evaluator the Mac kernel runs, now IN-PROCESS via libform_kernel_rust.so
+// (built by form/form-kernel-rust/build-android.sh with --features cabi; the .so
+// exports the JNI-named `Java_com_coherence_sense_FormKernel_eval` over the same
+// evaluator the C-ABI form_eval runs). The phone recognizes / predicts / learns
+// through proven Form recipes WITHOUT the Mac — v1 of the README's "phone-native
+// kernel" lane: shim + .so in jniLibs/arm64-v8a + recipes bundled as assets.
+object FormKernel {
+    @Volatile private var loaded = false
+    private var loadError: String? = null
+
+    init {
+        try {
+            System.loadLibrary("form_kernel_rust")
+            loaded = true
+        } catch (t: Throwable) {
+            loadError = t.message ?: t.toString()
+        }
+    }
+
+    val available: Boolean get() = loaded
+    val error: String? get() = loadError
+
+    // Evaluate a full Form source string; returns the kernel's display() text
+    // (or an "ERR:" string — the native side never throws across the boundary).
+    private external fun eval(src: String): String
+
+    private fun evalOrErr(src: String): String =
+        if (loaded) try { eval(src) } catch (t: Throwable) { "ERR: ${t.message}" }
+        else "ERR: kernel .so not loaded (${loadError ?: "unknown"})"
+
+    // Bundled recipe assets, read once and cached.
+    private val recipeCache = HashMap<String, String>()
+    private fun asset(ctx: Context, name: String): String =
+        recipeCache.getOrPut(name) {
+            ctx.assets.open("recipes/$name").bufferedReader().use { it.readText() }
+        }
+
+    // Compose recipe preludes + a trailing driver, then eval. Mirrors how the
+    // Mac kernel concatenates the recipe(s) + the trailing call before running.
+    private fun run(ctx: Context, recipeFiles: List<String>, driver: String): String {
+        val src = buildString {
+            for (f in recipeFiles) { append(asset(ctx, f)); append('\n') }
+            append(driver)
+        }
+        return evalOrErr(src)
+    }
+
+    // The on-device self-test: reproduce signal-derivative-band's proven verdict
+    // (127 — four-way Go=Rust=TS=fkwu) ON THE PHONE. signal-derivative.fk is
+    // self-contained on kernel builtins, so no core.fk is concatenated (adding it
+    // collides). A "127" result is the body recognizing without the Mac.
+    fun selfTestVerdict(ctx: Context): String =
+        run(ctx, listOf("signal-derivative.fk", "signal-derivative-band.fk"), "").trim()
+
+    // Live recognition: still vs moving from a window of scalar samples, via the
+    // proven signal-derivative recipe (sd-moving?), entirely on-device.
+    fun moving(ctx: Context, window: List<Int>, floor: Int): Boolean {
+        val list = window.joinToString(" ")
+        return run(ctx, listOf("signal-derivative.fk"), "(sd-moving? (list $list) $floor)")
+            .trim() == "1"
+    }
+}

--- a/experiments/coherence-sense-android/app/src/main/java/com/coherence/sense/MainActivity.kt
+++ b/experiments/coherence-sense-android/app/src/main/java/com/coherence/sense/MainActivity.kt
@@ -48,6 +48,7 @@ import android.opengl.EGLDisplay
 import android.opengl.EGLSurface
 import android.opengl.GLES20
 import android.provider.Settings
+import android.util.Log
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.View
@@ -141,6 +142,14 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
     private var cachedBluetoothState = "unknown"
     private var cachedSpeakerState = "unknown"
     private var cachedCameraState = "unknown"
+
+    // On-device recognition (v1 phone-native kernel): the Form body runs IN the
+    // app via libform_kernel_rust.so — no Mac. accelWindow holds recent accel
+    // magnitudes as coarse integers (quantization suppresses sensor jitter); the
+    // proven signal-derivative recipe reads still-vs-moving from them in-process.
+    private val accelWindow = ArrayDeque<Int>()
+    private var onDeviceSelfTest = "on-device kernel: warming"
+    private var onDeviceLive = "on-device recognition: gathering motion"
 
     private lateinit var feed: TextView
     private lateinit var status: TextView
@@ -241,6 +250,7 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
             }
         }
         handler.postDelayed({ checkForAppUpdate(false) }, 1600)
+        startOnDeviceRecognition()
     }
 
     private fun renderFirstFrame() {
@@ -646,6 +656,51 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
             refreshMesh()
             handler.postDelayed(this, 5000)
         }
+    }
+
+    // The phone-native recognition tick — entirely on-device, independent of the
+    // Mac. Each pass folds the latest accel magnitude into a coarse-int window and
+    // runs the proven signal-derivative recipe through the in-process kernel.
+    private val onDeviceLoop = object : Runnable {
+        override fun run() {
+            latest[Sensor.TYPE_ACCELEROMETER]?.let { a ->
+                val mag = sqrt((a[0] * a[0] + a[1] * a[1] + a[2] * a[2]).toDouble())
+                accelWindow.addLast(mag.toInt())
+                while (accelWindow.size > 8) accelWindow.removeFirst()
+            }
+            if (accelWindow.size >= 4 && FormKernel.available) {
+                val window = accelWindow.toList()
+                Thread {
+                    val moving = try { FormKernel.moving(this@MainActivity, window, 2) } catch (_: Exception) { false }
+                    runOnUiThread {
+                        onDeviceLive = "on-device recognition: ${if (moving) "MOVING" else "still"}  (signal-derivative on ${window.size} accel samples, no Mac)"
+                        requestDashboardRender()
+                    }
+                }.start()
+            }
+            handler.postDelayed(this, 800)
+        }
+    }
+
+    // Start on-device recognition: register accel independently of Mac sharing, run
+    // the live tick, and prove the body runs on the phone by reproducing the proven
+    // signal-derivative band verdict (127, four-way) in-process.
+    private fun startOnDeviceRecognition() {
+        registerSensor(Sensor.TYPE_ACCELEROMETER)
+        handler.removeCallbacks(onDeviceLoop)
+        handler.postDelayed(onDeviceLoop, 800)
+        Thread {
+            val verdict = if (FormKernel.available) FormKernel.selfTestVerdict(this) else "so-missing"
+            Log.i("FormKernel", "on-device signal-derivative band verdict = $verdict (expected 127); kernel available=${FormKernel.available} err=${FormKernel.error}")
+            runOnUiThread {
+                onDeviceSelfTest = if (verdict == "127") {
+                    "on-device kernel: LIVE — signal-derivative band = 127 ✓ (Go=Rust=TS=fkwu, now on this phone)"
+                } else {
+                    "on-device kernel: self-test = $verdict (expected 127) ${FormKernel.error ?: ""}"
+                }
+                requestDashboardRender()
+            }
+        }.start()
     }
 
     private fun announcePresence() {
@@ -1522,6 +1577,8 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
             "gpu $gpuSamples latency=${"%.2f".format(Locale.US, gpuLatencyMs)}ms",
         ).joinToString("\n")
         dashboard.text = listOf(
+            onDeviceSelfTest,
+            onDeviceLive,
             "floor: active samples, silence, unavailable hardware, and not-granted lanes are visible signals",
             "north-star: signed organs negotiate wifi, bluetooth, audio, video, screen, sensor, and network channels by heartbeat, then measure fidelity, confidence, and density",
             "learned from sister work: signals are information, not verdicts; silence is evidence",
@@ -1699,6 +1756,7 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
         sm.unregisterListener(this)
         handler.removeCallbacks(loop)
         handler.removeCallbacks(meshLoop)
+        handler.removeCallbacks(onDeviceLoop)
         stopMicSampling()
         stopCameraSampling()
         stopGpuSampling()
@@ -1706,6 +1764,10 @@ class MainActivity : AppCompatActivity(), SensorEventListener {
 
     override fun onResume() {
         super.onResume()
+        // On-device recognition runs whether or not we are sharing with a Mac.
+        registerSensor(Sensor.TYPE_ACCELEROMETER)
+        handler.removeCallbacks(onDeviceLoop)
+        handler.postDelayed(onDeviceLoop, 800)
         if (connected) {
             registerSensor(Sensor.TYPE_ACCELEROMETER)
             registerSensor(Sensor.TYPE_GYROSCOPE)

--- a/experiments/coherence-sense-android/build_signed_release.sh
+++ b/experiments/coherence-sense-android/build_signed_release.sh
@@ -100,6 +100,10 @@ repair_generated_pkcs12_config() {
 write_config_if_missing
 repair_generated_pkcs12_config
 
+# The phone-native kernel (.so) is gitignored; cross-compile + drop it into jniLibs
+# and refresh the bundled recipe assets so the signed APK ships the on-device kernel.
+"$ROOT/form/form-kernel-rust/build-android.sh"
+
 JAVA_HOME="$JAVA_HOME" "$ANDROID_DIR/gradlew" -p "$ANDROID_DIR" :app:assembleRelease
 [[ -f "$APK" ]] || { echo "FAIL signed release APK missing: $APK" >&2; exit 1; }
 

--- a/form/form-kernel-rust/Cargo.lock
+++ b/form/form-kernel-rust/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +102,16 @@ name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const-oid"
@@ -181,6 +197,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 name = "form-kernel-rust"
 version = "0.1.0"
 dependencies = [
+ "jni",
  "libloading",
  "postgres",
  "pyo3",
@@ -438,6 +455,50 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "js-sys"
@@ -854,6 +915,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1073,26 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tinystr"
@@ -1167,6 +1257,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,11 +1445,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1354,19 +1472,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1376,9 +1515,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1394,9 +1545,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1406,9 +1569,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/form/form-kernel-rust/Cargo.toml
+++ b/form/form-kernel-rust/Cargo.toml
@@ -27,7 +27,10 @@ pyo3 = ["dep:pyo3"]
 # CLI runs, for hosts without Python (Android, embedded). Off by default so the
 # bin build (validate.sh / CI) never compiles main.rs twice; the Android
 # cross-compile turns it on:  cargo ndk ... build --release --features cabi.
-cabi = []
+# Pulls `jni` so the SAME .so also exports the JNI-named entry the Android app
+# binds via System.loadLibrary — no separate C shim. jni is pure Rust and only
+# compiled under this feature, so the bin/pyo3 builds never see it.
+cabi = ["dep:jni"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -50,6 +53,10 @@ libloading = "0.8"
 # extension-module skips linking libpython (the interpreter provides it).
 # abi3-py39 keeps the .so importable across CPython 3.9+ without rebuilds.
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py39"], optional = true }
+# jni — optional, only pulled by the `cabi` feature (Android cdylib). Pure Rust;
+# gives the SAME .so a JNI-named `Java_..._eval` entry the Kotlin app binds, over
+# the same run_source the C-ABI form_eval runs. No effect on the bin/pyo3 builds.
+jni = { version = "0.21", optional = true }
 
 [profile.release]
 opt-level = 3

--- a/form/form-kernel-rust/build-android.sh
+++ b/form/form-kernel-rust/build-android.sh
@@ -58,9 +58,26 @@ case "$(file "$SO")" in
   *) echo "✗ cdylib is not an ARM aarch64 shared object — investigate"; exit 1 ;;
 esac
 
-# The .so drops into the app at app/src/main/jniLibs/arm64-v8a/libform_kernel_rust.so.
-# NEXT (carrier, not engine): a tiny JNI shim (FormKernel.kt: external fun formEval(src): String)
-# + a per-frame recognize() that builds the recipe+driver text and calls formEval — the phone then
-# recognizes WITHOUT the Mac. The engine work is done; this is wiring. Verify on an emulator with
-# `emulator -avd <arm64-avd>` + adb install, or on a physical device. See
-# docs/coherence-substrate/kernel-on-android.form.
+# 5. Drop the .so into the app so the gradle build packages it. The .so is
+#    gitignored (a 4 MB build artifact), so the APK build depends on THIS step
+#    having run — both build scripts (build_signed_release.sh,
+#    verify_android_sense_public_handshake.sh) invoke build-android.sh first.
+APP="$(cd "$(dirname "$0")/../../experiments/coherence-sense-android" && pwd)"
+JNILIBS="$APP/app/src/main/jniLibs/arm64-v8a"
+RECIPES="$APP/app/src/main/assets/recipes"
+STDLIB="$(cd "$(dirname "$0")/../form-stdlib" && pwd)"
+mkdir -p "$JNILIBS" "$RECIPES"
+cp "$SO" "$JNILIBS/libform_kernel_rust.so"
+echo "✓ .so → $JNILIBS/libform_kernel_rust.so"
+# Refresh the bundled recipe assets from the single source of truth (form-stdlib)
+# so the on-device kernel runs the SAME proven recipes (no drift). The phone-native
+# recognition (FormKernel.kt) loads these from assets/recipes/ at runtime.
+for fk in signal-derivative.fk; do cp "$STDLIB/$fk" "$RECIPES/$fk"; done
+cp "$STDLIB/tests/signal-derivative-band.fk" "$RECIPES/signal-derivative-band.fk"
+echo "✓ recipe assets refreshed → $RECIPES"
+
+# DONE (2026-06-23): the JNI shim is live. FormKernel.kt binds
+# Java_com_coherence_sense_FormKernel_eval (this .so, built with --features cabi);
+# MainActivity runs the proven signal-derivative recipe in-process — the phone
+# recognizes WITHOUT the Mac (self-test reproduces the four-way band verdict 127,
+# verified on a Galaxy S23 Ultra). See docs/coherence-substrate/kernel-on-android.form.

--- a/form/form-kernel-rust/src/lib.rs
+++ b/form/form-kernel-rust/src/lib.rs
@@ -107,6 +107,35 @@ mod cabi {
             unsafe { drop(CString::from_raw(p)) };
         }
     }
+
+    /// JNI door — the SAME evaluator the C-ABI `form_eval` runs, named so the
+    /// Android app binds it directly via `System.loadLibrary("form_kernel_rust")`
+    /// + `external fun eval(src: String): String` on `com.coherence.sense.FormKernel`.
+    /// No separate C shim, no second .so: the phone-native kernel is this one .so.
+    /// jni owns the jstring↔String marshalling; a panic or bad input returns an
+    /// "ERR:" string (never a crash across the boundary), mirroring form_eval.
+    #[cfg(feature = "cabi")]
+    #[no_mangle]
+    pub extern "system" fn Java_com_coherence_sense_FormKernel_eval<'local>(
+        mut env: jni::JNIEnv<'local>,
+        _class: jni::objects::JClass<'local>,
+        src: jni::objects::JString<'local>,
+    ) -> jni::sys::jstring {
+        let input: String = match env.get_string(&src) {
+            Ok(s) => s.into(),
+            Err(_) => {
+                return env
+                    .new_string("ERR: source not valid UTF-8")
+                    .map(|s| s.into_raw())
+                    .unwrap_or(std::ptr::null_mut());
+            }
+        };
+        let out = catch_unwind(AssertUnwindSafe(|| kernel::run_source(&input).display()))
+            .unwrap_or_else(|_| "ERR: kernel panic".to_string());
+        env.new_string(out)
+            .map(|s| s.into_raw())
+            .unwrap_or(std::ptr::null_mut())
+    }
 }
 
 #[cfg(feature = "pyo3")]

--- a/scripts/verify_android_sense_public_handshake.sh
+++ b/scripts/verify_android_sense_public_handshake.sh
@@ -72,6 +72,12 @@ WITNESS_URL="http://127.0.0.1:$WITNESS_PORT"
 
 mkdir -p "$OUT"
 
+echo "== cross-compile + bundle the Form kernel (.so + recipes) into the app =="
+# The phone-native kernel (libform_kernel_rust.so) is gitignored, so the APK build
+# depends on this running first: it drops the .so into jniLibs and refreshes the
+# bundled recipe assets so the app recognizes on-device (FormKernel.kt).
+"$ROOT/form/form-kernel-rust/build-android.sh"
+
 echo "== build Android APK =="
 (cd "$ANDROID_DIR" && JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk@21}" ./gradlew :app:assembleDebug)
 [[ -f "$APK" ]] || { echo "FAIL APK not found at $APK" >&2; exit 1; }


### PR DESCRIPTION
## What

Coherence Sense now **thinks for itself**: the same `run_source` evaluator the Mac kernel runs is loaded **in the app** via `libform_kernel_rust.so` and recognizes through proven Form recipes with **no Mac**. This closes the README's v1 "phone-native kernel" lane (shim + `.so` in `jniLibs` + recipes as assets), **verified on real hardware** (Galaxy S23 Ultra, arm64-v8a).

This is gap #1 of the Android sovereignty arc — the phone moving from *sense organ* (streams to the Mac, Mac recognizes) to *thinking cell* (recognizes in-process).

## How

- **`form-kernel-rust`** — add a JNI export `Java_com_coherence_sense_FormKernel_eval` in the `cabi` module (same `run_source` as the C-ABI `form_eval`), gated by the `cabi` feature via an optional `jni` dep. The bin/pyo3 builds never see it, so CI/`validate.sh` are unaffected. **One `.so`, two doors** (C-ABI + JNI) — no separate shim library.
- **`build-android.sh`** — now drops the `.so` into `app/src/main/jniLibs/arm64-v8a` and refreshes the bundled recipe assets from `form-stdlib` (single source of truth, no drift). Both build scripts (`build_signed_release.sh`, `verify_android_sense_public_handshake.sh`) invoke it **before** gradle, so the published/CI APK ships the kernel. The `.so` stays gitignored — regenerated, not committed.
- **`FormKernel.kt`** — `System.loadLibrary` + `external fun eval(src)`; loads recipes from assets and composes recipe+driver, mirroring the Mac kernel.
- **`MainActivity`** — on launch a self-test reproduces the proven `signal-derivative` band verdict **127** (four-way Go=Rust=TS=fkwu) **in-process**; a live tick recognizes accelerometer still-vs-moving through the same recipe. Both shown in the dashboard.

## Proof (on a Galaxy S23 Ultra)

```
FormKernel: on-device signal-derivative band verdict = 127 (expected 127); kernel available=true err=null
```

Installed as a `.dev` variant **alongside** the published app for verification, then removed — the user's installed build untouched. The `.so` is a genuine aarch64 ELF exporting both `form_eval` and the JNI symbol.

## Tissue aligned
`docs/coherence-substrate/kernel-on-android.form` updated: *"nobody has run the kernel on a phone"* is no longer true. PATH A step 2 (Rust cdylib + JNI) and step 3 (the accel sensor crossing) are now **MEASURED**, with the Go/TS arms, on-device three-way parity, the native ARM Form→asm JIT, and the Vulkan GPU lane kept honestly named as **still-open** — the remaining Android gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)