### PR TITLE
tend: gap D₃ — fam-dot-loop join semantics + asm witness

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -133,8 +133,10 @@
 ;        ✓ D₁ — block-join-causal.fk (15): full lblk-block-causal d=4 S=2, ALL SEVEN 4×4 matrices from
 ;        loaded bytes; y[0][0]=999794 ≠ toy 1893731.
 ;        ✓ D₂ — block-join-gqa-causal.fk (15): lgqa-block-causal n_q=2 n_kv=1 HD=2 cfg-llama3, same
-;        loaded seven matrices; y[0][0]=1000297 ≠ toy 1893731. Adjacent: d=3072 carrier vs numpy,
-;        form-asm matvec lane swap.
+;        loaded seven matrices; y[0][0]=1000297 ≠ toy 1893731.
+;        ✓ D₃ — block-join-asm.fk (255): join dot uses bj-dot-fam (fam-dot-loop semantics); composes
+;        with fam-dot-loop/fam-dot2 bytes; witness scripts/block_join_asm_witness.sh runs fam-dot2 on
+;        loaded weights bit-exact vs bj-dot-row-n. Adjacent: d=3072 carrier vs numpy; ll-buffer store-loop.
 ;     E. TOKENIZER CARRIERS — vocab + merge-table loaders feeding bpe-tokenizer (proven) for the decode side.
 ;     F. vLLM-CLASS SPEED — the Metal MSL emit lane (proven) + batching + paged-KV + fused dequant-matmul.
 ;   NORTH STAR: a sovereign, on-device, Form-native SPEECH faculty — real audio → transcript (STT), NL → NL

--- a/docs/system_audit/commit_evidence_2026-06-24_block_join_asm_gap_d3.json
+++ b/docs/system_audit/commit_evidence_2026-06-24_block_join_asm_gap_d3.json
@@ -1,0 +1,68 @@
+{
+  "date": "2026-06-24",
+  "thread_branch": "cursor/da996f0b",
+  "commit_scope": "Gap D₃ — block-join dot path uses fam-dot-loop semantics (bj-dot-fam); composes with form-asm bytes; execution witness on loaded Q6_K weights",
+  "files_owned": [
+    "form/form-stdlib/block-join.fk",
+    "form/form-stdlib/tests/block-join-asm-band.fk",
+    "form/form-stdlib/tests/block-join-asm-witness-snippet.fk",
+    "scripts/block_join_asm_witness.sh",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-24_block_join_asm_gap_d3.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/block-join.fk form-stdlib/tests/block-join-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/block-join.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/block-join-asm-band.fk",
+      "./scripts/block_join_asm_witness.sh"
+    ],
+    "fourth_arm": "validate.sh block-join-asm-band.fk → 255; fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables); 1 ok, 0 divergent",
+    "notes": "bj-dot-row-n/bj-dot-q6k now use bj-dot-fam (fam-dot-loop semantic twin); fam-dot2 witness on real loaded weights bit-exact"
+  },
+  "ci_validation": {"status": "pending", "notes": "Manifest row block-join-asm fks 255"},
+  "deploy_validation": {"status": "pending", "summary": "No deploy; Form recipe + witness script"},
+  "phase_gate": {
+    "phase": "llm-inference-gap-d",
+    "gate": "Load · compute · join — native asm lane wired at semantic + byte + execution layer",
+    "state": "d3-asm-lane-four-way",
+    "can_move_next_phase": false,
+    "next": "d=3072 sliced carrier vs numpy (llama block0 join); fam-dot-loop execution witness for n>2; ll-buffer store-loop"
+  },
+  "idea_ids": ["form-native-models"],
+  "spec_ids": ["form-native-models"],
+  "task_ids": ["block-join-gap-d3"],
+  "contributors": [
+    {"contributor_id": "urs-muff", "contributor_type": "human", "roles": ["direction"]},
+    {"contributor_id": "agent:cursor", "contributor_type": "machine", "roles": ["implementation", "four-way-proof", "execution-witness"]}
+  ],
+  "agent": {"name": "Cursor", "version": "Auto"},
+  "evidence_refs": [
+    "form/form-stdlib/block-join.fk",
+    "form/form-stdlib/tests/block-join-asm-band.fk",
+    "form/form-stdlib/form-asm-matvec.fk",
+    "scripts/block_join_asm_witness.sh",
+    "form/fourth-arm-bands.txt"
+  ],
+  "change_files": [
+    "form/form-stdlib/block-join.fk",
+    "form/form-stdlib/tests/block-join-asm-band.fk",
+    "form/form-stdlib/tests/block-join-asm-witness-snippet.fk",
+    "scripts/block_join_asm_witness.sh",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-24_block_join_asm_gap_d3.json"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "summary": "Four-way band 255 + arm64 fam-dot2 witness on loaded Q6_K weights",
+    "expected_behavior_delta": "Join matvec uses fam-dot-loop semantics; composes with proven asm bytes; native execution matches on real weights",
+    "public_endpoints": ["n/a-form-stdlib-band"],
+    "test_flows": [
+      "cd form && ./validate.sh ... block-join-asm-band.fk → 255",
+      "./scripts/block_join_asm_witness.sh → WITNESS MATCH"
+    ]
+  }
+}

--- a/form/form-stdlib/block-join.fk
+++ b/form/form-stdlib/block-join.fk
@@ -3,18 +3,17 @@
 ; lblk-block-causal) were proven separately in gaps A/B/C; this cell is the JOIN — real weights
 ; from a buffer feed the same matvec/block algebra the toy bands already four-way.
 ;
-; bj-dot-row-n / bj-matvec-q6k-row: load one Q6_K superblock from file bytes, then run the tree-walker
-; dot/matvec over the dequantized f32 list — load proven · compute proven → forward matvec proven.
-; bj-wq-row-n: the first n dequantized weights as one projection row (embed a real row into a weight
-; matrix for block forward). The form-asm matvec lane (fam-dot2 / fam-dot-loop) is the adjacent swap
-; for tb-dot once the ll-buffer store-loop lands f32 in the f64 read buffer.
+; bj-dot-row-n / bj-matvec-q6k-row: load one Q6_K superblock from file bytes, then run the
+; fam-dot-loop semantic (bj-dot-fam — upward counted fold, tree-walker twin of fam-dot-loop) over
+; the dequantized f32 list. Native bytes: (fam-dot-loop) / (fam-dot2) in form-asm-matvec.fk;
+; execution witness: scripts/block_join_asm_witness.sh on loaded weights.
 ;
 ; Kin: weight-load.fk (wl-load-q6k), transformer-block.fk (tb-dot/tb-matvec), llama-block.fk
 ; (lblk-proj-seq / lblk-block-causal), llama-gqa-block.fk (lgqa-block-causal), kv-llama-block.fk.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk
 ;
-; Proven by: form-stdlib/tests/block-join-band.fk form-stdlib/tests/block-join-causal-band.fk form-stdlib/tests/block-join-gqa-causal-band.fk
+; Proven by: form-stdlib/tests/block-join-band.fk form-stdlib/tests/block-join-causal-band.fk form-stdlib/tests/block-join-gqa-causal-band.fk form-stdlib/tests/block-join-asm-band.fk
 
 (do
     ; --- the first n dequantized weights as a row vector (for embedding in wq/wk/...) ---
@@ -24,13 +23,20 @@
                   (bj-row-n-from bytes off (add i 1) (sub n 1)))))
     (defn bj-row-n (bytes off n) (bj-row-n-from bytes off 0 n))
 
+    ; --- dot semantics matching fam-dot-loop (upward counted fold; tree-walker twin of native lane) ---
+    (defn bj-dot-fam-from (a b i n acc)
+        (if (eq i n) acc
+            (bj-dot-fam-from (tail a) (tail b) (add i 1) n
+                (add acc (mul (head a) (head b))))))
+    (defn bj-dot-fam (a b) (bj-dot-fam-from a b 0 (len a) 0.0))
+
     ; --- dot the first n loaded weights with x (len x must be n) ---
     (defn bj-dot-row-n (bytes off n x)
-        (tb-dot (bj-row-n bytes off n) x))
+        (bj-dot-fam (bj-row-n bytes off n) x))
 
     ; --- load + dot: full 256-list dotted with x (len x must be 256) ---
     (defn bj-dot-q6k (bytes off x)
-        (tb-dot (wl-load-q6k bytes off) x))
+        (bj-dot-fam (wl-load-q6k bytes off) x))
 
     ; --- load + single-row matvec: y = [ dot(first n weights, x) ] where n = len x ---
     (defn bj-matvec-q6k-row (bytes off x)

--- a/form/form-stdlib/tests/block-join-asm-band.fk
+++ b/form/form-stdlib/tests/block-join-asm-band.fk
@@ -1,0 +1,51 @@
+; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/llama-block.fk form-stdlib/block-join.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+;
+; block-join-asm-band — gap D₃: the join dot path uses fam-dot-loop semantics (bj-dot-fam) and composes
+; with the proven form-asm byte lane. Regression pins from block-join-band still land; fam-dot-loop /
+; fam-dot2 program bytes are present; bj-dot-fam matches tb-dot on loaded rows (walker ≡ native semantics).
+;
+; Verdict 255 when every claim lands:
+;   1    bj-dot-row-n n=1 x=[1] -> 11215                         (join regression)
+;   2    bj-dot-row-n n=4 x=token -> 61310                       (join regression)
+;   4    bj-dot-row-n n=32 x=e0+e31 -> -771                      (join regression)
+;   8    bj-dot-fam == tb-dot on loaded 4-vector (semantic swap)   (walker twin of fam-dot-loop)
+;   16   fam-dot-loop program is 56 bytes                         (native row kernel)
+;   32   fam-dot2 program is 32 bytes                             (native 2-wide kernel)
+;   64   bj-dot-fam first-2 == fam-dot2-down on loaded w,x       (2-wide fold matches)
+;   128  len (wl-load-q6k g off) still 256                        (load not broken by swap)
+(do
+    (let g (list
+        71 71 85 70 3 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0
+        1 0 0 0 0 0 0 0 97 4 0 0 0 42 0 0 0
+        1 0 0 0 0 0 0 0 116 1 0 0 0 0 1 0 0 0 0 0 0 14 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        129 67 45 48 246 235 134 149 186 127 28 200 234 116 6 4 49 221 74 254 192 205 18 137
+        34 162 64 213 250 173 64 57 126 163 27 184 54 160 166 158 148 231 71 98 8 92 31 12
+        221 193 69 80 20 103 72 176 235 201 188 123 81 139 162 183 40 198 208 233 142 80 135 134
+        25 169 70 99 147 0 200 106 135 2 231 97 45 177 89 92 55 93 105 158 202 125 1 89
+        13 118 37 32 255 88 100 181 162 50 128 188 42 29 39 252 218 93 46 23 143 250 181 135
+        239 144 2 33 0 129 2 107 17 117 84 164 74 130 149 138 110 222 169 173 162 150 16 197
+        149 153 182 101 28 105 134 173 98 151 170 155 128 98 166 158 216 21 214 81 154 96 101 105
+        148 106 21 102 149 10 110 148 5 36 229 172 106 83 120 9 170 120 154 193 89 46 6 213
+        192 142 156 84 171 59 159 128 171 183 158 97 146 61 77 171 196 0))
+    (let ti (gg-tinfo-start g))
+    (let off (add (mul (div (add (gg-ti-next g ti) 31) 32) 32) (gg-ti-dataoff g ti)))
+    (let xtok (list 1.0 -0.5 0.5 2.0))
+    (let x32 (list 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
+                    0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0))
+    (let row4 (bj-row-n g off 4))
+    ; fam-dot2 downward fold on first two elements (matches native byte lane for n=2)
+    (defn bja-dot-fam2-down (a b)
+        (add (mul (nth a 1) (nth b 1)) (mul (nth a 0) (nth b 0))))
+    (let c0 (if (eq (round (mul (bj-dot-row-n g off 1 (list 1.0)) 1000000.0)) 11215) 1 0))
+    (let c1 (if (eq (round (mul (bj-dot-row-n g off 4 xtok) 1000000.0)) 61310) 2 0))
+    (let c2 (if (eq (round (mul (bj-dot-row-n g off 32 x32) 1000000.0)) -771) 4 0))
+    (let c3 (if (eq (round (mul (bj-dot-fam row4 xtok) 1000000.0))
+                    (round (mul (tb-dot row4 xtok) 1000000.0))) 8 0))
+    (let c4 (if (eq (len (fam-dot-loop)) 56) 16 0))
+    (let c5 (if (eq (len (fam-dot2)) 32) 32 0))
+    (let c6 (if (eq (round (mul (bj-dot-fam (list (nth row4 0) (nth row4 1))
+                                        (list (nth xtok 0) (nth xtok 1))) 1000000.0))
+                    (round (mul (bja-dot-fam2-down row4 xtok) 1000000.0))) 64 0))
+    (let c7 (if (eq (len (wl-load-q6k g off)) 256) 128 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/form-stdlib/tests/block-join-asm-witness-snippet.fk
+++ b/form/form-stdlib/tests/block-join-asm-witness-snippet.fk
@@ -1,0 +1,25 @@
+; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/block-join.fk
+(do
+    (let g (list
+        71 71 85 70 3 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0
+        1 0 0 0 0 0 0 0 97 4 0 0 0 42 0 0 0
+        1 0 0 0 0 0 0 0 116 1 0 0 0 0 1 0 0 0 0 0 0 14 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        129 67 45 48 246 235 134 149 186 127 28 200 234 116 6 4 49 221 74 254 192 205 18 137
+        34 162 64 213 250 173 64 57 126 163 27 184 54 160 166 158 148 231 71 98 8 92 31 12
+        221 193 69 80 20 103 72 176 235 201 188 123 81 139 162 183 40 198 208 233 142 80 135 134
+        25 169 70 99 147 0 200 106 135 2 231 97 45 177 89 92 55 93 105 158 202 125 1 89
+        13 118 37 32 255 88 100 181 162 50 128 188 42 29 39 252 218 93 46 23 143 250 181 135
+        239 144 2 33 0 129 2 107 17 117 84 164 74 130 149 138 110 222 169 173 162 150 16 197
+        149 153 182 101 28 105 134 173 98 151 170 155 128 98 166 158 216 21 214 81 154 96 101 105
+        148 106 21 102 149 10 110 148 5 36 229 172 106 83 120 9 170 120 154 193 89 46 6 213
+        192 142 156 84 171 59 159 128 171 183 158 97 146 61 77 171 196 0))
+    (let ti (gg-tinfo-start g))
+    (let off (add (mul (div (add (gg-ti-next g ti) 31) 32) 32) (gg-ti-dataoff g ti)))
+    (let xtok (list 1.0 -0.5 0.5 2.0))
+    (print (wl-q6k-at g off 0))
+    (print (wl-q6k-at g off 1))
+    (print (nth xtok 0))
+    (print (nth xtok 1))
+    (print (bj-dot-row-n g off 2 (list (nth xtok 0) (nth xtok 1))))
+    0)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -994,4 +994,5 @@ weight-load fks 4095
 block-join fks 255
 block-join-causal fks 15
 block-join-gqa-causal fks 15
+block-join-asm fks 255
 form-glsl fks 7

--- a/scripts/block_join_asm_witness.sh
+++ b/scripts/block_join_asm_witness.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# block_join_asm_witness.sh — gap D₃ execution witness: fam-dot2 RUNS on REAL loaded weights
+# from the block-join mini-GGUF fixture and MATCHES the Form join dot (bj-dot-row-n n=2).
+#
+# Composes gap B (form_asm_matvec_witness.sh) with gap D (block-join loaded weights).
+# Skips on non-arm64-macOS hosts (same as gap B).
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS witness; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld; skipping"; exit 0; }
+command -v clang >/dev/null || { echo "need clang for harness; skipping"; exit 0; }
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/bjasm.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+SNIP="form-stdlib/tests/block-join-asm-witness-snippet.fk"
+raw="$(cd "$FORM" && ./validate.sh form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk \
+    form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk \
+    form-stdlib/transformer-block.fk form-stdlib/block-join.fk "$SNIP" 2>&1)"
+parsed="$(python3 - "$raw" <<'PY'
+import re, sys
+out = sys.argv[1]
+m = re.search(r'witness-snippet\.fk\s*→\s*([^\n]+)\n((?:-?\d[\d.]*\n)+)', out)
+if not m:
+    sys.exit(1)
+nums = [m.group(1).strip()] + re.findall(r'^(-?\d[\d.]*)', m.group(2), re.M)
+print("\n".join(nums[:5]))
+PY
+)" || { echo "FAIL: Form join dot parse"; echo "$raw" | tail -8; exit 1; }
+w0="$(echo "$parsed" | sed -n '1p')"
+w1="$(echo "$parsed" | sed -n '2p')"
+x0="$(echo "$parsed" | sed -n '3p')"
+x1="$(echo "$parsed" | sed -n '4p')"
+expect="$(echo "$parsed" | sed -n '5p')"
+echo "loaded w=[$w0,$w1] x=[$x0,$x1] bj-dot-row-n n=2 -> $expect"
+
+MATVEC="$FORM/form-stdlib/form-asm-matvec.fk"
+{ echo "(do"
+  echo '    (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))'
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$MATVEC"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<'DRV'
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (print (str_concat "MACHO " (hxb (mo-object-sym (fam-dot2) (list 95 114 101 99 105 112 101)))))
+    0)
+DRV
+} > "$work/emit.fk"
+hex="$(cd "$FORM" && "$GO" "$work/emit.fk" 2>/dev/null | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: no Mach-O"; exit 1; }
+echo "$hex" | xxd -r -p > "$work/recipe.o"
+SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$work/recipe.dylib" "$work/recipe.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null \
+   || { echo "FAIL: ld -dylib"; exit 1; }
+
+cat > "$work/harness.c" <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+typedef double (*dot_fn)(const double *);
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen: %s\n", dlerror()); return 2; }
+    dot_fn dot = (dot_fn)dlsym(h, "recipe");
+    if (!dot) { fprintf(stderr, "dlsym: %s\n", dlerror()); return 3; }
+    double buf[4] __attribute__((aligned(16)));
+    buf[0] = atof(argv[2]); buf[1] = atof(argv[3]);
+    buf[2] = atof(argv[4]); buf[3] = atof(argv[5]);
+    double got = dot(buf);
+    printf("%.17g\n", got);
+    return 0;
+}
+EOF
+clang -o "$work/harness" "$work/harness.c" || exit 1
+got="$("$work/harness" "$work/recipe.dylib" "$w0" "$w1" "$x0" "$x1")"
+echo "fam-dot2 EXEC on loaded weights -> $got"
+
+python3 - "$got" "$expect" <<'PY'
+import sys
+g, e = float(sys.argv[1]), float(sys.argv[2])
+if g == e:
+    print("WITNESS: fam-dot2 on loaded llama3.2:3b Q6_K weights MATCHES bj-dot-row-n n=2, bit-for-bit.")
+    sys.exit(0)
+print(f"WITNESS FAILED: got={g!r} expect={e!r}")
+sys.exit(1)
+PY


### PR DESCRIPTION
## Summary
- `bj-dot-fam` replaces `tb-dot` in `block-join.fk` — upward counted fold matching `fam-dot-loop` semantics
- `block-join-asm-band.fk` (255, four-way incl. fkwu): join regression + `bj-dot-fam == tb-dot` on loaded rows + `fam-dot-loop`/`fam-dot2` byte lengths
- `scripts/block_join_asm_witness.sh`: `fam-dot2` dylib executes on **real** loaded llama3.2:3b Q6_K weights, bit-exact vs `bj-dot-row-n n=2`

## Test plan
- [x] `validate.sh ... block-join-band.fk` → 255 (regression)
- [x] `validate.sh ... block-join-asm-band.fk` → 255, fourth arm four-way
- [x] `./scripts/block_join_asm_witness.sh` → WITNESS MATCH
- [x] causal + GQA bands still 15


Made with [Cursor](https://cursor.com)