### PR TITLE
Gate full real Llama generation claim

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-26_full_real_llama_generation_claim_gate.json
+++ b/docs/system_audit/commit_evidence_2026-06-26_full_real_llama_generation_claim_gate.json
@@ -1,0 +1,126 @@
+{
+  "date": "2026-06-26",
+  "thread_branch": "codex/full-real-llama-gguf-generation-20260626",
+  "commit_scope": "Add a hard claim gate for full real Llama GGUF token generation and wire it into the full model inference composition receipt so the system cannot claim the unfinished native path.",
+  "files_owned": [
+    "scripts/validate_form_cli_full_real_llama_generation_claim.sh",
+    "scripts/fkwu_form_cli_full_model_inference_composition_receipt.sh",
+    "docs/system_audit/commit_evidence_2026-06-26_full_real_llama_generation_claim_gate.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "PROMPT_GATE_SKIP_CONTINUITY=1 make prompt-guide -> pass before edits in worktree codex/full-real-llama-gguf-generation-20260626",
+      "make wellness -> pass before edits with no blocker for this task",
+      "bin/form-cli ask \"What is the smallest next executable path to close full real Llama GGUF token generation: prompt text to tokenizer arrays to real GGUF tensor bytes to Metal buffers to autoregressive token IDs to decoded text in form-cli?\" -> [ask: local fkwu RAG index has no grounded hit]",
+      "bash -n scripts/validate_form_cli_full_real_llama_generation_claim.sh -> pass",
+      "bash -n scripts/fkwu_form_cli_full_model_inference_composition_receipt.sh -> pass",
+      "scripts/validate_form_cli_full_real_llama_generation_claim.sh .cache/body-test-receipts/current-full-real-llama-generation-claim.json -> verdict=blocked_full_real_llama_generation_pending; claim-allowed=false; grounded-decoded-answer=true; full-real-llama-gguf-generation=pending; blocked-requirements=5",
+      "scripts/fkwu_form_cli_full_model_inference_composition_receipt.sh .cache/body-test-receipts/current-full-real-llama-composition-receipt.json -> verdict=pass_composition_receipt_decoded_answer_bound_full_width_not_yet_composed; full_model_inference_composed=false; ask_staged_decoded_answer_bound=false",
+      "jq summary on .cache/body-test-receipts/current-full-real-llama-composition-receipt.json -> steps_count=17, passed_count=14, skipped_count=3, failed_count=0, hard_failed_count=0, trace_sha256=71841524f255ffb38bae58ead2b197e5d08f77e0ec48692e6e41cc038e463587",
+      "grep local absolute path scan over current claim and composition receipts/traces -> no /Users/ursmuff, /private/var, or /var/folders matches after sanitization"
+    ],
+    "results": [
+      "The claim gate observed the current grounded decoded-answer lane, the model status gap, and a real Llama GGUF map with architecture=llama and tensor_count=255.",
+      "The claim gate intentionally returned claim_allowed=false with no hard failures because full real Llama GGUF token generation is still pending.",
+      "The full composition receipt now includes composition_gates.decoded_prose_answer_binding=true and composition_gates.full_real_llama_generation_claim_gate=true while still recording synthesis_boundary.missing=[full-real-llama-gguf-token-generation].",
+      "The composition receipt's open bridges now name the exact remaining work: materialize named real GGUF tensors into fkwu, dequant/place full-width tensors into Metal buffers, run the full multi-layer GQA loop, project logits/select token IDs/decode through real tokenizer arrays, and bind decoded text as the form-cli answer without HTTP, Ollama, MLX serving, or proxy oracle.",
+      "The receipt harness remains a shell/Python validation carrier; it does not add a runtime inference dependency to the native child proof path."
+    ]
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "PR checks pending until this branch is pushed.",
+      "Windows Host Floor should exercise scripts/fkwu_form_cli_full_model_inference_composition_receipt.sh through the existing workflow once the PR opens."
+    ],
+    "notes": "Local Mac proof is complete for the claim gate and full composition receipt. Android hardware was not attached locally. The first PR #3685 Windows Host Floor run failed because the new claim gate treated an absent grounded decoded-answer lane as ambiguous; the second run showed the same issue for Windows status-shape differences. The gate was corrected so every claim_allowed=false state passes as a blocked cross-device receipt, while future positive claims stay strict. Rerun is pending."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "reason": "No public deploy surface changed; this is a local receipt/claim-gate improvement."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Full real Llama GGUF token generation is still not implemented or proven as one native form-cli path from prompt text through real tokenizer/tensor bytes, accelerator buffers, autoregressive token IDs, and decoded text."
+  },
+  "idea_ids": [
+    "cognitive-sovereignty",
+    "form-native-model-execution",
+    "observable-body-test-receipts"
+  ],
+  "spec_ids": [
+    "form-cli-fkwu-metal-llm-lane",
+    "gguf-model-cell",
+    "full-real-llama-gguf-generation-claim-gate"
+  ],
+  "task_ids": [
+    "task-2026-06-26-full-real-llama-generation-claim-gate"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "constraints",
+        "claim-standard"
+      ]
+    },
+    {
+      "contributor_id": "openai-gpt-5-codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "evidence"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "codex",
+    "version": "OpenAI GPT-5 Codex"
+  },
+  "evidence_refs": [
+    "Subagent read-only inspection found no existing full real GGUF transformer step; closest pieces are gguf-read.fk, form-cli-gguf-cell.fk, gguf_weight_map_receipt.py, weight-load.fk, block-join.fk, llama-generate.fk, and form_cli_ask_staged_model_call.sh.",
+    "Claim receipt: .cache/body-test-receipts/current-full-real-llama-generation-claim.json",
+    "Claim trace: .cache/body-test-receipts/current-full-real-llama-generation-claim_trace",
+    "Composition receipt: .cache/body-test-receipts/current-full-real-llama-composition-receipt.json",
+    "Composition trace: .cache/body-test-receipts/current-full-real-llama-composition-receipt_trace/steps.jsonl",
+    "Composition trace sha256: 71841524f255ffb38bae58ead2b197e5d08f77e0ec48692e6e41cc038e463587",
+    "Form-first reasoning was attempted through bin/form-cli ask; the body returned no grounded/sufficient hit for the exact full-real-generation closure question."
+  ],
+  "change_files": [
+    "scripts/validate_form_cli_full_real_llama_generation_claim.sh",
+    "scripts/fkwu_form_cli_full_model_inference_composition_receipt.sh",
+    "docs/system_audit/commit_evidence_2026-06-26_full_real_llama_generation_claim_gate.json"
+  ],
+  "change_intent": "process_only",
+  "e2e_validation": {
+    "status": "pass",
+    "expected_behavior_delta": "The body-test composition receipt now has an observable hard claim gate for full real Llama GGUF token generation. It passes as a receipt when the current state is honest, but it returns claim_allowed=false until real tensor bytes drive a full native autoregressive generation path.",
+    "test_flows": [
+      "scripts/validate_form_cli_full_real_llama_generation_claim.sh .cache/body-test-receipts/current-full-real-llama-generation-claim.json",
+      "scripts/fkwu_form_cli_full_model_inference_composition_receipt.sh .cache/body-test-receipts/current-full-real-llama-composition-receipt.json"
+    ]
+  },
+  "sovereignty_receipt": {
+    "generated_by": "OpenAI GPT-5 Codex in Codex",
+    "native_body_share": "native/local proof commands generated the claim receipt, composition receipt, Form band outputs, GGUF map observation, and Metal model-cell/body trace rows",
+    "rented_oracle_share": "the script design, integration, and evidence synthesis were produced by the rented frontier model after form-cli ask returned a native miss",
+    "trust_matrix": {
+      "path": "native-first miss -> rented implementation orchestration -> native receipt proof",
+      "grounded": "receipts and trace hashes are grounded in local outputs; the initial form-cli ask was ungrounded",
+      "freq": "clear-not-fear; not machine-measured",
+      "suffic": "sufficient for preventing a false full-generation claim; not sufficient for claiming full model inference",
+      "observed": false
+    }
+  },
+  "coherence_cli_note": {
+    "attempted_commands": [
+      "cc inbox",
+      "cc status"
+    ],
+    "result": "Both commands resolved to the host C compiler alias and failed with clang: error: no such file or directory. The Coherence CLI was therefore not available through cc on this host."
+  }
+}

--- a/scripts/fkwu_form_cli_full_model_inference_composition_receipt.sh
+++ b/scripts/fkwu_form_cli_full_model_inference_composition_receipt.sh
@@ -9,8 +9,10 @@
 #   proven pieces: fkwu form-cli ask/status, GGUF find/model-cell,
 #                  tokenizer/loop bands, Metal model-cell/body trace on macOS.
 #   now bound:     ask-staged model-call witness -> decoded local answer receipt.
-#   still open:    upgrading that receipt-scored answer to full-width real GGUF
-#                  semantic generation across the platform device matrix.
+#   still open:    full real Llama GGUF token generation produced by real prompt text,
+#                  real GGUF tokenizer arrays, real GGUF tensor bytes,
+#                  accelerator buffers, full autoregressive token IDs, and
+#                  decoded token text.
 #
 # Runtime claims are read from the child receipts. Build/receipt tools may be
 # used by this harness; the sanitized proof binaries run with no HTTP/Ollama and
@@ -108,6 +110,9 @@ observation_for() {
             ;;
         real_gguf_weight_map)
             grep -E '^(receipt:|file:|header:|tensor-map:|types:|tokenizer-arrays:|required-tensors:|no real GGUF|SKIP)' "$out" || true
+            ;;
+        full_real_llama_generation_claim)
+            grep -E '^(receipt:|verdict:|claim-allowed:|grounded-decoded-answer:|full-real-llama-gguf-generation:|blocked-requirements:)' "$out" || true
             ;;
         android_*)
             grep -E '^(SKIP|FAIL|ok|  ✓|  ✗|witness on device|conditions:|device:|\{"status")' "$out" || true
@@ -230,6 +235,10 @@ run_step form_cli_ask current-host "native fkwu grounded ask" true \
     "bin/form-cli ask substrate" \
     "$ROOT/bin/form-cli" ask substrate
 
+run_step ask_staged_model_call current-host "ask-staged local model-call witness" true \
+    "bin/form-cli ask ungrounded-model-call-composition-probe" \
+    "$ROOT/bin/form-cli" ask "ungrounded model call composition probe $STAMP"
+
 run_step synthesis_status current-host "model synthesis binding" true \
     "bin/form-cli synthesis-status" \
     "$ROOT/bin/form-cli" synthesis-status
@@ -241,10 +250,6 @@ run_step model_status current-host "model status binding" true \
 run_step decoded_answer current-host "native decoded answer binding" true \
     "form/form-cli decoded-answer" \
     bash -lc "printf 'decoded-answer\nquit\n' | '$ROOT/form/form-cli' | sed '/^null$/d'"
-
-run_step ask_staged_model_call current-host "ask-staged local model-call witness" true \
-    "bin/form-cli ask ungrounded-model-call-composition-probe" \
-    "$ROOT/bin/form-cli" ask "ungrounded model call composition probe $STAMP"
 
 run_step gguf_find_four_way current-host "GGUF find-by-name and absolute offset four-way" true \
     "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/gguf-read.fk form-stdlib/tests/gguf-find-band.fk" \
@@ -269,6 +274,10 @@ if command -v python3 >/dev/null 2>&1; then
 else
     skip_step real_gguf_weight_map current-host "optional real GGUF tensor map witness" "python3 absent in receipt harness; runtime path unaffected"
 fi
+
+run_step full_real_llama_generation_claim current-host "full real Llama GGUF generation claim gate" true \
+    "scripts/validate_form_cli_full_real_llama_generation_claim.sh <trace>/full-real-llama-generation-claim.json" \
+    "$ROOT/scripts/validate_form_cli_full_real_llama_generation_claim.sh" "$TRACE_DIR/full-real-llama-generation-claim.json"
 
 gguf_model_cell_hard=true
 if is_windows_host; then
@@ -407,6 +416,7 @@ jq -n \
     --argjson autoregressive_loop "$(bool_or_false "$(step_passed autoregressive_loop_four_way)")" \
     --argjson real_gguf_weight_map "$(bool_or_false "$(step_passed real_gguf_weight_map)")" \
     --argjson real_gguf_skipped "$(bool_or_false "$(step_skipped real_gguf_weight_map)")" \
+    --argjson full_generation_claim_gate "$(bool_or_false "$(step_passed full_real_llama_generation_claim)")" \
     --argjson gguf_cell "$(bool_or_false "$(step_passed gguf_model_cell)")" \
     --argjson metal_cell "$(bool_or_false "$(step_passed metal_model_cell)")" \
     --argjson metal_trace "$(bool_or_false "$(step_passed metal_body_trace)")" \
@@ -429,7 +439,7 @@ jq -n \
       verdict: $verdict,
       full_model_inference_composed: false,
       ask_staged_decoded_answer_bound: $ask_staged_decoded_answer,
-      reason_full_inference_not_claimed: "decoded answer binding is observed through native form-cli; ask-staged binding is observed when local model-cell assets are present; full-width real GGUF semantic generation across every device lane is not yet claimed",
+      reason_full_inference_not_claimed: "decoded answer binding is observed through native form-cli and the claim gate passes as a blocker, but the answer is not yet produced by full real Llama GGUF tokenizer arrays, real tensor bytes, accelerator buffers, autoregressive token IDs, and decoded token text in one native form-cli path",
       host: {
         os: $host_os,
         arch: $host_arch
@@ -462,6 +472,7 @@ jq -n \
         autoregressive_generation_loop_four_way: $autoregressive_loop,
         optional_real_gguf_weight_map_observed: $real_gguf_weight_map,
         optional_real_gguf_weight_map_skipped: $real_gguf_skipped,
+        full_real_llama_generation_claim_gate: $full_generation_claim_gate,
         fkwu_form_cli_gguf_model_cell: $gguf_cell,
         fkwu_form_cli_metal_model_cell: $metal_cell,
         form_native_metal_body_trace: $metal_trace,
@@ -501,6 +512,11 @@ jq -n \
       },
       open_bridges: [
         "upgrade the receipt-scored decoded answer binding to full-width real GGUF semantic generation",
+        "materialize named real GGUF tensors into the fkwu-controlled model-cell path, not only a metadata map",
+        "dequant and place the full-width Llama tensor set into Metal/accelerator buffers",
+        "run the full multi-layer GQA autoregressive loop over those real tensors",
+        "project logits over the real vocabulary, select token IDs, and decode through the real tokenizer arrays",
+        "bind that decoded text as the form-cli ask answer without HTTP, Ollama, MLX serving, or a proxy oracle",
         "add Android Vulkan/NNAPI and Windows DirectML/D3D12 model-cell carriers matching the macOS Metal model-cell receipt"
       ],
       steps: $steps

--- a/scripts/validate_form_cli_full_real_llama_generation_claim.sh
+++ b/scripts/validate_form_cli_full_real_llama_generation_claim.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# validate_form_cli_full_real_llama_generation_claim.sh
+#
+# Claim gate for the strict full-real Llama GGUF generation path.
+# This receipt is intentionally stricter than the grounded decoded-answer lane:
+# it only allows the full claim when form-cli produces text through one native
+# path from real prompt text -> real GGUF tokenizer/tensor bytes -> accelerator
+# buffers -> full autoregressive token IDs -> decoded text.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+DEFAULT_RECEIPT="$ROOT/.cache/body-test-receipts/full-real-llama-generation-claim-$STAMP/receipt.json"
+RECEIPT_PATH="${1:-$DEFAULT_RECEIPT}"
+
+if [[ "$RECEIPT_PATH" != /* ]]; then
+    RECEIPT_PATH="$ROOT/$RECEIPT_PATH"
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "missing required receipt harness tool: python3" >&2
+    exit 2
+fi
+
+TRACE_DIR="${RECEIPT_PATH%.json}_trace"
+rm -rf "$TRACE_DIR"
+mkdir -p "$TRACE_DIR" "$(dirname "$RECEIPT_PATH")"
+
+sanitize_trace_file() {
+    local src="$1"
+    local tmp="$src.sanitized"
+    LC_ALL=C sed -E \
+        -e "s|$ROOT|<repo>|g" \
+        -e "s|$HOME|<home>|g" \
+        -e 's|[A-Za-z]:\\[^"[:space:]]*Coherence-Network\\Coherence-Network|<repo>|g' \
+        -e 's|[A-Za-z]:\\Users\\[^"[:space:]]+|<home>|g' \
+        -e 's|<home>/.ollama/models/blobs/sha256-[0-9a-fA-F]+|<local-gguf-blob>|g' \
+        -e 's|<home>/mentor-install/.models/[^"[:space:]]+|<local-gguf-file>|g' \
+        -e 's|/private/var/folders/[^[:space:]:]+|<tmp>|g' \
+        -e 's|/var/folders/[^[:space:]:]+|<tmp>|g' \
+        "$src" > "$tmp"
+    mv "$tmp" "$src"
+}
+
+sanitize_trace_tree() {
+    local file
+    while IFS= read -r -d '' file; do
+        sanitize_trace_file "$file"
+    done < <(find "$TRACE_DIR" -type f -print0)
+}
+
+run_capture() {
+    local key="$1"
+    shift
+    local out="$TRACE_DIR/$key.out"
+    local rcfile="$TRACE_DIR/$key.rc"
+    "$@" >"$out" 2>&1
+    local rc=$?
+    printf '%s\n' "$rc" >"$rcfile"
+}
+
+run_capture ask_full_real_claim \
+    "$ROOT/bin/form-cli" ask "full real Llama GGUF token generation claim gate $STAMP"
+
+run_capture model_status \
+    "$ROOT/bin/form-cli" model-status
+
+run_capture real_gguf_weight_map \
+    python3 "$ROOT/scripts/gguf_weight_map_receipt.py" --json "$TRACE_DIR/real-gguf-weight-map.json"
+
+sanitize_trace_tree
+
+python3 - "$ROOT" "$TRACE_DIR" "$RECEIPT_PATH" <<'PY'
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+trace_dir = Path(sys.argv[2])
+receipt_path = Path(sys.argv[3])
+
+
+def read_text(name: str) -> str:
+    path = trace_dir / f"{name}.out"
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def read_rc(name: str) -> int:
+    path = trace_dir / f"{name}.rc"
+    if not path.exists():
+        return 127
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except ValueError:
+        return 127
+
+
+def git_value(args: list[str], fallback: str) -> str:
+    try:
+        return subprocess.check_output(args, cwd=root, text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception:
+        return fallback
+
+
+def rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+ask = read_text("ask_full_real_claim")
+status = read_text("model_status")
+gguf_map_path = trace_dir / "real-gguf-weight-map.json"
+gguf_map = {}
+if gguf_map_path.exists():
+    try:
+        gguf_map = json.loads(gguf_map_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        gguf_map = {}
+
+observed_grounded_answer = (
+    read_rc("ask_full_real_claim") == 0
+    and "model-call-observed:true" in ask
+    and "prose-generation:decoded-grounded-answer" in ask
+)
+status_names_full_real_gap = (
+    read_rc("model_status") == 0
+    and "observed:tokenizer-carrier,full-gguf-weight-map,metal-weight-bytes-runtime,autoregressive-loop,ask-staged-model-call,decoded-prose-answer-binding" in status
+    and "missing:full-real-llama-gguf-token-generation" in status
+)
+ask_names_full_real_gap = "full-real-llama-gguf-generation:pending" in ask
+real_gguf_map_observed = read_rc("real_gguf_weight_map") == 0 and gguf_map.get("verdict") == "pass"
+
+claim_allowed = (
+    observed_grounded_answer
+    and not status_names_full_real_gap
+    and "full-real-llama-gguf-generation:pass" in ask
+)
+
+# A blocked claim is a successful gate result on every device row. Device rows
+# may differ in which local answer/status witnesses are present, but none may
+# promote the full-real generation claim unless the strict positive evidence is
+# present.
+hard_failures: list[str] = []
+if claim_allowed and not observed_grounded_answer:
+    hard_failures.append("claim_allowed_without_grounded_decoded_answer")
+if claim_allowed and not real_gguf_map_observed:
+    hard_failures.append("claim_allowed_without_real_gguf_weight_map")
+
+verdict = "pass_full_real_llama_generation_claimed" if claim_allowed else "blocked_full_real_llama_generation_pending"
+if hard_failures:
+    verdict = "fail_claim_gate_ambiguous"
+
+receipt = {
+    "receipt_kind": "form-cli-full-real-llama-generation-claim-receipt",
+    "trace_id": f"full-real-llama-generation-claim-{receipt_path.parent.name}",
+    "git_commit": git_value(["git", "rev-parse", "--short", "HEAD"], "unknown"),
+    "git_branch": git_value(["git", "rev-parse", "--abbrev-ref", "HEAD"], "unknown"),
+    "verdict": verdict,
+    "claim_allowed": claim_allowed,
+    "hard_failures": hard_failures,
+    "observed_components": {
+        "ask_staged_model_call_and_grounded_decoded_answer": observed_grounded_answer,
+        "model_status_names_full_real_generation_gap": status_names_full_real_gap,
+        "ask_trace_names_full_real_generation_gap": ask_names_full_real_gap,
+        "real_gguf_weight_map_observed": real_gguf_map_observed,
+        "real_gguf_tensor_count": ((gguf_map.get("tensor_map") or {}).get("count_observed")),
+        "real_gguf_architecture": ((gguf_map.get("metadata") or {}).get("architecture")),
+    },
+    "blocked_requirements": [] if claim_allowed else [
+        "materialize named real GGUF tensors into the fkwu-controlled model-cell path, not only a metadata map",
+        "dequant and place the full-width Llama tensor set into Metal/accelerator buffers",
+        "run the full multi-layer GQA autoregressive loop over those real tensors",
+        "project logits over the real vocabulary, select token IDs, and decode through the real tokenizer arrays",
+        "bind that decoded text as the form-cli ask answer without HTTP, Ollama, MLX serving, or a proxy oracle",
+    ],
+    "artifacts": {
+        "trace_dir": rel(trace_dir),
+        "ask_full_real_claim": rel(trace_dir / "ask_full_real_claim.out"),
+        "model_status": rel(trace_dir / "model_status.out"),
+        "real_gguf_weight_map": rel(gguf_map_path),
+    },
+}
+
+receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(f"receipt:{rel(receipt_path)}")
+print(f"verdict:{verdict}")
+print(f"claim-allowed:{str(claim_allowed).lower()}")
+print(f"grounded-decoded-answer:{str(observed_grounded_answer).lower()}")
+print(f"full-real-llama-gguf-generation:{'pass' if claim_allowed else 'pending'}")
+if not claim_allowed:
+    print("blocked-requirements:" + str(len(receipt["blocked_requirements"])))
+
+if hard_failures:
+    sys.exit(1)
+PY


### PR DESCRIPTION
## Summary
- add a strict form-cli full-real Llama GGUF generation claim gate
- wire the gate into the full model inference composition receipt while preserving the decoded-answer binding row from current main
- record evidence that decoded prose binding is observed, but full real GGUF token generation remains pending

## Local proof
- bash -n scripts/validate_form_cli_full_real_llama_generation_claim.sh
- bash -n scripts/fkwu_form_cli_full_model_inference_composition_receipt.sh
- scripts/validate_form_cli_full_real_llama_generation_claim.sh .cache/body-test-receipts/current-full-real-llama-generation-claim.json
- scripts/fkwu_form_cli_full_model_inference_composition_receipt.sh .cache/body-test-receipts/current-full-real-llama-composition-receipt.json
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main

## Receipt result
- claim_allowed=false
- verdict=pass_composition_receipt_decoded_answer_bound_full_width_not_yet_composed
- decoded_prose_answer_binding=true
- full_model_inference_composed=false
- missing=full-real-llama-gguf-token-generation
- trace_sha256=71841524f255ffb38bae58ead2b197e5d08f77e0ec48692e6e41cc038e463587