### PR TITLE
feat(form): Form-emitted GLSL matvec runs on a real Adreno 740 GPU — bit-exact (Vulkan lane physical witness)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 331 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 332 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/kernel-on-android.form
+++ b/docs/coherence-substrate/kernel-on-android.form
@@ -10,9 +10,19 @@
 ;   UPDATE 2026-06-23: the Rust Form kernel now RUNS on a phone. Coherence Sense loads
 ;   libform_kernel_rust.so over JNI and reproduces the proven signal-derivative band verdict 127
 ;   IN-PROCESS on a Galaxy S23 Ultra, plus live accel still/moving — no Mac (PATH A below, MEASURED).
-;   What is STILL not done stays named: the Go/TS arms on a phone, on-device three-way parity, the
-;   native Form->asm JIT on ARM, and the GPU (Vulkan) lane. The honesty is now in keeping
+;   What is STILL not done stays named: the Go/TS arms on a phone, on-device three-way parity, and the
+;   native Form->asm JIT on ARM. The honesty is now in keeping
 ;   built-and-run-on-hardware apart from documented-but-not-yet-built.
+;
+;   UPDATE 2026-06-23: the GPU (Vulkan) lane is now PHYSICALLY WITNESSED. The Form-emitted GLSL
+;   matvec (fglsl-matvec in form-stdlib/form-glsl.fk — byte-identical to native/vulkan/matvec.comp)
+;   mints to SPIR-V (glslangValidator) and runs on the Galaxy S23 Ultra's Adreno 740 GPU via the
+;   on-device libvulkan.so: BIT-EXACT to the recipe's CPU right-fold (max_abs_diff=0 at 256x256,
+;   1280x1280, 1024x768 — the precise/NoContraction path holds, zero ULP on Qualcomm hardware).
+;   Receipt: scripts/vulkan_matvec_android_audit.sh (the Adreno twin of metal_matvec_audit.sh);
+;   the matvec emit band crosses four-way (fourth-arm-bands.txt: form-glsl fks 7). What is NOT yet
+;   physical on the GPU: the FFN-forward shader (fglsl-ffn-fwd) — its text is four-way-proven but
+;   its on-device dispatch is the next increment.
 ;
 ; ── WHAT IS ALREADY TRUE (the ground this stands on) ── [MEASURED — in the body]
 ;   form/validate.sh proves three kernels identical: form/form-kernel-rust, form-kernel-go,

--- a/docs/system_audit/commit_evidence_2026-06-23_vulkan_matvec_on_adreno.json
+++ b/docs/system_audit/commit_evidence_2026-06-23_vulkan_matvec_on_adreno.json
@@ -1,0 +1,55 @@
+{
+  "date": "2026-06-23",
+  "brick": "the Form-emitted GLSL matvec compute shader runs on a real Adreno 740 GPU via Vulkan — bit-exact to the same recipe's CPU right-fold. The Android GPU twin of the M4 Metal lane: ONE recipe (fglsl-matvec in form-stdlib/form-glsl.fk) is both the four-way proof AND what the phone's GPU runs.",
+  "author": "Sema (Opus 4.8, vulkan-adreno-lane)",
+  "north_star_rung": "GPU driver-replacement on the phone: a Form recipe's GPU work runs natively on Adreno via Vulkan, the Android twin of the Metal lane (3m/3s/3u/3y/3zh). The emit lane was already four-way-proven text (form-glsl.fk + form-glsl-ffn-fwd-band); the open gap the band header named explicitly — 'running it bit-checks needs Android hardware' — is now closed for the matvec op. The emitted shader IS the recipe; there is no second hand-written shader to keep in sync.",
+  "lane": "PHYSICAL-WITNESS of an already-four-way-proven emit band. The emit (form-glsl.fk) and its byte-identity proof existed; the SPIR-V mint + NDK cross-compile + on-device Adreno dispatch + bit-exact gate are what this brick adds, plus registering the matvec emit band in the fourth-arm manifest so it crosses four-way (it was a file but not in the manifest).",
+  "read_the_body": "form/native/vulkan/matvec_vk.c was ALREADY written as a driver-only (dlopen libvulkan.so + vkGetInstanceProcAddr) headless carrier with the explicit Android NDK build line in its header AND a CPU right-fold oracle in the recipe's exact op order (val(n)=n/256, j DOWN, mul then add) — the same seeds and fold as metal_matvec_audit.sh. The harness needed zero changes: cross-compiling it for aarch64-android and feeding it the Form-minted .spv was the whole job. The emitter fglsl-matvec was DONE; the matvec band (form-glsl-band.fk) existed but was absent from fourth-arm-bands.txt, so it had never crossed the fourth arm.",
+  "what_changed": [
+    "scripts/vulkan_matvec_android_audit.sh: NEW — the Adreno twin of metal_matvec_audit.sh. Form emits the GLSL (kernel = mouth), asserts it byte-identical to native/vulkan/matvec.comp, glslangValidator mints the SPIR-V (vulkan1.1), the Android NDK aarch64 clang cross-compiles native/vulkan/matvec_vk.c, adb pushes both to the connected phone, and the harness DISPATCHES the .spv on the device's Adreno GPU and bit-checks every output row against its own CPU right-fold. Skips cleanly (exit 0) when no Go kernel / glslang / NDK / device is present.",
+    "form/fourth-arm-bands.txt: registered the matvec GLSL emit band as 'form-glsl fks 7' (stem of form-glsl-band.fk after -band is stripped), the sibling of form-glsl-ffn-fwd fks 7 — it crosses four-way (Go/Rust/TS/fkwu emit the matvec GLSL byte-identical).",
+    "docs/coherence-substrate/kernel-on-android.form: the top honesty summary moved the GPU (Vulkan) lane out of the 'still not done' list — it is now PHYSICALLY WITNESSED (bit-exact on the Adreno 740 at three sizes), with the FFN-forward on-device dispatch named as the next increment.",
+    "docs/system_audit/commit_evidence_2026-06-23_vulkan_matvec_on_adreno.json: this record."
+  ],
+  "proofs": {
+    "emit_band_four_way": {
+      "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-glsl.fk form-stdlib/tests/form-glsl-band.fk",
+      "verdict": 7,
+      "result": "1 ok, 0 divergent — Go/Rust/TS/fkwu emit the 1136-byte matvec GLSL byte-identical; 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)'"
+    },
+    "emit_byte_identity": {
+      "emitter": "fglsl-matvec in form/form-stdlib/form-glsl.fk",
+      "emitted_glsl_bytes": 1136,
+      "emitted_glsl_sha256": "e8d33e895acda4a4160dd1e824a8a5d5919a32ba4bd57055407473f20b1aec51",
+      "canonical_body": "form/native/vulkan/matvec.comp",
+      "match": "byte-identical — the recipe IS the shader (no hand-authored shader beside it)"
+    },
+    "spirv_mint": {
+      "tool": "glslangValidator -V --target-env vulkan1.1",
+      "spv_bytes": 2348,
+      "spv_sha256": "9113db3273206e872a88eb2f475052e1aa7b3b4abf7889869f3456e64d406374",
+      "note": "no spirv-opt — its MergeMulAddArithmetic would re-fuse mul+add and break the precise/NoContraction bit-exactness on Adreno"
+    },
+    "on_gpu": {
+      "device_id": "R5CW20DK17A",
+      "device_model": "SM-S918U1 (Samsung Galaxy S23 Ultra)",
+      "gpu": "Adreno (TM) 740 (Vulkan), Android 16, arm64-v8a",
+      "harness": "form/native/vulkan/matvec_vk.c cross-compiled with NDK r27c aarch64-linux-android30-clang (driver-only: dlopen libvulkan.so + vkGetInstanceProcAddr; links no Vulkan)",
+      "kernel": "form_matvec (the Form-minted matvec.spv, 2348 bytes)",
+      "runs": [
+        {"shape": "256x256",   "parity_bitexact_rows": "256/256",   "max_abs_diff": 0},
+        {"shape": "1280x1280", "parity_bitexact_rows": "1280/1280", "max_abs_diff": 0},
+        {"shape": "1024x768",  "parity_bitexact_rows": "1024/1024", "max_abs_diff": 0}
+      ],
+      "cpu_reference": "the harness's own CPU right-fold over the same val(n)=n/256 inputs in the recipe's exact op order (j = cols-1..0, prod = w*x then acc = prod + acc)",
+      "gate": "GPU fp32 == CPU fp32 right-fold BIT-FOR-BIT (max_abs_diff = 0, zero ULP). The precise/NoContraction path held on Qualcomm hardware — a fully bit-exact GPU-arithmetic result, not an fp-sound approximation.",
+      "runtime_deps": "libvulkan.so only (the on-device Vulkan loader); no nvcc/nvrtc/go/python/rust/shell/clang at run time — same .spv runs on Adreno/Mali"
+    }
+  },
+  "honest_floor": "Only the matvec op is physically on the Adreno. The FFN-forward shader (fglsl-ffn-fwd) is four-way-proven TEXT but its on-device dispatch is unrun — it needs the 7-buffer + 3-push-constant harness (the matvec harness has 3 buffers + 2 push constants) and a CPU FFN reference (W2*gelu(W1*x+b1)+b2 with the recipe's OWN 14-term Taylor gelu, never the driver's tanh). The matvec dispatch is single-invocation-per-row serial to match the recipe fold order; this is the same discipline the Metal lane holds. Not yet wired to real model weights — this is the GPU-arithmetic floor (bit-exact matvec on the phone GPU), the precondition for running a Form-emitted model block on Adreno.",
+  "named_next_stones": [
+    "build vulkan_ffn_android_audit.sh: cross-compile an FFN host harness (7 SSBOs w1/b1/w2/b2/x/y/a + 3 push constants indim/hid/outd), dispatch fglsl-ffn-fwd's .spv on the Adreno, gate against a CPU FFN right-fold with the recipe's 14-term Taylor gelu — the matvec brick proves the chain works; FFN exercises the barrier() + two-phase shared 'a' buffer on real hardware",
+    "emit a whole transformer block GLSL (the Adreno twin of the M4 GQA-llama-block #3590) and run it on the phone GPU bit-exact to the four-way recipe",
+    "wire the on-device JNI/dlopen kernel (PATH A, already running the Rust arm) to the Vulkan lane so the phone senses -> Form recipe -> Adreno dispatch is one in-process arc with no Mac"
+  ]
+}

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -905,3 +905,4 @@ mlp-fwd-emit fks 7
 pdf-text fks 1
 form-pe-coff-arm64 fks 63
 form-glsl-ffn-fwd fks 7
+form-glsl fks 7

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 331
+**Total files**: 332
 
 | File | Purpose |
 |---|---|
@@ -332,6 +332,7 @@
 | [video_recipe_proof.py](video_recipe_proof.py) | video_recipe_proof.py — ONE video source carries MANY parallel Recipe |
 | [view_recipe_library.py](view_recipe_library.py) | view_recipe_library.py — read a .recipelib bundle and render any tongue. |
 | [viewport_audit.py](viewport_audit.py) | Audit a list of URLs at desktop (1440x900) and mobile (390x844) widths. |
+| [vulkan_matvec_android_audit.sh](vulkan_matvec_android_audit.sh) | vulkan_matvec_android_audit.sh — Adreno GPU witness for the Form GLSL matvec emitter |
 | [wander.py](wander.py) | Launch a wandering sense into the field. |
 | [wellness_check.py](wellness_check.py) | Wellness check — a gentle sensing of the body. |
 | [whisper_block0_carrier.py](whisper_block0_carrier.py) | scripts/whisper_block0_carrier.py — M6 carrier: load safetensors, slice, quantize, and run reference forward pass. |

--- a/scripts/vulkan_matvec_android_audit.sh
+++ b/scripts/vulkan_matvec_android_audit.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# vulkan_matvec_android_audit.sh — Adreno GPU witness for the Form GLSL matvec emitter
+# (fglsl-matvec in form/form-stdlib/form-glsl.fk): the Android twin of metal_matvec_audit.sh.
+# The kernel's mouth prints the Form-emitted GLSL compute shader, glslangValidator mints the
+# SPIR-V (authoring, like nvrtc->cubin), the NDK cross-compiles the headless Vulkan host carrier
+# (form/native/vulkan/matvec_vk.c — driver-only: dlopen libvulkan.so + vkGetInstanceProcAddr),
+# adb pushes both to the connected phone, and the harness DISPATCHES the .spv on the device's
+# Adreno GPU and bit-checks every output row against its OWN CPU right-fold oracle (j DOWN,
+# mul then add, val(n)=n/256 — the same op order as the recipe / PTX / MSL / CPU lanes).
+#
+# The shader that runs on the GPU IS the Form recipe: the emitted GLSL is asserted byte-identical
+# to native/vulkan/matvec.comp (the canonical proven body) before it is ever compiled — never a
+# hand-authored shader beside the recipe. `precise` -> NoContraction keeps mul+add unfused so the
+# Adreno result is bit-exact (no spirv-opt: its MergeMulAddArithmetic would re-fuse).
+#
+# Carriers (all allowed host carriers per host-kernel.form host-resource-access — the emitter
+# intelligence lives in the body): form-kernel-go (the mouth), glslangValidator (SPIR-V mint),
+# the Android NDK aarch64 clang (cross-compile the carrier), adb + the on-device libvulkan.so.
+#
+# Skips cleanly (exit 0) when no Go kernel / glslang / NDK / connected device is present — a
+# witness is a sensing readout, never a gate that fails for missing hardware.
+#
+# Run:  scripts/vulkan_matvec_android_audit.sh [rows cols]    (defaults 1280 1280)
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMDIR="$ROOT/form"
+GO_BIN="$FORMDIR/form-kernel-go/bin-go"
+ROWS="${1:-1280}"; COLS="${2:-1280}"
+
+skip() { echo "SKIP  $1"; exit 0; }
+
+command -v glslangValidator >/dev/null || skip "no glslangValidator — the SPIR-V mint is absent (brew install glslang)"
+command -v adb >/dev/null || skip "no adb — cannot reach an Android device"
+
+# Locate an Android NDK aarch64 clang (env first, then the usual install roots).
+find_ndk_cc() {
+    local roots=()
+    [[ -n "${ANDROID_NDK_HOME:-}" ]] && roots+=("$ANDROID_NDK_HOME")
+    [[ -n "${ANDROID_NDK_ROOT:-}" ]] && roots+=("$ANDROID_NDK_ROOT")
+    roots+=("$HOME/Library/Android/ndk"/* "$HOME/Library/Android/sdk/ndk"/* "$HOME/Android/Sdk/ndk"/*)
+    local r cc
+    for r in "${roots[@]}"; do
+        [[ -d "$r" ]] || continue
+        cc="$(find "$r/toolchains/llvm/prebuilt" -name 'aarch64-linux-android30-clang' 2>/dev/null | head -1)"
+        [[ -z "$cc" ]] && cc="$(find "$r/toolchains/llvm/prebuilt" -name 'aarch64-linux-android*-clang' 2>/dev/null | sort | tail -1)"
+        if [[ -n "$cc" ]]; then echo "$cc"; return 0; fi
+    done
+    return 1
+}
+CC="$(find_ndk_cc)" || skip "no Android NDK aarch64 clang found (set ANDROID_NDK_HOME)"
+SYSINC="$(dirname "$(dirname "$CC")")/sysroot/usr/include"
+[[ -f "$SYSINC/vulkan/vulkan.h" ]] || skip "NDK at $CC has no vulkan/vulkan.h in its sysroot"
+
+DEV="$(adb devices | awk 'NR>1 && $2=="device" {print $1; exit}')"
+[[ -n "$DEV" ]] || skip "no Android device in 'adb devices' (connect a phone + authorize)"
+
+if [[ ! -x "$GO_BIN" ]]; then
+    echo "  building go kernel..." >&2
+    (cd "$FORMDIR/form-kernel-go" && go build -o bin-go .) || skip "go kernel build failed"
+fi
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/fkvkadreno.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+# ── 1. Form emits the GLSL; the kernel is only the mouth ─────────────────
+printf '(print "==GLSL==")\n(print (fglsl-matvec "64"))\n(print "==END==")\n' > "$work/print.fk"
+(cd "$FORMDIR" && "$GO_BIN" form-stdlib/form-glsl.fk "$work/print.fk" 2>/dev/null) > "$work/emit.out"
+# Strip the print frame; the recipe string already ends in \n, print adds one more — drop exactly that.
+sed -n '/^==GLSL==$/,/^==END==$/p' "$work/emit.out" | sed -e '1d' -e '$d' \
+    | perl -0777 -pe 's/\n\z//' > "$work/matvec.comp"
+if ! grep -q 'void main' "$work/matvec.comp"; then
+    echo "FAIL  GLSL emission did not produce the compute shader — see $work/emit.out"; exit 1
+fi
+EMITTED_SHA="$(shasum -a 256 "$work/matvec.comp" | cut -d' ' -f1)"
+CANON_SHA="$(shasum -a 256 "$FORMDIR/native/vulkan/matvec.comp" | cut -d' ' -f1)"
+echo "emitted GLSL: $(wc -c < "$work/matvec.comp" | tr -d ' ') bytes, sha256 $EMITTED_SHA — every byte authored by fglsl-matvec"
+if [[ "$EMITTED_SHA" != "$CANON_SHA" ]]; then
+    echo "FAIL  emitted shader differs from the canonical proven body native/vulkan/matvec.comp ($CANON_SHA)"; exit 1
+fi
+echo "  byte-identical to the canonical proven matvec.comp — the recipe IS the shader"
+
+# ── 2. glslangValidator mints the SPIR-V ─────────────────────────────────
+glslangValidator -V --target-env vulkan1.1 "$work/matvec.comp" -o "$work/matvec.spv" >/dev/null 2>&1 || {
+    echo "FAIL  glslangValidator could not mint SPIR-V"; exit 1; }
+SPV_SHA="$(shasum -a 256 "$work/matvec.spv" | cut -d' ' -f1)"
+echo "minted SPIR-V: $(wc -c < "$work/matvec.spv" | tr -d ' ') bytes, sha256 $SPV_SHA"
+
+# ── 3. The NDK cross-compiles the headless Vulkan carrier ────────────────
+"$CC" -O2 -I"$SYSINC" "$FORMDIR/native/vulkan/matvec_vk.c" -o "$work/matvec_vk" -ldl 2>"$work/cc.err" || {
+    echo "FAIL  NDK could not cross-compile the Vulkan carrier:"; cat "$work/cc.err"; exit 1; }
+echo "cross-compiled the host carrier for aarch64-android ($(basename "$CC"))"
+
+# ── 4. adb push + dispatch on the device's Adreno; the harness gates parity ──
+DD="/data/local/tmp/fkvkadreno.$$"
+adb -s "$DEV" shell "mkdir -p $DD" >/dev/null 2>&1
+adb -s "$DEV" push "$work/matvec_vk" "$DD/matvec_vk" >/dev/null 2>&1
+adb -s "$DEV" push "$work/matvec.spv" "$DD/matvec.spv" >/dev/null 2>&1
+adb -s "$DEV" shell "chmod 755 $DD/matvec_vk" >/dev/null 2>&1
+MODEL="$(adb -s "$DEV" shell getprop ro.product.model | tr -d '\r')"
+echo
+echo "witness on device $DEV ($MODEL), ${ROWS}x${COLS} Form-emitted matvec on the Adreno GPU:"
+out="$(adb -s "$DEV" shell "cd $DD && ./matvec_vk matvec.spv $ROWS $COLS" 2>&1)"
+rc_run=$?
+echo "$out" | sed 's/^/  /'
+adb -s "$DEV" shell "rm -rf $DD" >/dev/null 2>&1   # hold the device only as long as the dispatch needs
+
+echo
+echo "conditions: emit (form-kernel-go) -> SPIR-V (glslangValidator vulkan1.1) -> aarch64-android (NDK)" \
+     "-> adb dispatch on the device's Vulkan driver alone (libvulkan.so), parity = the harness's own CPU" \
+     "right-fold (j DOWN, mul then add, val(n)=n/256), precise -> NoContraction so no FMA re-fusion"
+if [[ "$rc_run" != "0" ]] || ! echo "$out" | grep -q "parity_bitexact_rows=${ROWS}/${ROWS}"; then
+    echo "FAIL  the Adreno output is not bit-exact to the recipe right-fold — diagnose the divergence"; exit 1
+fi
+echo "ok — the Form-emitted GLSL matvec ran on the real Adreno GPU, bit-exact to the recipe; emitter is form-stdlib/form-glsl.fk (fglsl-matvec)"


### PR DESCRIPTION
## The Android GPU twin of the M4 Metal lane is physically witnessed

ONE recipe (`fglsl-matvec` in `form/form-stdlib/form-glsl.fk`) is both the four-way proof AND what the phone's GPU runs. The emitted GLSL is **byte-identical** to `form/native/vulkan/matvec.comp` — there is no hand-written shader beside the recipe.

### The chain, end to end
```
Form emits the GLSL (kernel = mouth)        sha256 e8d33e89...  (1136 bytes)
  -> glslangValidator mints SPIR-V (vulkan1.1)  sha256 9113db32...  (2348 bytes)
  -> NDK r27c cross-compiles native/vulkan/matvec_vk.c for aarch64-android
  -> adb dispatches the .spv on the device's Adreno via on-device libvulkan.so
  -> bit-checks every output row vs the harness's own CPU right-fold
```

### On real hardware — Galaxy S23 Ultra, Adreno 740, Android 16
| shape | bit-exact rows | max_abs_diff |
|-------|---------------|--------------|
| 256×256 | 256/256 | **0** |
| 1280×1280 | 1280/1280 | **0** |
| 1024×768 | 1024/1024 | **0** |

The `precise`/NoContraction path **held on Qualcomm hardware** — fully bit-exact GPU arithmetic, zero ULP, not an fp-sound approximation. The open gap the emit band header named (*"running it bit-checks needs Android hardware"*) is now closed for matvec.

### What's new (the emit + its byte-identity proof already existed)
- **`scripts/vulkan_matvec_android_audit.sh`** — the Adreno twin of `metal_matvec_audit.sh`; mirrors its discipline (emit via Form → compile → run on the real GPU → bit-check vs the CPU recipe right-fold). Skips cleanly (exit 0) without NDK/glslang/device.
- **`form/fourth-arm-bands.txt`** — registered the matvec emit band as `form-glsl fks 7` (sibling of `form-glsl-ffn-fwd`). It crosses **four-way**: Go/Rust/TS/fkwu emit the matvec GLSL byte-identical, 0 divergent.
- **`docs/coherence-substrate/kernel-on-android.form`** — the GPU (Vulkan) lane moved out of the "still not done" list; now physically witnessed.
- **`docs/system_audit/commit_evidence_2026-06-23_vulkan_matvec_on_adreno.json`** — the receipt (device id, shader hash, SPIR-V hash, GPU output, CPU reference, match).

### Proof
- **Four-way band:** `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-glsl.fk form-stdlib/tests/form-glsl-band.fk` → `fourth arm: 1 band(s) four-way`, `1 ok, 0 divergent`
- **Physical witness:** `scripts/vulkan_matvec_android_audit.sh` → exit 0, bit-exact on the Adreno 740

### Honest floor
Only matvec is on the GPU. `fglsl-ffn-fwd` is four-way-proven **text** but its on-device dispatch (7 SSBOs + barrier + the recipe's own 14-term Taylor gelu) is the named next increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)