### PR TITLE
tend: gap D₂ — GQA causal block over loaded Q6_K weights

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -131,8 +131,10 @@
 ;     D. ✓ D₀ — block-join.fk (255): compose weight-load + tb-dot/tb-matvec/lblk-proj-seq on REAL
 ;        llama3.2:3b Q6_K bytes (mini-GGUF fixture) — load → dot → projection with a loaded wq row.
 ;        ✓ D₁ — block-join-causal.fk (15): full lblk-block-causal d=4 S=2, ALL SEVEN 4×4 matrices from
-;        loaded bytes; y[0][0]=999794 ≠ toy 1893731. Adjacent: lgqa-block-causal at sliced d, d=3072
-;        carrier vs numpy, form-asm matvec lane swap.
+;        loaded bytes; y[0][0]=999794 ≠ toy 1893731.
+;        ✓ D₂ — block-join-gqa-causal.fk (15): lgqa-block-causal n_q=2 n_kv=1 HD=2 cfg-llama3, same
+;        loaded seven matrices; y[0][0]=1000297 ≠ toy 1893731. Adjacent: d=3072 carrier vs numpy,
+;        form-asm matvec lane swap.
 ;     E. TOKENIZER CARRIERS — vocab + merge-table loaders feeding bpe-tokenizer (proven) for the decode side.
 ;     F. vLLM-CLASS SPEED — the Metal MSL emit lane (proven) + batching + paged-KV + fused dequant-matmul.
 ;   NORTH STAR: a sovereign, on-device, Form-native SPEECH faculty — real audio → transcript (STT), NL → NL

--- a/docs/system_audit/commit_evidence_2026-06-24_block_join_gqa_gap_d2.json
+++ b/docs/system_audit/commit_evidence_2026-06-24_block_join_gqa_gap_d2.json
@@ -1,0 +1,59 @@
+{
+  "date": "2026-06-24",
+  "thread_branch": "cursor/da996f0b",
+  "commit_scope": "Gap D₂ — block-join-gqa-causal: lgqa-block-causal (n_q=2, n_kv=1, HD=2, cfg-llama3) over seven loaded 4×4 Q6_K matrices; four-way 15 incl. fkwu",
+  "files_owned": [
+    "form/form-stdlib/block-join.fk",
+    "form/form-stdlib/tests/block-join-gqa-causal-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-24_block_join_gqa_gap_d2.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk form-stdlib/block-join.fk form-stdlib/tests/block-join-gqa-causal-band.fk"
+    ],
+    "fourth_arm": "block-join-gqa-causal four-way (Go/Rust/TS/fkwu) verdict 15, 0 divergent",
+    "notes": "bj-block-causal-gqa-d4 composes bj-block-mats-d4 with lgqa-block-causal; pins y[0][0]=1000297, y[1][0]=-1000107, y[1][2]=1499933; ≠ toy 1893731"
+  },
+  "ci_validation": {"status": "pending", "notes": "Manifest row block-join-gqa-causal fks 15 gates four-way in CI validate.sh"},
+  "deploy_validation": {"status": "pending", "summary": "No deploy; Form recipe landing"},
+  "phase_gate": {
+    "phase": "llm-inference-gap-d",
+    "gate": "Load proven · compute proven → GQA causal block uses file bytes",
+    "state": "d2-gqa-causal-four-way",
+    "can_move_next_phase": false,
+    "next": "d=3072 sliced carrier vs numpy (whisper_block0_real_carrier pattern); form-asm matvec lane swap (D₃)"
+  },
+  "idea_ids": ["form-native-models"],
+  "spec_ids": ["form-native-models"],
+  "task_ids": ["block-join-gap-d2"],
+  "contributors": [
+    {"contributor_id": "urs-muff", "contributor_type": "human", "roles": ["direction"]},
+    {"contributor_id": "agent:cursor", "contributor_type": "machine", "roles": ["implementation", "four-way-proof"]}
+  ],
+  "agent": {"name": "Cursor", "version": "Auto"},
+  "evidence_refs": [
+    "form/form-stdlib/block-join.fk",
+    "form/form-stdlib/tests/block-join-gqa-causal-band.fk",
+    "form/form-stdlib/tests/block-join-causal-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/form-native-models.form"
+  ],
+  "change_files": [
+    "form/form-stdlib/block-join.fk",
+    "form/form-stdlib/tests/block-join-gqa-causal-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-24_block_join_gqa_gap_d2.json"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "summary": "Four-way band at d=4 S=2; full-width carrier pending",
+    "expected_behavior_delta": "lgqa-block-causal runs with weights from weight-load on real Q6_K bytes",
+    "public_endpoints": ["n/a-form-stdlib-band"],
+    "test_flows": ["cd form && ./validate.sh ... block-join-gqa-causal-band.fk → 15 four-way"]
+  }
+}

--- a/form/form-stdlib/block-join.fk
+++ b/form/form-stdlib/block-join.fk
@@ -10,11 +10,11 @@
 ; for tb-dot once the ll-buffer store-loop lands f32 in the f64 read buffer.
 ;
 ; Kin: weight-load.fk (wl-load-q6k), transformer-block.fk (tb-dot/tb-matvec), llama-block.fk
-; (lblk-proj-seq / lblk-block-causal), kv-llama-block.fk (generation inner loop at block scale).
+; (lblk-proj-seq / lblk-block-causal), llama-gqa-block.fk (lgqa-block-causal), kv-llama-block.fk.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk
 ;
-; Proven by: form-stdlib/tests/block-join-band.fk form-stdlib/tests/block-join-causal-band.fk
+; Proven by: form-stdlib/tests/block-join-band.fk form-stdlib/tests/block-join-causal-band.fk form-stdlib/tests/block-join-gqa-causal-band.fk
 
 (do
     ; --- the first n dequantized weights as a row vector (for embedding in wq/wk/...) ---
@@ -72,6 +72,13 @@
         (lblk-block-causal xs g1 eps
             (nth mats 0) (nth mats 1) (nth mats 2) (nth mats 3)
             (div 1.0 (tn-sqrt 4.0)) 4
+            g2 (nth mats 4) (nth mats 5) (nth mats 6)))
+
+    ; --- causal GQA llama3 block (n_q=2, n_kv=1, HD=2, cfg-llama3) over loaded 4×4 matrices ---
+    (defn bj-block-causal-gqa-d4 (mats xs g1 eps g2)
+        (lgqa-block-causal xs g1 eps
+            (nth mats 0) (nth mats 1) (nth mats 2) (nth mats 3)
+            (div 1.0 (tn-sqrt 2.0)) 2 1 2 (rope-cfg-llama3)
             g2 (nth mats 4) (nth mats 5) (nth mats 6)))
 
     0)

--- a/form/form-stdlib/tests/block-join-gqa-causal-band.fk
+++ b/form/form-stdlib/tests/block-join-gqa-causal-band.fk
@@ -1,0 +1,39 @@
+; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-numerics.fk form-stdlib/trig.fk form-stdlib/llama-numerics.fk form-stdlib/rope.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/gqa-attn.fk form-stdlib/llama-block.fk form-stdlib/llama-gqa-block.fk form-stdlib/block-join.fk
+;
+; block-join-gqa-causal-band — gap D₂: lgqa-block-causal (n_q=2, n_kv=1, HD=2, cfg-llama3)
+; over ALL SEVEN 4×4 weight matrices loaded from real Q6_K file bytes. Same mini-GGUF fixture
+; as block-join-causal-band; forward algebra from llama-gqa-block.fk; weights from weight-load.
+;
+; Verdict 15 when every claim lands:
+;   1    y[0][0] -> 1000297     (causal token 0, loaded weights + GQA)
+;   2    y[1][0] -> -1000107   (causal last token dim 0)
+;   4    y[1][2] -> 1499933    (causal last token dim 2)
+;   8    y[0][0] != 1893731    (not toy kv-llama-block-band weights — join is real)
+(do
+    (let g (list
+        71 71 85 70 3 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0
+        1 0 0 0 0 0 0 0 97 4 0 0 0 42 0 0 0
+        1 0 0 0 0 0 0 0 116 1 0 0 0 0 1 0 0 0 0 0 0 14 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        129 67 45 48 246 235 134 149 186 127 28 200 234 116 6 4 49 221 74 254 192 205 18 137
+        34 162 64 213 250 173 64 57 126 163 27 184 54 160 166 158 148 231 71 98 8 92 31 12
+        221 193 69 80 20 103 72 176 235 201 188 123 81 139 162 183 40 198 208 233 142 80 135 134
+        25 169 70 99 147 0 200 106 135 2 231 97 45 177 89 92 55 93 105 158 202 125 1 89
+        13 118 37 32 255 88 100 181 162 50 128 188 42 29 39 252 218 93 46 23 143 250 181 135
+        239 144 2 33 0 129 2 107 17 117 84 164 74 130 149 138 110 222 169 173 162 150 16 197
+        149 153 182 101 28 105 134 173 98 151 170 155 128 98 166 158 216 21 214 81 154 96 101 105
+        148 106 21 102 149 10 110 148 5 36 229 172 106 83 120 9 170 120 154 193 89 46 6 213
+        192 142 156 84 171 59 159 128 171 183 158 97 146 61 77 171 196 0))
+    (let ti (gg-tinfo-start g))
+    (let off (add (mul (div (add (gg-ti-next g ti) 31) 32) 32) (gg-ti-dataoff g ti)))
+    (let x (list (list 1.0 -0.5 0.5 2.0) (list -1.0 0.25 1.5 -0.75)))
+    (let g1 (list 0.9 1.1 1.0 0.95))
+    (let g2 (list 1.05 0.95 1.0 0.9))
+    (let eps 0.00001)
+    (let mats (bj-block-mats-d4 g off))
+    (let yc (bj-block-causal-gqa-d4 mats x g1 eps g2))
+    (let c0 (if (eq (round (mul (nth (nth yc 0) 0) 1000000.0)) 1000297) 1 0))
+    (let c1 (if (eq (round (mul (nth (nth yc 1) 0) 1000000.0)) -1000107) 2 0))
+    (let c2 (if (eq (round (mul (nth (nth yc 1) 2) 1000000.0)) 1499933) 4 0))
+    (let c3 (if (eq (round (mul (nth (nth yc 0) 0) 1000000.0)) 1893731) 0 8))
+    (add c0 (add c1 (add c2 c3))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -990,4 +990,5 @@ form-asm-matvec-loop fks 127
 weight-load fks 4095
 block-join fks 255
 block-join-causal fks 15
+block-join-gqa-causal fks 15
 form-glsl fks 7


### PR DESCRIPTION
## Summary
- Adds `bj-block-causal-gqa-d4` to `block-join.fk` — composes `bj-block-mats-d4` with `lgqa-block-causal` (n_q=2, n_kv=1, HD=2, `rope-cfg-llama3`)
- New band `block-join-gqa-causal-band.fk`: seven 4×4 matrices from real llama3.2:3b Q6_K bytes, verdict **15**, four-way incl. fkwu
- Pins loaded outputs (`y[0][0]=1000297`, `y[1][0]=-1000107`, `y[1][2]=1499933`) and proves ≠ toy `1893731`
- Manifest + floor updated; evidence `commit_evidence_2026-06-24_block_join_gqa_gap_d2.json`

## Test plan
- [x] `cd form && ./validate.sh ... block-join-gqa-causal-band.fk` → 15, 0 divergent
- [x] `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-24_block_join_gqa_gap_d2.json`


Made with [Cursor](https://cursor.com)