### PR TITLE
tend: gap D₄′ — wl-load-q4k (Q4_K weight load)

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -138,8 +138,9 @@
 ;        with fam-dot-loop/fam-dot2 bytes; witness scripts/block_join_asm_witness.sh runs fam-dot2 on
 ;        loaded weights bit-exact vs bj-dot-row-n.
 ;        ✓ D₄ — scripts/llama_block0_join_carrier.py d=4: independent ref vs Form
-;        bj-block-causal-gqa-d4 on loaded Q6_K weights; max|Δ|=0, y[0][0]=1.000297. Adjacent:
-;        wl-load-q4k for blk.0 tensors, sliced d>4 toward d_model=3072.
+;        bj-block-causal-gqa-d4 on loaded Q6_K weights; max|Δ|=0, y[0][0]=1.000297.
+;        ✓ D₄′ — weight-load-q4k-band.fk (4095): wl-load-q4k composes q4k-dequant on REAL
+;        blk.0.ffn_gate Q4_K bytes (mini-GGUF). Adjacent: carrier at sliced d>4 from full GGUF.
 ;     E. TOKENIZER CARRIERS — vocab + merge-table loaders feeding bpe-tokenizer (proven) for the decode side.
 ;     F. vLLM-CLASS SPEED — the Metal MSL emit lane (proven) + batching + paged-KV + fused dequant-matmul.
 ;   NORTH STAR: a sovereign, on-device, Form-native SPEECH faculty — real audio → transcript (STT), NL → NL

--- a/docs/system_audit/commit_evidence_2026-06-24_weight_load_q4k_gap_d4p.json
+++ b/docs/system_audit/commit_evidence_2026-06-24_weight_load_q4k_gap_d4p.json
@@ -1,0 +1,59 @@
+{
+  "date": "2026-06-24",
+  "thread_branch": "cursor/da996f0b",
+  "commit_scope": "Gap D₄′ — wl-load-q4k composes q4k-dequant on real blk.0.ffn_gate Q4_K bytes; four-way 4095",
+  "files_owned": [
+    "form/form-stdlib/weight-load.fk",
+    "form/form-stdlib/tests/weight-load-q4k-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-24_weight_load_q4k_gap_d4p.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/q4k-dequant.fk form-stdlib/weight-load.fk form-stdlib/tests/weight-load-q4k-band.fk",
+      "cd form && ./validate.sh ... weight-load-band.fk (regression 4095)"
+    ],
+    "fourth_arm": "weight-load-q4k-band validate.sh → 4095; weight-load-band regression: fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables); 1 ok, 0 divergent",
+    "notes": "Real llama3.2:3b blk.0.ffn_gate Q4_K superblock in mini-GGUF; pins match q4k-dequant-band"
+  },
+  "ci_validation": {"status": "pending", "notes": "Manifest row weight-load-q4k fks 4095"},
+  "deploy_validation": {"status": "pending", "summary": "No deploy"},
+  "phase_gate": {
+    "phase": "llm-inference-gap-d",
+    "gate": "Q4_K load composes like Q6_K — file bytes to f32 weights",
+    "state": "d4p-q4k-load-four-way",
+    "can_move_next_phase": false,
+    "next": "block-join from Q4_K blk.0 tensors; carrier sliced d=96+ from full GGUF"
+  },
+  "idea_ids": ["form-native-models"],
+  "spec_ids": ["form-native-models"],
+  "task_ids": ["weight-load-q4k-gap-d4p"],
+  "contributors": [
+    {"contributor_id": "urs-muff", "contributor_type": "human", "roles": ["direction"]},
+    {"contributor_id": "agent:cursor", "contributor_type": "machine", "roles": ["implementation", "four-way-proof"]}
+  ],
+  "agent": {"name": "Cursor", "version": "Auto"},
+  "evidence_refs": [
+    "form/form-stdlib/weight-load.fk",
+    "form/form-stdlib/tests/weight-load-q4k-band.fk",
+    "form/form-stdlib/tests/q4k-dequant-band.fk",
+    "form/fourth-arm-bands.txt"
+  ],
+  "change_files": [
+    "form/form-stdlib/weight-load.fk",
+    "form/form-stdlib/tests/weight-load-q4k-band.fk",
+    "form/fourth-arm-bands.txt",
+    "docs/coherence-substrate/form-native-models.form",
+    "docs/system_audit/commit_evidence_2026-06-24_weight_load_q4k_gap_d4p.json"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "summary": "validate.sh weight-load-q4k-band → 4095",
+    "expected_behavior_delta": "wl-load-q4k / wl-q4k-at carve Q4_K superblock from GGUF buffer and dequant",
+    "public_endpoints": ["n/a-form-stdlib-band"],
+    "test_flows": ["cd form && ./validate.sh ... weight-load-q4k-band.fk → 4095"]
+  }
+}

--- a/form/form-stdlib/tests/weight-load-q4k-band.fk
+++ b/form/form-stdlib/tests/weight-load-q4k-band.fk
@@ -1,0 +1,53 @@
+; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q4k-dequant.fk form-stdlib/weight-load.fk
+;
+; weight-load-q4k-band — Q4_K load composition (gap D₄′): same mini-GGUF shape as weight-load-band but
+; type 12 (Q4_K) and the REAL blk.0.ffn_gate.weight superblock from llama3.2:3b (same bytes as
+; q4k-dequant-band). Proves gguf-locate → wl-slice → fd-f16 → q4k-dequant end-to-end from file bytes.
+;
+; Mini-GGUF: header + KV + Q4_K tensor-info (type 12) + 22-byte align pad + 144-byte superblock at off 96.
+;
+; Verdict 4095 when every claim lands (pins from q4k-dequant-band):
+;   1    gg-tinfo-start == 41
+;   2    gg-ti-type == 12 (Q4_K)
+;   4    dim0 == 256 AND dataoff == 0
+;   8    wl-q4k-d decoded from buffer bytes (round * 1e12)
+;   16   wl-q4k-at i=0   -> -2871
+;   32   wl-q4k-at i=31  -> -10722
+;   64   wl-q4k-at i=64  -> -34391
+;   128  wl-q4k-at i=128 -> 24084
+;   256  wl-q4k-at i=160 -> 29026
+;   512  wl-q4k-at i=191 -> -5137
+;   1024 wl-q4k-at i=200 -> -6369
+;   2048 len(wl-load-q4k)==256 AND list[255] -> 18738
+(do
+    (let g (list
+        71 71 85 70 3 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0
+        1 0 0 0 0 0 0 0 97 4 0 0 0 42 0 0 0
+        1 0 0 0 0 0 0 0 116 1 0 0 0 0 1 0 0 0 0 0 0 12 0 0 0 0 0 0 0 0 0 0 0
+        0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+        244 6 197 19 229 178 240 255 160 107 239 191 26 174 22 179 135 151 157 85 141 119 132 25
+        148 67 236 75 75 167 115 128 174 96 117 181 88 109 101 142 159 152 85 156 10 167 235 213
+        146 203 140 191 96 14 137 172 203 135 167 205 186 152 140 104 105 206 186 155 173 116 185 249
+        234 213 153 236 74 153 105 231 185 130 215 82 135 196 38 164 99 99 85 43 227 52 4 143
+        40 178 50 41 40 68 35 182 104 119 144 218 54 134 1 70 58 118 95 195 183 37 121 198
+        151 151 119 118 105 149 136 0 246 133 186 151 162 154 150 168 180 87 25 135 119 107 201 187))
+    (let ti (gg-tinfo-start g))
+    (let dataoff (gg-ti-dataoff g ti))
+    (let off (add (mul (div (add (gg-ti-next g ti) 31) 32) 32) dataoff))
+    (let full (wl-load-q4k g off))
+    (let c0  (if (eq ti 41)                                                     1 0))
+    (let c1  (if (eq (gg-ti-type g ti) 12)                                      2 0))
+    (let c2  (if (and (eq (gg-ti-dim0 g ti) 256) (eq dataoff 0))                4 0))
+    (let c3  (if (eq (round (mul (wl-q4k-d g off) 1000000000000.0))
+                     (round (mul 0.00010609626770019531 1000000000000.0)))    8 0))
+    (let c4  (if (eq (round (mul (wl-q4k-at g off 0)   1000000.0)) -2871)      16 0))
+    (let c5  (if (eq (round (mul (wl-q4k-at g off 31)  1000000.0)) -10722)     32 0))
+    (let c6  (if (eq (round (mul (wl-q4k-at g off 64)  1000000.0)) -34391)     64 0))
+    (let c7  (if (eq (round (mul (wl-q4k-at g off 128) 1000000.0)) 24084)     128 0))
+    (let c8  (if (eq (round (mul (wl-q4k-at g off 160) 1000000.0)) 29026)     256 0))
+    (let c9  (if (eq (round (mul (wl-q4k-at g off 191) 1000000.0)) -5137)     512 0))
+    (let c10 (if (eq (round (mul (wl-q4k-at g off 200) 1000000.0)) -6369)    1024 0))
+    (let c11 (if (and (eq (len full) 256)
+                      (eq (round (mul (nth full 255) 1000000.0)) 18738))    2048 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7
+    (add c8 (add c9 (add c10 c11))))))))))))

--- a/form/form-stdlib/weight-load.fk
+++ b/form/form-stdlib/weight-load.fk
@@ -21,15 +21,20 @@
 ;   d      = fd-f16 (le-u16 buf (off+208))
 ; and then (q6k-dequant d ql qh scales) -> the 256 dequantized weights.
 ;
-; Kin: gguf-read.fk (gg-ti-dataoff locates off), q6k-dequant.fk (the unpack), f16-decode.fk (the d decode),
-; q4k-dequant.fk (the sibling quant, same load shape with type 12), kv-llama-block.fk (the forward the loaded
-; weights feed). The ll-buffer fill (gap C's "fill an ll-buffer / fkwu f64 pool") is the adjacent rung: this
-; cell produces the f32 list; ll-buf wraps the store loop that lands it in the matvec's read buffer.
+; Q4_K block memory layout (llama.cpp block_q4_K, QK_K=256), 144 bytes at the block base:
+;   d (f16)    (off + 0)   super-scale
+;   dmin (f16) (off + 2)   super-min
+;   scales[12] (off + 4)   packed 6-bit block-scales/mins
+;   qs[128]    (off + 16)  packed 4-bit quants
+; wl-load-q4k composes q4k-dequant over bytes carved from the buffer (type 12 tensors — blk.0 ffn_*).
 ;
-; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk
+; Kin: gguf-read.fk (gg-ti-dataoff locates off), q6k-dequant.fk, q4k-dequant.fk (the unpack),
+; f16-decode.fk (d/dmin decode), block-join.fk (forward). The ll-buffer fill is adjacent.
 ;
-; Proven by: form-stdlib/tests/weight-load-band.fk (four-way, against a mini-GGUF carrying a REAL
-; llama3.2:3b token_embd Q6_K superblock, asserting the recovered weights match q6k-dequant-band's ground truth)
+; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/q4k-dequant.fk
+;
+; Proven by: form-stdlib/tests/weight-load-band.fk form-stdlib/tests/weight-load-q4k-band.fk (four-way,
+; mini-GGUF fixtures carrying REAL llama3.2:3b Q6_K / Q4_K superblocks)
 
 (do
     ; --- wl-slice: n bytes of `bytes` starting at `off` (drop the prefix, take the window). The carrier
@@ -62,5 +67,19 @@
                   (wl-q6k-ql bytes off)
                   (wl-q6k-qh bytes off)
                   (wl-q6k-scales bytes off)))
+
+    ; --- Q4_K fields carved from the buffer (block_q4_K, 144 bytes) ---
+    (defn wl-q4k-d      (bytes off) (fd-f16 (wl-u16 bytes off)))
+    (defn wl-q4k-dmin   (bytes off) (fd-f16 (wl-u16 bytes (add off 2))))
+    (defn wl-q4k-scales (bytes off) (wl-slice bytes (add off 4) 12))
+    (defn wl-q4k-qs     (bytes off) (wl-slice bytes (add off 16) 128))
+
+    (defn wl-load-q4k (bytes off)
+        (q4k-dequant (wl-q4k-d bytes off) (wl-q4k-dmin bytes off)
+                     (wl-q4k-scales bytes off) (wl-q4k-qs bytes off)))
+
+    (defn wl-q4k-at (bytes off i)
+        (q4k-at i (wl-q4k-d bytes off) (wl-q4k-dmin bytes off)
+                (wl-q4k-scales bytes off) (wl-q4k-qs bytes off)))
 
     0)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -991,6 +991,7 @@ gguf-locate fks 127
 form-asm-matvec fks 127
 form-asm-matvec-loop fks 127
 weight-load fks 4095
+weight-load-q4k fks 4095
 block-join fks 255
 block-join-causal fks 15
 block-join-gqa-causal fks 15


### PR DESCRIPTION
## Summary
- `wl-load-q4k` / `wl-q4k-at` in `weight-load.fk` — carve Q4_K superblock (d, dmin, scales, qs) from GGUF bytes → `q4k-dequant`
- `weight-load-q4k-band.fk` (4095, four-way incl. fkwu): mini-GGUF with **real** `blk.0.ffn_gate.weight` Q4_K superblock; pins match `q4k-dequant-band`

## Test plan
- [x] `validate.sh ... weight-load-q4k-band.fk` → 4095, fourth arm four-way
- [x] `weight-load-band.fk` + `block-join-band.fk` regression unchanged


Made with [Cursor](https://cursor.com)