### PR TITLE
Fix form-cli local model lane receipts

### DIFF
--- a/bin/form-cli
+++ b/bin/form-cli
@@ -19,9 +19,7 @@ ROOT="$(cd -P "$(dirname "$src")/.." && pwd)"
 RAG="$ROOT/scripts/form_cli_rag.py"
 
 ensure_native_cli() {
-  if [ ! -x "$ROOT/form/form-cli" ]; then
-    bash "$ROOT/scripts/ensure_form_cli_native.sh" >/dev/null 2>&1 || true
-  fi
+  bash "$ROOT/scripts/ensure_form_cli_native.sh" >/dev/null 2>&1 || true
   tries=0
   while [ ! -x "$ROOT/form/form-cli" ] && [ "$tries" -lt 20 ]; do
     sleep 1
@@ -47,11 +45,11 @@ form-cli — the one door (local-first, Form-native)
   form-cli -p "<question>"          one-shot print mode, same Form-native carrier as ask
   form-cli repl                     native fkwu form-cli REPL
 
-  form-cli ask "<question>" [-m LOCAL] [-j JUDGE] [--remote "claude -p"] [--judge-gate]
-        default ask path: Form-native local-first route through form-cli-ask-plus.fk;
-        the four-way sufficiency gate escalates only when local is not enough
+  form-cli ask "<question>"
+        default ask path: Form-native local-only staged RAG through the c-bootstrapped
+        fkwu binary; no hidden HTTP/Ollama/subscription fallback
   form-cli ask+ "<question>" [-m LOCAL] [-j JUDGE] [--remote "claude -p"] [--judge-gate]
-        daily-driver ask: local-first, then the four-way-proven sufficiency gate
+        explicit escalating ask: local-first, then the four-way-proven sufficiency gate
         (form-cli-sufficiency.fk via form-cli-ask-gate.fk) escalates to the
         subscription oracle when local is not enough. Sovereignty-first by default
         (a usable local answer stands; a local failure escalates); --judge-gate adds
@@ -117,14 +115,39 @@ run_native_cli() {
   printf '%s\n' "$out"
 }
 
+ask_native_local() {
+  q="$*"
+  [ -n "$q" ] || { echo "usage: form-cli ask '<question>'" >&2; exit 2; }
+  home="${HOME:-$ROOT}"
+  mkdir -p "$home/.coherence-network" || {
+    echo "form-cli ask: cannot create $home/.coherence-network" >&2
+    exit 3
+  }
+  printf '%s' "$q" > "$home/.coherence-network/rag-query.txt" || {
+    echo "form-cli ask: cannot stage local RAG query" >&2
+    exit 3
+  }
+  out="$(native_send "ask-staged")"
+  if [ -z "$out" ]; then
+    echo "form-cli: native staged ask returned no result; run form-cli index after T_flat is available" >&2
+    exit 4
+  fi
+  if printf '%s\n' "$out" | grep -q '^grounded:'; then
+    printf '%s\n' "trust  path:native  grounded:yes  freq:no  suffic:yes  -> native-partial" >&2
+  else
+    printf '%s\n' "trust  path:native  grounded:no  freq:no  suffic:no  -> native-miss" >&2
+  fi
+  printf '%s\n' "$out"
+}
+
 cmd="${1:-}"; shift 2>/dev/null || true
 case "$cmd" in
   "")        usage ;;
   help|-h|--help) usage ;;
   repl)      b="$(ensure_native_cli)" || exit "$?"; cd "${HOME:-$ROOT}" && exec "$b" ;;
-  -p|--print) exec bash "$ROOT/scripts/form_cli_ask.sh" "$@" ;;  # one-shot print mode uses the Form-native ask carrier
+  -p|--print) ask_native_local "$@" ;;  # one-shot print mode uses the local fkwu staged ask carrier
   -*)        exec bash "$ROOT/scripts/form_cli_ask.sh" "$cmd" "$@" ;; # ask flags (-m/-j/--remote/...) -> Form-native ask carrier
-  ask)       exec bash "$ROOT/scripts/form_cli_ask.sh" "$@" ;;  # default asks route through Form-native code
+  ask)       ask_native_local "$@" ;;  # default ask is local fkwu staged RAG only
   ask+)      exec bash "$ROOT/scripts/form_cli_ask.sh" "$@" ;;  # body is form-cli-ask.fk, run by the kernel
   grounded)  run_native_cli "grounded $*" ;;
   rag-status) run_native_cli "rag-status" ;;

--- a/docs/system_audit/commit_evidence_2026-06-26_form_cli_local_model_lane_next.json
+++ b/docs/system_audit/commit_evidence_2026-06-26_form_cli_local_model_lane_next.json
@@ -1,0 +1,116 @@
+{
+  "date": "2026-06-26",
+  "thread_branch": "codex/form-cli-model-lane-next-d617",
+  "commit_scope": "Close the next form-cli local-model-lane gaps by refreshing stale native c-bootstrap binaries, making ordinary form-cli ask bounded/local-only, and promoting the fkwu Metal model-cell receipt into the local validation contract.",
+  "files_owned": [
+    "bin/form-cli",
+    "docs/system_audit/commit_evidence_2026-06-26_form_cli_local_model_lane_next.json",
+    "form/form-stdlib/tests/form-cli-band.fk",
+    "scripts/ensure_form_cli_native.sh",
+    "scripts/validate_form_cli_local_receipts.sh"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide",
+      "make wellness",
+      "bin/form-cli model-status",
+      "bin/form-cli ask substrate",
+      "bin/form-cli ask \"what is the next smallest provable step for full end-to-end form-cli fkwu Metal local model inference after local RAG receipts\"",
+      "bin/form-cli ask+ --remote \"printf remote-disabled\" \"what is the next smallest provable step for full end-to-end form-cli fkwu Metal local model inference after local RAG receipts\"",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/text-tokenize.fk form-stdlib/rag-embed.fk form-stdlib/rag-index-codec.fk form-stdlib/rag-retrieve.fk form-stdlib/rag-ask.fk form-stdlib/form-cli-ask.fk form-stdlib/line-grammar.fk form-stdlib/voice-traits.fk form-stdlib/nearest-shape.fk form-stdlib/co-learning.fk form-stdlib/co-learning-stream.fk form-stdlib/mesh-dispatch.fk form-stdlib/surprise-salience.fk form-stdlib/host-sense-organ.fk form-stdlib/speech-organ.fk form-stdlib/native-host-instance.fk form-stdlib/resource-port.fk form-stdlib/bml-native-interface-package-import.fk form-stdlib/hati-os-targets.fk form-stdlib/form-native-resource-interfaces.fk form-stdlib/form-fs.fk form-stdlib/storage-port.fk form-stdlib/host-kernel-carrier.fk form-stdlib/fnri-standin.fk form-stdlib/fnri-receipt.fk form-stdlib/form-cli.fk form-stdlib/tests/form-cli-band.fk",
+      "scripts/fkwu_form_cli_metal_model_cell_receipt.sh .cache/body-test-receipts/current-model-cell-receipt.json",
+      "scripts/validate_form_cli_local_receipts.sh substrate",
+      "bin/form-cli preflight"
+    ],
+    "observed_outputs": [
+      "bin/form-cli model-status -> available:gguf-locate,weight-load,block-join,metal-matvec,metal-model-cell,metal-decode-step; missing:tokenizer-carrier,full-gguf-weight-map,autoregressive-loop-binding,ask-staged-model-call",
+      "bin/form-cli ask substrate -> trust path:native, grounded:yes, suffic:yes; grounded:form/form-stdlib/adler32.fk; local-lane:fkwu-rag-grounded",
+      "long local miss -> [ask: local fkwu RAG index has no grounded hit] plus trust path:native grounded:no suffic:no, with no remote wait",
+      "explicit ask+ remote-disabled -> trust path:rented and remote-disabled, proving escalation is now opt-in",
+      "form-cli-band -> 16383 four-way; fkwu + pre-flattened tables agree",
+      "fkwu form-cli Metal model-cell receipt -> model_cell_verified=true, http_or_ollama=absent, metal_owner=fkwu-form-cli, metal_device=Apple M4 Max, PASS fkwu-form-cli-metal-matvec-f32",
+      "bin/form-cli preflight -> 9 passed, 0 gaps, READY; prose synthesis remains an honest pending lane"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [],
+    "notes": "PR CI pending after push."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "local-cli-carrier-fix",
+    "notes": "This branch changes local CLI carrier behavior and local proof scripts; public deploy validation follows PR merge if required."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof passed; rebase, guard, CI, PR review, merge, and deploy verification remain pending."
+  },
+  "idea_ids": [
+    "coherence-substrate",
+    "form-first-reasoning"
+  ],
+  "spec_ids": [
+    "coherence-substrate-form-stdlib",
+    "form-cli-local-rag",
+    "fkwu-native-metal-model-cell"
+  ],
+  "task_ids": [
+    "task-2026-06-26-form-cli-local-model-lane-next"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance"
+      ]
+    },
+    {
+      "contributor_id": "openai-gpt-5-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "openai-gpt-5-codex"
+  },
+  "change_intent": "runtime_fix",
+  "evidence_refs": [
+    "Before fix: an existing stale form/form-cli binary made model-status omit the already-proven metal-model-cell lane because ensure_form_cli_native.sh exited on any executable target.",
+    "Before fix: bin/form-cli ask routed through the escalating ask+ shell path by default, so an ungrounded local query could wait on the subscription oracle and look like a pending local model lane.",
+    "After fix: ensure_form_cli_native.sh refreshes from a stamped committed platform bootstrap binary into a temporary output and swaps it into form/form-cli when it differs, preserving the no-Go/no-clang standard lane.",
+    "After fix: bin/form-cli ask and -p stage the query in the home RAG query file and invoke the c-bootstrapped fkwu ask-staged path; ask+ remains the explicit escalation path.",
+    "After fix: validate_form_cli_local_receipts.sh includes the fkwu form-cli Metal model-cell receipt and still refuses to claim full GGUF prose generation."
+  ],
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "Ordinary form-cli ask is now a bounded 100% local fkwu staged-RAG request; explicit ask+ is the only wrapper path that uses a rented oracle. The local model status names the proven fkwu Metal model-cell lane while preserving the pending full-GGUF decode gaps.",
+    "public_endpoints": [
+      "local CLI: bin/form-cli ask",
+      "local CLI: bin/form-cli ask+",
+      "local CLI: bin/form-cli model-status",
+      "local CLI: scripts/validate_form_cli_local_receipts.sh"
+    ],
+    "test_flows": [
+      "stale binary refresh updates model-status to include metal-model-cell",
+      "grounded ask returns native trust and grounded local RAG receipt",
+      "ungrounded ask returns native-miss immediately instead of invoking remote",
+      "explicit ask+ can still mark a rented path when a remote command is passed",
+      "model-cell receipt verifies content-addressed model bytes in Form before Metal dispatch"
+    ]
+  },
+  "change_files": [
+    "bin/form-cli",
+    "form/form-stdlib/tests/form-cli-band.fk",
+    "scripts/ensure_form_cli_native.sh",
+    "scripts/validate_form_cli_local_receipts.sh"
+  ]
+}

--- a/form/form-stdlib/tests/form-cli-band.fk
+++ b/form/form-stdlib/tests/form-cli-band.fk
@@ -21,5 +21,6 @@
     (let c12 (if (str_eq (fc-respond "ask standard receipt") "[ask: local fkwu RAG index has no grounded hit]") 4096 0))
     (let synth (fc-respond "synthesis-status"))
     (let c13 (if (and (not (lt (str_find synth "pending-fkwu-metal-llm" 0) 0))
-                      (not (lt (str_find synth "missing:tokenizer-carrier" 0) 0))) 8192 0))
+                      (and (not (lt (str_find synth "available:gguf-locate,weight-load,block-join,metal-matvec,metal-model-cell,metal-decode-step" 0) 0))
+                           (not (lt (str_find synth "missing:tokenizer-carrier,full-gguf-weight-map,autoregressive-loop-binding,ask-staged-model-call" 0) 0)))) 8192 0))
     (sum (list c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13)))

--- a/scripts/ensure_form_cli_native.sh
+++ b/scripts/ensure_form_cli_native.sh
@@ -6,20 +6,37 @@
 # when stamped — no bin-go, no clang. Maintainer regen:
 # scripts/regen_standard_lane_binaries.sh
 #
-# Idempotent: present binary → instant no-op. Missing binary → bootstrap copy
-# or one-time clang link from committed bootstrap C when platform binary absent.
+# Idempotent: refreshes from the stamped committed bootstrap binary when it is
+# newer/different. Missing bootstrap falls back to the cached target or one-time
+# clang link from committed bootstrap C when the platform binary is absent.
 set -u
 ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FORM_DIR="$ROOT/form"
 TARGET="$FORM_DIR/form-cli"
 LOG="$FORM_DIR/form-stdlib/.cache/form-cli-native-build.log"
 
-[ -x "$TARGET" ] && exit 0
-
 mkdir -p "$(dirname "$LOG")" 2>/dev/null || true
-if (cd "$FORM_DIR" && FORM_STANDARD_LANE=1 ./build-form-cli.sh) >>"$LOG" 2>&1; then
+
+refresh_from_standard_lane() {
+  tmp="$(mktemp "$FORM_DIR/.form-cli-standard.XXXXXX")" || return 1
+  if (cd "$FORM_DIR" && FORM_STANDARD_LANE=1 ./build-form-cli.sh "$tmp") >>"$LOG" 2>&1 && [ -x "$tmp" ]; then
+    if [ ! -x "$TARGET" ] || ! cmp -s "$tmp" "$TARGET"; then
+      mv -f "$tmp" "$TARGET"
+      chmod +x "$TARGET"
+    else
+      rm -f "$tmp"
+    fi
+    return 0
+  fi
+  rm -f "$tmp"
+  return 1
+}
+
+if refresh_from_standard_lane; then
   [ -x "$TARGET" ] && exit 0
 fi
+
+[ -x "$TARGET" ] && exit 0
 
 if ! command -v clang >/dev/null 2>&1; then
   for llvm_bin in "/c/Program Files/LLVM/bin" "/c/Program Files (x86)/LLVM/bin"; do

--- a/scripts/validate_form_cli_local_receipts.sh
+++ b/scripts/validate_form_cli_local_receipts.sh
@@ -44,8 +44,8 @@ fi
 
 synth_out="$("$ROOT/bin/form-cli" synthesis-status 2>&1)"
 if printf '%s' "$synth_out" | grep -q '^synthesis-lane:pending-fkwu-metal-llm' &&
-   printf '%s' "$synth_out" | grep -q '^available:gguf-locate,weight-load,block-join,metal-matvec,metal-decode-step' &&
-   printf '%s' "$synth_out" | grep -q '^missing:tokenizer-carrier,full-model-weight-map,autoregressive-loop-binding,ask-staged-model-call'; then
+   printf '%s' "$synth_out" | grep -q '^available:gguf-locate,weight-load,block-join,metal-matvec,metal-model-cell,metal-decode-step' &&
+   printf '%s' "$synth_out" | grep -q '^missing:tokenizer-carrier,full-gguf-weight-map,autoregressive-loop-binding,ask-staged-model-call'; then
     ok "synthesis lane receipt names available pieces and missing composition"
     printf '%s\n' "$synth_out" | sed 's/^/     /'
 else
@@ -65,6 +65,8 @@ run_receipt "Metal emitter band" \
 if [[ "$(uname -s)" == "Darwin" ]] && command -v swiftc >/dev/null 2>&1; then
     run_receipt "Metal matvec witness" "$ROOT/scripts/metal_matvec_audit.sh" 16 16 1
     run_receipt "Metal llama decode-step witness" "$ROOT/scripts/metal_llama_block_decode_audit.sh"
+    run_receipt "fkwu form-cli Metal model-cell receipt" \
+        "$ROOT/scripts/fkwu_form_cli_metal_model_cell_receipt.sh" "$ROOT/.cache/body-test-receipts/current-model-cell-receipt.json"
 else
     note "Metal witnesses skipped: Darwin + swiftc unavailable on this host"
 fi


### PR DESCRIPTION
## Summary
- refresh stale local form/form-cli binaries from the stamped c-bootstrap standard lane before use
- make ordinary `form-cli ask` / `-p` bounded local-only staged fkwu RAG, leaving rented escalation on explicit `ask+`
- update local receipts to prove the fkwu Metal model-cell lane while keeping full GGUF prose generation pending

## Proof
- `bin/form-cli model-status`
- `bin/form-cli ask substrate`
- `bin/form-cli ask "what is the next smallest provable step for full end-to-end form-cli fkwu Metal local model inference after local RAG receipts"`
- `bin/form-cli ask+ --remote "printf remote-disabled" "what is the next smallest provable step for full end-to-end form-cli fkwu Metal local model inference after local RAG receipts"`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/text-tokenize.fk form-stdlib/rag-embed.fk form-stdlib/rag-index-codec.fk form-stdlib/rag-retrieve.fk form-stdlib/rag-ask.fk form-stdlib/form-cli-ask.fk form-stdlib/line-grammar.fk form-stdlib/voice-traits.fk form-stdlib/nearest-shape.fk form-stdlib/co-learning.fk form-stdlib/co-learning-stream.fk form-stdlib/mesh-dispatch.fk form-stdlib/surprise-salience.fk form-stdlib/host-sense-organ.fk form-stdlib/speech-organ.fk form-stdlib/native-host-instance.fk form-stdlib/resource-port.fk form-stdlib/bml-native-interface-package-import.fk form-stdlib/hati-os-targets.fk form-stdlib/form-native-resource-interfaces.fk form-stdlib/form-fs.fk form-stdlib/storage-port.fk form-stdlib/host-kernel-carrier.fk form-stdlib/fnri-standin.fk form-stdlib/fnri-receipt.fk form-stdlib/form-cli.fk form-stdlib/tests/form-cli-band.fk`
- `scripts/fkwu_form_cli_metal_model_cell_receipt.sh .cache/body-test-receipts/current-model-cell-receipt.json`
- `scripts/validate_form_cli_local_receipts.sh substrate`
- `bin/form-cli preflight`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`