### PR TITLE
[codex] Bound form-cli ask carriers

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -44,7 +44,7 @@
 | [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 148 | Python bridge/API routers — current endpoint carrier and upstream tail while Form-native routes are promoted |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 247 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 58 | API models — Pydantic + ORM shapes |
-| [api/tests/INDEX.md](api/tests/INDEX.md) | 275 | API tests — flow-centric |
+| [api/tests/INDEX.md](api/tests/INDEX.md) | 276 | API tests — flow-centric |
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |

--- a/api/tests/INDEX.md
+++ b/api/tests/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 275
+**Total files**: 276
 
 | File | Purpose |
 |---|---|
@@ -108,6 +108,7 @@
 | [test_flow_workspaces.py](test_flow_workspaces.py) | Flow-centric tests for the Workspace tenant primitive. |
 | [test_form_cli_ask.py](test_form_cli_ask.py) | form_cli `ask` front door: serve Form-native, route the rest, capture for learning. |
 | [test_form_cli_capture.py](test_form_cli_capture.py) | form_cli `capture` — live training catalog: request + raw + transmuted, both kept. |
+| [test_form_cli_carriers.py](test_form_cli_carriers.py) | Regression coverage for thin form-cli host carriers. |
 | [test_form_cli_mcp_tools.py](test_form_cli_mcp_tools.py) | form-cli MCP tools + Stop-hook — the learning flywheel inside an agent session. |
 | [test_form_kernel_bridge_structure_access.py](test_form_kernel_bridge_structure_access.py) | Tests for the structure-access capability in the Form kernel bridge. |
 | [test_form_native_grammar_contract.py](test_form_native_grammar_contract.py) | Form-native grammar contract: host parser bridges are not completion. |

--- a/api/tests/test_form_cli_carriers.py
+++ b/api/tests/test_form_cli_carriers.py
@@ -1,0 +1,49 @@
+"""Regression coverage for thin form-cli host carriers."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+ASK_SMART_PATH = ROOT / "scripts" / "form_cli_ask_smart.py"
+GO_KERNEL = ROOT / "form" / "form-kernel-go" / "bin-go"
+
+_spec = importlib.util.spec_from_file_location("form_cli_ask_smart", ASK_SMART_PATH)
+assert _spec and _spec.loader
+form_cli_ask_smart = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(form_cli_ask_smart)
+
+
+@pytest.mark.skipif(not (GO_KERNEL.is_file() and os.access(GO_KERNEL, os.X_OK)), reason="Go kernel not built")
+def test_form_cli_smart_uses_pure_control_recipe_not_interactive_repl() -> None:
+    out = form_cli_ask_smart.kernel(
+        [
+            "(frepl-mode 1 0 1)",
+            "(frepl-classify 0 1 0)",
+        ],
+        timeout=5,
+    )
+
+    assert out == ["1", "0"]
+
+
+def test_form_cli_smart_forwards_timeout_to_ask_carrier(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run(args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return SimpleNamespace(returncode=124)
+
+    monkeypatch.setattr(form_cli_ask_smart.subprocess, "run", fake_run)
+    args = SimpleNamespace(model="coder", judge="judge", remote="remote", timeout=3.0)
+
+    assert form_cli_ask_smart.answer_once("question", args) == 124
+    assert "--timeout" in seen["args"]
+    assert "3.0" in seen["args"]
+    assert seen["kwargs"]["timeout"] == 8.0

--- a/bin/form-cli
+++ b/bin/form-cli
@@ -48,7 +48,7 @@ form-cli — the one door (local-first, Form-native)
   form-cli ask "<question>"
         default ask path: Form-native local-only staged RAG through the c-bootstrapped
         fkwu binary; no hidden HTTP/Ollama/subscription fallback
-  form-cli ask+ "<question>" [-m LOCAL] [-j JUDGE] [--remote "claude -p"] [--judge-gate]
+  form-cli ask+ "<question>" [-m LOCAL] [-j JUDGE] [--remote "claude -p"] [--judge-gate] [--timeout N]
         explicit escalating ask: local-first, then the four-way-proven sufficiency gate
         (form-cli-sufficiency.fk via form-cli-ask-gate.fk) escalates to the
         subscription oracle when local is not enough. Sovereignty-first by default

--- a/docs/system_audit/commit_evidence_2026-06-26_form_cli_hang_bounds.json
+++ b/docs/system_audit/commit_evidence_2026-06-26_form_cli_hang_bounds.json
@@ -1,0 +1,101 @@
+{
+  "date": "2026-06-26",
+  "thread_branch": "codex/form-cli-hang-bounds-20260626",
+  "commit_scope": "Bound form-cli ask carriers and stop host carriers from loading the fkwu-only interactive REPL in the Go proof walker.",
+  "files_owned": [
+    "docs/system_audit/commit_evidence_2026-06-26_form_cli_hang_bounds.json"
+  ],
+  "idea_ids": [
+    "agent-cli"
+  ],
+  "spec_ids": [
+    "form-cli-self-healing-memory",
+    "fkwu-native-host-resources"
+  ],
+  "task_ids": [
+    "task-2026-06-26-form-cli-hang-bounds"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "diagnosis",
+        "implementation",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "OpenAI GPT-5 Codex"
+  },
+  "change_intent": "runtime_fix",
+  "change_files": [
+    "MANIFEST.md",
+    "api/tests/INDEX.md",
+    "api/tests/test_form_cli_carriers.py",
+    "bin/form-cli",
+    "form/fourth-arm-bands.txt",
+    "form/form-stdlib/form-cli-repl-control.fk",
+    "form/form-stdlib/tests/form-cli-repl-control-band.fk",
+    "scripts/form_cli_ask.sh",
+    "scripts/form_cli_ask_smart.py",
+    "scripts/form_cli_rag.py"
+  ],
+  "evidence_refs": [
+    "FORM-FIRST MISS: the first bounded form-cli ask diagnosis in the older linked worktree timed out after 20s with no stdout/stderr.",
+    "ROOT CAUSE: scripts/form_cli_ask_smart.py loaded form-cli-repl.fk, which immediately enters the fkwu-only read_line/isatty loop and crashes on the Go walker.",
+    "CURRENT MAIN BASELINE: bin/form-cli already keeps ask on the native local-only staged RAG path; this branch preserves that and bounds the explicit ask+ carrier.",
+    "ROOT CAUSE: scripts/form_cli_ask.sh had no wall-clock bound around the final kernel ask+ path; native deadline support is still a carrier gap.",
+    "FOUR-WAY: cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-repl-control.fk form-stdlib/tests/form-cli-repl-control-band.fk -> 1023, 1 ok, 0 divergent.",
+    "SMOKE: form-cli ask+ --timeout 2 and direct scripts/form_cli_ask_smart.py -p --timeout 2 both exit 124 with 'timeout after 2s (nothing)'; fresh ask+ source compilation can add setup time before the bounded kernel ask.",
+    "SMOKE: form-cli ask \"reply with one word: ok\" stays on the native local-only path and returns a trust row plus native miss instead of entering the Python RAG bridge.",
+    "RAG BRIDGE: form-cli rag-ask --no-heal -k 1 \"health check\" returns grounded context only; embedding calls are now bounded at 30s."
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "python3 scripts/wellness_check.py",
+      "python3 -m py_compile scripts/form_cli_ask_smart.py scripts/form_cli_rag.py",
+      "cd api && /opt/homebrew/bin/ruff check ../scripts/form_cli_ask_smart.py ../scripts/form_cli_rag.py tests/test_form_cli_carriers.py",
+      "cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_form_cli_carriers.py tests/test_form_cli_ask.py tests/test_form_cli_capture.py tests/test_form_cli_mcp_tools.py",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-repl-control.fk form-stdlib/tests/form-cli-repl-control-band.fk",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "git diff --check"
+    ],
+    "fourth_arm_outputs": [
+      "form-cli-repl-control-band fks 1023",
+      "1 ok, 0 divergent"
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "not-deployed"
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof passes; CI/deploy are pending until this branch is published from a live upstream branch."
+  },
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "form-cli ask remains native local-only, while ask+ and the direct smart carrier terminate within the configured timeout and report timeout as first-class nothing instead of hanging or crashing.",
+    "public_endpoints": [
+      "bin/form-cli ask",
+      "bin/form-cli ask+",
+      "bin/form-cli -p",
+      "bin/form-cli rag-ask"
+    ],
+    "test_flows": [
+      "python3 scripts/form_cli_ask_smart.py -p --timeout 2 \"health check\"",
+      "form-cli ask+ --timeout 2 \"health check\"",
+      "form-cli ask \"reply with one word: ok\"",
+      "form-cli rag-ask --no-heal -k 1 \"health check\""
+    ]
+  }
+}

--- a/form/form-stdlib/form-cli-repl-control.fk
+++ b/form/form-stdlib/form-cli-repl-control.fk
@@ -1,0 +1,24 @@
+; form-cli-repl-control.fk — pure launch/classification helpers for thin carriers.
+;
+; preludes: form-stdlib/core.fk
+;
+; form-cli-repl.fk is the native interactive runtime and intentionally enters the
+; fkwu read_line/isatty loop when loaded. Host-side carriers that only need the
+; launch decision load this file instead, so they never execute fkwu-only IO ops
+; on the Go proof walker.
+
+(do
+    ; mode: 0 = interactive repl, 1 = one-shot answer, 2 = usage.
+    (defn frepl-mode (print-mode tty has-input)
+        (if (eq print-mode 1) 1
+            (if (eq tty 1)
+                (if (eq has-input 1) 1 0)
+                (if (eq has-input 1) 1 2))))
+
+    ; line kind: 0 = Form expression, 1 = meta-command, 2 = question, 3 = blank.
+    (defn frepl-classify (empty starts-expr starts-command)
+        (if (eq empty 1) 3
+            (if (eq starts-expr 1) 0
+                (if (eq starts-command 1) 1 2))))
+
+    0)

--- a/form/form-stdlib/tests/form-cli-repl-control-band.fk
+++ b/form/form-stdlib/tests/form-cli-repl-control-band.fk
@@ -1,0 +1,28 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-cli-repl-control.fk
+;
+; form-cli-repl-control-band — proves the host carrier's launch and line
+; classification decisions without entering the fkwu-only interactive REPL.
+;
+; Verdict 1023:
+;   1    bare TTY opens the REPL
+;   2    print mode answers once
+;   4    piped input answers once
+;   8    no TTY and no input shows usage
+;   16   TTY with an explicit question answers once
+;   32   blank line is ignored
+;   64   parenthesized line is Form eval
+;   128  slash line is a meta-command
+;   256  ordinary text is a question
+;   512  print mode wins even on a TTY with no input
+(do
+    (let c0 (if (eq (frepl-mode 0 1 0) 0) 1 0))
+    (let c1 (if (eq (frepl-mode 1 0 1) 1) 2 0))
+    (let c2 (if (eq (frepl-mode 0 0 1) 1) 4 0))
+    (let c3 (if (eq (frepl-mode 0 0 0) 2) 8 0))
+    (let c4 (if (eq (frepl-mode 0 1 1) 1) 16 0))
+    (let c5 (if (eq (frepl-classify 1 0 0) 3) 32 0))
+    (let c6 (if (eq (frepl-classify 0 1 0) 0) 64 0))
+    (let c7 (if (eq (frepl-classify 0 0 1) 1) 128 0))
+    (let c8 (if (eq (frepl-classify 0 0 0) 2) 256 0))
+    (let c9 (if (eq (frepl-mode 1 1 0) 1) 512 0))
+    (sum (list c0 c1 c2 c3 c4 c5 c6 c7 c8 c9)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -881,6 +881,7 @@ form-cli fks 31
 json-emitter fks 31
 json-promoted-types fks 115
 form-cli-band fks 16383
+form-cli-repl-control-band fks 1023
 http-client-render fks 2047
 socket-loopback fks 111111
 http-client-socket-verbs fks 127

--- a/scripts/form_cli_ask.sh
+++ b/scripts/form_cli_ask.sh
@@ -10,7 +10,7 @@
 # sufficiency / ask-gate), and invokes the kernel on the recipe. The decision math is
 # the gate's, proven four-way; this shell marshals args and wires the carriers.
 #
-# Usage: form_cli_ask.sh [-m local-model] [-j judge] [--remote "claude -p"] [--trust N] [--retries N] [--judge-gate] "question..."
+# Usage: form_cli_ask.sh [-m local-model] [-j judge] [--remote "claude -p"] [--trust N] [--retries N] [--judge-gate] [--timeout N] "question..."
 #   By default the local body is trusted (sovereignty-first): a grounded local hit
 #   stands, and only a local MISS escalates to the oracle. --judge-gate is kept as
 #   a compatibility flag; until the fkwu+Metal generator is wired, the judge lane
@@ -23,7 +23,7 @@ GO_ABS="$FORM/form-kernel-go/bin-go"
 GO="$GO_ABS"; STD="$FORM/form-stdlib"
 cd "${HOME:-$ROOT}"
 
-MODEL="coder"; JUDGE="llama3.2:3b"; REMOTE="claude -p"; TRUST=60; RETRIES=1; JUDGE_GATE=0
+MODEL="coder"; JUDGE="llama3.2:3b"; REMOTE="claude -p"; TRUST=60; RETRIES=1; JUDGE_GATE=0; ASK_TIMEOUT=30
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -m|--model)  MODEL="$2"; shift 2 ;;
@@ -31,12 +31,19 @@ while [[ $# -gt 0 ]]; do
     --remote)    REMOTE="$2"; shift 2 ;;
     --trust)     TRUST="$2"; shift 2 ;;
     --retries)   RETRIES="$2"; shift 2 ;;
+    --timeout)   ASK_TIMEOUT="$2"; shift 2 ;;
     --judge-gate) JUDGE_GATE=1; shift ;;
     *)           break ;;
   esac
 done
 Q="$*"
 [[ -n "$Q" ]] || { echo "usage: form-cli ask+ [-m model] [-j judge] [--remote CMD] \"question\"" >&2; exit 2; }
+case "$ASK_TIMEOUT" in
+  ''|*[!0-9.]*)
+    echo "form-cli ask+: --timeout must be numeric seconds" >&2
+    exit 2
+    ;;
+esac
 
 work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
 
@@ -88,8 +95,39 @@ esc(){ printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
 printf '(print (fca-ask-plus-traced "%s" "%s" "%s" "%s" %s %s %s))\n' \
   "$(esc "$Q")" "$(esc "$MODEL")" "$(esc "$JUDGE")" "$(esc "$REMOTE")" "$TRUST" "$RETRIES" "$JUDGE_GATE" > "$work/ask.fk"
 
-out="$("$GO" "$CORE" "$STD/text-tokenize.fk" "$STD/rag-embed.fk" "$STD/rag-index-codec.fk" "$STD/rag-retrieve.fk" "$STD/rag-ask.fk" "$ASK" \
+run_with_timeout() {
+  python3 - "$ASK_TIMEOUT" "$@" <<'PY'
+import subprocess
+import sys
+
+timeout = float(sys.argv[1])
+cmd = sys.argv[2:]
+try:
+    proc = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout)
+except subprocess.TimeoutExpired as exc:
+    if exc.stdout:
+        sys.stdout.write(exc.stdout if isinstance(exc.stdout, str) else exc.stdout.decode(errors="replace"))
+    if exc.stderr:
+        sys.stderr.write(exc.stderr if isinstance(exc.stderr, str) else exc.stderr.decode(errors="replace"))
+    sys.stderr.write(f"form-cli ask+: timeout after {timeout:g}s (nothing)\n")
+    raise SystemExit(124)
+
+sys.stdout.write(proc.stdout)
+sys.stderr.write(proc.stderr)
+raise SystemExit(proc.returncode)
+PY
+}
+
+raw="$work/out"; err="$work/run.err"
+run_with_timeout "$GO" "$CORE" "$STD/text-tokenize.fk" "$STD/rag-embed.fk" "$STD/rag-index-codec.fk" "$STD/rag-retrieve.fk" "$STD/rag-ask.fk" "$ASK" \
   "$STD/form-cli-router.fk" "$STD/form-cli-judge.fk" "$STD/form-cli-sufficiency.fk" "$STD/trust-row.fk" "$STD/form-cli-ask-gate.fk" \
-  "$ASKPLUS" "$work/ask.fk" | sed '/^null$/d')"
+  "$ASKPLUS" "$work/ask.fk" >"$raw" 2>"$err"
+rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  cat "$err" >&2
+  exit "$rc"
+fi
+cat "$err" >&2
+out="$(sed '/^null$/d' "$raw")"
 printf '%s\n' "$out" | sed -n '1p' >&2   # line 1: the live trust row -> stderr
 printf '%s\n' "$out" | sed '1d'          # the answer -> stdout

--- a/scripts/form_cli_ask_smart.py
+++ b/scripts/form_cli_ask_smart.py
@@ -2,7 +2,7 @@
 """form_cli_ask_smart.py — thin REPL CARRIER. The form-cli interactive shell.
 
 NO ask logic lives here. The decisions are PROVEN Form recipes run by the kernel:
-  - form-cli-repl.fk         launch mode (interactive / one-shot / help) + per-line routing
+  - form-cli-repl-control.fk launch mode (interactive / one-shot / help) + per-line routing
   - form-cli-ask.fk          the ask flow (fkwu grounded RAG -> sufficiency -> optional escalate),
                              run via scripts/form_cli_ask.sh — the kernel is the runtime
 This file only reads stdin lines, asks the kernel how to route each one, and dispatches:
@@ -10,33 +10,80 @@ This file only reads stdin lines, asks the kernel how to route each one, and dis
 
 Modes (like claude/codex/cursor/gemini/grok): bare at a terminal -> REPL; a question or pipe -> one-shot.
 """
-import argparse, os, subprocess, sys
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GO = os.path.join(ROOT, "form", "form-kernel-go", "bin-go")
 STD = os.path.join(ROOT, "form", "form-stdlib")
-LOGIC = ["form-cli-repl.fk"]   # the launch/line-routing recipe (decisions stay in Form)
+LOGIC = ["form-cli-repl-control.fk"]   # pure launch/line-routing recipe; no fkwu-only IO loop
 
 
-def kernel(exprs):
+def kernel(exprs, timeout=5.0):
     """run the control recipe + a list of (print ...) exprs on the Go kernel; return outputs."""
     src = "\n".join(open(os.path.join(STD, r)).read() for r in LOGIC)
     src += "\n" + "\n".join(f"(print {e})" for e in exprs) + "\n"
-    tmp = "/tmp/fcli_logic.fk"; open(tmp, "w").write(src)
-    return subprocess.run([GO, tmp], capture_output=True, text=True).stdout.split()
+    with tempfile.NamedTemporaryFile("w", suffix=".fk", delete=False) as f:
+        f.write(src)
+        tmp = f.name
+    try:
+        res = subprocess.run([GO, tmp], capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"control recipe timed out after {timeout:g}s") from exc
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+    if res.returncode != 0:
+        detail = (res.stderr or res.stdout or "no output").strip()
+        raise RuntimeError(f"control recipe failed: {detail}")
+    out = [token for token in res.stdout.split() if token != "null"]
+    if not out:
+        raise RuntimeError("control recipe produced no output")
+    return out
 
 
 def answer_once(q, a):
     """the ask BODY is Form (form-cli-ask.fk run by the kernel via form_cli_ask.sh) — no Python ask logic."""
-    subprocess.run(["bash", os.path.join(ROOT, "scripts", "form_cli_ask.sh"),
-                    "-m", a.model, "-j", a.judge, "--remote", a.remote, q])
+    try:
+        return subprocess.run(
+            [
+                "bash",
+                os.path.join(ROOT, "scripts", "form_cli_ask.sh"),
+                "-m",
+                a.model,
+                "-j",
+                a.judge,
+                "--remote",
+                a.remote,
+                "--timeout",
+                str(a.timeout),
+                q,
+            ],
+            timeout=a.timeout + 5,
+        ).returncode
+    except subprocess.TimeoutExpired:
+        print(f"form-cli ask: timeout after {a.timeout:g}s (nothing)", file=sys.stderr)
+        return 124
 
 
 def eval_form(expr):
     """REPL '(...)' line: evaluate a Form expression on the kernel (0 tokens)."""
-    tmp = "/tmp/fcli_eval.fk"; open(tmp, "w").write(f"(print {expr})\n")
-    res = subprocess.run([GO, tmp], capture_output=True, text=True)
-    out = [l for l in res.stdout.splitlines() if l.strip() and l.strip() != "null"]
+    with tempfile.NamedTemporaryFile("w", suffix=".fk", delete=False) as f:
+        f.write(f"(print {expr})\n")
+        tmp = f.name
+    try:
+        res = subprocess.run([GO, tmp], capture_output=True, text=True)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+    out = [line for line in res.stdout.splitlines() if line.strip() and line.strip() != "null"]
     print("\n".join(out) or (res.stderr.strip() or "(no result)"))
 
 
@@ -47,25 +94,37 @@ def repl(a):
         try:
             line = input("form-cli› ").strip()
         except (EOFError, KeyboardInterrupt):
-            print(); break
-        kind = int(kernel([f"(frepl-classify {1 if not line else 0} "
-                           f"{1 if line[:1] == '(' else 0} {1 if line[:1] == '/' else 0})"])[0])
+            print()
+            break
+        try:
+            kind = int(kernel([f"(frepl-classify {1 if not line else 0} "
+                               f"{1 if line[:1] == '(' else 0} {1 if line[:1] == '/' else 0})"])[0])
+        except RuntimeError as exc:
+            print(f"form-cli: {exc}", file=sys.stderr)
+            continue
         if kind == 3:
             continue
         if kind == 0:                                   # Form expression -> kernel
             eval_form(line)
         elif kind == 1:                                 # meta-command
-            cmd = line[1:].split(); name = cmd[0] if cmd else ""
-            if name in ("exit", "quit", "q"): break
+            cmd = line[1:].split()
+            name = cmd[0] if cmd else ""
+            if name in ("exit", "quit", "q"):
+                break
             elif name == "help":
                 print("  /do TASK  run the agent loop (read/edit/bash/search) · /model NAME · /judge NAME\n"
                       "  /exit  leave · '(expr)' eval Form · anything else = a question")
-            elif name == "model" and len(cmd) > 1: a.model = cmd[1]; print(f"  local model → {a.model}")
-            elif name == "judge" and len(cmd) > 1: a.judge = cmd[1]; print(f"  judge → {a.judge}")
+            elif name == "model" and len(cmd) > 1:
+                a.model = cmd[1]
+                print(f"  local model → {a.model}")
+            elif name == "judge" and len(cmd) > 1:
+                a.judge = cmd[1]
+                print(f"  judge → {a.judge}")
             elif name == "do" and len(cmd) > 1:     # agentic task: the TIERED Form agent loop (local-first, escalate)
                 subprocess.run(["bash", os.path.join(ROOT, "scripts", "form_cli_agent.sh"), line.split(None, 1)[1]],
                                env={**os.environ, "LOCAL": a.model, "REMOTE": a.remote})
-            else: print("  unknown command — /help")
+            else:
+                print("  unknown command — /help")
         else:                                           # a question -> the Form ask flow
             answer_once(line, a)
         print()
@@ -77,23 +136,29 @@ def main():
     ap.add_argument("-m", "--model", default="coder")
     ap.add_argument("-j", "--judge", default="llama3.2:3b")
     ap.add_argument("--remote", default="claude -p")
+    ap.add_argument("--timeout", type=float, default=30.0)
     ap.add_argument("--print", "-p", action="store_true", dest="print_mode", help="one-shot print mode")
     ap.add_argument("--repl", action="store_true", help="force interactive REPL")
     a = ap.parse_args()
 
     if a.repl:                                          # forced REPL must NOT pre-read stdin
-        repl(a); return 0
+        repl(a)
+        return 0
 
     # the LAUNCH decision is the proven recipe, not python ifs
     tty = 1 if sys.stdin.isatty() else 0
     piped = "" if tty else sys.stdin.read().strip()
     has_input = 1 if (a.question or piped) else 0
-    mode = int(kernel([f"(frepl-mode {1 if a.print_mode else 0} {tty} {has_input})"])[0])
+    try:
+        mode = int(kernel([f"(frepl-mode {1 if a.print_mode else 0} {tty} {has_input})"])[0])
+    except RuntimeError as exc:
+        print(f"form-cli: {exc}", file=sys.stderr)
+        return 1
 
     if mode == 0:
         repl(a)
     elif mode == 1:
-        answer_once(a.question or piped, a)
+        return answer_once(a.question or piped, a)
     else:
         print("usage: form-cli ask+ \"question\"   |   form-cli  (interactive)   |   form-cli -p \"q\"")
     return 0

--- a/scripts/form_cli_rag.py
+++ b/scripts/form_cli_rag.py
@@ -32,11 +32,19 @@ Usage:
   form_cli_rag.py search "query" [-k N] [--no-heal]
 """
 from __future__ import annotations
-import argparse, glob, json, os, sys, urllib.request, zlib
+import argparse
+import glob
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import zlib
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 INDEX = os.path.expanduser("~/.coherence-network/rag-index/index.jsonl")
 OLLAMA = "http://localhost:11434"
+OLLAMA_TIMEOUT_SECONDS = 30
 
 # adaptive retrieval bounds — depth is the knee within [K_MIN, K_MAX], not a constant.
 K_MIN, K_MAX = 3, 12
@@ -52,8 +60,13 @@ SOURCES = [
 def _post(path: str, payload: dict) -> dict:
     req = urllib.request.Request(OLLAMA + path,
         data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"})
-    with urllib.request.urlopen(req, timeout=120) as r:
-        return json.loads(r.read())
+    try:
+        with urllib.request.urlopen(req, timeout=OLLAMA_TIMEOUT_SECONDS) as r:
+            return json.loads(r.read())
+    except (TimeoutError, urllib.error.URLError, OSError) as exc:
+        raise RuntimeError(
+            f"ollama request to {path} failed or timed out after {OLLAMA_TIMEOUT_SECONDS}s: {exc}"
+        ) from exc
 
 
 def embed(text: str) -> list[float]:
@@ -123,7 +136,7 @@ def _snippet(path: str) -> str:
         txt = open(path, encoding="utf-8", errors="ignore").read()
     except Exception:
         return ""
-    lines = [l for l in txt.splitlines() if l.strip()]
+    lines = [line for line in txt.splitlines() if line.strip()]
     head = "\n".join(lines[:30])
     sig = _defn_names(txt)
     sig_line = ("\nsignature: " + " ".join(sig[:40])) if sig else ""
@@ -168,7 +181,7 @@ def _embed_cell(cell_id: str, kind: str, path: str) -> dict | None:
 def _load_index(index_path: str) -> list[dict]:
     if not os.path.exists(index_path):
         return []
-    return [json.loads(l) for l in open(index_path) if l.strip()]
+    return [json.loads(line) for line in open(index_path) if line.strip()]
 
 
 def _write_index(index_path: str, entries: list[dict]) -> None:
@@ -267,26 +280,37 @@ def retrieve(query: str, index_path: str, k: int | None) -> list[dict]:
 def main() -> int:
     ap = argparse.ArgumentParser()
     sub = ap.add_subparsers(dest="cmd", required=True)
-    b = sub.add_parser("build"); b.add_argument("--index", default=INDEX)
+    b = sub.add_parser("build")
+    b.add_argument("--index", default=INDEX)
     b.add_argument("--docs", action="append", default=[], help="extra local folder(s) to index, repeatable")
-    h = sub.add_parser("heal"); h.add_argument("--index", default=INDEX)
+    h = sub.add_parser("heal")
+    h.add_argument("--index", default=INDEX)
     h.add_argument("--docs", action="append", default=[])
-    f = sub.add_parser("fresh"); f.add_argument("--index", default=INDEX)
-    s = sub.add_parser("search"); s.add_argument("question")
-    s.add_argument("-k", type=int, default=0); s.add_argument("--index", default=INDEX)
+    f = sub.add_parser("fresh")
+    f.add_argument("--index", default=INDEX)
+    s = sub.add_parser("search")
+    s.add_argument("question")
+    s.add_argument("-k", type=int, default=0)
+    s.add_argument("--index", default=INDEX)
     s.add_argument("--no-heal", action="store_true")
-    c = sub.add_parser("context"); c.add_argument("question")
-    c.add_argument("-k", type=int, default=3); c.add_argument("--index", default=INDEX)
+    c = sub.add_parser("context")
+    c.add_argument("question")
+    c.add_argument("-k", type=int, default=3)
+    c.add_argument("--index", default=INDEX)
     c.add_argument("--no-heal", action="store_true")
-    a = sub.add_parser("ask"); a.add_argument("question")
+    a = sub.add_parser("ask")
+    a.add_argument("question")
     a.add_argument("-k", type=int, default=0)
-    a.add_argument("--index", default=INDEX); a.add_argument("--no-heal", action="store_true")
+    a.add_argument("--index", default=INDEX)
+    a.add_argument("--no-heal", action="store_true")
     args = ap.parse_args()
 
     if args.cmd == "build":
-        build(args.index, args.docs); return 0
+        build(args.index, args.docs)
+        return 0
     if args.cmd == "heal":
-        heal(args.index, args.docs); return 0
+        heal(args.index, args.docs)
+        return 0
     if args.cmd == "fresh":
         heal_cells, orphans = freshness(args.index)
         total = len(_load_index(args.index))
@@ -325,4 +349,8 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except RuntimeError as exc:
+        print(f"form-cli rag: {exc}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## What changed

- Added `form-cli-repl-control.fk`, a pure Form control recipe for launch/classification decisions, plus a four-way band proving it at `1023`.
- Updated `scripts/form_cli_ask_smart.py` to load the pure control recipe instead of `form-cli-repl.fk`, which is the fkwu-only interactive runtime and calls `read_line`/`isatty`.
- Added wall-clock bounds to the explicit `ask+` kernel carrier via `--timeout`, reporting timeout as first-class `nothing` instead of hanging.
- Kept current `bin/form-cli ask` behavior from main: native local-only staged RAG. `ask+` remains the explicit escalating path.
- Bounded the retiring Python RAG bridge's Ollama embedding calls and kept it context-only.
- Added focused carrier regression tests and commit evidence.

## Diagnosis

The initial Form-first query reproduced a hang: a bounded `form-cli ask ...` produced no output before timeout in the older linked worktree. On current main, `ask` has already moved to the native local-only staged path; this PR preserves that. The remaining obvious failures were:

- Direct smart carrier loaded `form-cli-repl.fk`, which enters the fkwu-only interactive loop and is not safe to run on the Go proof walker.
- `ask+` had no wall-clock bound around the final kernel ask invocation.
- The retiring RAG bridge still had long local model request windows.

## Validation

- `make prompt-guide`
- `python3 scripts/wellness_check.py`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-26_form_cli_hang_bounds.json`
- `python3 -m py_compile scripts/form_cli_ask_smart.py scripts/form_cli_rag.py`
- `bash -n bin/form-cli scripts/form_cli_ask.sh`
- `cd api && /opt/homebrew/bin/ruff check ../scripts/form_cli_ask_smart.py ../scripts/form_cli_rag.py tests/test_form_cli_carriers.py`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-repl-control.fk form-stdlib/tests/form-cli-repl-control-band.fk`
- `cd api && /Users/ursmuff/source/Coherence-Network/api/.venv/bin/pytest -q tests/test_form_cli_carriers.py tests/test_form_cli_ask.py tests/test_form_cli_capture.py tests/test_form_cli_mcp_tools.py`
- `python3 scripts/generate_repo_indexes.py --check && git diff --check`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`

## Smoke

- `python3 scripts/form_cli_ask_smart.py -p --timeout 2 "health check"` exits `124` with `timeout after 2s (nothing)` and no traceback.
- `bin/form-cli ask+ --timeout 2 "health check"` exits `124` with `timeout after 2s (nothing)`.
- `bin/form-cli ask "reply with one word: ok"` stays on native local-only path and returns a native miss/trust row.
- `bin/form-cli rag-ask --no-heal -k 1 "health check"` returns grounded context only.

## Notes

Wellness exited 0. It also reported external public API timeouts for substrate shape/deploy lag; those are outside this local carrier fix.
