### PR TITLE
tend(form): rag-sovereignty-corpus band (R6 four-way)

### DIFF
--- a/docs/system_audit/commit_evidence_20260624_rag_sovereignty_corpus_band.json
+++ b/docs/system_audit/commit_evidence_20260624_rag_sovereignty_corpus_band.json
@@ -1,0 +1,64 @@
+{
+  "date": "2026-06-24",
+  "thread_branch": "cursor/sovereignty-rag-witness",
+  "commit_scope": "R6 sovereignty corpus four-way band: fs_list witnesses standard-receipt.form and host-kernel.form on all kernels.",
+  "standard_receipt": {
+    "claim": "Merge corpus architecture cells are enumerable for rag-heal on every kernel.",
+    "body": "yes — rag-sovereignty-corpus-band fs_list membership",
+    "c_bootstrap": "partial",
+    "toolchain_free": "pending",
+    "platforms": {
+      "mac": "observed — four-way verdict 3",
+      "windows": "pending",
+      "android": "pending"
+    },
+    "honest_floor": "Band proves enumeration only; full heal loop remains host-io single-runtime witness."
+  },
+  "files_owned": [
+    "docs/system_audit/commit_evidence_20260624_rag_sovereignty_corpus_band.json"
+  ],
+  "idea_ids": ["agent-cli"],
+  "spec_ids": ["fkwu-native-host-resources", "form-cli-self-healing-memory"],
+  "task_ids": ["task-2026-06-24-rag-sovereignty-corpus"],
+  "contributors": [
+    {
+      "contributor_id": "cursor-agent",
+      "contributor_type": "machine",
+      "roles": ["implementation"]
+    }
+  ],
+  "agent": {
+    "name": "cursor",
+    "version": "claude-opus-4-8"
+  },
+  "change_intent": "runtime_feature",
+  "change_files": [
+    "form/form-stdlib/tests/rag-sovereignty-corpus-band.fk",
+    "form/fourth-arm-bands.txt"
+  ],
+  "evidence_refs": [
+    "FOUR-WAY: rag-sovereignty-corpus-band -> 3 Go/Rust/TS/fkwu",
+    "R6: standard-receipt.form + host-kernel.form in merge corpus path"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd form && FORM_STANDARD_LANE=1 ./validate.sh form-stdlib/tests/rag-sovereignty-corpus-band.fk"
+    ],
+    "fourth_arm_outputs": ["rag-sovereignty-corpus four-way 3"]
+  },
+  "ci_validation": { "status": "pending", "commands": [] },
+  "deploy_validation": { "status": "pending", "environment": "local-form-runtime" },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "form-cli ask grounded retrieval smoke and full heal witness still open."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Sovereignty corpus paths registered in fourth-arm manifest.",
+    "public_endpoints": ["local form-cli / fkwu only"],
+    "test_flows": [
+      "cd form && FORM_STANDARD_LANE=1 ./validate.sh form-stdlib/tests/rag-sovereignty-corpus-band.fk"
+    ]
+  }
+}

--- a/form/form-stdlib/tests/rag-sovereignty-corpus-band.fk
+++ b/form/form-stdlib/tests/rag-sovereignty-corpus-band.fk
@@ -1,0 +1,13 @@
+; rag-sovereignty-corpus-band.fk — merge corpus paths for local sovereignty retrieval.
+;
+; preludes: form-stdlib/core.fk
+;
+; R6 witness: the architecture docs rag-heal indexes are visible to fs_list on every
+; kernel at one moment. Membership of two load-bearing .form cells — fixed verdict 3.
+(do
+    (defn rsc-has (xs nm)
+        (if (eq (len xs) 0) 0
+            (if (str_eq (head xs) nm) 1 (rsc-has (tail xs) nm))))
+    (let entries (fs_list "../docs/coherence-substrate"))
+    (add (if (eq (rsc-has entries "standard-receipt.form") 1) 1 0)
+         (if (eq (rsc-has entries "host-kernel.form") 1) 2 0)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -753,6 +753,7 @@ rag-key fks 7
 rag-index-codec fks 15
 rag-embed fks 15
 fs-list fks 3
+rag-sovereignty-corpus fks 3
 host-filesystem fks 15
 gcd fkc 31
 form-cli-review-gap fkc 63


### PR DESCRIPTION
## Summary
- Adds `rag-sovereignty-corpus-band.fk` — four-way witness (verdict 3) that `standard-receipt.form` and `host-kernel.form` are enumerable under the merge corpus path used by `rag-heal.fk`.
- Registers band in `fourth-arm-bands.txt` toward spec R6 (local sovereignty knowledge corpus).

## Test plan
- [x] `cd form && FORM_STANDARD_LANE=1 ./validate.sh form-stdlib/tests/rag-sovereignty-corpus-band.fk` → 3 four-way
- [ ] CI windows-floor + validate-thread-process


Made with [Cursor](https://cursor.com)