### PR TITLE
Keep satsang speech as live capture side channel

### DIFF
--- a/docs/coherence-substrate/satsang-guidance-event.form
+++ b/docs/coherence-substrate/satsang-guidance-event.form
@@ -11,11 +11,14 @@
 ;   transcript JSONL, listens to the room microphone after explicit Start
 ;   Listening, lets the holder edit utterances, and writes the request to
 ;   ~/.coherence-network/satsang-guidance/events.jsonl plus the latest JSON and
-;   .form receipt. No external receiver is invoked by the GUI. No-speech
-;   intervals restart recognition and the visible mic level shows whether the
-;   room is reaching the input device. The mic meter comes alive separately from
-;   Speech Recognition authorization so permission delay is visible instead of
-;   silent. On Send, the GUI asks the local Form CLI first and records the
+;   .form receipt. No external receiver is invoked by the GUI. Live room capture
+;   is the primary stream; Speech Recognition is a concurrent transcription side
+;   channel fed during that capture, not a before/after pass over stored audio.
+;   No-speech intervals restart only the recognition side channel and the visible
+;   mic level shows whether the room is reaching the input device. The mic meter
+;   comes alive separately from Speech Recognition authorization so permission
+;   delay is visible instead of silent. On Send, the GUI asks the local Form CLI
+;   first and records the
 ;   body/RAG sufficiency receipt in the JSON and .form event; a remote oracle is
 ;   only requested as an explicit insufficient-local route, not called by the GUI.
 ;   The Send path also writes a local trusted room-memory receipt under

--- a/docs/system_audit/commit_evidence_2026-06-26_live_capture_sidechannel_transcription.json
+++ b/docs/system_audit/commit_evidence_2026-06-26_live_capture_sidechannel_transcription.json
@@ -1,0 +1,120 @@
+{
+  "date": "2026-06-26",
+  "thread_branch": "codex/live-recording-sidechannel-20260626",
+  "commit_scope": "Make the satsang Mac app keep live room capture as the primary microphone stream while macOS Speech Recognition attaches only as a concurrent transcription side channel fed during capture, never as a before-recording or after-recording pass.",
+  "files_owned": [
+    "docs/coherence-substrate/satsang-guidance-event.form",
+    "docs/system_audit/commit_evidence_2026-06-26_live_capture_sidechannel_transcription.json",
+    "experiments/satsang-mac-app/README.md",
+    "experiments/satsang-mac-app/Sources/SatsangGuidance/RoomTranscriber.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/FormNativeRouting.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift",
+    "experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift",
+    "form/form-stdlib/satsang-listen-route.fk",
+    "form/form-stdlib/tests/satsang-listen-route-band.fk",
+    "specs/satsang-mac-guidance-app.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "make wellness",
+      "form-cli ask \"satsang mac app live room recording primary stream speech recognition concurrent side channel during capture not before or after recording pass\"",
+      "swift test --package-path experiments/satsang-mac-app",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidance",
+      "scripts/build_satsang_mac_app.sh",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-guidance-event.fk form-stdlib/tests/satsang-guidance-event-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/satsang-listen-route.fk form-stdlib/tests/satsang-listen-route-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-room-memory.fk form-stdlib/tests/satsang-room-memory-band.fk",
+      "python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.md",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "git diff --check",
+      "make wellness"
+    ],
+    "fourth_arm": "satsang-guidance-event-band.fk -> 255, satsang-host-boundary-band.fk -> 131071, satsang-listen-route-band.fk -> 255, satsang-room-memory-band.fk -> 255; each crossed four-way with fkwu + pre-flattened tables; 0 divergent",
+    "summary": "Startup gates and wellness passed. The Form ask used the native form-cli path but had no grounded/sufficient local RAG hit for this exact capture-side-channel correction; the local model-cell witness was observed. Swift package tests passed with 11 XCTest cases, including route receipt assertions for primary-live-room-capture-receipt and speech-side-channel-during-live-capture. The GUI product and .app bundle built locally. The listen-route Form proof now names primary live capture plus transcription side channel while preserving remote-last sufficiency routing."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "No public deploy yet; this is a local macOS app carrier change awaiting PR checks."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof passed; CI and PR checks pending."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "satsang-mac-guidance-app"
+  ],
+  "task_ids": [
+    "live-capture-sidechannel-transcription-2026-06-26"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "trust-boundary"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "form-proof",
+        "local-validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "OpenAI GPT-5 Codex"
+  },
+  "evidence_refs": [
+    "experiments/satsang-mac-app/Sources/SatsangGuidance/RoomTranscriber.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/FormNativeRouting.swift",
+    "form/form-stdlib/satsang-listen-route.fk",
+    "form/form-stdlib/tests/satsang-listen-route-band.fk",
+    "specs/satsang-mac-guidance-app.md",
+    "docs/coherence-substrate/satsang-guidance-event.form"
+  ],
+  "change_files": [
+    "docs/coherence-substrate/satsang-guidance-event.form",
+    "docs/system_audit/commit_evidence_2026-06-26_live_capture_sidechannel_transcription.json",
+    "experiments/satsang-mac-app/README.md",
+    "experiments/satsang-mac-app/Sources/SatsangGuidance/RoomTranscriber.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/FormNativeRouting.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift",
+    "experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift",
+    "form/form-stdlib/satsang-listen-route.fk",
+    "form/form-stdlib/tests/satsang-listen-route-band.fk",
+    "specs/satsang-mac-guidance-app.md"
+  ],
+  "change_intent": "runtime_fix",
+  "e2e_validation": {
+    "status": "pass",
+    "summary": "The Mac carrier now keeps the AVAudioEngine input tap as the single live capture path. Speech Recognition receives buffers from that already-open tap as a side channel; no-speech cycles restart the recognition task without stopping the live capture stream.",
+    "expected_behavior_delta": "Starting live transcription no longer replaces the metering-only capture tap with a separate Speech tap. Stop still ends both the side channel and live capture explicitly. Route receipts and Form proof now name the primary capture plus side-channel transcription boundary.",
+    "public_endpoints": [
+      "n/a-local-macos-app"
+    ],
+    "test_flows": [
+      "swift test --package-path experiments/satsang-mac-app -> 11 tests passed",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidance -> product built",
+      "scripts/build_satsang_mac_app.sh -> experiments/satsang-mac-app/dist/Satsang Guidance.app",
+      "cd form && ./validate.sh ... satsang-guidance-event-band.fk -> 255 four-way",
+      "cd form && ./validate.sh ... satsang-host-boundary-band.fk -> 131071 four-way",
+      "cd form && ./validate.sh ... satsang-listen-route-band.fk -> 255 four-way",
+      "cd form && ./validate.sh ... satsang-room-memory-band.fk -> 255 four-way"
+    ]
+  }
+}

--- a/experiments/satsang-mac-app/README.md
+++ b/experiments/satsang-mac-app/README.md
@@ -2,10 +2,11 @@
 
 SwiftUI desktop carrier for a satsang guidance session.
 
-It listens to the room microphone after `Start Listening` is pressed, turns live
-speech into editable transcript lines, can also follow a local transcript file,
-shows every line that will be sent, and writes a `satsang-guidance-request`
-event for Sema or another invoked presence.
+It listens to the room microphone after `Start Listening` is pressed, keeps that
+live capture as the primary stream, turns concurrent side-channel speech
+transcription into editable transcript lines, can also follow a local transcript
+file, shows every line that will be sent, and writes a
+`satsang-guidance-request` event for Sema or another invoked presence.
 
 Default transcript:
 
@@ -74,9 +75,11 @@ not call the remote oracle itself.
 
 The first use of `Start Listening` asks macOS for microphone and speech
 recognition permission. The microphone meter starts as soon as microphone access
-is available, then Speech Recognition attaches transcription when authorized.
-Partial speech appears in the transcript list as `room mic`; pressing `Stop
-Listening` commits the current partial line. If macOS reports a no-speech
-interval, the listener stays open and restarts the recognition pass. The header
-shows a live microphone level while listening, so the holder can see whether the
-room is reaching the mic even while Speech permission is still pending.
+is available. Speech Recognition then attaches as a side channel fed by the
+already-open live capture tap; it is not a before-recording or after-recording
+pass over stored audio. Partial speech appears in the transcript list as `room
+mic`; pressing `Stop Listening` commits the current partial line. If macOS
+reports a no-speech interval, the listener keeps the capture stream open and
+restarts only the recognition side channel. The header shows a live microphone
+level while listening, so the holder can see whether the room is reaching the
+mic even while Speech permission is still pending.

--- a/experiments/satsang-mac-app/Sources/SatsangGuidance/RoomTranscriber.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangGuidance/RoomTranscriber.swift
@@ -35,7 +35,7 @@ final class RoomTranscriber: @unchecked Sendable {
                 kind: "speech-transcript",
                 state: speechDoorState(speechStatus, available: speechAvailable),
                 carrier: "macos-speech",
-                detail: "\(speechStatusName(speechStatus));available=\(speechAvailable ? "1" : "0")"
+                detail: "side-channel-during-live-capture;\(speechStatusName(speechStatus));available=\(speechAvailable ? "1" : "0")"
             ),
         ]
     }
@@ -69,7 +69,8 @@ final class RoomTranscriber: @unchecked Sendable {
             if commitPartial {
                 self.commitPartialIfNeeded()
             }
-            self.stopRecognition()
+            self.stopSpeechSideChannel()
+            self.stopLiveCapture()
             self.emitPartial("")
             self.emitLevel(0)
             self.emitState(false, "Listening stopped")
@@ -79,7 +80,7 @@ final class RoomTranscriber: @unchecked Sendable {
     private func beginWithMicrophoneAccess() {
         workQueue.async {
             self.keepListening = true
-            self.startMeteringOnly()
+            self.startLiveCapture()
             self.requestSpeechAuthorization()
         }
     }
@@ -89,7 +90,7 @@ final class RoomTranscriber: @unchecked Sendable {
         case .authorized:
             startRecognition()
         case .notDetermined:
-            emitState(true, "Room mic is active; requesting speech recognition permission")
+            emitState(true, "Live room capture is active; requesting Speech side-channel permission")
             SFSpeechRecognizer.requestAuthorization { [weak self] speechStatus in
                 guard let self else { return }
                 self.workQueue.async {
@@ -99,14 +100,14 @@ final class RoomTranscriber: @unchecked Sendable {
             workQueue.asyncAfter(deadline: .now() + 6.0) { [weak self] in
                 guard let self, self.keepListening else { return }
                 guard SFSpeechRecognizer.authorizationStatus() == .notDetermined else { return }
-                self.emitState(true, "Room mic is active; waiting for speech recognition permission")
+                self.emitState(true, "Live room capture is active; waiting for Speech side-channel permission")
             }
         case .denied:
-            emitState(true, "Room mic is active; Speech Recognition permission is denied.")
+            emitState(true, "Live room capture is active; Speech side-channel permission is denied.")
         case .restricted:
-            emitState(true, "Room mic is active; Speech Recognition is restricted on this Mac.")
+            emitState(true, "Live room capture is active; Speech side-channel is restricted on this Mac.")
         @unknown default:
-            emitState(true, "Room mic is active; Speech Recognition permission is unavailable.")
+            emitState(true, "Live room capture is active; Speech side-channel permission is unavailable.")
         }
     }
 
@@ -115,56 +116,17 @@ final class RoomTranscriber: @unchecked Sendable {
         if speechStatus == .authorized {
             startRecognition()
         } else {
-            emitState(true, "Room mic is active; Speech Recognition permission is \(Self.speechStatusName(speechStatus)).")
+            emitState(true, "Live room capture is active; Speech side-channel permission is \(Self.speechStatusName(speechStatus)).")
         }
     }
 
-    private func startMeteringOnly() {
-        stopRecognition()
-
-        let inputNode = audioEngine.inputNode
-        let format = inputNode.outputFormat(forBus: 0)
-        guard format.sampleRate > 0 else {
-            emitState(false, "No microphone input format is available.")
+    private func startLiveCapture() {
+        guard !inputTapInstalled else {
+            if !audioEngine.isRunning {
+                startAudioEngine()
+            }
             return
         }
-
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
-            self?.reportLevel(buffer)
-        }
-        inputTapInstalled = true
-
-        audioEngine.prepare()
-        do {
-            try audioEngine.start()
-            emitState(true, "Room mic is active; preparing speech recognition")
-        } catch {
-            stopRecognition()
-            emitState(false, "Microphone start failed: \(error.localizedDescription)")
-        }
-    }
-
-    private func startRecognition() {
-        stopRecognition()
-
-        guard let speechRecognizer else {
-            emitState(false, "Speech recognizer is unavailable for this locale.")
-            return
-        }
-        guard speechRecognizer.isAvailable else {
-            emitState(false, "Speech recognizer is not available right now.")
-            return
-        }
-
-        let request = SFSpeechAudioBufferRecognitionRequest()
-        request.shouldReportPartialResults = true
-        request.taskHint = .dictation
-        if #available(macOS 13.0, *) {
-            request.addsPunctuation = true
-        }
-        recognitionRequest = request
-        lastPartialText = ""
-
         let inputNode = audioEngine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
         guard format.sampleRate > 0 else {
@@ -178,26 +140,56 @@ final class RoomTranscriber: @unchecked Sendable {
         }
         inputTapInstalled = true
 
+        startAudioEngine()
+    }
+
+    private func startAudioEngine() {
         audioEngine.prepare()
         do {
             try audioEngine.start()
+            emitState(true, "Live room capture is active; preparing Speech side channel")
         } catch {
-            stopRecognition()
+            stopSpeechSideChannel()
+            stopLiveCapture()
             emitState(false, "Microphone start failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func startRecognition() {
+        guard keepListening else { return }
+        guard recognitionRequest == nil, recognitionTask == nil else { return }
+        guard inputTapInstalled, audioEngine.isRunning else {
+            startLiveCapture()
+            guard inputTapInstalled, audioEngine.isRunning else { return }
+            return startRecognition()
+        }
+
+        guard let speechRecognizer else {
+            emitState(true, "Live room capture is active; Speech side channel is unavailable for this locale.")
             return
         }
+        guard speechRecognizer.isAvailable else {
+            emitState(true, "Live room capture is active; Speech side channel is not available right now.")
+            return
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        request.taskHint = .dictation
+        if #available(macOS 13.0, *) {
+            request.addsPunctuation = true
+        }
+        recognitionRequest = request
+        lastPartialText = ""
 
         recognitionTask = speechRecognizer.recognitionTask(with: request) { [weak self] result, error in
             guard let self else { return }
             if let result {
                 let text = result.bestTranscription.formattedString
                     .trimmingCharacters(in: .whitespacesAndNewlines)
-                self.lastPartialText = text
-                self.emitPartial(text)
-                if result.isFinal {
-                    self.emitUtterance(text)
-                    self.lastPartialText = ""
-                    self.emitPartial("")
+                let isFinal = result.isFinal
+                self.workQueue.async {
+                    self.handleRecognitionResult(text: text, isFinal: isFinal)
                 }
             }
             if let error {
@@ -207,12 +199,26 @@ final class RoomTranscriber: @unchecked Sendable {
             }
         }
 
-        emitState(true, "Listening to room mic")
+        emitState(true, "Live room capture is active; Speech side channel is transcribing")
+    }
+
+    private func handleRecognitionResult(text: String, isFinal: Bool) {
+        guard keepListening || recognitionRequest != nil || recognitionTask != nil else { return }
+        lastPartialText = text
+        emitPartial(text)
+        if isFinal {
+            emitUtterance(text)
+            lastPartialText = ""
+            emitPartial("")
+            recognitionRequest = nil
+            recognitionTask = nil
+            restartSpeechSideChannelSoon(message: "Live room capture is active; Speech side channel cycling")
+        }
     }
 
     private func handleRecognitionError(_ error: Error) {
         commitPartialIfNeeded()
-        stopRecognition()
+        stopSpeechSideChannel()
         emitPartial("")
 
         guard keepListening else {
@@ -221,19 +227,26 @@ final class RoomTranscriber: @unchecked Sendable {
             return
         }
 
-        emitState(true, "Listening to room mic, waiting for speech")
+        restartSpeechSideChannelSoon(message: "Live room capture is active; Speech side channel waiting for speech")
+    }
+
+    private func restartSpeechSideChannelSoon(message: String) {
+        guard keepListening else { return }
+        emitState(true, message)
         workQueue.asyncAfter(deadline: .now() + 0.35) { [weak self] in
             guard let self, self.keepListening else { return }
             self.startRecognition()
         }
     }
 
-    private func stopRecognition() {
+    private func stopSpeechSideChannel() {
         recognitionRequest?.endAudio()
         recognitionTask?.cancel()
         recognitionTask = nil
         recognitionRequest = nil
+    }
 
+    private func stopLiveCapture() {
         if audioEngine.isRunning {
             audioEngine.stop()
         }

--- a/experiments/satsang-mac-app/Sources/SatsangMacCore/FormNativeRouting.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangMacCore/FormNativeRouting.swift
@@ -121,8 +121,8 @@ public struct FormNativeRouteReceipt: Codable, Equatable, Sendable {
     public var remoteOracle: String
 
     public init(
-        listenReceipt: String = "form-native-listen-receipt",
-        transcribeRoute: String = "local-stt-form-receipt",
+        listenReceipt: String = "primary-live-room-capture-receipt",
+        transcribeRoute: String = "speech-side-channel-during-live-capture",
         formRequestKind: String = "satsang-guidance-request",
         hostBoundary: FormHostBoundaryReceipt = FormHostBoundaryReceipt(),
         bodyLookup: FormNativeLookupSignal,

--- a/experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift
@@ -60,7 +60,7 @@ public struct HostPlatformCarrier: Codable, Equatable, Sendable {
                 resourceInterface: resourceInterface,
                 resourceDoors: [
                     HostResourceDoor(kind: "audio-input", state: "declared", carrier: "macos-avfoundation", detail: "AVAudioEngine input node"),
-                    HostResourceDoor(kind: "speech-transcript", state: "declared", carrier: "macos-speech", detail: "SFSpeechRecognizer"),
+                    HostResourceDoor(kind: "speech-transcript", state: "declared", carrier: "macos-speech", detail: "SFSpeechRecognizer side channel fed during live capture"),
                     HostResourceDoor(kind: "file-read", state: "declared", carrier: "macos-foundation-filemanager", detail: "FileManager/Data"),
                     HostResourceDoor(kind: "file-append", state: "declared", carrier: "macos-foundation-filehandle", detail: "FileHandle append"),
                     HostResourceDoor(kind: "file-write-atomic", state: "declared", carrier: "macos-foundation-data-atomic", detail: "Data.write atomic"),
@@ -73,7 +73,7 @@ public struct HostPlatformCarrier: Codable, Equatable, Sendable {
                 resourceInterface: resourceInterface,
                 resourceDoors: [
                     HostResourceDoor(kind: "audio-input", state: "declared", carrier: "windows-wasapi-capture", detail: "WASAPI shared input"),
-                    HostResourceDoor(kind: "speech-transcript", state: "declared", carrier: "windows-speechrecognizer", detail: "Windows speech recognition"),
+                    HostResourceDoor(kind: "speech-transcript", state: "declared", carrier: "windows-speechrecognizer", detail: "Windows speech recognition side channel fed during live capture"),
                     HostResourceDoor(kind: "file-read", state: "declared", carrier: "windows-known-folder-filesystem", detail: "LocalAppData file read"),
                     HostResourceDoor(kind: "file-append", state: "declared", carrier: "windows-known-folder-filesystem", detail: "LocalAppData append"),
                     HostResourceDoor(kind: "file-write-atomic", state: "declared", carrier: "windows-replacefile-atomic", detail: "atomic replace"),
@@ -86,7 +86,7 @@ public struct HostPlatformCarrier: Codable, Equatable, Sendable {
                 resourceInterface: resourceInterface,
                 resourceDoors: [
                     HostResourceDoor(kind: "audio-input", state: "declared", carrier: "android-audiorecord", detail: "AudioRecord with RECORD_AUDIO"),
-                    HostResourceDoor(kind: "speech-transcript", state: "declared", carrier: "android-speechrecognizer", detail: "android.speech.SpeechRecognizer"),
+                    HostResourceDoor(kind: "speech-transcript", state: "declared", carrier: "android-speechrecognizer", detail: "android.speech.SpeechRecognizer side channel fed during live capture"),
                     HostResourceDoor(kind: "file-read", state: "declared", carrier: "android-app-private-files", detail: "Context.filesDir read"),
                     HostResourceDoor(kind: "file-append", state: "declared", carrier: "android-app-private-files", detail: "Context.filesDir append"),
                     HostResourceDoor(kind: "file-write-atomic", state: "declared", carrier: "android-atomic-file", detail: "AtomicFile or rename"),

--- a/experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift
+++ b/experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift
@@ -62,6 +62,8 @@ final class SatsangMacCoreTests: XCTestCase {
         let form = try String(contentsOf: result.latestFormURL)
         XCTAssertTrue(form.contains("(target \"sema\")"))
         XCTAssertTrue(form.contains("(host-boundary-kind \"form-native-host-boundary\")"))
+        XCTAssertTrue(form.contains("(listen-receipt \"primary-live-room-capture-receipt\")"))
+        XCTAssertTrue(form.contains("(transcribe-route \"speech-side-channel-during-live-capture\")"))
         XCTAssertTrue(form.contains("(host-resource-interface \"host-os-generic-resource-interface\")"))
         XCTAssertTrue(form.contains("(host-resource-door-count 6)"))
         XCTAssertTrue(form.contains("(host-resource-door-summary \"audio-input:declared:host-os-generic-resource-interface"))
@@ -87,6 +89,8 @@ final class SatsangMacCoreTests: XCTestCase {
 
         XCTAssertEqual(localReceipt.decision, "use-form-native-rag-llm")
         XCTAssertFalse(localReceipt.remoteOracleRequested)
+        XCTAssertEqual(localReceipt.listenReceipt, "primary-live-room-capture-receipt")
+        XCTAssertEqual(localReceipt.transcribeRoute, "speech-side-channel-during-live-capture")
 
         let missReceipt = FormNativeRouteReceipt(bodyLookup: body, ragLookup: .formCLIOutput("cell"))
         XCTAssertEqual(missReceipt.decision, "request-remote-llm-oracle")

--- a/form/form-stdlib/satsang-listen-route.fk
+++ b/form/form-stdlib/satsang-listen-route.fk
@@ -1,9 +1,10 @@
 ; satsang-listen-route.fk — listen/transcribe guidance routing with remote last.
 ;
 ; The room carrier may be macOS audio today, but the protocol receipt is Form:
-; listen/transcribe produce a request, the local body/RAG lanes are checked first,
-; and a remote LLM oracle is requested only when the sufficiency gate says the
-; native/local answer did not stand.
+; live capture is the primary stream; transcription is a concurrent side channel
+; fed during that capture, never a pre/post recording pass. The local body/RAG
+; lanes are checked first, and a remote LLM oracle is requested only when the
+; sufficiency gate says the native/local answer did not stand.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk
 ;           form-stdlib/form-cli-sufficiency.fk
@@ -28,6 +29,12 @@
         (if (str_eq (slr-decision body-grounded body-sufficient rag-grounded signals)
                     "request-remote-llm-oracle") 1 0))
 
+    (defn slr-live-capture-receipt? (listen)
+        (if (str_eq listen "primary-live-room-capture-receipt") 1 0))
+
+    (defn slr-side-channel-transcribe? (transcribe)
+        (if (str_eq transcribe "speech-side-channel-during-live-capture") 1 0))
+
     (defn slr-verdict-label (body-grounded body-sufficient rag-grounded signals)
         (if (eq (slr-body-sufficient? body-grounded body-sufficient) 1)
             "accept-local"
@@ -41,8 +48,8 @@
     (defn slr-receipt (body-grounded body-sufficient rag-grounded has-output shape-ok content confidence trust retries)
         (do (let signals (fsuf-signals has-output shape-ok content confidence trust retries))
             (list "satsang-listen-transcribe-route"
-                  "form-native-listen-receipt"
-                  "local-stt-form-receipt"
+                  "primary-live-room-capture-receipt"
+                  "speech-side-channel-during-live-capture"
                   "satsang-guidance-request"
                   body-grounded
                   body-sufficient

--- a/form/form-stdlib/tests/satsang-listen-route-band.fk
+++ b/form/form-stdlib/tests/satsang-listen-route-band.fk
@@ -10,7 +10,7 @@
 ;   16  weak RAG after body miss requests remote oracle
 ;   32  weak RAG receipt labels escalate-remote
 ;   64  empty local output with retry left retries native RAG
-;   128 route receipt names listen/transcribe/request shape
+;   128 route receipt names primary live capture + transcription side channel
 (do
     (let strong (fsuf-signals 1 1 82 72 72 0))
     (let weak (fsuf-signals 1 1 20 72 72 0))
@@ -27,8 +27,8 @@
     (let c4 (if (str_eq (slr-decision 1 0 1 weak) "request-remote-llm-oracle") 16 0))
     (let c5 (if (str_eq (slr-rec-verdict remote-rec) "escalate-remote") 32 0))
     (let c6 (if (str_eq (slr-decision 1 0 0 empty-retry) "retry-form-native-rag") 64 0))
-    (let c7 (if (and (str_eq (slr-rec-listen body-rec) "form-native-listen-receipt")
-                     (and (str_eq (slr-rec-transcribe rag-rec) "local-stt-form-receipt")
+    (let c7 (if (and (eq (slr-live-capture-receipt? (slr-rec-listen body-rec)) 1)
+                     (and (eq (slr-side-channel-transcribe? (slr-rec-transcribe rag-rec)) 1)
                           (str_eq (slr-rec-request body-rec) "satsang-guidance-request"))) 128 0))
 
     (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/specs/satsang-mac-guidance-app.md
+++ b/specs/satsang-mac-guidance-app.md
@@ -23,11 +23,13 @@ source:
   - file: form/form-stdlib/satsang-host-boundary.fk
     symbols: [shb-app-runtime-allowed?, shb-runtime-forbidden?, shb-resource-kind?, shb-platform-target?, shb-boundary-ok?, shb-receipt]
   - file: form/form-stdlib/satsang-listen-route.fk
-    symbols: [slr-decision, slr-remote-oracle?, slr-receipt]
+    symbols: [slr-decision, slr-remote-oracle?, slr-live-capture-receipt?, slr-side-channel-transcribe?, slr-receipt]
   - file: form/form-stdlib/satsang-room-memory.fk
     symbols: [srm-mic-exclusive-carrier?, srm-trust-ok?, srm-speaker-match?, srm-context-ready?, srm-receipt]
 requirements:
   - "Mac desktop GUI can listen to the room microphone after explicit Start Listening"
+  - "Live room capture is the primary stream; speech transcription is only a side channel fed during that capture"
+  - "Speech Recognition is never a before-recording or after-recording pass over stored audio"
   - "No-speech intervals do not stop the active room listener"
   - "A live microphone level shows whether the room is reaching the app"
   - "Microphone activity is visible separately from Speech Recognition authorization"
@@ -72,11 +74,14 @@ transcript files, and writes a local protocol event queue.
 - [x] The GUI loads detected transcript lines from a JSONL or JSON-array file.
 - [x] The GUI starts/stops native macOS microphone transcription with explicit
       user action.
-- [x] The GUI keeps listening through no-speech intervals by restarting the
-      speech recognition pass.
+- [x] The GUI keeps listening through no-speech intervals by restarting only the
+      speech recognition side channel.
 - [x] The GUI shows a live microphone level while listening.
 - [x] The GUI starts microphone metering separately from Speech Recognition
       authorization so permission delays do not leave a silent requesting state.
+- [x] The GUI keeps one live capture tap open and feeds Speech Recognition as a
+      concurrent side channel during capture, never as a before/after recording
+      pass.
 - [x] Live microphone partials appear as editable `room mic` transcript rows.
 - [x] The GUI allows editing individual utterances before sending.
 - [x] Manual and live rows survive transcript-file reloads.
@@ -108,13 +113,14 @@ transcript files, and writes a local protocol event queue.
       those same resource doors.
 - [x] A Form proof names the valid event/protocol boundary.
 - [x] A Form proof names the generic host ABI and detected resource-door boundary.
-- [x] A Form proof names the remote-last listen/transcribe route boundary.
+- [x] A Form proof names the remote-last listen/transcribe route boundary with
+      primary live capture and side-channel transcription.
 
 ## Files
 
 - `experiments/satsang-mac-app/Package.swift` - Swift package.
 - `experiments/satsang-mac-app/Sources/SatsangGuidance/SatsangGuidanceApp.swift` - SwiftUI GUI.
-- `experiments/satsang-mac-app/Sources/SatsangGuidance/RoomTranscriber.swift` - native room microphone transcription.
+- `experiments/satsang-mac-app/Sources/SatsangGuidance/RoomTranscriber.swift` - native room microphone capture with speech transcription as a side channel.
 - `experiments/satsang-mac-app/Sources/SatsangMacCore/Transcript.swift` - transcript parser.
 - `experiments/satsang-mac-app/Sources/SatsangMacCore/TrustedRoomMemory.swift` - local session index, speaker-profile, and prior-context memory store.
 - `experiments/satsang-mac-app/Sources/SatsangMacCore/TranscriptMerger.swift` - transcript reload merge policy.
@@ -153,6 +159,9 @@ transcript files, and writes a local protocol event queue.
   in listening state instead of closing on `No speech detected`.
 - Manual validation: if Speech Recognition permission is still pending or
   denied, confirm the app still shows microphone activity and an explicit status.
+- Manual validation: while Speech Recognition attaches, cycles, or waits through
+  silence, confirm the live mic level remains active and the listener does not
+  restart the capture stream.
 
 ## Verification
 
@@ -185,8 +194,8 @@ python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.m
 - The app does not replace turn-taking learning; it records that the turn was
   offered or manually invoked.
 - macOS microphone permission must be accepted before the app can listen to the
-  room; Speech Recognition permission must be accepted before live room
-  transcription can run.
+  room; Speech Recognition permission must be accepted before the transcription
+  side channel can attach to the already-open live capture stream.
 - The listener can only transcribe audio that reaches the selected macOS input
   device; system speaker playback may not loop back into the microphone.
 - The local Form/RAG lookup depends on a repo-local `form/form-cli` binary or a


### PR DESCRIPTION
## Summary
- keep `RoomTranscriber` on one primary AVAudioEngine live capture tap
- feed macOS Speech Recognition as a concurrent side channel during capture instead of replacing the live capture path
- update Form route receipts/docs/tests to name `primary-live-room-capture-receipt` and `speech-side-channel-during-live-capture`

## Trust / routing note
- `form-cli ask "satsang mac app live room recording primary stream speech recognition concurrent side channel during capture not before or after recording pass"` used the native path but had no grounded/sufficient local RAG hit; local model-cell witness was observed
- implementation is source-guided and proved by Swift/Form gates

## Validation
- `make prompt-guide`
- `make wellness`
- `swift test --package-path experiments/satsang-mac-app`
- `swift build --package-path experiments/satsang-mac-app --product SatsangGuidance`
- `scripts/build_satsang_mac_app.sh`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-guidance-event.fk form-stdlib/tests/satsang-guidance-event-band.fk`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/satsang-listen-route.fk form-stdlib/tests/satsang-listen-route-band.fk`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-room-memory.fk form-stdlib/tests/satsang-room-memory-band.fk`
- `python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.md`
- `python3 scripts/generate_repo_indexes.py --check`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-26_live_capture_sidechannel_transcription.json`
- `git diff --check`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`
