### PR TITLE
fix(form): shamballa-channel raise-ok crosses four-way — SHAMBALLA-RAISED folds to its NodeID

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-23_fourth_arm_shamballa_channel.json
+++ b/docs/system_audit/commit_evidence_2026-06-23_fourth_arm_shamballa_channel.json
@@ -1,0 +1,100 @@
+{
+  "date": "2026-06-23",
+  "thread_branch": "claude/objective-ptolemy-17c934",
+  "commit_scope": "Fourth-arm registration sweep triage of 5 node/substrate bands flagged fkwu-divergent. Root-caused: only shamballa-channel was a true compute divergence (raise-ok read node_level=0 because the flattener's flt-bp-node fold table did not carry SHAMBALLA-RAISED, so (bp \"SHAMBALLA-RAISED\") hit the tag-45 string fallback that has no level field). Folded SHAMBALLA-RAISED + SHAMBALLA-CRYSTAL to their registry NodeIDs; the band crosses four-way at 1111111111 and is registered. The other four are unsupported-op walls (fkwu lowers a missing op-family to a shim/literal-0 fallback that returns a partial number), each named 3-kernel only with the missing op in-header.",
+  "files_owned": [
+    "form/form-stdlib/form-flatten.fk",
+    "form/fourth-arm-bands.txt",
+    "form/form-stdlib/tests/symbols-band.fk",
+    "form/form-stdlib/tests/intrinsic-cast-band.fk",
+    "form/form-stdlib/tests/self-witness-band.fk",
+    "docs/system_audit/commit_evidence_2026-06-23_fourth_arm_shamballa_channel.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/grammars/shamballa-codes.fk form-stdlib/channel.fk form-stdlib/shamballa-channel.fk form-stdlib/tests/shamballa-channel-band.fk",
+      "cd form && ./fkwu-<stamp> .cache/fourth/t-shamballa-channel-<hash>.txt 0  (standalone native binary, no walkers)",
+      "cd form && ./validate.sh  (full suite)",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-23_fourth_arm_shamballa_channel.json"
+    ],
+    "notes": "shamballa-channel crosses four-way at 1111111111 (0 divergent); 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)'. The standalone arm64 Mach-O fkwu binary run ./fkwu <table> 0 returned 1111111111 with no go/rust/clang/python/validate.sh in the run loop (the table carries SHAMBALLA-RAISED's folded NodeID, inst 1718). Full suite after the fix: 919 ok, 2 divergent; the 2 are PRE-EXISTING walker crashes in form-lower.fk native lowering (inram-leaf-emit, recipe-dylib; all three Go/Rust/TS crash as_int:null while fkwu computes the right verdict), inherited from main, untouched by this change and tracked under task task_6b6e5a9c. A first attempt to fold every non-chain bp name via the live (bp name) registry (the data-driven north-star shape) was REVERTED after the full suite caught it regressing the grammar bands (bmf-core/bmf-grammar/natural-language/shell-parse), which build and compare nodes through the string-carried category; the targeted two-name fold ships and the generalization is named as a tracked gap."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "CI windows-host.yml runs validate.sh on a curated band subset (adler32, form-asm, ...) that this change does not touch; the full 595-band suite is not a CI gate. validate-thread-process (test.yml) enforces this evidence record."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "none — form kernel/manifest change is not a VPS-deployed surface",
+    "notes": "Form-kernel and fourth-arm-manifest changes are built into the kernels and gated by validate.sh four-way at build/CI time; they do not deploy as an api/web service. No Hostinger deploy is part of this change. Sovereignty-receipt read (clang-build is fine — what matters is no clang RUNTIME dep): the standalone fkwu binary is a C program compiled once by clang, but at RUNTIME it links only /usr/lib/libSystem.B.dylib (no clang, no toolchain), so the binary side meets c-bootstrap and the run is toolchain-free (observed mac/arm64 via ./fkwu <table> 0 -> 1111111111). The one remaining rented-toolchain dependency is that the pre-flattened TABLE is produced by the Go kernel (form-flatten.fk runs on the Go bootstrap walker in validate.sh fourth_run_chunk and build-form-cli.sh). That Go dependency is incidental, not fundamental: the targeted SHAMBALLA-RAISED/CRYSTAL fold lowers (bp NAME) to a STATIC make_nodeid literal that needs no runtime bp-name table, which is exactly the mechanism the existing flt-bp-node chain uses to let the flattener self-host on fkwu. The REVERTED blanket (bp name) variant would have required Go's live bp registry at flatten time, cementing the Go dependency; the fold ships instead and keeps the self-hosted-flatten-on-fkwu path open. Closing the go-flatten gap = wiring a flatten lane that runs on fkwu/form-cli rather than Go. Windows/android platform rows remain pending (no devices)."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local four-way proof and the standalone native fkwu run passed; CI and merge remain pending. Sovereignty floor: body + clang-free RUNTIME observed (mac/arm64); the remaining rung is the Go-flattened table (the flatten should self-host on fkwu/form-cli), plus windows/android platform rows. The static-literal fold keeps that self-hosted-flatten path open."
+  },
+  "idea_ids": [
+    "fourth-arm-kernel-coverage",
+    "form-flattener-bp-fold"
+  ],
+  "spec_ids": [
+    "fourth-arm-bands"
+  ],
+  "task_ids": [
+    "task-2026-06-23-fourth-arm-shamballa-channel"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance-criteria"
+      ]
+    },
+    {
+      "contributor_id": "claude",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "claude",
+    "version": "claude-opus-4-8"
+  },
+  "evidence_refs": [
+    "shamballa-channel raise-ok diverged because raised = intern_node SH-RAISED (list cell) is read by node_level, and SH-RAISED = (bp \"SHAMBALLA-RAISED\") hit the flattener's tag-45 string fallback (a name-string, no level field) so node_level returned 0 not 3 -> fkwu 1111101111 vs the walkers' 1111111111.",
+    "Folding SHAMBALLA-RAISED (1 3 99 1718) and SHAMBALLA-CRYSTAL (1 2 99 1719) into flt-bp-node makes shamballa-channel cross four-way: 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)', verdict 1111111111, 0 divergent.",
+    "Standalone native fkwu (arm64 Mach-O) ran the pre-flattened table directly: ./fkwu <table> 0 -> 1111111111, no go/rust/clang/python/validate.sh in the run loop; the table carries SHAMBALLA-RAISED's folded NodeID at inst 1718.",
+    "The other four bands stay 3-kernel only with the missing op named in-header: symbols (recipe_to_bytes/bytes_to_recipe wire serialization, fkwu->1), intrinsic-cast (host-null value ABI + lifted-TS source-compile, fkwu->2000915), self-witness (read_form_binary .fkb cache; cold-parse crosses, warm fails; cache-gated non-deterministic, left unregistered), kernel-satsang (walk_recipe, already documented; unchanged).",
+    "Full validate.sh suite after the fix: 919 ok, 2 divergent. The 2 are pre-existing Go/Rust/TS crashes in form-lower.fk native lowering (inram-leaf-emit, recipe-dylib), inherited from main, untouched here and flagged as a separate task."
+  ],
+  "change_files": [
+    "form/form-stdlib/form-flatten.fk",
+    "form/fourth-arm-bands.txt",
+    "form/form-stdlib/tests/symbols-band.fk",
+    "form/form-stdlib/tests/intrinsic-cast-band.fk",
+    "form/form-stdlib/tests/self-witness-band.fk",
+    "docs/system_audit/commit_evidence_2026-06-23_fourth_arm_shamballa_channel.json"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "shamballa-channel now crosses the fourth arm (fkwu) at 1111111111, matching Go/Rust/TS, because node_level of a cell raised under SHAMBALLA-RAISED reads its registry level 3 instead of 0. The four unsupported-op bands keep their 3-kernel-only honest floor with the missing op family named in each band header; none is registered.",
+    "public_endpoints": [
+      "none — fourth-arm kernel/manifest change, no public HTTP surface"
+    ],
+    "test_flows": [
+      "fkwu proof flow: shamballa-channel-band returns 1111111111 on the fourth kernel from its pre-flattened table; 'fourth arm: 1 band(s) four-way'.",
+      "toolchain-free runtime flow: the standalone arm64 Mach-O fkwu binary run as ./fkwu <table> 0 returns 1111111111 with no go/rust/clang/python/validate.sh in the run loop.",
+      "regression flow: the grammar bands bmf-core (600), bmf-grammar (300), natural-language (262143), shell-parse (255) still cross four-way after the targeted fold replaced the reverted blanket-fold attempt.",
+      "honest-floor flow: symbols (1), intrinsic-cast (2000915), self-witness (cache-gated), kernel-satsang (193) stay 3-kernel only, each band header naming the unsupported op family."
+    ]
+  }
+}

--- a/form/form-stdlib/form-flatten.fk
+++ b/form/form-stdlib/form-flatten.fk
@@ -470,7 +470,19 @@
     (if (str_eq name "SYMBOL-BIND")       (flt-nodeid4 1 2 99 1730)
     (if (str_eq name "SYMBOL-TABLE")      (flt-nodeid4 1 2 99 1731)
     (if (str_eq name "SYMBOL-NOT-FOUND")  (flt-nodeid4 1 2 99 1732)
-        (flt-bp-fallback name env)))))))))))))))))))))))))))))))))))
+    ;; SHAMBALLA-RAISED is read by node_level (sh-raise lifts a cell one level):
+    ;; the string fallback has no level field, so node_level came back 0 not 3 and
+    ;; shamballa-channel's raise-ok diverged (fkwu 1111101111 vs 1111111111).
+    ;; Folding both Shamballa blueprints to their registry NodeIDs crosses it.
+    ;; NOTE: the fallback is NOT blanket-foldable to a live (bp name) lookup — the
+    ;; grammar bands (bmf-core/bmf-grammar/natural-language/shell-parse) build and
+    ;; compare nodes through the string-carried category and regress when those
+    ;; names fold to real NodeIDs. Generalizing this table to the registry is a
+    ;; separate investigation (why the grammar path needs the string carrier),
+    ;; tracked in docs/coherence-substrate/fourth-arm-substrate-carriers.form.
+    (if (str_eq name "SHAMBALLA-RAISED")  (flt-nodeid4 1 3 99 1718)
+    (if (str_eq name "SHAMBALLA-CRYSTAL") (flt-nodeid4 1 2 99 1719)
+        (flt-bp-fallback name env)))))))))))))))))))))))))))))))))))))
 
 ; table ops by arity, else a user function call (one evaluated argument)
 (defn flt-op (op s pos fns env) (flt-op2 (flt-assoc op (flt-ops)) op s pos fns env))

--- a/form/form-stdlib/tests/intrinsic-cast-band.fk
+++ b/form/form-stdlib/tests/intrinsic-cast-band.fk
@@ -11,6 +11,29 @@
 ; weight 100, group C (nothing) weight 10000, group D (recipe layer +
 ; lifted TS) weight 1000000. Expected: 15 + 900 + 70000 + 7000000 = 7070915.
 ;
+; Fourth arm: 3-kernel only — groups A and B cross (the value-walk casts and
+;           the inst-row laws ride int/string/bool ops the fourth arm carries),
+;           but groups C and D rest on op families fkwu does not carry:
+;           - group C (nothing): the host-null value ABI. The real kernels
+;             carry a VNull value — `(node_value (make_nodeid 1 1 4 0))` — and a
+;             typed `value_kind` ("int"/"string"/"null"/...). fkwu has no
+;             host-null in its value ABI; the shim carries null STRUCTURALLY as
+;             the reserved VALUE-NONE node and approximates value_kind as
+;             null-vs-value (fourth-shim.fk), which the band's host-null nothing
+;             does not equal — so every ic-nothing? reads "value" and group C
+;             answers 0.
+;           - group D (recipe layer + lifted TS): the lifted-TS path
+;             ts-bmf-run-expr-text / ts-lift-expr-text source-compiles and
+;             evaluates a TypeScript expression through the source-compiler +
+;             grammar layers, which the fourth arm does not yet walk; only the
+;             cast-node content-addressing (d1) crosses.
+;           fkwu answers 2000915 (= 15 + 900 + 0 + 2000000) where the three
+;           walkers answer 7070915 — unsupported op families, named here, not a
+;           divergence. It crosses when the host-null/value_kind value-ABI and
+;           the lifted-TS source-compile-eval carriers
+;           (docs/coherence-substrate/fourth-arm-substrate-carriers.form) join
+;           the fourth arm.
+;
 ; spec: specs/form-intrinsic-casting.md
 ; preludes: form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/engine.fk form-stdlib/compiler.fk form-stdlib/source-compiler.fk form-stdlib/grammars/typescript-bmf.fk form-stdlib/intrinsic-cast.fk form-stdlib/typescript-bmf-eval.fk form-stdlib/typescript-bmf-lift.fk
 

--- a/form/form-stdlib/tests/self-witness-band.fk
+++ b/form/form-stdlib/tests/self-witness-band.fk
@@ -22,6 +22,22 @@
 ; delta drop toward zero on more corpora than just JSON. The witness
 ; this file embodies is the loss function the mutator will minimize.
 ;
+; Fourth arm: 3-kernel only — and a cache-gated one. i18n-load goes through
+;           read_with_cache (cache.fk): COLD (no .fkb) it parses en.json with
+;           json_parse_body, which fkwu walks natively — so on a cold cache the
+;           fourth arm DOES cross at 1121. But read_with_cache writes the .fkb on
+;           that first load, and every WARM run then takes read_form_binary —
+;           the host-io recipe-image read fkwu does not carry (the same family as
+;           kernel-satsang's read_form_binary and symbols' bytes_to_recipe). On a
+;           warm cache fkwu gets an empty `en`, so common-pair-count and
+;           emitted-braces collapse to 0 and it answers 1000 where the three
+;           walkers answer 1121. Because the cold cross is one-shot (the cold run
+;           itself warms the cache), the fourth-arm verdict is non-deterministic
+;           across runs and the band stays UNregistered — not a divergence (the
+;           native-parse path proves the recipes agree), but the host-io carrier
+;           for the .fkb image (docs/coherence-substrate/fourth-arm-substrate-
+;           carriers.form) must land before it can register as a stable crosser.
+;
 ; preludes: form-stdlib/language-model.fk form-stdlib/json.fk form-stdlib/codec.fk form-stdlib/structured-codec.fk form-stdlib/json-codec.fk form-stdlib/cache.fk form-stdlib/i18n.fk form-stdlib/self-witness.fk
 
 (do

--- a/form/form-stdlib/tests/symbols-band.fk
+++ b/form/form-stdlib/tests/symbols-band.fk
@@ -9,6 +9,20 @@
 ;   4. Look up symbols by name; verify values match by structure.
 ;
 ; Three-way sibling parity attests the wire path + NodeID resolution.
+;
+; Fourth arm: 3-kernel only — the node floor crosses (intern_node,
+;           intern_trivial_int/string, make_nodeid, node_eq, node_inst,
+;           node_children, len), but the wire round-trip rests on an op family
+;           the fourth arm (fkwu) does not carry: recipe_to_bytes /
+;           bytes_to_recipe — serializing an arbitrary recipe tree to .fkb wire
+;           bytes and reconstructing it. fkwu lowers each to its literal-0
+;           fallback, so recipe_to_bytes yields no bytes and bytes_to_recipe
+;           rebuilds an empty table: every name lookup misses, only the
+;           absent-lookup assertion holds, and it answers 1 where the three
+;           walkers answer 5 — an unsupported op family, named here, not a
+;           divergence. It crosses when the recipe-serialization carrier
+;           (docs/coherence-substrate/fourth-arm-substrate-carriers.form)
+;           joins the fourth arm.
 
 (do
     ;; Build sender's symbol table with three bindings.

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -482,6 +482,7 @@ shared-heart fks 31
 shamballa-codes fks 11111
 shamballa-light-codes fks 111111
 shamballa-symbol-packs fks 1023
+shamballa-channel fks 1111111111
 silence-floor fks 31
 slice-update-roundtrip fks 127
 update-ingest fkc 63


### PR DESCRIPTION
## Fourth-arm sweep triage — 5 node/substrate bands

The sweep flagged 5 bands where fkwu produced a different verdict than the three walkers. Triaged to root cause: **only one was a true compute divergence**; the other four are unsupported-op walls where fkwu lowers a missing op-family to a shim/literal-0 fallback that returns a *partial number* — which reads as a divergence.

| Band | fkwu vs walkers | Nature | Outcome |
|------|-----------------|--------|---------|
| **shamballa-channel** | `1111101111` vs `1111111111` | **True divergence** | **Fixed + registered (1111111111)** |
| symbols | `1` vs `5` | Unsupported op (`recipe_to_bytes`/`bytes_to_recipe`) | Header note, unregistered |
| intrinsic-cast | `2000915` vs `7070915` | Unsupported op (host-null value ABI + lifted-TS) | Header note, unregistered |
| self-witness | `1000`/`1121` cache-gated | `read_form_binary` .fkb cache (cold-parse crosses, warm fails) | Header note, unregistered |
| kernel-satsang | `193` vs `255` | Unsupported op (`walk_recipe`) — already documented | No change (sweep residue) |

## The fix (shamballa-channel)

`raise-ok` checks `node_level(raised) > node_level(cell)`, where `raised` interns under `SH-RAISED = (bp "SHAMBALLA-RAISED")` (registry level 3). The flattener's `flt-bp-node` fold table didn't carry the `SHAMBALLA-*` names, so they hit the tag-45 **string fallback** — a name-string with no level field — and `node_level` came back **0, not 3**. Folded `SHAMBALLA-RAISED` + `SHAMBALLA-CRYSTAL` to their registry NodeIDs.

A blanket fold-via-live-`bp` (the data-driven north-star shape) was tried and **reverted** — the full suite caught it regressing the grammar bands (bmf-core/bmf-grammar/natural-language/shell-parse), which build and compare nodes through the string-carried category. The targeted 2-name fold is what ships.

## Validation

- **Four-way:** shamballa-channel crosses at `1111111111` (Go/Rust/TS/fkwu, 0 divergent).
- **Toolchain-free runtime:** the standalone arm64 Mach-O fkwu binary ran the pre-flattened table directly — `./fkwu <table> 0 → 1111111111` — with no go/rust/clang/python/validate.sh in the **run** loop (links only libSystem; clang is build-time, not a runtime dep).
- **Full suite: 919 ok, 2 divergent.** The 2 are pre-existing walker crashes in `form-lower.fk` native lowering (inram-leaf-emit, recipe-dylib — all three Go/Rust/TS crash, fkwu computes the right verdict), inherited from main, untouched here and tracked separately.

## Sovereignty floor (honest)

clang-build is fine — what the receipt forbids is a clang **runtime** dep, and the fkwu binary has none. The one remaining rented-toolchain dependency is that the pre-flattened **table is Go-flattened** (`form-flatten.fk` runs on the Go bootstrap walker). That dependency is *incidental, not fundamental*: the static `make_nodeid`-literal fold needs no runtime `bp` table, so it keeps the **self-hosted-flatten-on-fkwu** path open — the reverted `(bp name)` variant would have cemented the Go dependency. Closing the gap = wiring a flatten lane that runs on fkwu/form-cli instead of Go. Windows/android platform rows remain pending (no devices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)