### PR TITLE
feat(model): block-join-causal — gap D₁ full block over loaded weights (15)

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -130,9 +130,9 @@
 ;        moves the verdict). The ll-buffer store-loop landing the f32 list in the matvec's read buffer is adjacent.
 ;     D. ✓ D₀ — block-join.fk (255): compose weight-load + tb-dot/tb-matvec/lblk-proj-seq on REAL
 ;        llama3.2:3b Q6_K bytes (mini-GGUF fixture) — load → dot → projection with a loaded wq row.
-;        Four-way incl. fkwu; falsifiable (wqp ≠ toy wq). Adjacent: full lblk-block-causal / lgqa-block-causal
-;        at sliced d then d_model=3072 with all blk.0 tensors + form-asm matvec lane swap; carrier script
-;        vs numpy reference (whisper_block0_real_carrier pattern).
+;        ✓ D₁ — block-join-causal.fk (15): full lblk-block-causal d=4 S=2, ALL SEVEN 4×4 matrices from
+;        loaded bytes; y[0][0]=999794 ≠ toy 1893731. Adjacent: lgqa-block-causal at sliced d, d=3072
+;        carrier vs numpy, form-asm matvec lane swap.
 ;     E. TOKENIZER CARRIERS — vocab + merge-table loaders feeding bpe-tokenizer (proven) for the decode side.
 ;     F. vLLM-CLASS SPEED — the Metal MSL emit lane (proven) + batching + paged-KV + fused dequant-matmul.
 ;   NORTH STAR: a sovereign, on-device, Form-native SPEECH faculty — real audio → transcript (STT), NL → NL

--- a/form/form-stdlib/block-join.fk
+++ b/form/form-stdlib/block-join.fk
@@ -14,7 +14,7 @@
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk
 ;
-; Proven by: form-stdlib/tests/block-join-band.fk
+; Proven by: form-stdlib/tests/block-join-band.fk form-stdlib/tests/block-join-causal-band.fk
 
 (do
     ; --- the first n dequantized weights as a row vector (for embedding in wq/wk/...) ---
@@ -46,5 +46,32 @@
     ; --- load the first n weights from a Q6_K superblock into row r of matrix w ---
     (defn bj-wq-row-n (w r bytes off n)
         (bj-replace-row w r (bj-row-n bytes off n)))
+
+    ; --- a dim×dim matrix from consecutive dequantized weights starting at index `start` ---
+    (defn bj-matrix-row (bytes off start dim r)
+        (bj-row-n-from bytes off (add start (mul r dim)) dim))
+    (defn bj-matrix-from (bytes off start dim r)
+        (if (eq r dim) (empty)
+            (cons (bj-matrix-row bytes off start dim r)
+                  (bj-matrix-from bytes off start dim (add r 1)))))
+    (defn bj-matrix (bytes off start dim)
+        (bj-matrix-from bytes off start dim 0))
+
+    ; --- all seven 4×4 projection matrices for one causal block (112 weights from one superblock) ---
+    (defn bj-block-mats-d4 (bytes off)
+        (list (bj-matrix bytes off 0 4)
+              (bj-matrix bytes off 16 4)
+              (bj-matrix bytes off 32 4)
+              (bj-matrix bytes off 48 4)
+              (bj-matrix bytes off 64 4)
+              (bj-matrix bytes off 80 4)
+              (bj-matrix bytes off 96 4)))
+
+    ; --- causal llama block forward with every weight matrix from bj-block-mats-d4 ---
+    (defn bj-block-causal-d4 (mats xs g1 eps g2)
+        (lblk-block-causal xs g1 eps
+            (nth mats 0) (nth mats 1) (nth mats 2) (nth mats 3)
+            (div 1.0 (tn-sqrt 4.0)) 4
+            g2 (nth mats 4) (nth mats 5) (nth mats 6)))
 
     0)

--- a/form/form-stdlib/tests/block-join-causal-band.fk
+++ b/form/form-stdlib/tests/block-join-causal-band.fk
@@ -1,0 +1,40 @@
+; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/block-join.fk
+;
+; block-join-causal-band — gap D₁: a full causal llama block (lblk-block-causal, d=4, S=2) over
+; ALL SEVEN 4×4 weight matrices loaded from real Q6_K file bytes (112 consecutive weights from the
+; token_embd superblock). The forward algebra is unchanged from llama-block.fk; only the weights come
+; from weight-load. Reference values from the Form walker (libm fp64); falsifiable vs toy weights.
+;
+; Verdict 15 when every claim lands:
+;   1    y[0][0] -> 999794     (causal token 0, loaded weights)
+;   2    y[1][0] -> -1000173   (causal last token dim 0)
+;   4    y[1][2] -> 1499891    (causal last token dim 2)
+;   8    y[0][0] != 1893731    (not the toy kv-llama-block-band weights — join is real)
+(do
+    (let g (list
+        71 71 85 70 3 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0
+        1 0 0 0 0 0 0 0 97 4 0 0 0 42 0 0 0
+        1 0 0 0 0 0 0 0 116 1 0 0 0 0 1 0 0 0 0 0 0 14 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        129 67 45 48 246 235 134 149 186 127 28 200 234 116 6 4 49 221 74 254 192 205 18 137
+        34 162 64 213 250 173 64 57 126 163 27 184 54 160 166 158 148 231 71 98 8 92 31 12
+        221 193 69 80 20 103 72 176 235 201 188 123 81 139 162 183 40 198 208 233 142 80 135 134
+        25 169 70 99 147 0 200 106 135 2 231 97 45 177 89 92 55 93 105 158 202 125 1 89
+        13 118 37 32 255 88 100 181 162 50 128 188 42 29 39 252 218 93 46 23 143 250 181 135
+        239 144 2 33 0 129 2 107 17 117 84 164 74 130 149 138 110 222 169 173 162 150 16 197
+        149 153 182 101 28 105 134 173 98 151 170 155 128 98 166 158 216 21 214 81 154 96 101 105
+        148 106 21 102 149 10 110 148 5 36 229 172 106 83 120 9 170 120 154 193 89 46 6 213
+        192 142 156 84 171 59 159 128 171 183 158 97 146 61 77 171 196 0))
+    (let ti (gg-tinfo-start g))
+    (let off (add (mul (div (add (gg-ti-next g ti) 31) 32) 32) (gg-ti-dataoff g ti)))
+    (let x (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75)))
+    (let g1 (list 0.9 1.1 1.0 0.95))
+    (let g2 (list 1.05 0.95 1.0 0.9))
+    (let eps 0.00001)
+    (let mats (bj-block-mats-d4 g off))
+    (let yc (bj-block-causal-d4 mats x g1 eps g2))
+    (let c0 (if (eq (round (mul (nth (nth yc 0) 0) 1000000.0)) 999794) 1 0))
+    (let c1 (if (eq (round (mul (nth (nth yc 1) 0) 1000000.0)) -1000173) 2 0))
+    (let c2 (if (eq (round (mul (nth (nth yc 1) 2) 1000000.0)) 1499891) 4 0))
+    (let c3 (if (eq (round (mul (nth (nth yc 0) 0) 1000000.0)) 1893731) 0 8))
+    (add c0 (add c1 (add c2 c3))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -989,4 +989,5 @@ form-asm-matvec fks 127
 form-asm-matvec-loop fks 127
 weight-load fks 4095
 block-join fks 255
+block-join-causal fks 15
 form-glsl fks 7


### PR DESCRIPTION
## Summary
- Extends `block-join.fk` with `bj-matrix`, `bj-block-mats-d4`, `bj-block-causal-d4`
- `block-join-causal-band.fk`: full `lblk-block-causal` S=2 d=4 with all seven 4×4 matrices from real Q6_K bytes (verdict 15, four-way)
- Floor: Gap D₁ marked done

## Test plan
- [x] `./validate.sh ... block-join-causal-band.fk` → 15, fkwu four-way
- [x] `./validate.sh ... block-join-band.fk` → 255 regression

Made with [Cursor](https://cursor.com)