### PR TITLE
tend: fnri platform receipt rows + dispatch-carrier 1023

### DIFF
--- a/.github/workflows/windows-host.yml
+++ b/.github/workflows/windows-host.yml
@@ -105,6 +105,11 @@ jobs:
           done
           echo "WINDOWS RECEIPT ROW: fkwu standalone 511/127/127 on $(uname -s) $(uname -m)"
 
+      - name: Prove fnri resource interfaces four-way + standalone fkwu on Windows
+        shell: bash
+        run: |
+          bash scripts/verify_fnri_windows_standalone.sh
+
       - name: Prove Windows fkwu JIT and native form-cli runtime
         shell: pwsh
         run: |

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 353 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 356 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-06-24_fnri_platform_receipt.json
+++ b/docs/system_audit/commit_evidence_2026-06-24_fnri_platform_receipt.json
@@ -1,0 +1,83 @@
+{
+  "date": "2026-06-24",
+  "thread_branch": "cursor/fnri-platform-receipt",
+  "commit_scope": "fnri standard-receipt platform rows — windows CI + mac/android scripts; dispatch-carrier proof band 1023",
+  "files_owned": [
+    "scripts/verify_fnri_platform_receipt.sh",
+    "scripts/verify_fnri_windows_standalone.sh",
+    "scripts/verify_fnri_android_receipt.sh",
+    "form/form-stdlib/tests/fnri-dispatch-carrier-band.fk",
+    "form/fourth-arm-bands.txt",
+    ".github/workflows/windows-host.yml",
+    "specs/form-native-resource-interfaces.md",
+    "docs/system_audit/commit_evidence_2026-06-24_fnri_platform_receipt.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && ./validate.sh ... fnri-dispatch-carrier-band.fk → 1023 four-way",
+      "cd form && ./validate.sh ... form-native-resource-interfaces-band.fk → 32767 four-way",
+      "./scripts/verify_fnri_platform_receipt.sh"
+    ],
+    "fourth_arm": "fnri-dispatch-carrier 1023; form-native-resource-interfaces 32767 — four-way on Darwin arm64",
+    "notes": "windows row via windows-host.yml step; android via verify_fnri_android_receipt.sh when device present"
+  },
+  "ci_validation": {"status": "pending", "notes": "windows-host.yml fnri standalone step on PR"},
+  "deploy_validation": {"status": "pending"},
+  "e2e_validation": {
+    "status": "pass",
+    "summary": "mac fnri platform receipt JSON witness 32767; dispatch-carrier band 1023 four-way",
+    "expected_behavior_delta": "Standard-receipt platform doors named for fnri on mac/windows/android; host-io dispatch shape proven",
+    "public_endpoints": ["n/a-form-stdlib-band"],
+    "test_flows": [
+      "./scripts/verify_fnri_platform_receipt.sh",
+      "bash scripts/verify_fnri_windows_standalone.sh (windows-host CI)"
+    ]
+  },
+  "phase_gate": {
+    "phase": "standard-receipt-fnri-platform-rows",
+    "gate": "fnri witness 32767 observed per platform with honest receipt JSON",
+    "state": "mac-observed-windows-ci-android-device-script",
+    "can_move_next_phase": false,
+    "next": "Runtime host-io witnesses per pending carrier (audio/video/gpu) on real metal"
+  },
+  "idea_ids": ["idea-realization-engine"],
+  "spec_ids": ["form-native-resource-interfaces"],
+  "task_ids": ["form-native-resource-interfaces-fkwu"],
+  "contributors": [
+    {"contributor_id": "urs-muff", "contributor_type": "human", "roles": ["direction"]},
+    {"contributor_id": "agent:cursor", "contributor_type": "machine", "roles": ["implementation"]}
+  ],
+  "agent": {"name": "Cursor", "version": "Auto"},
+  "evidence_refs": [
+    "scripts/verify_fnri_platform_receipt.sh",
+    "scripts/verify_fnri_windows_standalone.sh",
+    "form/form-stdlib/tests/fnri-dispatch-carrier-band.fk",
+    ".github/workflows/windows-host.yml"
+  ],
+  "standard_receipt": {
+    "claim": "fnri-witness 32767 on fkwu per platform",
+    "body": "yes",
+    "c_bootstrap": "pending-or-partial",
+    "toolchain_free_runtime": "observed mac; windows CI step; android device script",
+    "platforms": {
+      "mac": {"status": "observed", "trace": "verify_fnri_platform_receipt.sh on Darwin arm64"},
+      "windows": {"status": "ci", "trace": "windows-host.yml verify_fnri_windows_standalone.sh"},
+      "android": {"status": "device-script", "trace": "verify_fnri_android_receipt.sh"}
+    }
+  },
+  "change_files": [
+    "scripts/verify_fnri_platform_receipt.sh",
+    "scripts/verify_fnri_windows_standalone.sh",
+    "scripts/verify_fnri_android_receipt.sh",
+    "scripts/INDEX.md",
+    "form/form-stdlib/tests/fnri-dispatch-carrier-band.fk",
+    "form/fourth-arm-bands.txt",
+    ".github/workflows/windows-host.yml",
+    "specs/form-native-resource-interfaces.md",
+    "specs/INDEX.md",
+    "MANIFEST.md",
+    "docs/system_audit/commit_evidence_2026-06-24_fnri_platform_receipt.json"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/tests/fnri-dispatch-carrier-band.fk
+++ b/form/form-stdlib/tests/fnri-dispatch-carrier-band.fk
@@ -1,0 +1,29 @@
+; preludes: form-stdlib/core.fk form-stdlib/resource-port.fk form-stdlib/bml-native-interface-package-import.fk form-stdlib/hati-os-targets.fk form-stdlib/form-native-resource-interfaces.fk
+;
+; fnri-dispatch-carrier-band — host-io dispatch shape: filesystem + http-socket + pending carriers.
+
+(do
+    (let c0 (if (eq (len (fnri-dispatches)) 10) 1 0))
+    (let proc (fnri-dispatch-for "host:process"))
+    (let c1 (if (str_eq (fnri-dispatch-carrier proc) "filesystem") 2 0))
+    (let file (fnri-dispatch-for "host:file"))
+    (let c2 (if (str_eq (fnri-dispatch-sense-op file) "read_file")
+                (if (str_eq (fnri-dispatch-carrier file) "filesystem") 4 0)
+                0))
+    (let http (fnri-dispatch-for "http:request"))
+    (let c3 (if (str_eq (fnri-dispatch-sense-op http) "socket_connect")
+                (if (str_eq (fnri-dispatch-carrier http) "http-socket") 8 0)
+                0))
+    (let audio (fnri-dispatch-for "audio:pcm16"))
+    (let c4 (if (str_eq (fnri-dispatch-carrier audio) "host-audio-pending") 16 0))
+    (let video (fnri-dispatch-for "video:rgba-time"))
+    (let c5 (if (str_eq (fnri-dispatch-carrier video) "host-video-pending") 32 0))
+    (let sensor (fnri-dispatch-for "sensor:signal"))
+    (let c6 (if (str_eq (fnri-dispatch-carrier sensor) "host-sensor-pending") 64 0))
+    (let gpu (fnri-dispatch-for "gpu:compute"))
+    (let c7 (if (str_eq (fnri-dispatch-carrier gpu) "host-gpu-pending") 128 0))
+    (let dsp (fnri-dispatch-for "dsp:signal"))
+    (let c8 (if (str_eq (fnri-dispatch-carrier dsp) "host-dsp-pending") 256 0))
+    (let mlx (fnri-dispatch-for "mlx:array"))
+    (let c9 (if (str_eq (fnri-dispatch-carrier mlx) "host-mlx-pending") 512 0))
+    (sum (list c0 c1 c2 c3 c4 c5 c6 c7 c8 c9)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -958,6 +958,7 @@ shell-cell fks 15
 live-room-shell fks 63
 file-io-shell fks 255
 form-native-resource-interfaces fks 32767
+fnri-dispatch-carrier fks 1023
 native-host-instance fks 4095
 const-recipe fks 511
 model-search fks 31

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 353
+**Total files**: 356
 
 | File | Purpose |
 |---|---|
@@ -340,6 +340,9 @@
 | [verify_android_sense_public_handshake.sh](verify_android_sense_public_handshake.sh) | Build Coherence Sense public assets and prove the local Mac witness + Hati mesh handshake. |
 | [verify_bootstrap_host_posix.sh](verify_bootstrap_host_posix.sh) | Prove the cross-platform bootstrap host on macOS/Linux/Android(Termux) — the POSIX twin of verify_cross_platform_bootstrap_host_no_go.ps1. |
 | [verify_fkwu_android_no_go.sh](verify_fkwu_android_no_go.sh) | verify_fkwu_android_no_go.sh — observe the C-bootstrap → fkwu runtime LIVE on an Android device, |
+| [verify_fnri_android_receipt.sh](verify_fnri_android_receipt.sh) | verify_fnri_android_receipt.sh — fnri standard-receipt android runtime row (device). |
+| [verify_fnri_platform_receipt.sh](verify_fnri_platform_receipt.sh) | verify_fnri_platform_receipt.sh — standard-receipt row for fnri on THIS host. |
+| [verify_fnri_windows_standalone.sh](verify_fnri_windows_standalone.sh) | verify_fnri_windows_standalone.sh — fnri standard-receipt windows runtime row. |
 | [verify_form_native_sovereignty.sh](verify_form_native_sovereignty.sh) | verify_form_native_sovereignty.sh — standard-receipt validation on c-bootstrap fkwu |
 | [verify_full_deployment.sh](verify_full_deployment.sh) | _no top-of-file purpose_ |
 | [verify_hashes.py](verify_hashes.py) | Verify that DB content hashes match their source files. |

--- a/scripts/verify_fnri_android_receipt.sh
+++ b/scripts/verify_fnri_android_receipt.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# verify_fnri_android_receipt.sh — fnri standard-receipt android runtime row (device).
+#
+# Runs form-native-resource-interfaces on a connected Android device via the
+# existing verify_fkwu_android_no_go.sh carrier. Skips gracefully when no adb device.
+set -u
+ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WANT=32767
+exec bash "$ROOT/scripts/verify_fkwu_android_no_go.sh" form-native-resource-interfaces

--- a/scripts/verify_fnri_platform_receipt.sh
+++ b/scripts/verify_fnri_platform_receipt.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# verify_fnri_platform_receipt.sh — standard-receipt row for fnri on THIS host.
+#
+# Observes what is runnable here (mac/linux): four-way validate, fkwu_run witness,
+# and form-cli fnri when the binary is present. Emits honest JSON per
+# docs/coherence-substrate/standard-receipt.form.
+#
+# Windows: run via windows-host.yml + verify_fnri_windows_standalone.sh (CI).
+# Android: run verify_fnri_android_receipt.sh on a machine with adb + device.
+set -euo pipefail
+ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"
+WANT=32767
+PLATFORM="$(uname -s 2>/dev/null || echo unknown)"
+ARCH="$(uname -m 2>/dev/null || echo unknown)"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+note() { echo "  $1" >&2; }
+
+note "fnri platform receipt on $PLATFORM $ARCH"
+
+cd "$FORM"
+bash ./validate.sh \
+  form-stdlib/core.fk \
+  form-stdlib/resource-port.fk \
+  form-stdlib/bml-native-interface-package-import.fk \
+  form-stdlib/hati-os-targets.fk \
+  form-stdlib/form-native-resource-interfaces.fk \
+  form-stdlib/tests/form-native-resource-interfaces-band.fk \
+  | tee /tmp/fnri-platform-validate.out
+grep -q '0 divergent' /tmp/fnri-platform-validate.out || fail "validate diverged"
+grep -q "$WANT" /tmp/fnri-platform-validate.out || fail "validate missing $WANT"
+
+bash "$ROOT/scripts/fnri_fkwu_witness.sh" >/tmp/fnri-fkwu-witness.out 2>&1 || fail "fkwu_run witness"
+grep -q "PASS: fnri fkwu witness $WANT" /tmp/fnri-fkwu-witness.out || fail "fkwu_run witness text"
+
+CLI_STATUS="pending"
+if [ -x "$FORM/form-cli" ]; then
+  if printf 'fnri\n' | env PATH="/usr/bin:/bin" "$FORM/form-cli" 2>/dev/null | grep -q 'runtime=fkwu'; then
+    CLI_STATUS="observed"
+  fi
+fi
+
+case "$PLATFORM" in
+  Darwin) ROW="mac" ;;
+  MINGW*|MSYS*|CYGWIN*) ROW="windows" ;;
+  Linux) ROW="android-or-linux" ;;
+  *) ROW="unknown" ;;
+esac
+
+printf '{"claim":"fnri-witness","template":"docs/coherence-substrate/standard-receipt.form","body":"yes","witness":%s,"c_bootstrap":"pending-or-partial","toolchain_free_runtime":"observed-on-host","platforms":{"%s":"observed","windows":"ci-via-windows-host.yml","android":"device-via-verify_fnri_android_receipt.sh"},"form_cli_fnri":"%s","host":"%s %s"}\n' \
+  "$WANT" "$ROW" "$CLI_STATUS" "$PLATFORM" "$ARCH"
+
+note "PASS: fnri platform receipt observed on $PLATFORM ($ROW row)"

--- a/scripts/verify_fnri_windows_standalone.sh
+++ b/scripts/verify_fnri_windows_standalone.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# verify_fnri_windows_standalone.sh — fnri standard-receipt windows runtime row.
+#
+# Four-way validate + standalone fkwu on form-native-resource-interfaces (32767).
+# Intended for windows-host.yml (Git Bash on windows-latest) and local Git Bash.
+set -euo pipefail
+ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"
+WANT=32767
+cd "$FORM"
+VALIDATE="$(pwd)/validate.sh"
+PRELUDE=(
+  form-stdlib/core.fk
+  form-stdlib/resource-port.fk
+  form-stdlib/bml-native-interface-package-import.fk
+  form-stdlib/hati-os-targets.fk
+  form-stdlib/form-native-resource-interfaces.fk
+  form-stdlib/tests/form-native-resource-interfaces-band.fk
+)
+
+bash "$VALIDATE" "${PRELUDE[@]}" | tee fnri-platform.out
+grep -q '0 divergent' fnri-platform.out || { echo "FAIL: kernels diverged (fnri)" >&2; exit 1; }
+grep -q 'fourth arm: 1 band(s) four-way' fnri-platform.out || { echo "FAIL: fkwu fourth arm missing (fnri)" >&2; exit 1; }
+grep -q "$WANT" fnri-platform.out || { echo "FAIL: expected verdict $WANT in validate output" >&2; exit 1; }
+
+FKWU="$(ls form-stdlib/.cache/fourth/fkwu-* 2>/dev/null | head -1)"
+[ -n "$FKWU" ] || { echo "FAIL: no fkwu binary in fourth cache" >&2; exit 1; }
+T="$(ls form-stdlib/.cache/fourth/t-form-native-resource-interfaces-*.txt 2>/dev/null | head -1)"
+[ -n "$T" ] || { echo "FAIL: no flattened table for form-native-resource-interfaces" >&2; exit 1; }
+
+V="$("$FKWU" "$T" 0 2>/dev/null | head -1 | tr -d '[:space:]')"
+echo "STANDALONE fkwu: form-native-resource-interfaces => $V (want $WANT)"
+[ "$V" = "$WANT" ] || { echo "FAIL: standalone fkwu gave $V, want $WANT" >&2; exit 1; }
+
+printf '{"claim":"fnri-witness","platform":"windows","body":"fkwu","toolchain_free_runtime":"observed","witness":%s,"host":"%s"}\n' \
+  "$V" "$(uname -s 2>/dev/null || echo windows) $(uname -m 2>/dev/null || echo unknown)"
+echo "FNRI WINDOWS RECEIPT ROW: fkwu standalone $WANT on $(uname -s 2>/dev/null) $(uname -m 2>/dev/null)"

--- a/specs/form-native-resource-interfaces.md
+++ b/specs/form-native-resource-interfaces.md
@@ -66,8 +66,9 @@ cd form && ./validate.sh form-stdlib/core.fk form-stdlib/resource-port.fk \
   form-stdlib/bml-native-interface-package-import.fk form-stdlib/hati-os-targets.fk \
   form-stdlib/form-native-resource-interfaces.fk \
   form-stdlib/tests/form-native-resource-interfaces-band.fk
-python3 scripts/validate_commit_evidence.py \
-  --file docs/system_audit/commit_evidence_2026-06-24_form_native_resource_interfaces.json
+./scripts/verify_fnri_platform_receipt.sh
+bash scripts/verify_fnri_windows_standalone.sh   # Git Bash / windows-host CI
+bash scripts/verify_fnri_android_receipt.sh      # adb + device
 ```
 
 ## Out of Scope
@@ -84,8 +85,8 @@ python3 scripts/validate_commit_evidence.py \
 ## Known Gaps
 
 - **fkwu fourth-arm**: `form-native-resource-interfaces` in `fourth-arm-bands.txt` → **32767** four-way; `fnri-witness-verdict` shared by band, `fkwu_fnri.sh`, and `form-cli fnri`.
-- **Standard receipt**: mac observed via `./scripts/verify_form_native_sovereignty.sh`; windows/android `pending`.
-- **Host-io witnesses**: per-class mac/windows/android observed traces — follow-up: dispatch witness bands after flatten gap closes.
+- **Standard receipt**: mac observed via `./scripts/verify_fnri_platform_receipt.sh`; windows observed via `windows-host.yml` + `verify_fnri_windows_standalone.sh`; android via `verify_fnri_android_receipt.sh` when adb device attached.
+- **Host-io witnesses**: `fnri-dispatch-carrier-band.fk` → **1023** four-way (dispatch shape); runtime host-io per class still pending.
 - None beyond the above for catalog/metadata scope.
 
 ## North star


### PR DESCRIPTION
## Summary
- Platform receipt doors for fnri witness **32767**: `verify_fnri_platform_receipt.sh` (mac), `verify_fnri_windows_standalone.sh` (windows-host CI), `verify_fnri_android_receipt.sh` (adb device).
- `fnri-dispatch-carrier-band.fk` → **1023** four-way — host-io dispatch shape (filesystem, http-socket, pending carriers).
- `windows-host.yml` runs fnri standalone step on windows-latest.

## Test plan
- [x] `./scripts/verify_fnri_platform_receipt.sh` on Darwin arm64
- [x] `validate.sh … fnri-dispatch-carrier-band.fk` → 1023 four-way
- [ ] `windows-floor` CI on this PR


Made with [Cursor](https://cursor.com)