### PR TITLE
feat(form): a REAL multi-arg recipe crystallizes to a phone-native .so — native == interpreter, four-way 127

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 331 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 332 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-06-23_form_lower_multiarg_native_so.json
+++ b/docs/system_audit/commit_evidence_2026-06-23_form_lower_multiarg_native_so.json
@@ -1,0 +1,46 @@
+{
+  "kind": "native-lane-increment",
+  "date": "2026-06-23",
+  "headline": "The Android native-JIT lane now carries a REAL multi-arg arithmetic recipe, not a constant: ((a*b)+c) lowers to an arm64 byte body (AAPCS64: args w0,w1,w2; result w0), wraps into a loadable aarch64 ELF .so via elf-so-body, dlopens on a real phone, and form_native(a,b,c) returns the SAME integer the Form interpreter walks. Four-way 127 + two on-device receipts.",
+  "increment": {
+    "from": "form-elf-so floor: a CONSTANT-returning .so (movz x0,#42; ret) loads and runs on-device (gap #2 floor, PR #3589).",
+    "to": "a real pure-arithmetic recipe of THREE arguments crystallizes through form-lower -> elf-so-body -> dlopen and equals its interpretation on the device."
+  },
+  "core_abstraction": {
+    "rule": "ONE lowering engine, the argument index is DATA — no per-arity code path.",
+    "shape": "An ARG node carries its argument INDEX in slot 1 (the legacy single-arg shape (2 0 0 0) is index 0). lo-argr maps index k to register base+k. The straight-line single-arg fn passes base=1 (arg0->w1, byte-identical to before); the recursive frame passes base=0/19; lo-compile-fn-n banks N args w0..w(n-1) into the contiguous callee-saved block w19..w(19+n-1) (base 19, the AAPCS64 multi-arg convention) so the single-accumulator body never clobbers a live argument.",
+    "backward_compat": "form-lower / form-lower-cond / form-lower-map / form-lower-rec / form-lower-streq all re-cross at their prior verdicts (31) four-way, byte-identical — every existing band uses arg index 0, and base+0 = base."
+  },
+  "recipe": {
+    "tree": "((a*b)+c) — nodes: 0 ARG#0(a), 1 ARG#1(b), 2 MUL(0,1), 3 ARG#2(c), 4 ADD(2,3)=root",
+    "lowered_44_bytes": "mov w19,w0; mov w20,w1; mov w21,w2; mov w0,w19; mov w9,w0; mov w0,w20; mul w0,w9,w0; mov w9,w0; mov w0,w21; add w0,w9,w0; ret",
+    "exercises": "multi-arg banking (indices 0,1,2 -> w19,w20,w21), the general register-stack tree (lo-tree), and the register-form MUL/ADD — the whole multi-register frontier the single-accumulator scheme could not reach before."
+  },
+  "verified_four_way": {
+    "band": "form-lower-multiarg",
+    "verdict": 127,
+    "arms": "go / rust / ts / fkwu — 1 ok, 0 divergent",
+    "bits": "1 N-arg bank w19/w20/w21 | 2 index->register w19(a)/w20(b)/w21(c) | 4 44-byte body ends in ret | 8 byte-conviction: lowered bytes == hand form-asm sequence | 16 interpreter walk(a=7,b=6,c=5)=47 == native intent | 32 loadable ET_DYN aarch64 .so, code at offset 176 | 64 .dynsym[1] form_native st_info 0x12, st_value 176",
+    "manifest_row": "form-lower-multiarg fks 127"
+  },
+  "on_device_receipt": {
+    "script": "scripts/form_lower_multiarg_receipt.sh",
+    "device": "R5CW20DK17A (real Android phone, adb)",
+    "so_bytes": 840,
+    "so_kind": "ELF 64-bit LSB shared object, ARM aarch64, dynamically linked (ZERO clang in the .so; NDK clang builds only the dlopen harness rig)",
+    "cases": [
+      {"args": [7, 6, 5], "interpreter": 47, "native": 47, "match": true},
+      {"args": [11, 9, 13], "interpreter": 112, "native": 112, "match": true}
+    ],
+    "meaning": "two distinct arg triples confirm the values flow through the w0/w1/w2 -> w19/w20/w21 registers (a real recipe, not a baked constant)."
+  },
+  "files_changed": [
+    "form/form-stdlib/form-lower.fk (lo-argr index->register; lo-bank-args + lo-compile-fn-n; operand-aware paths resolve ARG register from index; header)",
+    "form/form-stdlib/form-elf-so.fk (elf-so-body: wrap an arbitrary lowered body into the loadable .so; header)",
+    "form/form-stdlib/tests/form-lower-multiarg-band.fk (new four-way band, verdict 127)",
+    "form/fourth-arm-bands.txt (manifest row: form-lower-multiarg fks 127)",
+    "scripts/form_lower_multiarg_receipt.sh (new on-device receipt)",
+    "scripts/INDEX.md + MANIFEST.md (auto-generated edges)"
+  ],
+  "next_increment": "float (fp64) crystallization on the d-register path — lower an fp64 recipe via lo-fcompile-fn over d0/d1/..., wrap via elf-so-body, and prove form_native(double)->double on-device equals the interpreter; the fa-f* encoders and lo-ftree FP register stack are already four-way-proven, so the gap is the multi-arg d-register banking preamble + a double-returning harness."
+}

--- a/form/form-stdlib/form-elf-so.fk
+++ b/form/form-stdlib/form-elf-so.fk
@@ -11,6 +11,11 @@
 ; LOADABLE shape: program headers (PT_LOAD + PT_DYNAMIC), a dynamic section, a
 ; dynamic symbol table, a SysV hash table — everything dlopen/dlsym resolve a
 ; symbol through, with no relocations (a position-independent leaf body needs none).
+; The exported body is arbitrary arm64 bytes: elf-so-leaf-const wraps a constant
+; leaf; elf-so-body wraps a REAL lowered recipe (form-lower's bytes, e.g.
+; (add (mul a b) c) over w0,w1,w2), so a hot Form recipe crystallizes to a .so the
+; phone dlopens and calls with concrete integer args — the form-lower -> elf-so-body
+; -> dlopen native-JIT-on-ARM lane, twin of the Mac recipe-dylib path.
 ;
 ; Layout (file offset == vaddr; one PT_LOAD mapped at base 0, the loader rebases):
 ;   0    ELF header (64)            64   2 program headers (2*56=112)
@@ -163,5 +168,16 @@
               210))
     (defn so-ret () (list 192 3 95 214))    ; 0xd65f03c0
     (defn elf-so-leaf-const (imm) (so-cat (list (so-movz-x0 imm) (so-ret))))
+
+    ; ── elf-so-body: wrap an ARBITRARY lowered recipe body into the loadable .so ──
+    ; The body is the byte image form-lower produces for a real recipe (already
+    ; ret-terminated by lo-compile / lo-compile-fn-n), taking its integer args in
+    ; w0,w1,w2,... and returning in w0 — the AAPCS64 leaf convention dlopen+dlsym
+    ; resolve form_native through. This is the named door the native-JIT-on-ARM lane
+    ; crystallizes a hot recipe through: form-lower bytes -> elf-so-body -> dlopen.
+    ; elf-so-leaf-const is just the constant case of the same wrap; elf-so is the
+    ; lower-level image assembler both ride. No relocations: a position-independent
+    ; arithmetic leaf needs none (the integer arg registers are caller-provided).
+    (defn elf-so-body (code) (elf-so code))
 
     0)

--- a/form/form-stdlib/form-lower.fk
+++ b/form/form-stdlib/form-lower.fk
@@ -13,9 +13,15 @@
 ;   lower(ADD(x, LIT i))= lower(x) ; add w0, w0, #i
 ;   lower(SUB(x, LIT i))= lower(x) ; sub w0, w0, #i
 ;   compile(tree)       = lower(tree) ; ret
-; Multi-register operands, the calling convention, and control flow for COND are
-; the named closing cells (form-to-asm.form). Proven three-way by
-; tests/form-lower-band.fk; witnessed against clang by scripts/form_lower_demo.sh.
+; An ARG node carries its argument INDEX in slot 1, and lo-argr maps index k to the
+; register base+k — ONE formula, the index is data. The straight-line single-arg
+; function banks w0->w1 (base 1, arg 0 -> w1); lo-compile-fn-n banks N args
+; w0..w(n-1) into the contiguous callee-saved block w19..w(19+n-1) (base 19, the
+; AAPCS64 multi-arg calling convention) so the single-accumulator body never
+; clobbers a live argument. Control flow for COND and the recursive CALL scheme are
+; the named closing cells (form-to-asm.form). Proven four-way by
+; tests/form-lower-band.fk (and form-lower-multiarg-band.fk for the N-arg path);
+; witnessed against clang by scripts/form_lower_demo.sh.
 
 (do
     (defn lo-nil? (xs) (eq (len xs) 0))
@@ -28,8 +34,17 @@
     (defn lo-imm (prog i) (lo-val prog (lo-c2 prog i))) ; the immediate = LIT value of child-2
 
     (defn lo-c3  (prog i) (nth (lo-row prog i) 3))     ; COND else-branch index (slot 3)
-    (defn lo-arg? (prog i) (eq (lo-tag prog i) 2))     ; is the node ARG (n, held in w1)?
+    (defn lo-arg? (prog i) (eq (lo-tag prog i) 2))     ; is the node ARG (held in w<base+index>)?
     (defn lo-lit? (prog i) (eq (lo-tag prog i) 1))
+    ; an ARG node carries its argument INDEX in slot 1 (a single-arg function's only
+    ; ARG is index 0 — the legacy shape (2 0 0 0)). The register holding arg k is
+    ; base + k: ONE formula, the index is data, no per-arity code. A single-arg
+    ; function passes base = its banked register (1 for the straight-line fn, 0/19
+    ; in the recursive frame); arg 0 -> base + 0 = base, byte-identical to before.
+    ; A multi-arg function banks w0..w(n-1) into a contiguous block w19..w(19+n-1)
+    ; (base 19), so arg k -> w(19+k) — w19+ are callee-saved, untouched by the
+    ; single-accumulator scratch (w0/w2) a leaf body uses.
+    (defn lo-argr (prog i base) (add base (lo-val prog i)))   ; register holding ARG node i
 
     ; lower the subtree rooted at i to its instruction byte image. Convention: the
     ; single argument n lives in w<argr> (1 for the straight-line function, 19 —
@@ -39,7 +54,7 @@
     ; because the naive lower-then-fold would clobber w0 (correctness, not elegance).
     (defn lo-node (prog i argr)
         (if (eq (lo-tag prog i) 1) (fa-movz 0 (lo-val prog i))
-        (if (eq (lo-tag prog i) 2) (fa-mov 0 argr)
+        (if (eq (lo-tag prog i) 2) (fa-mov 0 (lo-argr prog i argr))
         (if (eq (lo-tag prog i) 3) (lo-add prog i argr)
         (if (eq (lo-tag prog i) 4) (lo-sub prog i argr)
         (if (eq (lo-tag prog i) 5) (lo-mul prog i argr)
@@ -56,7 +71,7 @@
         (if (lo-lit? prog (lo-c2 prog i))
             (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-add 0 0 (lo-imm prog i)))
         (if (lo-arg? prog (lo-c1 prog i))
-            (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-add-r 0 argr 0))
+            (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-add-r 0 (lo-argr prog (lo-c1 prog i) argr) 0))
             (lo-tree prog i argr 0))))
     ; SUB: (ARG, LIT i) -> sub w0,w<argr>,#i (direct) · (x, LIT i) -> lower(x); sub w0,w0,#i ·
     ; else (denominator not a LIT) -> lo-tree. Both fast paths require c2=LIT (they read its
@@ -64,7 +79,7 @@
     (defn lo-sub (prog i argr)
         (if (lo-lit? prog (lo-c2 prog i))
             (if (lo-arg? prog (lo-c1 prog i))
-                (fa-sub 0 argr (lo-imm prog i))
+                (fa-sub 0 (lo-argr prog (lo-c1 prog i) argr) (lo-imm prog i))
                 (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-sub 0 0 (lo-imm prog i))))
             (lo-tree prog i argr 0)))
     ; MUL: arm64 has no mul-immediate, so it's operand-aware like ADD/SUB. (ARG, x) /
@@ -74,9 +89,9 @@
     ; frontier (would need allocation) — left as the empty tail, never a wrong answer.
     (defn lo-mul (prog i argr)
         (if (lo-arg? prog (lo-c1 prog i))
-            (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-mul 0 0 argr))
+            (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-mul 0 0 (lo-argr prog (lo-c1 prog i) argr)))
         (if (lo-arg? prog (lo-c2 prog i))
-            (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-mul 0 0 argr))
+            (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-mul 0 0 (lo-argr prog (lo-c2 prog i) argr)))
         (if (lo-lit? prog (lo-c2 prog i))
             (lo-app (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-movz 2 (lo-imm prog i))) (fa-mul 0 0 2))
         (if (lo-lit? prog (lo-c1 prog i))
@@ -87,9 +102,9 @@
     ; (x, LIT i) -> x/i: lower x->w0; movz w2,#i; udiv w0,w0,w2 · (LIT a, x) -> a/x: lower x->w0; movz w2,#a; udiv w0,w2,w0
     (defn lo-div (prog i argr)
         (if (lo-arg? prog (lo-c1 prog i))
-            (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-udiv 0 argr 0))
+            (lo-app (lo-node prog (lo-c2 prog i) argr) (fa-udiv 0 (lo-argr prog (lo-c1 prog i) argr) 0))
         (if (lo-arg? prog (lo-c2 prog i))
-            (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-udiv 0 0 argr))
+            (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-udiv 0 0 (lo-argr prog (lo-c2 prog i) argr)))
         (if (lo-lit? prog (lo-c2 prog i))
             (lo-app (lo-app (lo-node prog (lo-c1 prog i) argr) (fa-movz 2 (lo-imm prog i))) (fa-udiv 0 0 2))
         (if (lo-lit? prog (lo-c1 prog i))
@@ -116,7 +131,7 @@
             (lo-tree-op (lo-tag prog i) sr)))
     (defn lo-tree (prog i argr depth)
         (if (lo-lit? prog i) (fa-movz 0 (lo-val prog i))
-        (if (lo-arg? prog i) (fa-mov 0 argr)
+        (if (lo-arg? prog i) (fa-mov 0 (lo-argr prog i argr))
             (lo-tree-bin prog i argr depth (add 9 depth)))))
     ; COND(LE(ARG, LIT i), then, else) — the control-flow scheme with computed
     ; branch offsets (in instructions = bytes/4):
@@ -125,7 +140,7 @@
         (lo-cond2 prog i argr (lo-node prog (lo-c2 prog i) argr) (lo-node prog (lo-c3 prog i) argr)))
     (defn lo-cond2 (prog i argr tcode ecode)
         (lo-cat (list
-            (fa-cmp argr (lo-val prog (lo-c2 prog (lo-c1 prog i))))   ; LE's LIT operand
+            (fa-cmp (lo-argr prog (lo-c1 prog (lo-c1 prog i)) argr) (lo-val prog (lo-c2 prog (lo-c1 prog i))))   ; cmp w<arg>,#LIT (LE's ARG, LIT)
             (fa-bgt (add (div (len tcode) 4) 2))
             tcode
             (fa-b (add (div (len ecode) 4) 1))
@@ -215,6 +230,19 @@
     (defn lo-compile (prog root) (lo-app (lo-node prog root 1) (fa-ret)))
     ; compile a function OF n: the preamble banks argc (arriving in w0) into w1
     (defn lo-compile-fn (prog root) (lo-app (fa-mov 1 0) (lo-compile prog root)))
+
+    ; compile a function OF n ARGS (the AAPCS64 calling convention, the generalization
+    ; of lo-compile-fn): the args arrive in w0..w(n-1); the preamble banks them into a
+    ; contiguous callee-saved block w19..w(19+n-1) so the single-accumulator body
+    ; (which churns w0/w2) never clobbers a live argument. lo-bank-args is GENERAL —
+    ; it banks w0->w19, w1->w20, ... by recursion, so any arity lowers without
+    ; per-arity code (the source w0..w(n-1) and dest w19.. are disjoint for n<=19, so
+    ; the moves never step on a not-yet-banked arg). The body then lowers with base 19:
+    ; an ARG node of index k reads w(19+k) via lo-argr. ret returns w0.
+    (defn lo-bank-args (k n)
+        (if (eq k n) (list) (lo-app (fa-mov (add 19 k) k) (lo-bank-args (add k 1) n))))
+    (defn lo-compile-fn-n (prog root n)
+        (lo-app (lo-bank-args 0 n) (lo-app (lo-node prog root 19) (fa-ret))))
 
     ; ── the FLOAT lowering twin — lower a float-op tree to arm64 scalar-double bytes ──
     ; The integer lane above lowers to w-registers; this lowers the SAME op-tagged tree to

--- a/form/form-stdlib/tests/form-lower-multiarg-band.fk
+++ b/form/form-stdlib/tests/form-lower-multiarg-band.fk
@@ -1,0 +1,83 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-lower.fk form-stdlib/form-elf-so.fk
+;
+; form-lower-multiarg-band — the N-ARG native lane: a REAL pure-arithmetic recipe of
+; THREE arguments lowers to an arm64 byte body (AAPCS64: args in w0,w1,w2; result in
+; w0), the lowered bytes byte-equal the form-asm encoding (byte-conviction), the
+; recipe WALKED by an in-band interpreter on concrete args equals the integer the
+; lowered program computes, and elf-so-body wraps the body into a loadable .so. This
+; is the form-lower -> elf-so-body -> dlopen native-JIT-on-ARM lane carrying a real
+; recipe, not a constant — the on-device half is scripts/form_lower_multiarg_receipt.sh.
+;
+; The recipe: ((a * b) + c). Nodes (tag c1 c2 c3); ARG slot 1 = argument INDEX:
+;   0 ARG#0 (a) · 1 ARG#1 (b) · 2 MUL(0,1) · 3 ARG#2 (c) · 4 ADD(2,3) = root
+; lo-compile-fn-n prog 4 3 lowers to 11 instructions (44 bytes):
+;   mov w19,w0 ; mov w20,w1 ; mov w21,w2          (bank a,b,c into the callee-saved block)
+;   mov w0,w19 ; mov w9,w0 ; mov w0,w20 ; mul w0,w9,w0     ((a*b) via the register stack)
+;   mov w9,w0 ; mov w0,w21 ; add w0,w9,w0 ; ret            ((a*b)+c, return in w0)
+; On the strange-but-covering case a=7,b=6,c=5 the answer is 7*6+5 = 47, exercising
+; multi-arg banking (indices 0,1,2 -> w19,w20,w21), the general register-stack tree
+; (lo-tree), and the register-form MUL/ADD — the whole multi-register frontier.
+;
+; Verdict 127:
+;   1   N-ARG BANK — the preamble banks the 3 args into the contiguous w19,w20,w21
+;        (mov w19,w0 = f3 03 00 2a ; mov w20,w1 = f4 03 01 2a ; mov w21,w2 = f5 03 02 2a)
+;   2   INDEX->REGISTER — lo-argr maps ARG index k to base+k: arg#0->w19 (mov w0,w19),
+;        arg#1->w20 (mov w0,w20), arg#2->w21 (mov w0,w21) read inside the body
+;   4   SHAPE — the lowered body is 44 bytes (11 instructions) ending in ret
+;   8   BYTE-CONVICTION — the lowered bytes byte-equal the hand form-asm sequence
+;        (compile(recipe) == [bank][mov][mov][mov][mul][mov][mov][add][ret], byte-for-byte)
+;   16  INTERPRETER == NATIVE-INTENT — the recipe walked by the in-band evaluator on
+;        (a=7,b=6,c=5) equals 47, the integer the lowered program returns in w0
+;   32  LOADABLE — elf-so-body wraps the 44-byte body into an 840-byte ET_DYN .so:
+;        ELF64 magic + EM_AARCH64, the code lands at offset 176 (mov w19,w0 = f3 03 00 2a)
+;   64  EXPORT — .dynsym[1] form_native: st_info 0x12 (GLOBAL|FUNC), st_value 176 (the body)
+(do
+    (defn ma-nil? (xs) (eq (len xs) 0))
+    (defn ma-app (xs ys) (if (ma-nil? xs) ys (cons (head xs) (ma-app (tail xs) ys))))
+
+    (let prog (list
+        (list 2 0 0 0)    ; 0 ARG#0 (a)
+        (list 2 1 0 0)    ; 1 ARG#1 (b)
+        (list 5 0 1 0)    ; 2 MUL(0,1)
+        (list 2 2 0 0)    ; 3 ARG#2 (c)
+        (list 3 2 3 0)))  ; 4 ADD(2,3) = root
+
+    (let body (lo-compile-fn-n prog 4 3))   ; the lowered arm64 byte image (ret-terminated)
+    (let img (elf-so-body body))            ; wrapped into the loadable .so
+
+    ; the hand form-asm sequence the lowering must byte-equal (the oracle):
+    (let hand (fa-image (list
+        (fa-mov 19 0) (fa-mov 20 1) (fa-mov 21 2)   ; bank a,b,c -> w19,w20,w21
+        (fa-mov 0 19) (fa-mov 9 0) (fa-mov 0 20) (fa-mul 0 9 0)   ; (a*b)
+        (fa-mov 9 0) (fa-mov 0 21) (fa-add-r 0 9 0) (fa-ret))))   ; (a*b)+c ; ret
+
+    ; the in-band interpreter: walk the SAME op-tagged recipe on concrete args.
+    ; args is a list indexed by ARG index; this is the recipe's interpreted value
+    ; (the integer the native body must also return).
+    (defn ma-row (prog i) (nth prog i))
+    (defn ma-tag (prog i) (nth (ma-row prog i) 0))
+    (defn ma-eval (prog i args)
+        (if (eq (ma-tag prog i) 1) (nth (ma-row prog i) 1)                              ; LIT
+        (if (eq (ma-tag prog i) 2) (nth args (nth (ma-row prog i) 1))                   ; ARG#k
+        (if (eq (ma-tag prog i) 5)                                                       ; MUL
+            (mul (ma-eval prog (nth (ma-row prog i) 1) args) (ma-eval prog (nth (ma-row prog i) 2) args))
+        (if (eq (ma-tag prog i) 3)                                                       ; ADD
+            (add (ma-eval prog (nth (ma-row prog i) 1) args) (ma-eval prog (nth (ma-row prog i) 2) args))
+            0)))))
+    (let walked (ma-eval prog 4 (list 7 6 5)))   ; the interpreter's value on (a=7,b=6,c=5)
+
+    (let c0 (if (eq (nth body 0) 243) (if (eq (nth body 4) 244)
+            (if (eq (nth body 8) 245) 1 0) 0) 0))   ; mov w19/w20/w21 first bytes f3/f4/f5
+    (let c1 (if (eq (nth body 14) 19) (if (eq (nth body 22) 20)
+            (if (eq (nth body 34) 21) 2 0) 0) 0))   ; body reads w19 (a), w20 (b), w21 (c)
+    (let c2 (if (eq (len body) 44)
+            (if (eq (nth body 40) 192) (if (eq (nth body 43) 214) 4 0) 0) 0))  ; 44 bytes, ends in ret
+    (let c3 (if (eq (fa-conviction body hand) 1)
+            (if (eq (fa-may-drop (fa-conviction body hand) 1) 1) 8 0) 0))      ; bytes == form-asm
+    (let c4 (if (eq walked 47) 16 0))               ; interpreter walk = 47 (= native intent)
+    (let c5 (if (eq (nth img 0) 127) (if (eq (nth img 18) 183)
+            (if (eq (nth img 176) 243) 32 0) 0) 0)) ; ELF64 + EM_AARCH64, code at 176 (f3=mov w19,w0)
+    (let c6 (if (eq (nth img 248) 1) (if (eq (nth img 252) 18)
+            (if (eq (nth img 256) 176) 64 0) 0) 0)) ; form_native: st_name 1, st_info 0x12, st_value 176
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -395,6 +395,7 @@ form-lower-cond fks 31
 form-lower-map fks 31
 form-lower-rec fks 31
 form-lower-streq fks 31
+form-lower-multiarg fks 127
 form-macho fks 31
 form-pe-coff fks 16383
 form-pe-coff-affine fks 127

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 331
+**Total files**: 332
 
 | File | Purpose |
 |---|---|
@@ -131,6 +131,7 @@
 | [form_first_offline_setup.sh](form_first_offline_setup.sh) | form_first_offline_setup.sh — bring the body home so Form-first answers OFFLINE. |
 | [form_headn_demo.sh](form_headn_demo.sh) | form_headn_demo.sh — `head N`, the REAL head, built with ZERO clang and direct |
 | [form_lower_demo.sh](form_lower_demo.sh) | form_lower_demo.sh — the Form -> assembly COMPILER. Lower an op-tagged expression |
+| [form_lower_multiarg_receipt.sh](form_lower_multiarg_receipt.sh) | form_lower_multiarg_receipt.sh — the physical on-device receipt for the N-ARG native |
 | [form_macho_demo.sh](form_macho_demo.sh) | form_macho_demo.sh — a RUNNABLE native binary built with ZERO clang. The Form |
 | [form_map_demo.sh](form_map_demo.sh) | form_map_demo.sh — the FULL asm-to-source mapping for a native 4th-kernel |
 | [form_mut_demo.sh](form_mut_demo.sh) | form_mut_demo.sh — the MUTATION channel live: track cell creation (heap CONS) |

--- a/scripts/form_lower_multiarg_receipt.sh
+++ b/scripts/form_lower_multiarg_receipt.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# form_lower_multiarg_receipt.sh — the physical on-device receipt for the N-ARG native
+# lane: a Form recipe ((a*b)+c) is LOWERED by form-lower to an arm64 byte body (AAPCS64:
+# args in w0,w1,w2; result in w0), wrapped by elf-so-body into a LOADABLE aarch64 ELF .so
+# (ZERO clang — Form is compiler, assembler, AND linker for the .so), which the Android
+# dynamic linker dlopen's on a real device, and whose exported form_native(a,b,c) runs as
+# native code returning a*b+c. The script also evaluates the SAME recipe through the Form
+# interpreter and asserts native == interpreter for the same args — one recipe, two carriers.
+#
+# The only clang here is the NDK building the tiny dlopen HARNESS (a test rig); never the
+# .so. Skips cleanly (exit 0) when no NDK or no adb device is present; the four-way byte +
+# interpreter==native-intent proof is tests/form-lower-multiarg-band.fk (127). This is the
+# runtime half — the form-lower -> elf-so-body -> dlopen native-JIT-on-ARM lane, on a phone.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"
+KERNEL="$FORM/form-kernel-rust/target/release/form-kernel-rust"
+[[ -x "$KERNEL" ]] || KERNEL="$FORM/form-kernel-rust/target/debug/form-kernel-rust"
+[[ -x "$KERNEL" ]] || { echo "no form-kernel-rust binary; skipping"; exit 0; }
+
+DEV="$(adb devices 2>/dev/null | awk 'NR>1 && $2=="device"{print $1; exit}')"
+[[ -n "$DEV" ]] || { echo "no adb device attached; skipping (byte proof is form-lower-multiarg-band 127)"; exit 0; }
+NDK="${ANDROID_NDK_HOME:-$(ls -d /opt/homebrew/Caskroom/android-ndk/*/AndroidNDK*.app/Contents/NDK 2>/dev/null | head -1)}"
+CC="$(ls "$NDK"/toolchains/llvm/prebuilt/*/bin/aarch64-linux-android*-clang 2>/dev/null | sort -V | tail -1)"
+[[ -x "$CC" ]] || { echo "no NDK aarch64 clang for the harness; skipping"; exit 0; }
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/flma.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+A="${1:-7}"; B="${2:-6}"; C="${3:-5}"
+
+# Form lowers the recipe, wraps the .so, AND walks the interpreter — one engine.
+# Merge form-asm + form-lower + form-elf-so module bodies into one (do ...) (their
+# own (do/0) wrappers stripped) so the recipe sees every defn it needs.
+asm_body="$(sed '1,/^(do$/d' "$FORM/form-stdlib/form-asm.fk" | sed '$ d')"
+low_body="$(sed '1,/^(do$/d' "$FORM/form-stdlib/form-lower.fk" | sed '$ d')"
+so_body="$(sed '1,/^(do$/d' "$FORM/form-stdlib/form-elf-so.fk" | sed '$ d')"
+{
+  echo "(do"
+  echo "$asm_body"
+  echo "$low_body"
+  echo "$so_body"
+  cat <<DRV
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    ; the recipe ((a*b)+c) as an op-tagged tree; ARG slot 1 = argument index
+    (defn me-row (prog i) (nth prog i))
+    (defn me-tag (prog i) (nth (me-row prog i) 0))
+    (defn me-eval (prog i args)
+        (if (eq (me-tag prog i) 1) (nth (me-row prog i) 1)
+        (if (eq (me-tag prog i) 2) (nth args (nth (me-row prog i) 1))
+        (if (eq (me-tag prog i) 5) (mul (me-eval prog (nth (me-row prog i) 1) args) (me-eval prog (nth (me-row prog i) 2) args))
+        (if (eq (me-tag prog i) 3) (add (me-eval prog (nth (me-row prog i) 1) args) (me-eval prog (nth (me-row prog i) 2) args))
+            0)))))
+    (let prog (list (list 2 0 0 0) (list 2 1 0 0) (list 5 0 1 0) (list 2 2 0 0) (list 3 2 3 0)))
+    (let body (lo-compile-fn-n prog 4 3))
+    (print (str_concat "INTERP " (hxb (list (me-eval prog 4 (list $A $B $C))))))
+    (print (str_concat "ELFSO " (hxb (elf-so-body body))))
+    0)
+DRV
+} > "$work/emit.fk"
+emit="$(cd "$FORM" && "$KERNEL" "$work/emit.fk" 2>/dev/null)"
+hex="$(echo "$emit" | grep '^ELFSO ' | sed 's/^ELFSO //')"
+interp_hex="$(echo "$emit" | grep '^INTERP ' | sed 's/^INTERP //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no .so"; exit 1; }
+INTERP=$((16#$interp_hex))
+echo "$hex" | xxd -r -p > "$work/form_native.so"
+echo "Form-emitted ELF .so: $(wc -c < "$work/form_native.so" | tr -d ' ') bytes (ZERO clang) — recipe ((a*b)+c)"
+file "$work/form_native.so" | sed 's/^[^:]*: /  /'
+echo "Form interpreter walk:  form_native($A,$B,$C) = $INTERP"
+
+# The dlopen harness — NDK clang builds the RIG, not the .so. It calls form_native(a,b,c).
+cat > "$work/harness.c" <<'C'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+typedef long (*fn)(long, long, long);
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { printf("DLOPEN_FAIL %s\n", dlerror()); return 10; }
+    fn f = (fn)dlsym(h, "form_native");
+    if (!f) { printf("DLSYM_FAIL %s\n", dlerror()); return 11; }
+    long a = atol(argv[2]), b = atol(argv[3]), c = atol(argv[4]);
+    printf("RESULT %ld\n", f(a, b, c));
+    return 0;
+}
+C
+"$CC" -o "$work/harness" "$work/harness.c" || { echo "FAIL: harness build"; exit 1; }
+
+D=/data/local/tmp/form-lower-multiarg-receipt
+adb -s "$DEV" shell "mkdir -p $D" >/dev/null 2>&1
+adb -s "$DEV" push "$work/form_native.so" "$D/form_native.so" >/dev/null 2>&1
+adb -s "$DEV" push "$work/harness" "$D/harness" >/dev/null 2>&1
+adb -s "$DEV" shell "chmod 755 $D/harness" >/dev/null 2>&1
+echo
+echo "running on device $DEV — dlopen the Form-emitted .so, call form_native($A,$B,$C) (expect $INTERP):"
+out="$(adb -s "$DEV" shell "cd $D && ./harness ./form_native.so $A $B $C" 2>&1 | tr -d '\r')"
+echo "  $out"
+adb -s "$DEV" shell "rm -rf $D" >/dev/null 2>&1
+case "$out" in
+  "RESULT $INTERP")
+    echo
+    echo "ON-DEVICE NATIVE, ZERO CLANG (.so): a Form recipe ((a*b)+c) was LOWERED to arm64"
+    echo "bytes, wrapped into a loadable aarch64 ELF .so; the Android linker dlopen'd it and"
+    echo "its exported native form_native($A,$B,$C) ran on the phone, returning $INTERP — equal"
+    echo "to the SAME recipe walked by the Form interpreter. The native-JIT-on-ARM lane carries"
+    echo "a real multi-arg recipe, end to end." ;;
+  *) echo; echo "device dlopen/call did not match the interpreter — named carrier step. out: $out (interp=$INTERP)"; exit 2 ;;
+esac


### PR DESCRIPTION
## What is now true that wasn't

The Android native-JIT lane moves from *a constant-returning .so loads on-device* (gap #2 floor, #3589) to **a REAL pure-arithmetic recipe of three arguments crystallizes and equals its interpretation, on a real phone**. `((a*b)+c)` lowers to an arm64 byte body (AAPCS64: `a,b,c` in `w0,w1,w2`; result in `w0`), wraps into a loadable aarch64 ELF `.so` via `elf-so-body`, dlopens on the device, and `form_native(a,b,c)` returns the **same integer the Form interpreter walks**. One recipe is both the four-way proof and the native binary.

## Core abstraction — the index is data, ONE engine

`form-lower` stays a single lowering engine. An ARG node carries its **argument index** in slot 1 (the legacy single-arg shape `(2 0 0 0)` is index 0); `lo-argr` maps index `k` to register `base + k` — no per-arity code path.

- Single-arg straight-line fn: `base 1`, arg0 → `w1` — **byte-identical to before**.
- Recursive frame: `base 0/19` — byte-identical.
- `lo-compile-fn-n` banks N args `w0..w(n-1)` into the contiguous callee-saved block `w19..w(19+n-1)` (the AAPCS64 multi-arg convention) so the single-accumulator body never clobbers a live argument.

All five prior lower bands (`form-lower`, `-cond`, `-map`, `-rec`, `-streq`) re-cross at **31 four-way, byte-identical**.

## New band — `form-lower-multiarg` → 127 four-way (go / rust / ts / fkwu, 0 divergent)

`((a*b)+c)` lowers to 44 bytes: `mov w19,w0; mov w20,w1; mov w21,w2; mov w0,w19; mov w9,w0; mov w0,w20; mul w0,w9,w0; mov w9,w0; mov w0,w21; add w0,w9,w0; ret`. The seven verdict bits prove: N-arg bank, index→register, 44-byte body ending in ret, **byte-conviction** (lowered bytes == hand `form-asm` sequence), **interpreter walk(7,6,5)=47 == native intent**, loadable ET_DYN `.so`, `form_native` export at code offset 176.

## On-device receipt — `scripts/form_lower_multiarg_receipt.sh`

Device **R5CW20DK17A** (real Android phone), 840-byte ELF aarch64 `.so`, **ZERO clang in the `.so`** (NDK clang builds only the dlopen harness rig). Two distinct arg triples confirm the values flow through the registers (a real recipe, not a baked constant):

| args | interpreter | native | match |
|------|-------------|--------|-------|
| (7,6,5) | 47 | 47 | ✓ |
| (11,9,13) | 112 | 112 | ✓ |

## Next increment

Float (fp64) crystallization on the d-register path — the `fa-f*` encoders and `lo-ftree` FP register stack are already four-way-proven; the gap is the multi-arg d-register banking preamble + a double-returning harness.

Evidence: `docs/system_audit/commit_evidence_2026-06-23_form_lower_multiarg_native_so.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)