### PR TITLE
receipt: fkwu binary runs fiv-verdict standalone (511) — first observed row of the standard receipt

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-23_fkwu_standalone_receipt.json
+++ b/docs/system_audit/commit_evidence_2026-06-23_fkwu_standalone_receipt.json
@@ -1,0 +1,40 @@
+{
+  "date": "2026-06-23",
+  "thread_branch": "claude/fkwu-standalone-receipt",
+  "commit_scope": "First standard-receipt row flipped pending->observed: the fiv-verdict recipe (field-identity, 511) executed on the fkwu universal-kernel BINARY directly (./fkwu <table> 0 -> 511), no go/rust/ts/python/clang in the run loop, no validate.sh orchestration; the ELF links only libc.so.6 + ld-linux. Records the observation per docs/coherence-substrate/standard-receipt.form, honestly scoped: BODY + toolchain-free-RUNTIME observed on linux/elf (Android's arch+object family); c-bootstrap pending (binary clang-bootstrapped, table Go-flattened); mac/windows/android-device pending (no devices/network in this sandbox).",
+  "files_owned": ["docs/system_audit/commit_evidence_2026-06-23_fkwu_standalone_receipt.json"],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/field-identity.fk form-stdlib/tests/field-identity-band.fk",
+      "FKWU=form/form-stdlib/.cache/fourth/fkwu-* ; ./$FKWU <field-identity-table> 0"
+    ],
+    "fourth_arm": "field-identity four-way (Go/Rust/TS/fkwu) verdict 511, 0 divergent.",
+    "native_binary": "validate.sh --binary 511; AND the fkwu ELF run directly on the pre-flattened table -> 511.",
+    "notes": "ldd of the fkwu binary: linux-vdso, libc.so.6, ld-linux only -- no toolchain runtime. The RUN of the recipe is toolchain-free; the BUILD of the binary used clang (emit C -> clang) and the table used the Go flattener, so this is the runtime rung, not yet the c-bootstrap clang-free form-asm lane."
+  },
+  "ci_validation": {"status": "pending", "notes": "Observation record; the four-way gate runs in CI on the underlying band."},
+  "deploy_validation": {"status": "pending", "summary": "No deploy; a runtime-observation receipt."},
+  "phase_gate": {
+    "phase": "standard-receipt-first-observed-row",
+    "gate": "Earn, in this sandbox, the rungs of the standard receipt that are actually earnable: BODY (fkwu runs the recipe) + toolchain-free RUNTIME on linux/elf, directly observed. The clang-free c-bootstrap form-asm lane and real mac/windows/android device runs remain pending (need the form-asm runnable form-cli + devices + network, none available here).",
+    "state": "runtime-rung-observed-linux-elf",
+    "can_move_next_phase": false
+  },
+  "idea_ids": ["federation-and-nodes"],
+  "spec_ids": ["field-identity-verdict"],
+  "task_ids": ["fkwu-standalone-receipt"],
+  "contributors": [
+    {"contributor_id": "urs-muff", "contributor_type": "human", "roles": ["direction", "standard-setting", "acceptance"]},
+    {"contributor_id": "agent:claude", "contributor_type": "machine", "roles": ["observation", "evidence"]}
+  ],
+  "agent": {"name": "Claude", "version": "4.x"},
+  "evidence_refs": [
+    "docs/coherence-substrate/standard-receipt.form",
+    "form/form-stdlib/field-identity.fk",
+    "form/form-stdlib/tests/field-identity-band.fk",
+    "form/scripts/fourth-arm.sh"
+  ],
+  "change_files": ["docs/system_audit/commit_evidence_2026-06-23_fkwu_standalone_receipt.json"],
+  "change_intent": "docs_only"
+}


### PR DESCRIPTION
## First standard-receipt row flipped: pending → observed

"Continue until you have receipts" — I earned the rung this sandbox can actually earn, and recorded it per `standard-receipt.form`.

**Observed, directly, just now:**
```
fkwu ELF (71 KB) — ldd: linux-vdso, libc.so.6, ld-linux ONLY
./fkwu  t-field-identity.txt  0   →   511
```
The `fiv-verdict` recipe ran on the **fkwu universal-kernel binary alone** — no Go/Rust/TS/Python/clang in the run loop, no `validate.sh` bash orchestration. The process links nothing but the C library.

**Standard receipt, honest rows:**
| row | status |
|---|---|
| body (fkwu runs it) | ✅ observed — 511, directly |
| toolchain-free **runtime** | ✅ observed on linux/elf |
| android | ◑ near — linux/elf is Android's arch+object family (`form-elf`); not yet a device |
| c-bootstrap (clang-free form-asm) | ⬜ pending — binary clang-bootstrapped, table Go-flattened (the *build* used the toolchain; the *run* didn't) |
| mac / windows | ⬜ pending — no device/network in this sandbox |

So: I have a receipt — a real, directly-observed one — for the rung that's reachable here. The full sovereignty receipt (clang-free c-bootstrap form-asm form-cli, on real Mac/Windows/Android) needs the unbuilt form-asm runnable lane + actual devices, which this environment cannot provide. Recorded as a receipt, not a claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XcMKs4fjCCP8zDmk7j5htv)_