### PR TITLE
feat(form): multi-layer GQA llama decode STACK crosses four-way — the real llama3.2 depth structure (255)

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-24_gqa_multi_layer_stack_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-24_gqa_multi_layer_stack_four_way.json
@@ -1,0 +1,39 @@
+{
+  "brick": "3zl",
+  "date": "2026-06-24",
+  "title": "the MULTI-LAYER causal GQA llama DECODE STACK crosses four-way — the depth structure the REAL llama3.2 runs (28 GQA blocks, llama3 RoPE theta-500000), the KV-cached GQA depth stack BIT-IDENTICAL to the full causal recompute stack",
+  "author": "Sema (Opus 4.8), autonomous native-ML walk",
+  "summary": "multi-layer-stack.fk (#3z, #3601's predecessor lane) folds the SINGLE-head MHA llama block across depth. Real llama3.2:3b uses GROUPED-QUERY attention (24 query heads sharing 8 KV heads) + llama3 RoPE (theta 500000, piecewise scaling) — so the real model's depth stack is the GQA block, not MHA. The single GQA block runs on the M4 GPU forward (#3587/#3590) and steps incrementally via the GQA KV cache (lgqa-generate-causal, #3601), which also runs on the GPU as a cached decode step (#3612) — but no GQA DEPTH stack existed. This is the named next stone from #3612 ('the multi-layer GQA decode STACK — stack the kernel across the real 28 blocks'), taken at the recipe-altitude rung first (the GPU emit needs a proven fp64 recipe to mirror, exactly as multi-layer-stack.fk backs the MHA GPU stack #3424). gqa-multi-layer-stack.fk folds the causal GQA llama block across depth two ways — the full causal recompute (lgqa-stack-causal) and the KV-cached incremental decode (lgqa-stack-generate) — and proves them BIT-IDENTICAL four-way.",
+  "recipe": "form/form-stdlib/gqa-multi-layer-stack.fk",
+  "band": "form/form-stdlib/tests/gqa-multi-layer-stack-band.fk",
+  "reference": "no new reference — self-grounding: single-head cfg10 reuses the published MHA-stack libm pins (scripts/multi_layer_stack_reference.py, group=1 GQA == MHA bit-for-bit); GQA-sharing magnitudes grounded by equivalence to the already-four-way lgqa-block-causal (#3590)",
+  "manifest_row": "gqa-multi-layer-stack fks 255",
+  "verdict": 255,
+  "four_way": true,
+  "divergent": 0,
+  "validate_cmd": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk form-stdlib/kv-cache.fk form-stdlib/kv-llama-block.fk form-stdlib/kv-gqa-llama-block.fk form-stdlib/multi-layer-stack.fk form-stdlib/gqa-multi-layer-stack.fk form-stdlib/tests/gqa-multi-layer-stack-band.fk",
+  "validate_result": "core.fk+...+gqa-multi-layer-stack.fk+gqa-multi-layer-stack-band.fk → 255 ; fourth arm: 1 band four-way (fkwu + pre-flattened tables) ; 1 ok, 0 divergent",
+  "claims": {
+    "1": "scn1[0][0] → 1893731 (1-layer cfg10 GQA stack base case == causal-attention-band, libm-pinned)",
+    "2": "scn2[0][0] → 1936158 (2-layer cfg10 GQA stack == MHA-stack libm pin)",
+    "4": "scn2[1][2] → 1944810 (2-layer cfg10 GQA stack, last token == MHA-stack libm pin)",
+    "8": "sgn2 == scn2 (S=2 cfg10: KV-cached GQA depth stack EXACTLY equals recompute stack, bit-for-bit)",
+    "16": "sgn2s == scn2s (REAL GQA sharing n_q=2 n_kv=1 HD=2 theta-500000: cached == recompute — the heart)",
+    "32": "sgn3s == scn3s (S=3 GQA sharing: the cache threads past the boundary through depth — the inductive step)",
+    "64": "sgn3s[0] == sgn2s[0] (AR invariant through depth + grouping: token 0 unchanged by appending future)",
+    "128": "scn2 == mha2 (consolidation: group=1 cfg10 GQA stack == the MHA stack bit-for-bit — GQA is the general case, MHA the group=1 special case, NO parallel path)"
+  },
+  "load_bearing_claim": "The KV-cached GQA depth stack is BIT-IDENTICAL to the full-recompute GQA depth stack. lgqa-generate-causal == lgqa-block-causal bit-for-bit per layer (#3601); lgqa-block-causal is four-way #3590; so folding the cached decode across layers feeds each layer exactly the input the recompute fold feeds it — by induction over depth, lgqa-stack-generate == lgqa-stack-causal. Composes lgqa-block-causal and lgqa-generate-causal verbatim; no numeric change, nothing re-derived. The layer-bundle accessors (lyr-g1..lyr-wd) are reused from multi-layer-stack.fk verbatim — one bundle shape, MHA and GQA share it.",
+  "consolidation": "group=1 (n_kv=n_q, base-10000 cfg) reduces lgqa-stack-* EXACTLY to multi-layer-stack.fk's lblk-stack-* — claim 128 proves scn2 == mha2 bit-for-bit, so the GQA stack is the general case and the MHA stack its group=1 special case (core-abstraction-first: one engine, not a parallel path). This is why the single-head cfg10 magnitudes can reuse the published MHA-stack libm pins.",
+  "ar_invariant_through_depth": "Appending a future token never changes an earlier token's STACKED GQA output (sgn3s[0] == sgn2s[0]) — because every GQA layer is causal and every (narrower n_kv*HD-wide) cache entry is frozen at its (layer, position). That invariant THROUGH the depth AND grouping is exactly why a multi-layer GQA KV cache is reusable across generation steps.",
+  "two_distinct_layers": "L0 = the causal-attention-band weights; L1 = a second, different bundle — so the stack genuinely threads per-layer weights forward, not one block applied twice.",
+  "read_the_body": "lgqa-block-causal (#3590), lgqa-generate-causal (#3601), the GQA grouping (gqa-attn #3577), llama3 RoPE (theta-500000), and the lyr-* bundle accessors (multi-layer-stack.fk) were all ALREADY four-way / present. The brick composed them at the reusable decoder-engine altitude into a depth fold — no new numeric, no re-derive, no new reference (self-grounded against published MHA-stack pins + equivalence to the four-way GQA block). The cheapest-brick lesson held again for a composition brick: design (the depth-fold signature with the GQA model-wide constants, the self-grounding band shape, the consolidation claim) was the cost; the four-way proof was seconds.",
+  "lane": "recipe-altitude four-way (like 3r/3v/3x/3z/3zj). The GQA sibling of brick 3z (multi-layer-stack.fk). Design was the cost; the four-way proof was seconds.",
+  "named_next_stones": [
+    "emit the multi-layer GQA decode stack to Metal — stack the GQA decode-step kernel (#3612), each layer its OWN device KV-cache buffer (narrower n_kv*HD wide), threaded across S dispatches; fp32 CPU-mirror bit-exact gate (the 3zk/#3612 GPU lane for the stack)",
+    "the full generation loop: tokenize-llama (#3573) + multi-layer GQA decode + greedy argmax (#3402) over real llama3.2:3b GGUF weights at full width (n_q=24, n_kv=8, HD=128, d=3072 — load path q4k/q6k/f16 already Form-native four-way) — the first end-to-end native local llama token",
+    "parallelize the GQA decode step across query heads/rows (one threadgroup per query head)"
+  ],
+  "predecessor_bricks": ["#3590 (causal GQA block four-way)", "#3601 (KV-cached causal GQA decode step four-way)", "#3612 (KV-cached GQA decode step on the M4 GPU)", "#3z/multi-layer-stack.fk (the MHA depth stack four-way)"],
+  "teaching": "lc-cognitive-sovereignty"
+}

--- a/form/form-stdlib/gqa-multi-layer-stack.fk
+++ b/form/form-stdlib/gqa-multi-layer-stack.fk
@@ -1,0 +1,66 @@
+; gqa-multi-layer-stack.fk — the DEPTH stack of causal GQA llama decoder blocks: the depth structure
+; the REAL llama3.2:3b runs (28 decoder blocks, each layer its OWN weights and OWN KV cache, GROUPED-QUERY
+; attention: 24 query heads sharing 8 KV heads, llama3 RoPE theta-500000). The single GQA block runs on the
+; M4 GPU forward (#3587/#3590) and steps incrementally via the GQA KV cache (lgqa-generate-causal,
+; kv-gqa-llama-block.fk, four-way #3601) which also runs on the GPU as a cached decode step (#3612). This
+; file is the GQA sibling of multi-layer-stack.fk (#3z, MHA): the named next stone after #3612, "the
+; multi-layer GQA decode STACK — stack the kernel across the real 28 blocks, each its own device cache."
+;
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk form-stdlib/kv-cache.fk form-stdlib/kv-llama-block.fk form-stdlib/kv-gqa-llama-block.fk form-stdlib/multi-layer-stack.fk
+;
+; A model is depth. Layer 0 reads the embeddings; each later layer reads the previous layer's output
+; sequence: x¹ = block₀(x⁰); x² = block₁(x¹); …; x^N = block_{N-1}(x^{N-1}). The weights are recipe DATA all
+; the way down — a layer is a SEQUENCE element, the stack a fold, mutable at runtime. Each GQA layer keeps
+; its OWN KV cache: a cached k_i/v_i in layer ℓ is RoPE(Wk_ℓ·RMSNorm1_ℓ(x_i^ℓ), i) — narrower (n_kv·HD wide)
+; and frozen at (layer ℓ, position i), independent of later tokens and of other layers' caches.
+;
+; The layer bundle is multi-layer-stack.fk's SAME 9-element (g1 wq wk wv wo g2 wg wu wd) — reused verbatim
+; via lyr-g1..lyr-wd (one bundle accessor, MHA and GQA share it). GQA adds only the model-wide constants
+; n_q, n_kv, c (the rope-cfg) over the MHA stack's eps/scale/HD; group=1 (n_kv=n_q, base-10000 cfg) reduces
+; lgqa-stack-* EXACTLY to multi-layer-stack.fk's lblk-stack-* (core-abstraction-first: MHA is the GQA
+; special case, not a parallel path — the band proves it bit-for-bit).
+;
+; The load-bearing claim, composing what is already four-way: the KV-cached GQA depth stack is BIT-IDENTICAL
+; to the full-recompute GQA depth stack. lgqa-generate-causal == lgqa-block-causal bit-for-bit per layer
+; (#3601), so folding the cached decode across layers feeds each layer exactly the input the recompute fold
+; feeds it — by induction over depth, lgqa-stack-generate == lgqa-stack-causal. The stack is the efficient
+; realization of the same N four-way-proven causal GQA blocks; no numeric change, nothing re-derived — it
+; composes lgqa-block-causal (#3590, four-way 15) and lgqa-generate-causal (#3601, four-way 255) verbatim.
+;
+; The autoregressive INVARIANT survives depth AND grouping: appending a future token never changes an
+; earlier token's STACKED GQA output — because every layer is causal and every (narrower) cache entry is
+; frozen at its (layer, position). That invariant THROUGH the depth is exactly why a multi-layer GQA KV
+; cache can be reused across generation steps; the band proves stack-gen3[earlier]==stack-gen2[earlier].
+;
+; Lives at the reusable decoder-engine altitude (like multi-layer-stack.fk before it): any list of causal
+; GQA blocks stacks the same way; this instance is the real llama3 block (RMSNorm + llama3 RoPE + GQA +
+; SwiGLU). eps/scale/n_q/n_kv/HD/c are model-wide architecture constants; a layer bundle carries the
+; per-layer weights. fp64 lane; the GPU emit (stack the GQA decode-step kernel #3612, each layer its own
+; device cache) is the named follow-up. Proven four-way against the full-recompute GQA stack and — for the
+; single-head base-10000 case — the published MHA-stack libm pins (multi_layer_stack_reference.py, group=1
+; GQA == MHA bit-for-bit) by tests/gqa-multi-layer-stack-band.fk.
+; teaching: lc-cognitive-sovereignty
+
+; --- one GQA layer, full causal recompute (the whole sequence at once). Reuses multi-layer-stack.fk's
+;     lyr-* bundle accessors verbatim; n_q/n_kv/c are the GQA model-wide constants over the MHA signature. ---
+(defn lgqa-layer-causal (xs L eps scale n_q n_kv HD c)
+  (lgqa-block-causal xs (lyr-g1 L) eps (lyr-wq L) (lyr-wk L) (lyr-wv L) (lyr-wo L)
+                     scale n_q n_kv HD c (lyr-g2 L) (lyr-wg L) (lyr-wu L) (lyr-wd L)))
+
+; --- one GQA layer, KV-cached incremental decode (its OWN narrower cache, grown fresh from empty inside) ---
+(defn lgqa-layer-generate (xs L eps scale n_q n_kv HD c)
+  (lgqa-generate-causal xs (lyr-g1 L) eps (lyr-wq L) (lyr-wk L) (lyr-wv L) (lyr-wo L)
+                        scale n_q n_kv HD c (lyr-g2 L) (lyr-wg L) (lyr-wu L) (lyr-wd L)))
+
+; --- fold the full causal GQA block across depth: the recompute stack (a fold of the four-way #3590 block) ---
+(defn lgqa-stack-causal (xs layers eps scale n_q n_kv HD c)
+  (if (eq (len layers) 0) xs
+      (lgqa-stack-causal (lgqa-layer-causal xs (head layers) eps scale n_q n_kv HD c)
+                         (tail layers) eps scale n_q n_kv HD c)))
+
+; --- fold the KV-cached GQA decode across depth, each layer its own narrower cache: the real generation
+;     stack. == lgqa-stack-causal bit-for-bit (the equivalence the band proves). ---
+(defn lgqa-stack-generate (xs layers eps scale n_q n_kv HD c)
+  (if (eq (len layers) 0) xs
+      (lgqa-stack-generate (lgqa-layer-generate xs (head layers) eps scale n_q n_kv HD c)
+                           (tail layers) eps scale n_q n_kv HD c)))

--- a/form/form-stdlib/tests/gqa-multi-layer-stack-band.fk
+++ b/form/form-stdlib/tests/gqa-multi-layer-stack-band.fk
@@ -1,0 +1,94 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk form-stdlib/kv-cache.fk form-stdlib/kv-llama-block.fk form-stdlib/kv-gqa-llama-block.fk form-stdlib/multi-layer-stack.fk form-stdlib/gqa-multi-layer-stack.fk
+;
+; gqa-multi-layer-stack-band — the DEPTH stack of causal GQA llama decoder blocks lifted to the four-kernel
+; floor: the depth structure the REAL llama3.2:3b runs (28 blocks, each its OWN weights and OWN KV cache,
+; GROUPED-QUERY attention + llama3 RoPE theta-500000). The single GQA block runs on the M4 GPU forward
+; (#3587/#3590) and the GQA KV-cached decode step runs on the GPU (#3612, four-way recipe #3601); this proves
+; they STACK through DEPTH. The proof is that the KV-cached GQA depth stack is BIT-IDENTICAL to the
+; full-recompute GQA depth stack (each layer's cached decode == its full causal recompute, #3601;
+; lgqa-block-causal is four-way #3590).
+;
+; Self-grounding — every magnitude is either a PUBLISHED four-way pin or an equivalence to an already-four-way
+; recipe; no new libm reference authored (the GQA-stack sibling of kv-gqa-llama-block-band's discipline):
+;   the single-head (n_q=1 n_kv=1 HD=4, base-10000 cfg) GQA stack reduces EXACTLY to the MHA stack
+;     (multi-layer-stack.fk), so its magnitudes are the PUBLISHED MHA-stack libm pins
+;     (multi_layer_stack_reference.py, self-checked to reproduce causal-attention-band): 1893731 / 1936158 /
+;     1944810 — and the band proves group=1 GQA stack == MHA stack bit-for-bit (the consolidation, claim 128).
+;   the REAL GQA sharing (n_q=2, n_kv=1, HD=2, llama3 theta-500000) magnitudes are grounded by EQUIVALENCE to
+;     the already-four-way lgqa-block-causal (#3590): the recompute GQA stack is a fold of that proven block,
+;     and the cached GQA stack == it bit-for-bit (S=2 AND the S=3 inductive step that threads the cache past
+;     the boundary THROUGH the depth).
+;
+; Two distinct layers (L0 = the causal-attention-band weights; L1 = a second, different bundle) so the stack
+; genuinely threads per-layer weights forward — not one block applied twice.
+;
+; Verdict 255 when the multi-layer causal GQA llama stack lands four-way:
+;   1     scn1[0][0]  → 1893731   (1-layer cfg10 GQA stack base case == causal-attention-band, libm-pinned)
+;   2     scn2[0][0]  → 1936158   (2-layer cfg10 GQA stack == MHA-stack libm pin)
+;   4     scn2[1][2]  → 1944810   (2-layer cfg10 GQA stack, last token == MHA-stack libm pin)
+;   8     sgn2 == scn2            (S=2 cfg10: the KV-cached GQA depth stack EXACTLY equals the recompute stack)
+;   16    sgn2s == scn2s          (REAL GQA sharing n_q=2 n_kv=1 HD=2 theta-500000: cached == recompute — heart)
+;   32    sgn3s == scn3s          (S=3 GQA sharing: the cache threads past the boundary through depth — inductive)
+;   64    sgn3s[0] == sgn2s[0]    (AR invariant through depth+grouping: token 0 unchanged by appending future)
+;   128   scn2 == mha2            (consolidation: group=1 cfg10 GQA stack == the MHA stack bit-for-bit — GQA is
+;                                  the general case, MHA the group=1 special case, NO parallel path)
+(do
+    ; --- element-wise float vector equality (for the AR-invariant token-vector claim) ---
+    (defn gm-veq (a b)
+      (if (eq (len a) 0) 1
+          (if (eq (head a) (head b)) (gm-veq (tail a) (tail b)) 0)))
+
+    ; --- layer 0: the causal-attention-band / llama-block-band fixture (d=4, weights re-read per cfg) ---
+    (let x  (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75)))
+    (let g1 (list 0.9 1.1 1.0 0.95))   (let g2 (list 1.05 0.95 1.0 0.9))
+    (let wq (list (list 0.5 -0.25 0.1 0.3) (list 0.2 0.4 -0.3 0.1) (list -0.1 0.2 0.5 -0.2) (list 0.3 0.0 -0.15 0.25)))
+    (let wk (list (list 0.2 0.4 -0.3 0.1) (list 0.3 -0.2 0.25 0.5) (list 0.1 0.15 -0.05 0.2) (list -0.25 0.3 0.4 -0.1)))
+    (let wv (list (list 0.3 -0.2 0.25 0.5) (list 0.6 0.1 -0.2 0.4) (list 0.05 -0.1 0.3 0.2) (list 0.15 0.35 -0.25 0.1)))
+    (let wo (list (list 0.6 0.1 -0.2 0.4) (list -0.2 0.4 0.3 0.1) (list 0.25 -0.15 0.5 0.05) (list 0.1 0.2 -0.3 0.45)))
+    (let wg (list (list 0.5 -0.3 0.2 0.1) (list 0.2 0.7 -0.4 0.3) (list -0.1 0.25 0.4 -0.2) (list 0.3 0.1 -0.15 0.5)))
+    (let wu (list (list 0.25 -0.15 0.3 0.05) (list 0.1 0.4 -0.2 0.15) (list 0.35 0.2 -0.1 0.25) (list -0.2 0.3 0.15 0.4)))
+    (let wd (list (list 0.4 -0.2 0.3 0.1) (list 0.15 0.5 -0.25 0.2) (list -0.3 0.1 0.45 -0.15) (list 0.2 -0.1 0.35 0.3)))
+    ; --- layer 1: a SECOND, distinct weight bundle (same architecture, different weights) ---
+    (let g1b (list 1.0 0.9 1.05 1.1))  (let g2b (list 0.95 1.1 0.9 1.0))
+    (let wqb (list (list 0.1 0.3 -0.2 0.4) (list -0.3 0.2 0.5 -0.1) (list 0.4 -0.1 0.2 0.3) (list 0.0 0.25 -0.35 0.15)))
+    (let wkb (list (list 0.3 -0.2 0.4 0.1) (list 0.15 0.5 -0.1 0.2) (list -0.05 0.3 0.25 -0.15) (list 0.4 -0.25 0.1 0.35)))
+    (let wvb (list (list 0.2 0.4 -0.15 0.3) (list 0.5 -0.1 0.2 0.45) (list -0.2 0.35 0.1 -0.05) (list 0.25 0.15 -0.3 0.2)))
+    (let wob (list (list 0.4 -0.3 0.2 0.5) (list 0.1 0.45 -0.15 0.2) (list -0.25 0.3 0.4 0.05) (list 0.35 -0.1 0.25 -0.2)))
+    (let wgb (list (list 0.3 0.2 -0.4 0.1) (list 0.5 -0.3 0.15 0.25) (list -0.1 0.4 0.3 -0.2) (list 0.2 0.05 -0.25 0.45)))
+    (let wub (list (list 0.15 0.35 -0.2 0.1) (list 0.4 -0.15 0.25 0.3) (list -0.25 0.2 0.35 -0.1) (list 0.3 0.1 -0.05 0.4)))
+    (let wdb (list (list 0.35 -0.15 0.25 0.2) (list 0.2 0.4 -0.3 0.1) (list -0.2 0.15 0.5 -0.25) (list 0.1 -0.05 0.3 0.45)))
+    (let eps 0.00001)
+    ; --- the SAME 9-element layer bundles multi-layer-stack.fk uses (lyr-* accessors shared) ---
+    (let L0 (list g1 wq wk wv wo g2 wg wu wd))
+    (let L1 (list g1b wqb wkb wvb wob g2b wgb wub wdb))
+    (let layers1 (list L0))
+    (let layers2 (list L0 L1))
+    (let x3 (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75) (list 0.5 1.0 -0.5 0.25)))
+
+    ; --- single-head cfg10 (n_q=1 n_kv=1 HD=4): the GQA stack reduces EXACTLY to the MHA stack ---
+    (let cfg10 (rope-cfg 10000.0 32.0 1.0 4.0 8192.0))
+    (let sc4 (div 1.0 (tn-sqrt 4.0)))
+    (let scn1 (lgqa-stack-causal   x  layers1 eps sc4 1 1 4 cfg10))
+    (let scn2 (lgqa-stack-causal   x  layers2 eps sc4 1 1 4 cfg10))
+    (let sgn2 (lgqa-stack-generate x  layers2 eps sc4 1 1 4 cfg10))
+    (let c0 (if (eq (round (mul (nth (nth scn1 0) 0) 1000000.0)) 1893731) 1 0))
+    (let c1 (if (eq (round (mul (nth (nth scn2 0) 0) 1000000.0)) 1936158) 2 0))
+    (let c2 (if (eq (round (mul (nth (nth scn2 1) 2) 1000000.0)) 1944810) 4 0))
+    (let c3 (if (eq (kv-lol-eq sgn2 scn2) 1) 8 0))
+
+    ; --- the REAL GQA sharing (n_q=2 n_kv=1 HD=2) under the llama3 theta-500000 cfg, S=2 and S=3 ---
+    (let cfgl3 (rope-cfg-llama3))
+    (let sc2 (div 1.0 (tn-sqrt 2.0)))
+    (let scn2s (lgqa-stack-causal   x  layers2 eps sc2 2 1 2 cfgl3))
+    (let sgn2s (lgqa-stack-generate x  layers2 eps sc2 2 1 2 cfgl3))
+    (let scn3s (lgqa-stack-causal   x3 layers2 eps sc2 2 1 2 cfgl3))
+    (let sgn3s (lgqa-stack-generate x3 layers2 eps sc2 2 1 2 cfgl3))
+    (let c4 (if (eq (kv-lol-eq sgn2s scn2s) 1) 16 0))
+    (let c5 (if (eq (kv-lol-eq sgn3s scn3s) 1) 32 0))
+    (let c6 (if (eq (gm-veq (nth sgn3s 0) (nth sgn2s 0)) 1) 64 0))
+
+    ; --- consolidation: group=1 cfg10 GQA stack == the MHA stack (multi-layer-stack.fk) bit-for-bit ---
+    (let mha2 (lblk-stack-causal x layers2 eps sc4 4))
+    (let c7 (if (eq (kv-lol-eq scn2 mha2) 1) 128 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -826,6 +826,7 @@ greedy-decode fks 255
 kv-llama-block fks 255
 kv-gqa-llama-block fks 255
 multi-layer-stack fks 255
+gqa-multi-layer-stack fks 255
 
 # ── gap-close lane (2026-06-19): bands the survey found crossing fkwu, each
 # GATED four-way by scripts/fourth-arm-gate.sh (validate.sh: 0 divergent AND


### PR DESCRIPTION
## The brick (3zl)

`multi-layer-stack.fk` (#3z) folds the **single-head MHA** llama block across depth. The **real llama3.2:3b** uses **grouped-query attention** (24 query heads sharing 8 KV heads) + llama3 RoPE (theta-500000) — so the real model's depth stack is the GQA block, not MHA. The single GQA block runs on the M4 GPU (#3587/#3590) and the GQA KV-cached decode step runs on the GPU (#3612), but **no GQA depth stack existed**. This is #3612's named next stone ("the multi-layer GQA decode STACK — stack the kernel across the real 28 blocks"), taken at the **recipe-altitude rung first** — the GPU emit needs a proven fp64 recipe to mirror, exactly as `multi-layer-stack.fk` backs the MHA GPU stack (#3424).

`gqa-multi-layer-stack.fk` folds the causal GQA llama block across depth two ways and proves them **bit-identical four-way**:
- `lgqa-stack-causal` — full causal recompute (a fold of the four-way #3590 block)
- `lgqa-stack-generate` — KV-cached incremental decode, each layer its **own** narrower n_kv·HD-wide cache

It composes `lgqa-block-causal` (#3590) and `lgqa-generate-causal` (#3601) **verbatim** — no new arithmetic — and reuses `multi-layer-stack.fk`'s `lyr-*` bundle accessors (one bundle shape, MHA and GQA share it). **group=1 reduces exactly to the MHA stack** (claim 128: `scn2 == mha2` bit-for-bit — core-abstraction-first, no parallel path).

## Proof — `gqa-multi-layer-stack-band` four-way **255**, 0 divergent

Self-grounding (no new reference): single-head cfg10 reuses the published MHA-stack libm pins (1893731 / 1936158 / 1944810); the real GQA sharing (n_q=2, n_kv=1, HD=2, theta-500000) magnitudes grounded by equivalence to the already-four-way `lgqa-block-causal`.

| bit | claim |
|----|----|
| 1 | 1-layer cfg10 GQA stack base case == causal-attention-band pin (1893731) |
| 2,4 | 2-layer cfg10 GQA stack == MHA-stack libm pins (1936158, 1944810) |
| 8 | S=2 cfg10: cached GQA stack == recompute stack bit-for-bit |
| 16 | **REAL GQA sharing: cached == recompute (the heart)** |
| 32 | S=3 GQA sharing: cache threads past the boundary through depth (inductive step) |
| 64 | AR invariant through depth + grouping |
| 128 | **consolidation: group=1 GQA stack == MHA stack bit-for-bit** (no parallel path) |

```
core.fk+...+gqa-multi-layer-stack.fk+gqa-multi-layer-stack-band.fk → 255
fourth arm: 1 band four-way (fkwu + pre-flattened tables)
1 ok, 0 divergent — kernels agree on every sample.
```

Manifest row `gqa-multi-layer-stack fks 255` added in the same PR. Receipt: `docs/system_audit/commit_evidence_2026-06-24_gqa_multi_layer_stack_four_way.json`.

## Named next stones
- Emit the multi-layer GQA decode stack to Metal (stack the GQA decode-step kernel #3612, each layer its own device cache), fp32 CPU-mirror bit-exact gate
- The full generation loop: tokenize-llama (#3573) + multi-layer GQA decode + greedy argmax (#3402) over real llama3.2:3b GGUF at full width — the first end-to-end native local llama token

🤖 Generated with [Claude Code](https://claude.com/claude-code)