### PR TITLE
tend: mac fnri dispatch proven in verify scripts

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-24_fnri_mac_dispatch.json
+++ b/docs/system_audit/commit_evidence_2026-06-24_fnri_mac_dispatch.json
@@ -1,0 +1,73 @@
+{
+  "date": "2026-06-24",
+  "thread_branch": "cursor/fnri-dispatch-proven",
+  "commit_scope": "FNRI fnri-cli-band via fc-fnri; mac binary dispatch receipt observed in verify scripts",
+  "files_owned": [
+    "form/form-stdlib/tests/fnri-cli-band.fk",
+    "scripts/verify_fnri_mac_binary_dispatch.sh",
+    "scripts/verify_fnri_platform_receipt.sh",
+    "scripts/fnri_fkwu_witness.sh",
+    "docs/system_audit/commit_evidence_2026-06-24_fnri_mac_dispatch.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "bash scripts/fnri_fkwu_witness.sh → PASS (4095 + mac binary)",
+      "bash scripts/verify_fnri_platform_receipt.sh → PASS",
+      "bash scripts/verify_fnri_mac_binary_dispatch.sh → witness=32767"
+    ],
+    "fourth_arm": "form-cli-band 4095; mac form-cli dispatch observed",
+    "notes": "fnri-cli-band calls fc-fnri (dispatch body) not duplicate catalog helpers"
+  },
+  "ci_validation": {"status": "pending"},
+  "deploy_validation": {"status": "pending"},
+  "e2e_validation": {
+    "status": "pass",
+    "summary": "Platform receipt script now requires mac form-cli binary dispatch, not bands alone",
+    "expected_behavior_delta": "named band-only receipt → proven fkwu + binary dispatch",
+    "public_endpoints": ["n/a-form-stdlib-band"],
+    "test_flows": [
+      "bash scripts/fnri_fkwu_witness.sh",
+      "bash scripts/verify_fnri_platform_receipt.sh",
+      "bash scripts/verify_fnri_mac_binary_dispatch.sh"
+    ]
+  },
+  "phase_gate": {
+    "phase": "fnri-mac-dispatch-observed",
+    "gate": "4095 + mac binary witness/know/receipt",
+    "state": "mac-observed",
+    "can_move_next_phase": false,
+    "next": "windows/android platform receipt rows"
+  },
+  "idea_ids": ["idea-realization-engine"],
+  "spec_ids": ["form-native-resource-interfaces"],
+  "task_ids": ["form-native-resource-interfaces-fkwu"],
+  "contributors": [
+    {"contributor_id": "urs-muff", "contributor_type": "human", "roles": ["direction"]},
+    {"contributor_id": "agent:cursor", "contributor_type": "machine", "roles": ["implementation"]}
+  ],
+  "agent": {"name": "Cursor", "version": "Auto"},
+  "evidence_refs": [
+    "scripts/verify_fnri_mac_binary_dispatch.sh",
+    "scripts/fnri_fkwu_witness.sh",
+    "form/form-stdlib/tests/form-cli-band.fk"
+  ],
+  "standard_receipt": {
+    "claim": "fnri mac platform dispatch observed via form-cli binary",
+    "body": "yes",
+    "c_bootstrap": "observed",
+    "toolchain_free_runtime": "partial",
+    "platforms": {
+      "mac": {"status": "observed", "trace": "verify_fnri_mac_binary_dispatch.sh"},
+      "windows": {"status": "pending", "trace": "verify_fnri_windows_standalone.sh"},
+      "android": {"status": "pending", "trace": "verify_fnri_android_receipt.sh"}
+    }
+  },
+  "change_files": [
+    "form/form-stdlib/tests/fnri-cli-band.fk",
+    "scripts/verify_fnri_mac_binary_dispatch.sh",
+    "scripts/verify_fnri_platform_receipt.sh",
+    "scripts/fnri_fkwu_witness.sh"
+  ],
+  "change_intent": "runtime_feature"
+}

--- a/form/form-stdlib/tests/fnri-cli-band.fk
+++ b/form/form-stdlib/tests/fnri-cli-band.fk
@@ -1,4 +1,4 @@
-; fnri-cli-band.fk — witness / resolve / know tails via catalog + form-cli.fk helpers.
+; fnri-cli-band.fk — witness / resolve / know via fc-fnri (form-cli dispatch body).
 ; preludes: form-stdlib/core.fk form-stdlib/resource-port.fk form-stdlib/bml-native-interface-package-import.fk form-stdlib/hati-os-targets.fk form-stdlib/form-native-resource-interfaces.fk form-stdlib/form-fs.fk form-stdlib/storage-port.fk form-stdlib/host-kernel-carrier.fk form-stdlib/fnri-standin.fk form-stdlib/fnri-receipt.fk form-stdlib/form-cli.fk
 
 (do
@@ -7,12 +7,4 @@
             (if (eq b 0) acc
                 (if (eq b 10) acc
                     (fnri-read-line (add i 1) (str_concat acc (byte_to_str b)))))))
-    (defn fnri-cli-dispatch (line)
-        (do (let parts (split-on line " "))
-            (let sub (head parts))
-            (if (str_eq sub "witness") (fnri-witness-str)
-            (if (str_eq sub "know") (fnri-know-line (fc-part parts 1 ""))
-            (if (str_eq sub "resolve")
-                (fnri-resolve-line (fc-part parts 1 "") (fc-part parts 2 ""))
-                (str_concat "fnri-cli: unknown subcommand '" (str_concat sub "'")))))))
-    (fnri-cli-dispatch (fnri-read-line 0 "")))
+    (fc-fnri (fnri-read-line 0 "")))

--- a/scripts/fnri_fkwu_witness.sh
+++ b/scripts/fnri_fkwu_witness.sh
@@ -7,4 +7,5 @@ OUT="$(cd "$ROOT/form" && ./validate.sh form-stdlib/tests/form-cli-band.fk 2>&1 
 echo "$OUT"
 VERDICT="$(echo "$OUT" | awk '{print $NF}')"
 [ "$VERDICT" = "$WANT" ] || { echo "FAIL: form-cli-band fourth=$VERDICT want $WANT" >&2; exit 1; }
-echo "PASS: fnri form-cli-band $WANT (fkwu source)"
+"$ROOT/scripts/verify_fnri_mac_binary_dispatch.sh" >/dev/null || exit 1
+echo "PASS: fnri form-cli-band $WANT (fkwu source + mac binary dispatch)"

--- a/scripts/verify_fnri_mac_binary_dispatch.sh
+++ b/scripts/verify_fnri_mac_binary_dispatch.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# verify_fnri_mac_binary_dispatch.sh — mac form-cli binary fnri/receipt dispatch (observed).
+set -eu
+ROOT="$(cd -P "$(dirname "$0")/.." && pwd)"
+WANT_WITNESS=32767
+WITNESS="$("$ROOT/scripts/form-cli-run.sh" fnri witness 2>/dev/null | grep -E '^[0-9]+$' | tail -1 || true)"
+[ "$WITNESS" = "$WANT_WITNESS" ] || {
+  echo "FAIL: form-cli fnri witness=$WITNESS want $WANT_WITNESS" >&2
+  exit 1
+}
+KNOW="$("$ROOT/scripts/form-cli-run.sh" fnri know standard-receipt 2>/dev/null | grep -E '^docs/' | tail -1 || true)"
+[ "$KNOW" = "docs/coherence-substrate/standard-receipt.form" ] || {
+  echo "FAIL: form-cli fnri know=$KNOW" >&2
+  exit 1
+}
+RECEIPT="$("$ROOT/scripts/form-cli-run.sh" receipt platform 2>/dev/null | grep '^claim=' | tail -1 || true)"
+echo "$RECEIPT" | grep -q "witness=$WANT_WITNESS" || {
+  echo "FAIL: form-cli receipt platform missing witness=$WANT_WITNESS ($RECEIPT)" >&2
+  exit 1
+}
+echo "PASS: mac form-cli dispatch witness=$WITNESS know=$KNOW" >&2
+echo "$RECEIPT"

--- a/scripts/verify_fnri_platform_receipt.sh
+++ b/scripts/verify_fnri_platform_receipt.sh
@@ -13,5 +13,6 @@ VERDICT="$(echo "$OUT" | awk -F'= ' '{print $2}')"
 # interfaces band 32767 + stand-ins 15 each = witness row components; check interfaces fourth
 IFACE="$(cd "$ROOT/form" && ./validate.sh form-stdlib/tests/form-native-resource-interfaces-band.fk 2>&1 | grep 'fourth' | awk '{print $NF}')"
 [ "$IFACE" = "32767" ] || { echo "FAIL: fnri witness band fourth=$IFACE" >&2; exit 1; }
+"$ROOT/scripts/verify_fnri_mac_binary_dispatch.sh" || exit 1
 echo "claim=fnri-witness witness=$IFACE audio=15 video=15 gpu=15 staged=1"
 echo "PASS: fnri platform receipt (fkwu bands)" >&2


### PR DESCRIPTION
## Summary
- **fnri-cli-band** routes through `fc-fnri` (dispatch body) instead of duplicate catalog helpers.
- **`verify_fnri_mac_binary_dispatch.sh`** — observes mac `form-cli` witness=32767, know path, receipt platform row.
- **`verify_fnri_platform_receipt.sh`** and **`fnri_fkwu_witness.sh`** now require binary dispatch, not fkwu bands alone.

## Test plan
- [x] `bash scripts/fnri_fkwu_witness.sh`
- [x] `bash scripts/verify_fnri_platform_receipt.sh`
- [x] `bash scripts/verify_fnri_mac_binary_dispatch.sh`


Made with [Cursor](https://cursor.com)