### PR TITLE
[codex] fix Windows startup python probe

### DIFF
--- a/api/tests/test_edge_cases_regression.py
+++ b/api/tests/test_edge_cases_regression.py
@@ -689,6 +689,24 @@ def test_wellness_reading_projects_sections_into_shared_shape() -> None:
     assert "Witness-trace: trace breathing within budget" in reading["what_can_compost"][1]
 
 
+def test_wellness_nested_python_checks_use_current_interpreter(monkeypatch) -> None:
+    """Nested wellness probes should not depend on a literal python3 launcher."""
+    mod = _load_script_module("wellness_check")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    assert mod.sense_form_ontology() == ["  form ontology matches kernel parsers (Go/Rust/TS)"]
+    assert mod.sense_form_blueprints()[0].startswith("  every Form Blueprint number is registered")
+    assert mod.sense_form_primitives()[0].startswith("  every kernel native carries")
+    assert calls
+    assert all(cmd[0] == mod.sys.executable for cmd in calls)
+
+
 def test_static_to_dynamic_cells_are_live_not_attention() -> None:
     """Resolved static-to-dynamic surfaces leave wants_attention."""
     mod = _load_script_module("wellness_check")

--- a/docs/system_audit/commit_evidence_2026-06-25_startup_sequence_windows_python.json
+++ b/docs/system_audit/commit_evidence_2026-06-25_startup_sequence_windows_python.json
@@ -1,0 +1,96 @@
+{
+  "date": "2026-06-25",
+  "thread_branch": "codex/fix-startup-sequence",
+  "commit_scope": "Repair Windows startup sensing by making nested Python startup and wellness probes reuse the interpreter already running the parent script instead of shelling out to a literal python3 launcher. This keeps make wellness, arrival.py, and nested Form drift checks aligned with the Windows Makefile launcher py -3 and avoids the Microsoft Store python alias.",
+  "files_owned": [
+    "scripts/wellness_check.py",
+    "scripts/arrival.py",
+    "api/tests/test_edge_cases_regression.py",
+    "docs/system_audit/commit_evidence_2026-06-25_startup_sequence_windows_python.json"
+  ],
+  "idea_ids": [
+    "agent-pipeline"
+  ],
+  "spec_ids": [
+    "developer-quick-start"
+  ],
+  "task_ids": [
+    "task-2026-06-25-startup-sequence-windows-python"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance-criteria"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "analysis",
+        "implementation",
+        "verification",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "gpt-5"
+  },
+  "evidence_refs": [
+    "Before the fix, make wellness launched on Windows through Makefile PYTHON=py -3, but nested wellness checks invoked literal python3 and reported the Microsoft Store alias message under Form ontology.",
+    "scripts/wellness_check.py now has _python_cmd(), returning the current sys.executable, and sense_form_ontology, sense_form_blueprints, and sense_form_primitives all use it for nested Python probes.",
+    "scripts/arrival.py now invokes scripts/wellness_check.py through sys.executable as well, so session arrival and manual wellness share the same interpreter selection.",
+    "api/tests/test_edge_cases_regression.py pins the nested wellness probes so they use the current interpreter instead of a literal python3 launcher.",
+    "Post-fix make wellness no longer reports the Microsoft Store alias message; Form ontology reports 'form ontology matches kernel parsers (Go/Rust/TS)'."
+    ,
+    "Sub-agent validation (Hilbert, qa-engineer) inspected the diff, confirmed the intended interpreter replacement and regression test, ran py_compile and make wellness successfully, and reported the same focused pytest environment blocker: ModuleNotFoundError for pywebpush with no API venv present."
+  ],
+  "change_files": [
+    "scripts/wellness_check.py",
+    "scripts/arrival.py",
+    "api/tests/test_edge_cases_regression.py",
+    "docs/system_audit/commit_evidence_2026-06-25_startup_sequence_windows_python.json"
+  ],
+  "change_intent": "process_only",
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "py -3 -m py_compile scripts\\wellness_check.py scripts\\arrival.py",
+      "make wellness",
+      "standalone regression probe importing scripts/wellness_check.py and stubbing subprocess.run to assert nested probes call sys.executable",
+      "sub-agent Hilbert read-only validation: git diff inspection, py_compile, make wellness, git diff --check"
+    ],
+    "notes": "Focused pytest target with system Python was blocked before collection by missing optional API dependency pywebpush. The regression logic was run standalone without importing app.main, and make wellness exercised the affected startup path."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "CI has not run yet for this branch."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed-startup-tooling-change",
+    "notes": "Local startup scripts and wellness sensing changed; no public HTTP endpoint was changed."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local validation passed; PR CI and merge validation remain pending."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "On Windows, make wellness and session arrival no longer depend on a literal python3 executable for nested Python probes. The body-state read reaches the real Form ontology, blueprint, and primitive drift checks.",
+    "public_endpoints": [
+      "none changed; local startup and wellness tooling only"
+    ],
+    "test_flows": [
+      "make wellness on Windows worktree reports Form ontology match instead of Microsoft Store python alias message.",
+      "Nested wellness probe regression asserts child commands start with sys.executable."
+    ]
+  }
+}

--- a/scripts/arrival.py
+++ b/scripts/arrival.py
@@ -226,7 +226,7 @@ def main() -> int:
     print()
     print("── body state right now ──\n")
     subprocess.run(
-        ["python3", str(ROOT / "scripts" / "wellness_check.py")],
+        [sys.executable or "python3", str(ROOT / "scripts" / "wellness_check.py")],
         check=False,
     )
     return 0

--- a/scripts/wellness_check.py
+++ b/scripts/wellness_check.py
@@ -25,6 +25,11 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
+
+def _python_cmd() -> list[str]:
+    """Run nested Python checks with the interpreter already executing wellness."""
+    return [sys.executable or "python3"]
+
 # Files at root that are meant to be there even without incoming refs.
 # Config, tooling, canonical orientation, license-style docs.
 ROOT_EXEMPT = {
@@ -886,7 +891,7 @@ def sense_form_ontology() -> list[str]:
         return ["  (form/scripts/validate_form_ontology.py not present; skipping)"]
     try:
         result = subprocess.run(
-            ["python3", str(script)],
+            [*_python_cmd(), str(script)],
             capture_output=True, text=True, timeout=15,
         )
     except Exception as exc:
@@ -918,7 +923,7 @@ def sense_form_blueprints() -> list[str]:
         return ["  (scripts/scan_form_blueprints.py not present; skipping)"]
     try:
         result = subprocess.run(
-            ["python3", str(script), "--check"],
+            [*_python_cmd(), str(script), "--check"],
             capture_output=True, text=True, timeout=30,
         )
     except Exception as exc:
@@ -966,7 +971,7 @@ def sense_form_primitives() -> list[str]:
         return ["  (form/scripts/validate_primitive_registry.py not present; skipping)"]
     try:
         result = subprocess.run(
-            ["python3", str(script)],
+            [*_python_cmd(), str(script)],
             capture_output=True, text=True, timeout=30,
         )
     except Exception as exc:


### PR DESCRIPTION
## What changed
- Reused the running Python interpreter for nested wellness probes instead of a literal `python3` launcher.
- Reused the running interpreter when `arrival.py` invokes `scripts/wellness_check.py`.
- Added a regression test proving nested wellness probes start with `sys.executable`.
- Added commit evidence for the startup-sequence repair.

## Why
On Windows, `make wellness` correctly enters through `py -3`, but nested checks still invoked `python3`. That could hit the Microsoft Store alias and report `Python was not found` instead of the real Form ontology reading.

## Validation
- `make prompt-guide`
- `py -3 -m py_compile scripts\wellness_check.py scripts\arrival.py`
- `make wellness` now reports `form ontology matches kernel parsers (Go/Rust/TS)` instead of the alias error
- standalone regression probe for nested interpreter selection
- sub-agent Hilbert read-only validation: diff inspection, py_compile, make wellness, git diff --check
- `py -3 scripts\validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence`
- `py -3 scripts\worktree_pr_guard.py --mode local --base-ref origin/main`
- `py -3 scripts\check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`

## Known blocker
The focused pytest target is blocked in this worktree before collection because the API env is absent and system Python lacks `pywebpush`.