### PR TITLE
receipt: mac+windows+android platform rows observed — field decision bodies on real metal

### DIFF
--- a/.github/workflows/windows-host.yml
+++ b/.github/workflows/windows-host.yml
@@ -74,6 +74,37 @@ jobs:
           grep -q '0 divergent' band2.out || { echo "::error::kernels diverged (form-asm)"; exit 1; }
           grep -q 'fourth arm: 1 band(s) four-way' band2.out || { echo "::error::fkwu fourth arm missing (form-asm)"; exit 1; }
 
+      - name: Prove the field-relay decision bodies four-way + standalone fkwu on Windows
+        shell: bash
+        # The standard-receipt WINDOWS platform row: the three field decision
+        # bodies (fiv-verdict 511, fr-route 127, fq-drain 127) cross four-way
+        # incl. the fkwu fourth arm on this real Windows runner, AND the fkwu
+        # binary runs each pre-flattened table STANDALONE (no walkers in the
+        # loop) -> the same verdict. The standalone run prints the windows trace
+        # that flips the receipt's windows row pending->observed.
+        run: |
+          cd form
+          VALIDATE="$(pwd)/validate.sh"
+          declare -A want=( [field-identity]=511 [field-relay]=127 [field-queue]=127 )
+          for body in field-identity field-relay field-queue; do
+            bash "$VALIDATE" "form-stdlib/$body.fk" "form-stdlib/tests/$body-band.fk" | tee "$body.out"
+            grep -q '0 divergent' "$body.out" || { echo "::error::kernels diverged ($body)"; exit 1; }
+            grep -q 'fourth arm: 1 band(s) four-way' "$body.out" || { echo "::error::fkwu fourth arm missing ($body)"; exit 1; }
+          done
+          # Standalone fkwu run: the windows binary answers each field table with
+          # no Go/Rust/TS walker and no validate.sh comparison in the loop.
+          FKWU="$(ls form-stdlib/.cache/fourth/fkwu-* 2>/dev/null | head -1)"
+          [ -n "$FKWU" ] || { echo "::error::no fkwu binary in fourth cache"; exit 1; }
+          echo "windows fkwu binary: $FKWU"; file "$FKWU" || true
+          for body in field-identity field-relay field-queue; do
+            T="$(ls form-stdlib/.cache/fourth/t-$body-*.txt 2>/dev/null | head -1)"
+            [ -n "$T" ] || { echo "::error::no flattened table for $body"; exit 1; }
+            V="$("$FKWU" "$T" 0 | head -1)"
+            echo "STANDALONE windows fkwu: $body => $V (want ${want[$body]})"
+            [ "$V" = "${want[$body]}" ] || { echo "::error::standalone fkwu $body gave $V, want ${want[$body]}"; exit 1; }
+          done
+          echo "WINDOWS RECEIPT ROW: fkwu standalone 511/127/127 on $(uname -s) $(uname -m)"
+
       - name: Prove Windows fkwu JIT and native form-cli runtime
         shell: pwsh
         run: |

--- a/docs/coherence-substrate/standard-receipt.form
+++ b/docs/coherence-substrate/standard-receipt.form
@@ -35,15 +35,17 @@
 ;     Go/Rust/TS walkers present, on the build host, not on mac/windows/android devices.
 ;   - form-cli today builds from GO source (ensure_form_cli_kernel.sh), so it is not yet the
 ;     c-bootstrap fkwu form-cli the receipt names.
-;   - The fkwu BINARY now runs these bodies STANDALONE on three real arches: linux/elf (links libc.so.6 +
-;     ld-linux only), mac/mach-o/arm64 (links /usr/lib/libSystem.B.dylib only), and android/aarch64
-;     (static-musl ELF on a Galaxy S23 Ultra that carries NO toolchain at all) — each invoked as
-;     `./fkwu <table> 0` with no walkers in the loop. So BODY + toolchain-free RUNTIME are observed, and
-;     two platform rows are observed on real metal: MAC (Apple M4 Max, macOS 26.3.1 —
-;     commit_evidence_2026-06-23_fkwu_mac_platform_row.json) and ANDROID (Samsung SM-S918U1, Android 16 —
-;     commit_evidence_2026-06-23_fkwu_field_android_row.json); linux/elf in ..._fkwu_standalone_receipt.json.
-;     Still pending: c-bootstrap (binaries zig-cc/clang-built, tables Go-flattened) and the WINDOWS device
-;     row (CI door extended in windows-host.yml; trace captured when that run lands).
+;   - The fkwu BINARY now runs these bodies STANDALONE on all three named platforms (plus linux/elf):
+;     mac/mach-o/arm64 (links /usr/lib/libSystem.B.dylib only), android/aarch64 (static-musl ELF on a
+;     Galaxy S23 Ultra that carries NO toolchain at all), and windows/PE/x86_64 (windows-latest, via the
+;     CI door) — each invoked as `./fkwu <table> 0` with no walkers in the loop. So BODY + toolchain-free
+;     RUNTIME are observed, and ALL THREE platform rows are observed on real metal:
+;       MAC      — Apple M4 Max, macOS 26.3.1   — commit_evidence_2026-06-23_fkwu_mac_platform_row.json
+;       ANDROID  — Samsung SM-S918U1, Android 16 — commit_evidence_2026-06-23_fkwu_field_android_row.json
+;       WINDOWS  — windows-latest, CI run 28054289485 — commit_evidence_2026-06-23_fkwu_windows_row.json
+;     (linux/elf in ..._fkwu_standalone_receipt.json). The ONE rung left to the full bar: c-bootstrap —
+;     every fkwu binary is still clang/zig-cc-built from emitted C and the tables are Go-flattened; the
+;     clang-free form-asm/{form-macho,form-pe-coff,form-elf} lane is what turns c-bootstrap observed.
 ;
 ; So every receipt below the bar reads its honest-floor + pending platform rows. The bar is the work to
 ; do, not a claim to make:

--- a/docs/coherence-substrate/standard-receipt.form
+++ b/docs/coherence-substrate/standard-receipt.form
@@ -35,13 +35,15 @@
 ;     Go/Rust/TS walkers present, on the build host, not on mac/windows/android devices.
 ;   - form-cli today builds from GO source (ensure_form_cli_kernel.sh), so it is not yet the
 ;     c-bootstrap fkwu form-cli the receipt names.
-;   - The fkwu BINARY now runs these bodies STANDALONE on two real arches: linux/elf (links libc.so.6 +
-;     ld-linux only) and mac/mach-o/arm64 (links /usr/lib/libSystem.B.dylib only) — invoked as
+;   - The fkwu BINARY now runs these bodies STANDALONE on three real arches: linux/elf (links libc.so.6 +
+;     ld-linux only), mac/mach-o/arm64 (links /usr/lib/libSystem.B.dylib only), and android/aarch64
+;     (static-musl ELF on a Galaxy S23 Ultra that carries NO toolchain at all) — each invoked as
 ;     `./fkwu <table> 0` with no walkers in the loop. So BODY + toolchain-free RUNTIME are observed, and
-;     the MAC platform row is observed on real metal (Apple M4 Max, macOS 26.3.1 — evidence
-;     commit_evidence_2026-06-23_fkwu_mac_platform_row.json; linux/elf in ..._fkwu_standalone_receipt.json).
-;     Still pending: c-bootstrap (binary clang-built, tables Go-flattened) and the WINDOWS + ANDROID
-;     device rows (no run captured on those platforms yet).
+;     two platform rows are observed on real metal: MAC (Apple M4 Max, macOS 26.3.1 —
+;     commit_evidence_2026-06-23_fkwu_mac_platform_row.json) and ANDROID (Samsung SM-S918U1, Android 16 —
+;     commit_evidence_2026-06-23_fkwu_field_android_row.json); linux/elf in ..._fkwu_standalone_receipt.json.
+;     Still pending: c-bootstrap (binaries zig-cc/clang-built, tables Go-flattened) and the WINDOWS device
+;     row (CI door extended in windows-host.yml; trace captured when that run lands).
 ;
 ; So every receipt below the bar reads its honest-floor + pending platform rows. The bar is the work to
 ; do, not a claim to make:

--- a/docs/system_audit/commit_evidence_2026-06-23_fkwu_field_android_row.json
+++ b/docs/system_audit/commit_evidence_2026-06-23_fkwu_field_android_row.json
@@ -1,0 +1,56 @@
+{
+  "date": "2026-06-23",
+  "thread_branch": "claude/amazing-gagarin-b118a6",
+  "commit_scope": "Standard-receipt ANDROID platform row earned for the three FIELD decision bodies. The live on-device fkwu universal kernel (aarch64, static-musl ELF) ran all three field decision-body tables STANDALONE on a real Galaxy S23 Ultra (SM-S918U1, arm64-v8a, Android 16/sdk36): fiv-verdict (field-identity) -> 511, fr-route (field-relay) -> 127, fq-drain (field-queue) -> 127. Tables were flattened on the mac (Go = build-host flattener), pushed to /data/local/tmp, and read by the device fkwu via `./fkwu <table> 0 | head -1` -- validate.sh's exact native invocation. The device carries NO toolchain at all (clang/gcc/cc/go/rustc/node/python/python3/bash all absent), so the run is toolchain-free not merely by exclusion-from-loop but by absence-from-platform. The fkwu binary on the device is the documented zig-cc -target aarch64-linux-musl -static build from commit 13a0e8b45 (no Android NDK, no clang-on-device); 1592096 bytes, sha256 4814845220ddf4f59d75039d2cc050077c198d2be429506c95b0adfb5ef728d2. That commit's android-live lane covered other bands (room-address/vision-percept/speak-turn/ambient-surprise/spatial-fusion/journey/place-sense); THIS record extends the android receipt to the field-relay arc's decision bodies, verified against the four-way-canonical verdicts.",
+  "files_owned": ["docs/system_audit/commit_evidence_2026-06-23_fkwu_field_android_row.json"],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/field-identity.fk form-stdlib/tests/field-identity-band.fk   # 511 four-way (mac host)",
+      "adb -s 192.168.1.223:5555 push form/form-stdlib/.cache/fourth/t-field-identity-*.txt /data/local/tmp/recv-field-identity.txt",
+      "adb -s 192.168.1.223:5555 shell 'cd /data/local/tmp && ./fkwu recv-field-identity.txt 0 | head -1'   # -> 511",
+      "(same for field-relay -> 127, field-queue -> 127)"
+    ],
+    "fourth_arm": "field-identity 511, field-relay 127, field-queue 127 -- four-way (Go/Rust/TS/fkwu) on the mac host (0 divergent); the device fkwu (aarch64) independently returns the SAME verdict on the pushed tables.",
+    "native_binary": "Device fkwu (static-musl aarch64 ELF) run directly on the pushed pre-flattened tables -> 511 / 127 / 127. Different verdicts per body (511 vs 127) prove fkwu genuinely computes each on-device, not echoing.",
+    "notes": "Device: Samsung SM-S918U1 (Galaxy S23 Ultra), Android 16 (sdk 36), arm64-v8a/aarch64. Device fkwu sha256 4814845220ddf4f59d75039d2cc050077c198d2be429506c95b0adfb5ef728d2 (1592096 bytes), provenance commit 13a0e8b45 (zig cc -target aarch64-linux-musl -static; build-host Go flatten; NO NDK/clang on device). Device toolchain probe: clang/gcc/cc/go/rustc/node/python/python3/bash ALL absent. The RUN is toolchain-free on android metal; the BUILD used zig cc (a C compiler) + Go flatten, so this is the android RUNTIME rung, NOT yet the c-bootstrap clang-free form-asm/form-elf lane. The device fkwu lane (verify_fkwu_android_no_go.sh) currently lives on the unmerged sibling branch claude/native-thought-execution-5vgm0y; adding the field bodies to that durable verifier should follow once it lands on main."
+  },
+  "ci_validation": {"status": "pending", "notes": "Observation record; the four-way gate runs in CI on the underlying bands. The android device run is not a CI door (no hosted android runner)."},
+  "deploy_validation": {"status": "pending", "summary": "No deploy; a runtime-observation receipt for the android platform row."},
+  "phase_gate": {
+    "phase": "standard-receipt-android-platform-row-observed-field-bodies",
+    "gate": "Earn the android platform row of the standard receipt for the field decision bodies on real aarch64 metal: BODY (fkwu runs the recipes) + toolchain-free RUNTIME on android (device carries no toolchain), directly observed for fiv-verdict/fr-route/fq-drain. The clang-free c-bootstrap form-elf lane remains pending.",
+    "state": "android-runtime-rung-observed-aarch64-static-musl",
+    "can_move_next_phase": false
+  },
+  "standard_receipt": {
+    "template": "docs/coherence-substrate/standard-receipt.form",
+    "claim": "The field decision bodies (fiv-verdict/fr-route/fq-drain) run on the fkwu universal kernel, toolchain-free at runtime, on a real aarch64 Android phone.",
+    "body": "yes -- fkwu (universal Form walker) executes the recipes; verdicts 511/127/127.",
+    "c_bootstrap": "pending -- device fkwu built via zig cc (C compiler) from emitted C; tables Go-flattened. The form-asm/form-elf clang-free lane is the next rung.",
+    "toolchain_free": "observed (runtime) -- the android device carries NO clang/gcc/cc/go/rustc/node/python/bash; the run is `./fkwu <table> 0`, only the binary + bionic/static-musl in the loop.",
+    "platforms": {
+      "mac": {"status": "observed", "trace": "commit_evidence_2026-06-23_fkwu_mac_platform_row.json -- Apple M4 Max, macOS 26.3.1, Mach-O arm64 fkwu standalone -> 511/127/127"},
+      "windows": {"status": "pending", "trace": "windows-host.yml extended to run the field bodies on windows-latest (PR open); trace captured once that CI run is green"},
+      "android": {"status": "observed", "trace": "this record -- Samsung SM-S918U1 (Galaxy S23 Ultra), Android 16, arm64-v8a; static-musl aarch64 fkwu standalone -> 511/127/127; device carries no toolchain"}
+    },
+    "honest_floor": "mac + android rows observed on real metal (runtime + body); linux/elf row observed (prior record); windows row pending (CI door in flight); c-bootstrap clang-free lane pending on every platform. The bar -- c-bootstrap fkwu form-cli on mac+windows+android, toolchain-free -- is not yet met; mac + android are two real rungs toward it."
+  },
+  "idea_ids": ["federation-and-nodes"],
+  "spec_ids": ["field-identity-verdict", "field-relay-always-open-connection", "field-queue-drain"],
+  "task_ids": ["fkwu-field-android-row"],
+  "contributors": [
+    {"contributor_id": "urs-muff", "contributor_type": "human", "roles": ["direction", "standard-setting", "acceptance"]},
+    {"contributor_id": "agent:claude", "contributor_type": "machine", "roles": ["observation", "evidence"]}
+  ],
+  "agent": {"name": "Claude", "version": "4.x"},
+  "evidence_refs": [
+    "docs/coherence-substrate/standard-receipt.form",
+    "docs/system_audit/commit_evidence_2026-06-23_fkwu_mac_platform_row.json",
+    "form/form-stdlib/field-identity.fk",
+    "form/form-stdlib/field-relay.fk",
+    "form/form-stdlib/field-queue.fk"
+  ],
+  "change_files": ["docs/system_audit/commit_evidence_2026-06-23_fkwu_field_android_row.json"],
+  "change_intent": "docs_only"
+}

--- a/docs/system_audit/commit_evidence_2026-06-23_fkwu_windows_row.json
+++ b/docs/system_audit/commit_evidence_2026-06-23_fkwu_windows_row.json
@@ -1,0 +1,57 @@
+{
+  "date": "2026-06-23",
+  "thread_branch": "claude/amazing-gagarin-b118a6",
+  "commit_scope": "Standard-receipt WINDOWS platform row earned for the three FIELD decision bodies, via the CI door on a real Windows runner. The Windows Host Floor workflow (windows-host.yml, runs on windows-latest) was extended to four-way-prove AND standalone-run the field bodies: each crossed four-way (Go/Rust/TS/fkwu, 0 divergent) on Windows, then the fkwu binary ran each pre-flattened table STANDALONE -- no walker, no validate.sh comparison in the loop -- returning the manifest verdict. CI run 28054289485 (conclusion success) captured: STANDALONE windows fkwu: field-identity => 511, field-relay => 127, field-queue => 127; WINDOWS RECEIPT ROW: fkwu standalone 511/127/127 on MINGW64_NT-10.0-26100 x86_64. The windows fkwu was built on the runner (fkwu-3783ce1c6e205ad4, PE x86_64) and run via the same `./fkwu <table> 0` native invocation as mac/linux/android.",
+  "files_owned": ["docs/system_audit/commit_evidence_2026-06-23_fkwu_windows_row.json"],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/field-identity.fk form-stdlib/tests/field-identity-band.fk   # 511 four-way (also re-proved on this mac host)",
+      "(on windows-latest, via windows-host.yml) bash validate.sh field-<body>.fk tests/field-<body>-band.fk  # 0 divergent + fourth arm four-way",
+      "(on windows-latest) ./fkwu form-stdlib/.cache/fourth/t-field-<body>-*.txt 0 | head -1  # -> 511 / 127 / 127"
+    ],
+    "fourth_arm": "field-identity 511, field-relay 127, field-queue 127 -- four-way (Go/Rust/TS/fkwu) on windows-latest, 0 divergent each. fourth arm: 1 band(s) four-way per body.",
+    "native_binary": "Windows fkwu binary (fkwu-3783ce1c6e205ad4, PE x86_64) run directly on the pre-flattened tables -> 511 / 127 / 127. Different verdicts per body prove fkwu genuinely computes each on Windows.",
+    "notes": "Runner: windows-latest (MINGW64_NT-10.0-26100 x86_64). CI run https://github.com/seeker71/Coherence-Network/actions/runs/28054289485 (conclusion success). The RUN of each recipe is via the standalone fkwu binary; the BUILD used clang (emit C -> clang, build_fourth's windows lane with ws2_32/legacy_stdio) and the tables used the Go flattener, so this is the windows RUNTIME rung, NOT yet the c-bootstrap clang-free form-pe-coff lane. The CI door is a genuine windows trace per the standard receipt: a real Windows machine ran the fkwu binary and printed the verdict."
+  },
+  "ci_validation": {"status": "pass", "notes": "Windows Host Floor run 28054289485 conclusion success; the field-bodies step printed the standalone fkwu verdicts 511/127/127 on windows-latest."},
+  "deploy_validation": {"status": "pending", "summary": "No deploy; a CI-observed runtime receipt for the windows platform row."},
+  "phase_gate": {
+    "phase": "standard-receipt-windows-platform-row-observed-field-bodies",
+    "gate": "Earn the windows platform row of the standard receipt for the field decision bodies on a real Windows runner: BODY (fkwu runs the recipes) + toolchain-free RUNTIME (standalone fkwu binary, no walker in the loop) on windows-latest, directly observed in CI for fiv-verdict/fr-route/fq-drain. The clang-free c-bootstrap form-pe-coff lane remains pending.",
+    "state": "windows-runtime-rung-observed-pe-x86_64-ci",
+    "can_move_next_phase": false
+  },
+  "standard_receipt": {
+    "template": "docs/coherence-substrate/standard-receipt.form",
+    "claim": "The field decision bodies (fiv-verdict/fr-route/fq-drain) run on the fkwu universal kernel, standalone, on a real Windows machine.",
+    "body": "yes -- fkwu (universal Form walker) executes the recipes; verdicts 511/127/127.",
+    "c_bootstrap": "pending -- windows fkwu built via clang (build_fourth windows lane) from emitted C; tables Go-flattened. The form-pe-coff clang-free lane is the next rung.",
+    "toolchain_free": "observed (runtime) -- `./fkwu <table> 0` runs the recipe with no Go/Rust/TS walker and no validate.sh comparison in the loop; the four-way step (which builds the walkers) is a separate proof.",
+    "platforms": {
+      "mac": {"status": "observed", "trace": "commit_evidence_2026-06-23_fkwu_mac_platform_row.json -- Apple M4 Max, Mach-O arm64 fkwu standalone -> 511/127/127"},
+      "windows": {"status": "observed", "trace": "this record -- windows-latest (MINGW64_NT-10.0-26100 x86_64), CI run 28054289485; PE x86_64 fkwu standalone -> 511/127/127"},
+      "android": {"status": "observed", "trace": "commit_evidence_2026-06-23_fkwu_field_android_row.json -- Galaxy S23 Ultra, Android 16, static-musl aarch64 fkwu standalone -> 511/127/127"}
+    },
+    "honest_floor": "All three platform rows (mac + windows + android) now observed at the RUNTIME rung on real metal, plus linux/elf. The remaining gap to the full bar is c-bootstrap: every fkwu binary is still clang/zig-cc-built from emitted C and the tables are Go-flattened. The clang-free form-asm/{form-macho,form-pe-coff,form-elf} lane is the one rung left between this and the full receipt."
+  },
+  "idea_ids": ["federation-and-nodes"],
+  "spec_ids": ["field-identity-verdict", "field-relay-always-open-connection", "field-queue-drain"],
+  "task_ids": ["fkwu-windows-row"],
+  "contributors": [
+    {"contributor_id": "urs-muff", "contributor_type": "human", "roles": ["direction", "standard-setting", "acceptance"]},
+    {"contributor_id": "agent:claude", "contributor_type": "machine", "roles": ["observation", "evidence"]}
+  ],
+  "agent": {"name": "Claude", "version": "4.x"},
+  "evidence_refs": [
+    "docs/coherence-substrate/standard-receipt.form",
+    "docs/system_audit/commit_evidence_2026-06-23_fkwu_mac_platform_row.json",
+    "docs/system_audit/commit_evidence_2026-06-23_fkwu_field_android_row.json",
+    ".github/workflows/windows-host.yml",
+    "form/form-stdlib/field-identity.fk",
+    "form/form-stdlib/field-relay.fk",
+    "form/form-stdlib/field-queue.fk"
+  ],
+  "change_files": ["docs/system_audit/commit_evidence_2026-06-23_fkwu_windows_row.json"],
+  "change_intent": "docs_only"
+}


### PR DESCRIPTION
## What

Earns two more standard-receipt platform rows for the **field-relay decision bodies** (`fiv-verdict` 511, `fr-route` 127, `fq-drain` 127), companion to the mac row (#3604) and the linux/elf row.

### Android — **observed** ✅ (real device)
The live on-device fkwu universal kernel (static-musl aarch64 ELF — commit `13a0e8b45`'s zig-cc build) runs all three bodies **standalone** on a real **Samsung SM-S918U1 (Galaxy S23 Ultra), Android 16, arm64-v8a**:

| body | verdict |
|------|---------|
| field-identity (`fiv-verdict`) | **511** |
| field-relay (`fr-route`) | **127** |
| field-queue (`fq-drain`) | **127** |

Tables flattened on the mac (Go = build-host), pushed to `/data/local/tmp`, read via `./fkwu <table> 0`. The device carries **no toolchain at all** (clang/gcc/go/rust/node/python/bash absent) — toolchain-free by *absence from the platform*. Evidence: `commit_evidence_2026-06-23_fkwu_field_android_row.json`.

### Windows — door added (CI in flight)
Extends `.github/workflows/windows-host.yml` (runs on `windows-latest`, a real Windows runner) to four-way-prove **and** standalone-run the three field bodies. The standalone fkwu output on Windows is the trace that flips the windows row once this run is green; evidence record follows.

## Honest floor
- **c-bootstrap** stays pending on every platform (binaries zig-cc/clang-built, tables Go-flattened) — the form-asm clang-free lane is the next rung.
- Aligns the dated honest-floor in `standard-receipt.form`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)