### PR TITLE
feat(form): KV-cached causal GQA llama decode step crosses four-way

### DIFF
--- a/form/form-stdlib/kv-gqa-llama-block.fk
+++ b/form/form-stdlib/kv-gqa-llama-block.fk
@@ -1,0 +1,85 @@
+; kv-gqa-llama-block.fk — the KV-cached causal GQA llama decoder block: the inner step of the
+; autoregressive generation loop for the REAL llama3.2 (24 query heads, 8 KV heads), proven
+; BIT-IDENTICAL to the full causal GQA llama block (lgqa-block-causal, llama-gqa-block.fk four-way 15).
+;
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk form-stdlib/kv-cache.fk
+;
+; kv-llama-block.fk (#3408) proved the cache for a SINGLE-head (MHA) llama block: lblk-generate-causal ==
+; lblk-block-causal bit-for-bit. Real llama3.2 uses GROUPED-QUERY attention — n_q query heads share
+; n_kv < n_q KV heads — so the cache stores the SMALLER n_kv*HD-wide k/v per position, and query head h
+; attends KV head (h / (n_q/n_kv)). This lifts the cached decode to GQA, composing gqa-attn's grouping with
+; the cache; no new arithmetic — the (n_q=n_kv=1) case IS lblk-generate-causal (core-abstraction-first, MHA
+; is the group=1 special case, not a parallel path).
+;
+; The load-bearing claim is the same as #3408: the cache is EXACT, not approximating. A cached k_i/v_i is
+; RoPE(Wk·RMSNorm1(x_i), i) / Wv·RMSNorm1(x_i) — narrower (n_kv*HD wide) but still position-only, never the
+; future. So at step p the grown cache is exactly the prefix [k_0..k_p] = (tb-take ks (add p 1)) the causal
+; GQA mask cuts at query p. Per query head h, tb-gqa-attend-one slices q_p's head h and attends it (one query
+; over the whole prefix) against KV head (h/group)'s slice of that cached prefix — IDENTICAL arguments to
+; tb-gqa-head-causal's masked attention at position p (tb-attend-one over the full prefix == the causal mask
+; at the last query of that prefix). The Wo/residual/RMSNorm2/SwiGLU/residual tail is per-token. Therefore
+; lgqa-generate-causal == lgqa-block-causal bit-for-bit. Composes tb-attend-one (per head over the cache),
+; tb-vslice/tb-seq-headslice (gqa-attn's own slicing), kv-append, and llama-block's own RMSNorm/proj/RoPE/
+; SwiGLU verbatim — no numeric change.
+;
+; The autoregressive INVARIANT (the reason a cache is reusable across generation steps): appending a future
+; token never changes an earlier token's GQA output — a cached k_i/v_i is frozen at its narrower position i.
+; Proven here as gen3[token i] == gen2[token i].
+;
+; This lives at the reusable decoder-engine altitude (like tb-attn-seq-causal, kv-generate, lblk-generate-
+; causal before it): any causal GQA block generates through the same cache; this instance is the real llama3
+; block (RMSNorm + llama3 RoPE + GQA + SwiGLU). Position = absolute token index. fp64 lane; the GPU emit
+; (cached GQA attention as a key-prefix in the threadgroup walk, mirroring jte-gqa-llama-block-fwd-causal-msl
+; #3590) is the named follow-up. Proven four-way against lgqa-block-causal (#3590) by tests/kv-gqa-llama-block-band.fk.
+; teaching: lc-cognitive-sovereignty
+
+; --- single-query GQA attend over the grown cache: query head h reads KV head (div h grp) over the cache's
+;     kvh-slice. q is the new token's full n_q*HD-wide query; gks/gvs hold the narrower n_kv*HD-wide cached
+;     keys/values for positions 0..p. tb-attend-one over the whole prefix is the causal mask at the last
+;     query of that prefix — so this mirrors tb-gqa-attn-causal at a single position, head by head. ---
+(defn gqa-attend-one-head (q gks gvs h kvh HD scale)
+  (tb-attend-one (tb-vslice q (mul h HD) HD)
+                 (tb-seq-headslice gks kvh HD)
+                 (tb-seq-headslice gvs kvh HD) scale))
+; heads h..n_q-1 of the single new token, concatenated toward d_model (head h reads kv head (div h grp)).
+(defn gqa-attend-one-loop (q gks gvs h n_q grp HD scale)
+  (if (eq h (sub n_q 1))
+      (gqa-attend-one-head q gks gvs h (div h grp) HD scale)
+      (tb-cat (gqa-attend-one-head q gks gvs h (div h grp) HD scale)
+              (gqa-attend-one-loop q gks gvs (add h 1) n_q grp HD scale))))
+; GQA attend for one query vector over the cache: group=1 (n_kv=n_q) reduces to tb-attend-one over one head.
+(defn tb-gqa-attend-one (q gks gvs n_q n_kv HD scale)
+  (gqa-attend-one-loop q gks gvs 0 n_q (div n_q n_kv) HD scale))
+
+; --- the block TAIL, per token: h = x + Wo·a ; y = h + Wdown·SwiGLU(Wgate·RMSNorm2(h), Wup·RMSNorm2(h)).
+;     Identical to kv-llama-block.fk's lblk-dec-tail — taken one token at a time. ---
+(defn lgqa-dec-tail (h g2 eps wg wu wd)
+  (tb-vec-add h (lblk-ffn wg wu wd (ln-rmsnorm h g2 eps))))
+(defn lgqa-dec-out (x q gks gvs scale wo n_q n_kv HD g2 eps wg wu wd)
+  (lgqa-dec-tail (tb-vec-add x (tb-matvec wo (tb-gqa-attend-one q gks gvs n_q n_kv HD scale))) g2 eps wg wu wd))
+
+; --- one decode step over an already-grown cache (gks/gvs hold positions 0..p): emit this token's block
+;     output, then thread the grown cache forward as the next step's prior cache. ---
+(defn lgqa-dec-grow (x q gks gvs xs p g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd)
+  (cons (lgqa-dec-out x q gks gvs scale wo n_q n_kv HD g2 eps wg wu wd)
+        (lgqa-dec-run xs p gks gvs g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd)))
+
+; --- per token: RMSNorm1 once (n1), then project+RoPE q (n_q*HD wide) / k (narrower n_kv*HD wide), project v
+;     (n_kv*HD wide), APPEND k/v to the cache, and hand the grown cache to lgqa-dec-grow. Position p is the
+;     token's absolute index; rope-scaled walks pairwise with (mod i HD) so the rotation resets per head. ---
+(defn lgqa-dec-n1 (x n1 xs p cks cvs g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd)
+  (lgqa-dec-grow x (rope-scaled (tb-matvec wq n1) p HD c)
+                 (kv-append cks (rope-scaled (tb-matvec wk n1) p HD c))
+                 (kv-append cvs (tb-matvec wv n1))
+                 xs (add p 1) g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd))
+
+; --- the autoregressive walk: front to back, threading the growing cache (cks/cvs = positions 0..p-1) ---
+(defn lgqa-dec-run (xs p cks cvs g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd)
+  (if (eq (len xs) 0) (empty)
+      (lgqa-dec-n1 (head xs) (ln-rmsnorm (head xs) g1 eps) (tail xs) p cks cvs
+                   g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd)))
+
+; --- generate the whole output sequence incrementally from an empty cache. Equals
+;     (lgqa-block-causal xs ...) bit-for-bit — the equivalence the band proves. ---
+(defn lgqa-generate-causal (xs g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd)
+  (lgqa-dec-run xs 0 (empty) (empty) g1 eps wq wk wv wo scale n_q n_kv HD c g2 wg wu wd))

--- a/form/form-stdlib/tests/kv-gqa-llama-block-band.fk
+++ b/form/form-stdlib/tests/kv-gqa-llama-block-band.fk
@@ -1,0 +1,86 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk form-stdlib/kv-cache.fk form-stdlib/kv-llama-block.fk form-stdlib/kv-gqa-llama-block.fk
+;
+; kv-gqa-llama-block-band — the KV-cached causal GQA llama decoder block (lgqa-generate-causal) lifted to
+; the four-kernel floor: the inner step of the autoregressive generation loop for the REAL llama3.2 (n_q
+; query heads sharing n_kv < n_q KV heads). Each token is RMSNorm'd, q/k/v projected, q/k RoPE'd by position
+; (llama3 theta-500000 scaling), the SMALLER n_kv*HD-wide k/v APPENDED to the cache, the query attends
+; head-by-head over the grown prefix (query head h reads KV head h/group), then the Wo/residual/RMSNorm2/
+; SwiGLU/residual tail runs — only the NEW token projected each step.
+;
+; The proof is that the cache is EXACT — lgqa-generate-causal is BIT-IDENTICAL to the full causal GQA llama
+; block (lgqa-block-causal, four-way 15 #3590) — because a cached k_i/v_i depends only on position i, never
+; the future, so the grown cache at step p equals exactly the prefix the causal GQA mask cuts. The proof is
+; the RELATIONSHIPS, grounded against ALREADY-four-way recipes and published libm pins — no new reference:
+;
+;   the cache reproduces causal-attention-band / kv-llama-block-band's libm-pinned base-10000 values —
+;     token-0 [0][0]=1893731 (mask-restricted; at pos 0 RoPE is identity so cfg theta is irrelevant) and
+;     last-token [1][0]=-1069281 — with NO recompute of earlier tokens' attention.
+;   the EQUIVALENCE LAW (the heart): lgqa-generate-causal == lgqa-block-causal element-for-element, at S=2
+;     AND S=3, for BOTH the single-head (cfg10) case AND the REAL GQA sharing (n_q=2, n_kv=1, HD=2) under
+;     the llama3 theta-500000 cfg — the S=3 fixture proves the recursion threads the cache past the boundary
+;     (the inductive step), grounded by equivalence to the already-four-way lgqa-block-causal.
+;   the autoregressive INVARIANT (why a KV cache is reusable across steps): appending a future token never
+;     changes an earlier token's GQA output — gen3_shr[token 0] == gen2_shr[token 0].
+;   the GENERALIZATION: group=1 (n_kv=n_q, HD=4, cfg base 10000) IS the proven MHA KV decode
+;     lblk-generate-causal (kv-llama-block.fk) bit-for-bit — MHA is the GQA special case, not a parallel path.
+;
+; Fixture: the llama-gqa-block-causal-band fixture (S=2, d=4; the same 4x4 weights re-read as 2 heads of
+; width 2 for GQA sharing). With n_kv=1,HD=2 the k/v project to full width 4 but GQA headslices the first 2 —
+; the cache stores the full RoPE'd projection and headslices identically, so cached == recompute exactly.
+;
+; Verdict 255 when the KV-cached causal GQA llama block lands four-way:
+;   1     gen2[0][0] → 1893731   (single-head cfg10: cache reproduces causal token 0, libm-pinned)
+;   2     gen2[1][0] → -1069281  (single-head cfg10: cache reproduces causal last token — no recompute)
+;   4     gen2 == yc2  (S=2, single-head cfg10: cached decode EXACTLY equals the full causal block)
+;   8     gen3 == yc3  (S=3, single-head: the cache threads correctly past the boundary — inductive step)
+;   16    gen2_shr == yc2_shr  (REAL GQA sharing n_q=2 n_kv=1 HD=2 + llama3 theta: cached == recompute — heart)
+;   32    gen3_shr == yc3_shr  (S=3, GQA sharing: the inductive step under grouping + theta-500000)
+;   64    gen3_shr[0] == gen2_shr[0]  (the AR invariant: token 0 unchanged by appending future, under GQA)
+;   128   lgqa-generate-causal(n_q=1 n_kv=1 HD=4 cfg10) == lblk-generate-causal  (MHA is the group=1 case)
+(do
+    ; --- element-wise float vector equality (for the AR-invariant token-vector claim) ---
+    (defn kg-veq (a b)
+      (if (eq (len a) 0) 1
+          (if (eq (head a) (head b)) (kg-veq (tail a) (tail b)) 0)))
+
+    ; --- the llama-gqa-block-causal-band fixture (S=2 tokens, d=4) ---
+    (let x  (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75)))
+    (let g1 (list 0.9 1.1 1.0 0.95))   (let g2 (list 1.05 0.95 1.0 0.9))
+    (let wq (list (list 0.5 -0.25 0.1 0.3) (list 0.2 0.4 -0.3 0.1) (list -0.1 0.2 0.5 -0.2) (list 0.3 0.0 -0.15 0.25)))
+    (let wk (list (list 0.2 0.4 -0.3 0.1) (list 0.3 -0.2 0.25 0.5) (list 0.1 0.15 -0.05 0.2) (list -0.25 0.3 0.4 -0.1)))
+    (let wv (list (list 0.3 -0.2 0.25 0.5) (list 0.6 0.1 -0.2 0.4) (list 0.05 -0.1 0.3 0.2) (list 0.15 0.35 -0.25 0.1)))
+    (let wo (list (list 0.6 0.1 -0.2 0.4) (list -0.2 0.4 0.3 0.1) (list 0.25 -0.15 0.5 0.05) (list 0.1 0.2 -0.3 0.45)))
+    (let wg (list (list 0.5 -0.3 0.2 0.1) (list 0.2 0.7 -0.4 0.3) (list -0.1 0.25 0.4 -0.2) (list 0.3 0.1 -0.15 0.5)))
+    (let wu (list (list 0.25 -0.15 0.3 0.05) (list 0.1 0.4 -0.2 0.15) (list 0.35 0.2 -0.1 0.25) (list -0.2 0.3 0.15 0.4)))
+    (let wd (list (list 0.4 -0.2 0.3 0.1) (list 0.15 0.5 -0.25 0.2) (list -0.3 0.1 0.45 -0.15) (list 0.2 -0.1 0.35 0.3)))
+    (let eps 0.00001)
+    (let cfg10 (rope-cfg 10000.0 32.0 1.0 4.0 8192.0))
+    (let cfgl3 (rope-cfg-llama3))
+    (let x3 (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75) (list 0.5 1.0 -0.5 0.25)))
+
+    ; --- single-head cfg10 (n_q=1, n_kv=1, HD=4): reproduces the published base-10000 causal pins ---
+    (let sc4 (div 1.0 (tn-sqrt 4.0)))
+    (let gen2 (lgqa-generate-causal x  g1 eps wq wk wv wo sc4 1 1 4 cfg10 g2 wg wu wd))
+    (let yc2  (lgqa-block-causal    x  g1 eps wq wk wv wo sc4 1 1 4 cfg10 g2 wg wu wd))
+    (let gen3 (lgqa-generate-causal x3 g1 eps wq wk wv wo sc4 1 1 4 cfg10 g2 wg wu wd))
+    (let yc3  (lgqa-block-causal    x3 g1 eps wq wk wv wo sc4 1 1 4 cfg10 g2 wg wu wd))
+    (let c0 (if (eq (round (mul (nth (nth gen2 0) 0) 1000000.0)) 1893731) 1 0))
+    (let c1 (if (eq (round (mul (nth (nth gen2 1) 0) 1000000.0)) -1069281) 2 0))
+    (let c2 (if (eq (kv-lol-eq gen2 yc2) 1) 4 0))
+    (let c3 (if (eq (kv-lol-eq gen3 yc3) 1) 8 0))
+
+    ; --- the REAL GQA sharing (n_q=2, n_kv=1, HD=2) under the llama3 theta-500000 cfg ---
+    (let sc2 (div 1.0 (tn-sqrt 2.0)))
+    (let g2s (lgqa-generate-causal x  g1 eps wq wk wv wo sc2 2 1 2 cfgl3 g2 wg wu wd))
+    (let y2s (lgqa-block-causal    x  g1 eps wq wk wv wo sc2 2 1 2 cfgl3 g2 wg wu wd))
+    (let g3s (lgqa-generate-causal x3 g1 eps wq wk wv wo sc2 2 1 2 cfgl3 g2 wg wu wd))
+    (let y3s (lgqa-block-causal    x3 g1 eps wq wk wv wo sc2 2 1 2 cfgl3 g2 wg wu wd))
+    (let c4 (if (eq (kv-lol-eq g2s y2s) 1) 16 0))
+    (let c5 (if (eq (kv-lol-eq g3s y3s) 1) 32 0))
+    (let c6 (if (eq (kg-veq (nth g3s 0) (nth g2s 0)) 1) 64 0))
+
+    ; --- generalization: group=1 cfg10 == the proven MHA KV decode (kv-llama-block.fk), bit-for-bit ---
+    (let mha (lblk-generate-causal x g1 eps wq wk wv wo sc4 4 g2 wg wu wd))
+    (let c7 (if (eq (kv-lol-eq gen2 mha) 1) 128 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -820,6 +820,7 @@ nanite-mem-parse fks 15
 kv-cache fks 255
 greedy-decode fks 255
 kv-llama-block fks 255
+kv-gqa-llama-block fks 255
 multi-layer-stack fks 255
 
 # ── gap-close lane (2026-06-19): bands the survey found crossing fkwu, each


### PR DESCRIPTION
The inner step of the autoregressive generation loop for the REAL llama3.2 (n_q query heads sharing n_kv < n_q KV heads), proven BIT-IDENTICAL to the full causal GQA llama block (`lgqa-block-causal`, four-way 15 [#3590]).

`kv-llama-block.fk` (#3408) proved the cache for a SINGLE-head (MHA) llama block. Real llama3.2 uses **grouped-query attention** — so the cache stores the smaller `n_kv*HD`-wide k/v per position and query head h attends KV head `h/group`. `lgqa-generate-causal` lifts the cached decode to GQA, composing gqa-attn's grouping with the cache — **no new arithmetic**. The `(n_q=n_kv=1)` case IS `lblk-generate-causal` (core-abstraction-first: MHA is the group=1 special case, not a parallel path).

**Why bit-identical:** a cached `k_i/v_i` is position-only, never the future, so the grown cache at step p equals exactly the prefix the causal GQA mask cuts at query p — `tb-gqa-attend-one` hands each head identical arguments to `tb-gqa-head-causal` at position p.

**Four-way 255, 0 divergent, fourth arm crossed (proof 23s).** 8 claims:
- single-head cfg10 reproduces the published base-10000 causal pins (1893731 / -1069281)
- cached == recompute at **S=2 AND S=3** for both single-head AND the **real GQA sharing** (n_q=2, n_kv=1, HD=2) under the **llama3 theta-500000** cfg
- the autoregressive invariant (token 0 unchanged by appending future tokens, under GQA)
- group=1 == the proven MHA KV decode `lblk-generate-causal` bit-for-bit

Named next: emit this cached GQA decode step to Metal (mirroring jte-gqa-llama-block-fwd-causal-msl #3590) and run on the M4 GPU with an fp32 CPU-mirror bit-exact gate; multi-layer GQA decode stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)