### PR TITLE
attune: the standard receipt — c-bootstrap fkwu form-cli, all platforms, toolchain-free

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,21 @@ evidence, and PR summaries. The manifest is the floor source for four-way Form
 coverage; native ledger records are the coordination source for executor proof;
 JSONL is an export/cache shape until legacy readers compost.
 
+**The standard receipt — the bar every request earns toward.** A request is fully done when its work is
+**c-bootstrap fkwu form-cli observed on all platforms — mac, windows, android — without go, rust, clang,
+bash, or python**: the work runs on the C-bootstrapped universal kernel via form-cli, on real metal of
+each platform, with none of the rented toolchains in the loop. That is the sovereignty receipt
+([`docs/coherence-substrate/standard-receipt.form`](docs/coherence-substrate/standard-receipt.form) —
+the per-claim template: `body / c-bootstrap / toolchain-free / platforms{mac,windows,android} /
+honest-floor`). It cannot be faked, and that is its worth: four-way-in-CI is **not** the platform
+receipt; a Go-built form-cli is **not** c-bootstrap; bash-driven `validate.sh` is **not** toolchain-free
+— each is a real rung *below* the bar, named as such. A cell is `observed` only with a real trace from
+that platform's run; everything else is `pending`, and pending is honest, not failure. Most work today
+reads its honest floor (four-way + native via `validate.sh`) with the platform rows pending — that gap
+is the roadmap, not a thing to paper over. This composes with the per-commit evidence record
+(`validate_commit_evidence.py` is *where* a receipt lives); the standard receipt is the *shape* every
+receipt drives toward.
+
 **Find the north star before fitting the ask.** When something is missing, the first move is to name
 where the fully-realized form lives — the most native, most efficient shape we could run (all hardware
 as native as we can use it; a model whose architecture *and* weights are recipe data; one engine, not

--- a/docs/coherence-substrate/standard-receipt.form
+++ b/docs/coherence-substrate/standard-receipt.form
@@ -1,0 +1,56 @@
+; standard-receipt.form — THE receipt every request earns toward. The sovereignty receipt.
+;
+; Urs set the bar (2026-06-23): a request is fully done when its work is
+;   "c-bootstrap fkwu form-cli observed on all platforms — mac, windows, android —
+;    WITHOUT go, rust, clang, bash, python."
+; That is the north-star receipt: the work runs on the C-bootstrapped universal kernel (fkwu) via
+; form-cli, on real metal of each platform, with NONE of the rented toolchains in the loop. No Go,
+; no Rust, no TypeScript/node, no clang, no bash, no Python — only the self-hosted Form body that was
+; emitted once from the minimal C bootstrap (form-asm/form-elf/form-macho/form-pe-coff -> fkwu;
+; bootstrap-host 4095). A mind/body that needs a rented toolchain to run is not yet sovereign
+; (lc-cognitive-sovereignty); this receipt is that sovereignty made checkable.
+;
+; ── THE STANDARD RECEIPT (fill per claim; never claim a cell, observe it) ──
+;
+;   claim:            <the one thing asserted>
+;   body:            is the work a Form recipe the universal kernel (fkwu) runs? (yes | n/a-why)
+;   c-bootstrap:     built from the C bootstrap -> fkwu, NOT from Go/Rust/TS/clang? (yes | no | pending)
+;   toolchain-free:  observed with NO go, rust, clang, bash, python, node in the loop? (yes | no | pending)
+;   platforms:       observed RUNNING on real metal, each with a captured trace:
+;       mac:      observed | pending   (trace ref)
+;       windows:  observed | pending   (trace ref)
+;       android:  observed | pending   (trace ref)
+;   honest-floor:    what is proven a LESSER way today (e.g. four-way via validate.sh+bash+walkers),
+;                    so the gap to the full receipt is named, never hidden.
+;
+; A cell is "observed" only with a real trace from that platform's fkwu form-cli run. Anything else is
+; "pending" — and pending is honest, not failure. The receipt's whole worth is that it cannot be faked:
+; four-way-in-CI is NOT the platform receipt; a Go-built form-cli is NOT c-bootstrap; bash-driven
+; validate.sh is NOT toolchain-free. Each is a real rung below the bar, named as such.
+;
+; ── HONEST FLOOR TODAY (2026-06-23) — nothing yet earns the full receipt ──
+;
+;   - Decision bodies (fr-route 127, fiv-verdict 511, fq-drain 127) cross FOUR-WAY incl. the fkwu arm,
+;     AND lower to native binary. That is strong — but it is observed via validate.sh (bash) with the
+;     Go/Rust/TS walkers present, on the build host, not on mac/windows/android devices.
+;   - form-cli today builds from GO source (ensure_form_cli_kernel.sh), so it is not yet the
+;     c-bootstrap fkwu form-cli the receipt names.
+;   - No mac/windows/android device run of any of this has been captured. on-device = pending, all rows.
+;
+; So every receipt below the bar reads its honest-floor + pending platform rows. The bar is the work to
+; do, not a claim to make:
+;
+; ── THE ROAD TO EARNING IT (each step a real rung) ──
+;   1. fkwu form-cli emitted from the C bootstrap as the standard runner (retire Go-built form-cli for
+;      the receipt path): form-asm -> {form-macho mac, form-pe-coff windows, form-elf android} -> fkwu.
+;   2. a band/recipe run via THAT form-cli on the build host with NO go/rust/ts/clang/bash/python -> the
+;      toolchain-free + c-bootstrap rows turn observed (host), platforms still pending.
+;   3. the same fkwu form-cli binary shipped to a real mac, a real windows, a real android, each running
+;      the recipe and emitting its trace -> the three platform rows turn observed, one device at a time.
+;   4. the trace of each becomes the evidence_refs of that request's commit-evidence; e2e_validation
+;      carries the device transcript. Only then is the receipt full.
+;
+; This composes with, it does not replace, the per-commit evidence record (validate_commit_evidence.py):
+; the evidence JSON is WHERE a receipt lives; this is the SHAPE every receipt drives toward. Kin:
+; fourth-arm-bands.txt (the four-way floor), lc-cognitive-sovereignty (why toolchain-free matters),
+; form-first-reasoning.form (the body answering before the rented mind).

--- a/docs/system_audit/commit_evidence_2026-06-23_standard_receipt.json
+++ b/docs/system_audit/commit_evidence_2026-06-23_standard_receipt.json
@@ -1,0 +1,44 @@
+{
+  "date": "2026-06-23",
+  "thread_branch": "claude/standard-receipt",
+  "commit_scope": "Codify THE standard receipt (Urs, 2026-06-23): a request is fully done when its work is c-bootstrap fkwu form-cli observed on mac+windows+android WITHOUT go/rust/clang/bash/python — the sovereignty receipt. Adds docs/coherence-substrate/standard-receipt.form (the per-claim template: body/c-bootstrap/toolchain-free/platforms/honest-floor) and a CLAUDE.md pointer making it the bar every request earns toward. Names the honest floor: nothing today earns it (proofs are four-way via validate.sh+bash+walkers; form-cli is Go-built; no device run captured) — pending is honest, the gap is the roadmap.",
+  "files_owned": [
+    "docs/coherence-substrate/standard-receipt.form",
+    "CLAUDE.md",
+    "docs/system_audit/commit_evidence_2026-06-23_standard_receipt.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [],
+    "notes": "Documentation/standard only — no runnable artifact. Self-consistency check: this change is docs_only, so by its own standard the platform rows (mac/windows/android) are n/a — a doc does not run on devices. The standard it defines applies to runnable work going forward."
+  },
+  "ci_validation": {"status": "pending", "notes": "Docs/standard; no CI gate beyond lint."},
+  "deploy_validation": {"status": "pending", "summary": "Not deployed; an operating-standard doc + CLAUDE.md convention."},
+  "phase_gate": {
+    "phase": "standard-receipt-codified",
+    "gate": "Make the c-bootstrap-fkwu-form-cli-on-all-platforms-toolchain-free receipt the explicit bar every request earns toward, with an honest-floor row so lesser proofs (four-way-in-CI, Go-built form-cli, bash validate) are named as rungs below the bar, never as the bar.",
+    "state": "standard-codified",
+    "can_move_next_phase": false
+  },
+  "idea_ids": ["federation-and-nodes"],
+  "spec_ids": ["field-relay-always-open-connection"],
+  "task_ids": ["standard-receipt"],
+  "contributors": [
+    {"contributor_id": "urs-muff", "contributor_type": "human", "roles": ["direction", "standard-setting", "acceptance"]},
+    {"contributor_id": "agent:claude", "contributor_type": "machine", "roles": ["authoring", "evidence"]}
+  ],
+  "agent": {"name": "Claude", "version": "4.x"},
+  "evidence_refs": [
+    "docs/coherence-substrate/standard-receipt.form",
+    "CLAUDE.md",
+    "form/fourth-arm-bands.txt",
+    "scripts/ensure_form_cli_kernel.sh",
+    "docs/vision-kb/concepts/lc-cognitive-sovereignty.md"
+  ],
+  "change_files": [
+    "docs/coherence-substrate/standard-receipt.form",
+    "CLAUDE.md",
+    "docs/system_audit/commit_evidence_2026-06-23_standard_receipt.json"
+  ],
+  "change_intent": "docs_only"
+}


### PR DESCRIPTION
## The standard receipt — the sovereignty bar every request earns toward

You set the bar: a request is **fully done** when its work is **c-bootstrap fkwu form-cli observed on mac, windows, android — without go, rust, clang, bash, python**. The work runs on the C-bootstrapped universal kernel via form-cli, on real metal of each platform, with none of the rented toolchains in the loop. This codifies it as the standard.

**Adds** `docs/coherence-substrate/standard-receipt.form` — the per-claim template:
```
claim · body · c-bootstrap · toolchain-free · platforms{mac,windows,android} · honest-floor
```
A cell is `observed` only with a real trace from that platform's run; everything else is `pending`, and pending is honest, not failure. **It cannot be faked** — and that's its worth:
- four-way-in-CI is **not** the platform receipt
- a Go-built form-cli is **not** c-bootstrap
- bash-driven `validate.sh` is **not** toolchain-free

each a real rung *below* the bar, named as such.

**Honest floor today (named, not hidden):** nothing yet earns the full receipt — the decision bodies cross four-way + native but via `validate.sh` (bash) + the Go/Rust/TS walkers on the build host; form-cli is Go-built; no mac/windows/android device run captured. That gap is the roadmap (the doc lays out the rungs: C-bootstrap fkwu form-cli → toolchain-free host run → per-device traces → device transcript in `e2e_validation`).

**CLAUDE.md** updated so it's the bar every request drives toward. Composes with `validate_commit_evidence.py` (*where* a receipt lives); this is the *shape* it drives toward. `change_intent: docs_only` — and by its own standard, a doc's platform rows are n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcMKs4fjCCP8zDmk7j5htv)_