### PR TITLE
feat(model): block-join — gap D₀ load·compute join (four-way 255)

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -128,8 +128,11 @@
 ;     C. ✓ DONE — weight-load.fk (4095): gguf-locate + wl-slice + f16-decode + q6k-dequant load a REAL
 ;        llama3.2:3b token_embd Q6_K tensor's weights to f32, four-way, perturbation-checked (one byte flip
 ;        moves the verdict). The ll-buffer store-loop landing the f32 list in the matvec's read buffer is adjacent.
-;     D. COMPOSE BLOCK-0 FORWARD — kv-llama-block (255) over the loaded real weights at real width
-;        (llama3.2:3b d_model=3072) → one block's output vs a reference; stack → logits → the ollama seam retires.
+;     D. ✓ D₀ — block-join.fk (255): compose weight-load + tb-dot/tb-matvec/lblk-proj-seq on REAL
+;        llama3.2:3b Q6_K bytes (mini-GGUF fixture) — load → dot → projection with a loaded wq row.
+;        Four-way incl. fkwu; falsifiable (wqp ≠ toy wq). Adjacent: full lblk-block-causal / lgqa-block-causal
+;        at sliced d then d_model=3072 with all blk.0 tensors + form-asm matvec lane swap; carrier script
+;        vs numpy reference (whisper_block0_real_carrier pattern).
 ;     E. TOKENIZER CARRIERS — vocab + merge-table loaders feeding bpe-tokenizer (proven) for the decode side.
 ;     F. vLLM-CLASS SPEED — the Metal MSL emit lane (proven) + batching + paged-KV + fused dequant-matmul.
 ;   NORTH STAR: a sovereign, on-device, Form-native SPEECH faculty — real audio → transcript (STT), NL → NL

--- a/docs/system_audit/commit_evidence_2026-06-24_block_join_gap_d.json
+++ b/docs/system_audit/commit_evidence_2026-06-24_block_join_gap_d.json
@@ -1,0 +1,59 @@
+{
+  "date": "2026-06-24",
+  "thread_branch": "cursor/da996f0b",
+  "commit_scope": "Gap D₀ — block-join.fk composes weight-load with forward matvec/projection on real llama3.2:3b Q6_K bytes; four-way 255 incl. fkwu",
+  "files_owned": [
+    "form/form-stdlib/block-join.fk",
+    "form/form-stdlib/tests/block-join-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-24_block_join_gap_d.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/block-join.fk form-stdlib/tests/block-join-band.fk"
+    ],
+    "fourth_arm": "block-join four-way (Go/Rust/TS/fkwu) verdict 255, 0 divergent",
+    "notes": "Mini-GGUF fixture carries real token_embd Q6_K superblock; join claims load→dot→lblk-proj-seq with bj-wq-row-n"
+  },
+  "ci_validation": {"status": "pending", "notes": "Manifest row block-join fks 255 gates four-way in CI validate.sh"},
+  "deploy_validation": {"status": "pending", "summary": "No deploy; Form recipe landing"},
+  "phase_gate": {
+    "phase": "llm-inference-gap-d",
+    "gate": "Load proven · compute proven → forward uses file bytes",
+    "state": "d0-join-four-way",
+    "can_move_next_phase": false,
+    "next": "Full lblk-block-causal / lgqa-block-causal over all blk.0 tensors at sliced d, then d_model=3072 carrier vs reference; form-asm matvec lane swap"
+  },
+  "idea_ids": ["form-native-models"],
+  "spec_ids": ["form-native-models"],
+  "task_ids": ["block-join-gap-d"],
+  "contributors": [
+    {"contributor_id": "urs-muff", "contributor_type": "human", "roles": ["direction", "parallel-orchestration"]},
+    {"contributor_id": "agent:cursor", "contributor_type": "machine", "roles": ["implementation", "four-way-proof"]}
+  ],
+  "agent": {"name": "Cursor", "version": "Auto"},
+  "evidence_refs": [
+    "form/form-stdlib/block-join.fk",
+    "form/form-stdlib/tests/block-join-band.fk",
+    "form/form-stdlib/weight-load.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "change_files": [
+    "form/form-stdlib/block-join.fk",
+    "form/form-stdlib/tests/block-join-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-24_block_join_gap_d.json"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "summary": "D₀ band only; full block carrier at d=3072 is the next rung",
+    "expected_behavior_delta": "weight-load composes with lblk-proj-seq on real Q6_K bytes; four-way verdict 255",
+    "public_endpoints": ["n/a-form-stdlib-band"],
+    "test_flows": ["cd form && ./validate.sh ... block-join-band.fk → 255 four-way"]
+  }
+}

--- a/form/form-stdlib/block-join.fk
+++ b/form/form-stdlib/block-join.fk
@@ -1,0 +1,50 @@
+; block-join.fk — gap D of the LLM-inference arc: compose weight-load with the proven forward
+; recipes. The load seam (gguf bytes → f32 weights) and the compute seam (tb-dot / tb-matvec /
+; lblk-block-causal) were proven separately in gaps A/B/C; this cell is the JOIN — real weights
+; from a buffer feed the same matvec/block algebra the toy bands already four-way.
+;
+; bj-dot-row-n / bj-matvec-q6k-row: load one Q6_K superblock from file bytes, then run the tree-walker
+; dot/matvec over the dequantized f32 list — load proven · compute proven → forward matvec proven.
+; bj-wq-row-n: the first n dequantized weights as one projection row (embed a real row into a weight
+; matrix for block forward). The form-asm matvec lane (fam-dot2 / fam-dot-loop) is the adjacent swap
+; for tb-dot once the ll-buffer store-loop lands f32 in the f64 read buffer.
+;
+; Kin: weight-load.fk (wl-load-q6k), transformer-block.fk (tb-dot/tb-matvec), llama-block.fk
+; (lblk-proj-seq / lblk-block-causal), kv-llama-block.fk (generation inner loop at block scale).
+;
+; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk
+;
+; Proven by: form-stdlib/tests/block-join-band.fk
+
+(do
+    ; --- the first n dequantized weights as a row vector (for embedding in wq/wk/...) ---
+    (defn bj-row-n-from (bytes off i n)
+        (if (eq n 0) (empty)
+            (cons (wl-q6k-at bytes off i)
+                  (bj-row-n-from bytes off (add i 1) (sub n 1)))))
+    (defn bj-row-n (bytes off n) (bj-row-n-from bytes off 0 n))
+
+    ; --- dot the first n loaded weights with x (len x must be n) ---
+    (defn bj-dot-row-n (bytes off n x)
+        (tb-dot (bj-row-n bytes off n) x))
+
+    ; --- load + dot: full 256-list dotted with x (len x must be 256) ---
+    (defn bj-dot-q6k (bytes off x)
+        (tb-dot (wl-load-q6k bytes off) x))
+
+    ; --- load + single-row matvec: y = [ dot(first n weights, x) ] where n = len x ---
+    (defn bj-matvec-q6k-row (bytes off x)
+        (list (bj-dot-row-n bytes off (len x) x)))
+
+    ; --- replace row `r` of matrix `w` with `row` (same width); other rows unchanged ---
+    (defn bj-replace-row-from (w r row i)
+        (if (eq (len w) 0) (empty)
+            (if (eq i r) (cons row (tail w))
+                (cons (head w) (bj-replace-row-from (tail w) r row (add i 1))))))
+    (defn bj-replace-row (w r row) (bj-replace-row-from w r row 0))
+
+    ; --- load the first n weights from a Q6_K superblock into row r of matrix w ---
+    (defn bj-wq-row-n (w r bytes off n)
+        (bj-replace-row w r (bj-row-n bytes off n)))
+
+    0)

--- a/form/form-stdlib/tests/block-join-band.fk
+++ b/form/form-stdlib/tests/block-join-band.fk
@@ -1,0 +1,51 @@
+; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/block-join.fk
+;
+; block-join-band — gap D made falsifiable: COMPOSE weight-load with the forward matvec/block algebra.
+; The fixture is the SAME mini-GGUF as weight-load-band (real llama3.2:3b token_embd Q6_K superblock at
+; offset 96). Claims walk load → dot → projection → one lblk-proj-seq step with a real weight row —
+; the join that turns "load proven · compute proven" into "forward uses file bytes".
+;
+; Verdict 255 when every claim lands:
+;   1    load still works: wl-q6k-at i=0 -> 11215                    (weight-load compose)
+;   2    bj-dot-row-n n=1 x=[1] -> 11215                             (load + tb-dot, one weight)
+;   4    bj-dot-row-n n=32 x=e0+e31 -> -771                          (load + tb-dot, two weights)
+;   8    bj-dot-row-n n=4 x=token -> 61310                           (real row · fixture token)
+;   16   bj-matvec-q6k-row first 4 of x -> 61310                     (matvec row = dot)
+;   32   lblk-proj-seq wq' token[0] -> 61310                         (block proj with loaded row 0)
+;   64   bj-wq-row-n replaces row 0 only: row0 dot unchanged         (matrix surgery is correct)
+;   128  full 256-load length still 256                               (load not truncated by join)
+(do
+    ; --- mini-GGUF (identical to weight-load-band) ---
+    (let g (list
+        71 71 85 70 3 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0
+        1 0 0 0 0 0 0 0 97 4 0 0 0 42 0 0 0
+        1 0 0 0 0 0 0 0 116 1 0 0 0 0 1 0 0 0 0 0 0 14 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        129 67 45 48 246 235 134 149 186 127 28 200 234 116 6 4 49 221 74 254 192 205 18 137
+        34 162 64 213 250 173 64 57 126 163 27 184 54 160 166 158 148 231 71 98 8 92 31 12
+        221 193 69 80 20 103 72 176 235 201 188 123 81 139 162 183 40 198 208 233 142 80 135 134
+        25 169 70 99 147 0 200 106 135 2 231 97 45 177 89 92 55 93 105 158 202 125 1 89
+        13 118 37 32 255 88 100 181 162 50 128 188 42 29 39 252 218 93 46 23 143 250 181 135
+        239 144 2 33 0 129 2 107 17 117 84 164 74 130 149 138 110 222 169 173 162 150 16 197
+        149 153 182 101 28 105 134 173 98 151 170 155 128 98 166 158 216 21 214 81 154 96 101 105
+        148 106 21 102 149 10 110 148 5 36 229 172 106 83 120 9 170 120 154 193 89 46 6 213
+        192 142 156 84 171 59 159 128 171 183 158 97 146 61 77 171 196 0))
+    (let ti (gg-tinfo-start g))
+    (let off (add (mul (div (add (gg-ti-next g ti) 31) 32) 32) (gg-ti-dataoff g ti)))
+    ; fixture token + toy wq (kv-llama-block-band 4x4)
+    (let xtok (list 1.0 -0.5 0.5 2.0))
+    (let wq (list (list 0.5 -0.25 0.1 0.3) (list 0.2 0.4 -0.3 0.1) (list -0.1 0.2 0.5 -0.2) (list 0.3 0.0 -0.15 0.25)))
+    (let wqp (bj-wq-row-n wq 0 g off 4))
+    ; x32: unit at index 0 and 31 (load + dot two real weights)
+    (let x32 (list 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
+                    0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0))
+    (let c0 (if (eq (round (mul (wl-q6k-at g off 0) 1000000.0)) 11215) 1 0))
+    (let c1 (if (eq (round (mul (bj-dot-row-n g off 1 (list 1.0)) 1000000.0)) 11215) 2 0))
+    (let c2 (if (eq (round (mul (bj-dot-row-n g off 32 x32) 1000000.0)) -771) 4 0))
+    (let c3 (if (eq (round (mul (bj-dot-row-n g off 4 xtok) 1000000.0)) 61310) 8 0))
+    (let c4 (if (eq (round (mul (nth (bj-matvec-q6k-row g off xtok) 0) 1000000.0)) 61310) 16 0))
+    (let c5 (if (eq (round (mul (nth (head (lblk-proj-seq wqp (list xtok))) 0) 1000000.0)) 61310) 32 0))
+    (let c6 (if (eq (round (mul (nth (head (lblk-proj-seq wqp (list xtok))) 0) 1000000.0))
+                    (round (mul (nth (head (lblk-proj-seq wq (list xtok))) 0) 1000000.0))) 0 64))
+    (let c7 (if (eq (len (wl-load-q6k g off)) 256) 128 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -988,4 +988,5 @@ gguf-locate fks 127
 form-asm-matvec fks 127
 form-asm-matvec-loop fks 127
 weight-load fks 4095
+block-join fks 255
 form-glsl fks 7


### PR DESCRIPTION
## Summary
- Adds `block-join.fk` composing `weight-load` with `tb-dot` / `lblk-proj-seq` on real llama3.2:3b Q6_K bytes
- `block-join-band.fk` crosses four-way (verdict 255, incl. fkwu) using the mini-GGUF fixture from weight-load
- Floor updated: Gap D₀ done; D₁ (full block at sliced d) named adjacent

## Test plan
- [x] `cd form && ./validate.sh ... block-join.fk block-join-band.fk` → 255, fourth arm four-way
- [x] `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-24_block_join_gap_d.json`

Made with [Cursor](https://cursor.com)