### PR TITLE
feat(scripts): field_relay_dev_setup.sh — enable breath-4 carrier build + proof

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 332 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 334 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-06-23_field_relay_dev_setup.json
+++ b/docs/system_audit/commit_evidence_2026-06-23_field_relay_dev_setup.json
@@ -1,0 +1,72 @@
+{
+  "date": "2026-06-23",
+  "thread_branch": "claude/field-relay-dev-setup",
+  "commit_scope": "Add scripts/field_relay_dev_setup.sh — a cloud-session setup script that provisions the breath-4 carrier deps (fastapi + uvicorn[standard]->websockets + cryptography + PyNaCl, all already declared in api/requirements.txt) so the next session can BUILD and PROVE the field relay's carriers/clients end-to-end (ed25519 identity carrier, dial-out client, reconnect drain), which the bare sandbox cannot. The decision bodies are already proven and merged (verdicts fr-route 127, fiv-verdict 511, fq-drain 127; their proofs live in the per-recipe evidence records). Modeled on form_first_offline_setup.sh; idempotent, best-effort, carrier/process only.",
+  "files_owned": [
+    "scripts/field_relay_dev_setup.sh",
+    "docs/system_audit/commit_evidence_2026-06-23_field_relay_dev_setup.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "bash -n scripts/field_relay_dev_setup.sh"
+    ],
+    "notes": "Shell syntax check passes. Dep INSTALL is not run here (the sandbox agent phase has no network and the script is meant for the setup phase); the script is idempotent and verifies importability of fastapi/websockets/ed25519 before declaring ready."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Process tooling; no CI gate beyond shellcheck/lint if configured."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "Not deployed; a developer/setup-phase script."
+  },
+  "phase_gate": {
+    "phase": "field-relay-breath4-enablement",
+    "gate": "Give a cloud session the deps to build + prove the breath-4 carriers (crypto, client, board I/O) end-to-end. The decision bodies (fr-route, fiv-verdict, fq-drain) are already proven and merged per their own evidence records; this unblocks their carriers.",
+    "state": "enablement-script-added",
+    "can_move_next_phase": false
+  },
+  "idea_ids": [
+    "federation-and-nodes"
+  ],
+  "spec_ids": [
+    "field-relay-always-open-connection"
+  ],
+  "task_ids": [
+    "field-relay-dev-setup"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance"
+      ]
+    },
+    {
+      "contributor_id": "agent:claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Claude",
+    "version": "4.x"
+  },
+  "evidence_refs": [
+    "scripts/field_relay_dev_setup.sh",
+    "scripts/form_first_offline_setup.sh",
+    "api/requirements.txt",
+    "specs/field-relay-always-open-connection.md"
+  ],
+  "change_files": [
+    "scripts/field_relay_dev_setup.sh",
+    "docs/system_audit/commit_evidence_2026-06-23_field_relay_dev_setup.json"
+  ],
+  "change_intent": "process_only"
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 332
+**Total files**: 334
 
 | File | Purpose |
 |---|---|
@@ -85,6 +85,7 @@
 | [external_proof_demo.py](external_proof_demo.py) | External proof demo — exercises the Coherence Network public API from outside the repo. |
 | [fatal_http_all_kernels_probe.py](fatal_http_all_kernels_probe.py) | Probe fatal HTTP replies across the current four kernel carriers. |
 | [federation_peer_poll.py](federation_peer_poll.py) | federation_peer_poll — fire one peer-poll cycle from the command line. |
+| [field_relay_dev_setup.sh](field_relay_dev_setup.sh) | field_relay_dev_setup.sh — provision a session to BUILD + PROVE the field relay's breath-4 carriers. |
 | [fill_missing_spec_sections.py](fill_missing_spec_sections.py) | Heal pre-existing spec body gaps the validator surfaces. |
 | [fkwu_run.sh](fkwu_run.sh) | fkwu_run.sh — run a Form recipe on the 4th kernel (fkwu) with a staged-input bundle. |
 | [form-convert.sh](form-convert.sh) | form-convert — the machine-native kernel-cli for the goal Urs named: |

--- a/scripts/field_relay_dev_setup.sh
+++ b/scripts/field_relay_dev_setup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# field_relay_dev_setup.sh — provision a session to BUILD + PROVE the field relay's breath-4 carriers.
+#
+# Point a cloud environment's SETUP SCRIPT at this (Claude Code: Environment -> setup script; Codex:
+# the setup phase, which has network while the agent phase does not). The relay's DECISION bodies are
+# already proven four-way + native and merged:
+#   field-relay.fk   (fr-route, 127)    — open, content-blind routing + consent
+#   field-identity.fk(fiv-verdict, 511) — trust verdict at the edge (breath 3 keystone)
+#   field-queue.fk   (fq-drain, 127)    — reconnect backlog drain (breath 2)
+# What is NOT yet built is the CARRIERS + CLIENTS (breath 4): the ed25519 sign/verify carrier, the
+# sha256 NodeID-derivation wiring, the TOFU pin store, the append-only board I/O, and a dial-out client.
+# Those need deps the bare sandbox lacks. This script installs exactly those deps so the next session
+# can build them AND prove them end-to-end against the live relay or a local one.
+#
+# The deps are already declared in api/requirements.txt:
+#   fastapi + uvicorn[standard] (brings the websockets lib) — the relay transport + a WS client
+#   cryptography>=41 / PyNaCl>=1.5 — ed25519 keygen/sign/verify, the identity carrier
+# So provisioning is mostly `pip install -e api`. Idempotent: a satisfied env is a fast no-op.
+#
+# Optional (FIELD_RELAY_BUILD_KERNELS=1): also build the Go/Rust/TS form kernels so `form/validate.sh`
+# can re-prove the four-way decision bands here. The carriers themselves are Python and do not need it;
+# it is only for re-running the Form proofs.
+set -u
+ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 0
+
+ok=0
+need_install=0
+# already provisioned? (the three carrier deps import) -> fast no-op
+if python3 -c "import fastapi, websockets; from nacl import signing; from cryptography.hazmat.primitives.asymmetric import ed25519" >/dev/null 2>&1; then
+  echo "⟐ breath-4 carrier deps already present (fastapi + websockets + ed25519) — ready to build + prove."
+  ok=1
+else
+  need_install=1
+fi
+
+if [[ "$need_install" == 1 ]]; then
+  echo "⟐ installing breath-4 carrier deps (api/requirements.txt: fastapi, uvicorn[standard]->websockets, cryptography, PyNaCl)…"
+  if python3 -m pip install -e api -q >/dev/null 2>&1 || python3 -m pip install -r api/requirements.txt -q >/dev/null 2>&1; then
+    if python3 -c "import fastapi, websockets; from nacl import signing; from cryptography.hazmat.primitives.asymmetric import ed25519" >/dev/null 2>&1; then
+      echo "⟐ done — fastapi + websockets + ed25519 importable. Breath-4 carriers can be built and proven."
+      ok=1
+    else
+      echo "⟐ install ran but a carrier dep is still missing — check pip output; breath-4 build will be partial."
+    fi
+  else
+    echo "⟐ pip install failed (no network in agent phase? run this in the SETUP phase). Breath-4 build blocked until deps land."
+  fi
+fi
+
+# Optional: build the form kernels so validate.sh can re-prove the decision bands locally.
+if [[ "${FIELD_RELAY_BUILD_KERNELS:-0}" == 1 ]]; then
+  echo "⟐ FIELD_RELAY_BUILD_KERNELS=1 — building Go/Rust/TS kernels for form/validate.sh (best-effort)…"
+  ( cd form/form-kernel-go && go build -o bin-go . ) >/dev/null 2>&1 && echo "  go kernel built" || echo "  go kernel build skipped/failed"
+  ( cd form/form-kernel-rust && cargo build --release ) >/dev/null 2>&1 && echo "  rust kernel built" || echo "  rust kernel build skipped/failed"
+fi
+
+if [[ "$ok" == 1 ]]; then
+  cat <<'NEXT'
+⟐ ready. Next session can now build + prove breath 4:
+   - ed25519 identity carrier:  keygen -> NodeID=sha256(pubkey); sign/verify -> feed fiv-verdict (field-identity.fk)
+   - dial-out client (Python, runs Mac/Windows/Linux): connect wss://…/api/field/relay/{nodeid}, hello+interface, sign envelopes
+   - reconnect drain: read the append-only board -> fq-drain (field-queue.fk) -> replay the gap, advance the cursor
+   - e2e proof: start the relay locally (uvicorn app.main:app) OR use the live endpoint; two clients exchange a signed
+     envelope; impersonation (wrong key) is rejected by fiv-verdict; an offline cell drains its backlog on reconnect.
+   Keep the proof discipline: the decision stays the proven Form recipe; the carrier is the thin shell around it.
+NEXT
+fi
+exit 0

--- a/scripts/field_relay_dev_setup.sh
+++ b/scripts/field_relay_dev_setup.sh
@@ -49,10 +49,17 @@ if [[ "$need_install" == 1 ]]; then
 fi
 
 # Optional: build the form kernels so validate.sh can re-prove the decision bands locally.
+# All THREE walker kernels must be prepared in the (networked) setup phase — the later agent phase has
+# no network, so a missing TS bundle/node_modules would make validate.sh try `npx` and stall.
 if [[ "${FIELD_RELAY_BUILD_KERNELS:-0}" == 1 ]]; then
   echo "⟐ FIELD_RELAY_BUILD_KERNELS=1 — building Go/Rust/TS kernels for form/validate.sh (best-effort)…"
   ( cd form/form-kernel-go && go build -o bin-go . ) >/dev/null 2>&1 && echo "  go kernel built" || echo "  go kernel build skipped/failed"
   ( cd form/form-kernel-rust && cargo build --release ) >/dev/null 2>&1 && echo "  rust kernel built" || echo "  rust kernel build skipped/failed"
+  # TS: install deps + pre-bundle dist/main.mjs so the agent phase runs `node dist/main.mjs` with NO network
+  ( cd form/form-kernel-ts \
+      && { npm ci --no-audit --no-fund >/dev/null 2>&1 || npm install --no-audit --no-fund >/dev/null 2>&1; } \
+      && npx --yes esbuild src/main.ts --bundle --platform=node --format=esm --outfile=dist/main.mjs ) >/dev/null 2>&1 \
+    && [[ -s form/form-kernel-ts/dist/main.mjs ]] && echo "  ts kernel bundled (dist/main.mjs)" || echo "  ts kernel build skipped/failed"
 fi
 
 if [[ "$ok" == 1 ]]; then


### PR DESCRIPTION
## Provision a session to build + prove breath 4

"yes, please" — the setup script so a cloud session comes up able to **build and prove** the field relay's breath-4 carriers/clients end-to-end, which the bare sandbox can't (it lacks `fastapi`/crypto/`websockets`).

The deps are **already declared** in `api/requirements.txt` (`fastapi` + `uvicorn[standard]`→`websockets` + `cryptography` + `PyNaCl`), so provisioning is mostly `pip install -e api`. The script:
- verifies `fastapi` + `websockets` + ed25519 import (idempotent fast no-op if present),
- installs them if missing (setup-phase network),
- optional `FIELD_RELAY_BUILD_KERNELS=1` builds Go/Rust/TS so `form/validate.sh` can re-prove the bands,
- prints the breath-4 build plan: ed25519 identity carrier → `fiv-verdict`, dial-out client (Python, runs Mac/Windows/Linux), board read → `fq-drain`, and an e2e proof (two clients exchange a signed envelope; impersonation rejected by `fiv-verdict`; offline cell drains its backlog on reconnect).

Modeled on `form_first_offline_setup.sh`. **Point the environment's setup script at this.** The decision bodies (`fr-route` 127, `fiv-verdict` 511, `fq-drain` 127) are already proven + merged; this unblocks their carriers. Commit-evidence (`process_only`) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcMKs4fjCCP8zDmk7j5htv)_