### PR TITLE
tend: add iphone health wearable memory

### DIFF
--- a/docs/coherence-substrate/satsang-guidance-event.form
+++ b/docs/coherence-substrate/satsang-guidance-event.form
@@ -8,7 +8,7 @@
 ;
 ; Carrier:
 ;   experiments/satsang-mac-app - shared SwiftUI native app. macOS and iPhone
-;   entry points share one tabbed body: Room, Guidance, Memory, Learning,
+;   entry points share one tabbed body: Room, Guidance, Memory, Health, Learning,
 ;   Resources, and Settings. The app tails the local transcript JSONL, listens to
 ;   the room microphone after explicit Start Listening, lets the holder edit
 ;   utterances, and writes the request to ~/.coherence-network/satsang-guidance/
@@ -29,8 +29,12 @@
 ;   when present, or by visible channel label when not. Acoustic continuity can
 ;   only arrive through a passive sidecar sharing the already-open listening
 ;   stream; macOS biometric speaker identification is outside the carrier.
-;   File, process, audio-input, and speech-transcript resources cross one
-;   generic host OS resource-door receipt in the Swift core. The receipt carries
+;   The Health tab imports iPhone HealthKit wearable samples after explicit
+;   permission and source filtering, then writes local health-memory context under
+;   ~/.coherence-network/health-memory for later reference, memory, reasoning,
+;   and analysis. File, process, audio-input, speech-transcript, and
+;   health-samples resources cross one generic host OS resource-door receipt in
+;   the Swift core. The receipt carries
 ;   resolved macOS, Windows, Android, and iPhone/iOS carrier mappings for every
 ;   resource kind; live state is detected on Apple hosts today, while
 ;   Windows/Android device packages still promote declared doors to observed/open
@@ -52,10 +56,13 @@
 ;   form/form-stdlib/satsang-host-boundary.fk names the generic host ABI,
 ;   detected resource doors, resolved platform carriers, and forbidden
 ;   app-boundary runtimes. Proof:
-;   form/form-stdlib/tests/satsang-host-boundary-band.fk -> 1048575.
+;   form/form-stdlib/tests/satsang-host-boundary-band.fk -> 2097151.
 ;   form/form-stdlib/satsang-room-memory.fk names explicit local session memory,
 ;   speaker continuity, no-hidden-capture, and later context. Proof:
 ;   form/form-stdlib/tests/satsang-room-memory-band.fk -> 255.
+;   form/form-stdlib/satsang-health-memory.fk names explicit local health memory,
+;   source-filtered HealthKit import, no-hidden-capture, and analysis boundary.
+;   Proof: form/form-stdlib/tests/satsang-health-memory-band.fk -> 255.
 ;
 ; Boundary:
 ;   The event is an offer, not an interruption. The GUI does not decide that a

--- a/docs/coherence-substrate/satsang-health-memory.form
+++ b/docs/coherence-substrate/satsang-health-memory.form
@@ -1,0 +1,23 @@
+# Satsang Health Memory
+
+Health memory is a consented local context lane for wearable samples that the
+holder explicitly imports from the iPhone health store.
+
+The first native carrier is iOS HealthKit. Oura, Oz/O2, Wellue, ViHealth, and
+other oxygen or ring sources enter through Apple Health when the holder grants
+read access for the selected categories. The app stores imported samples in the
+local health-memory folder and makes only compact summaries available to the
+guidance request.
+
+The trust receipt is the boundary:
+
+- capture boundary: explicit import
+- source carrier: iOS HealthKit source-filtered samples
+- storage carrier: local JSON/Form files
+- retrieval scope: same-holder local health memory
+- analysis boundary: reference memory, reasoning, and analysis; not diagnosis
+- hidden capture: false
+- later context: allowed after explicit import
+
+The Form proof is `form/form-stdlib/satsang-health-memory.fk`, with
+`form/form-stdlib/tests/satsang-health-memory-band.fk` as the fourth-arm band.

--- a/docs/system_audit/commit_evidence_2026-06-26_iphone_health_wearable_memory.json
+++ b/docs/system_audit/commit_evidence_2026-06-26_iphone_health_wearable_memory.json
@@ -1,0 +1,154 @@
+{
+  "date": "2026-06-26",
+  "thread_branch": "codex/iphone-health-wearables-20260626",
+  "commit_scope": "Add an explicit iPhone HealthKit wearable import path to the shared satsang native app, storing Oura/Oz/O2-style source-filtered samples in local trusted health memory and feeding compact health context into the Form/RAG guidance request.",
+  "files_owned": [
+    "docs/coherence-substrate/satsang-guidance-event.form",
+    "docs/coherence-substrate/satsang-health-memory.form",
+    "docs/system_audit/commit_evidence_2026-06-26_iphone_health_wearable_memory.json",
+    "experiments/satsang-mac-app/Package.swift",
+    "experiments/satsang-mac-app/README.md",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/GuidanceRequest.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/SatsangNativeAppMode.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/TrustedHealthMemory.swift",
+    "experiments/satsang-mac-app/Support/SatsangGuidancePhone/Info.plist",
+    "experiments/satsang-mac-app/Support/SatsangGuidancePhone/SatsangGuidancePhone.entitlements",
+    "experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift",
+    "form/form-stdlib/satsang-health-memory.fk",
+    "form/form-stdlib/satsang-host-boundary.fk",
+    "form/form-stdlib/tests/satsang-health-memory-band.fk",
+    "form/form-stdlib/tests/satsang-host-boundary-band.fk",
+    "form/fourth-arm-bands.txt",
+    "specs/satsang-mac-guidance-app.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "make wellness",
+      "form-cli ask \"iPhone HealthKit Oura ring Oz sensor wearable health memory native app integration source carrier resource door\"",
+      "swift test --package-path experiments/satsang-mac-app",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidance",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone",
+      "scripts/build_satsang_mac_app.sh",
+      "xcodebuild -scheme SatsangGuidancePhone -destination 'generic/platform=iOS' -derivedDataPath .build/xcode-derived build",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-guidance-event.fk form-stdlib/tests/satsang-guidance-event-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/satsang-listen-route.fk form-stdlib/tests/satsang-listen-route-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-room-memory.fk form-stdlib/tests/satsang-room-memory-band.fk",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-health-memory.fk form-stdlib/tests/satsang-health-memory-band.fk",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.md",
+      "git diff --check",
+      "make wellness"
+    ],
+    "fourth_arm": "satsang-guidance-event-band.fk -> 255, satsang-host-boundary-band.fk -> 2097151, satsang-listen-route-band.fk -> 255, satsang-room-memory-band.fk -> 255, satsang-health-memory-band.fk -> 255; each focused output included 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)' and '0 divergent'.",
+    "summary": "Startup gate passed on a fresh worktree. form-cli ask used the native route but had no grounded/sufficient local RAG hit for this exact HealthKit wearable-memory shape, then observed the fkwu+Metal model-cell witness. Swift tests passed with 13 XCTest cases, including trusted health memory and the seven-mode app receipt. Both Swift package app products built, and scripts/build_satsang_mac_app.sh produced the packaged macOS app. Generic iOS build remains blocked on this host because iOS 26.2 platform support is not installed; the iOS HealthKit code path is source-present but not device-compiled here."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "No public deploy yet; this is a local native app carrier/source change awaiting PR checks."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local source and Form proof passed; CI, PR checks, and signed iPhone/device HealthKit validation are pending."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "satsang-mac-guidance-app"
+  ],
+  "task_ids": [
+    "iphone-health-wearables-2026-06-26"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "health-memory-boundary"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "form-proof",
+        "local-validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "OpenAI GPT-5 Codex"
+  },
+  "evidence_refs": [
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/TrustedHealthMemory.swift",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/GuidanceRequest.swift",
+    "form/form-stdlib/satsang-health-memory.fk",
+    "form/form-stdlib/tests/satsang-health-memory-band.fk",
+    "form/form-stdlib/satsang-host-boundary.fk",
+    "form/form-stdlib/tests/satsang-host-boundary-band.fk",
+    "specs/satsang-mac-guidance-app.md",
+    "docs/coherence-substrate/satsang-health-memory.form"
+  ],
+  "change_files": [
+    "docs/coherence-substrate/satsang-guidance-event.form",
+    "docs/coherence-substrate/satsang-health-memory.form",
+    "docs/system_audit/commit_evidence_2026-06-26_iphone_health_wearable_memory.json",
+    "experiments/satsang-mac-app/Package.swift",
+    "experiments/satsang-mac-app/README.md",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/GuidanceRequest.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/SatsangNativeAppMode.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/TrustedHealthMemory.swift",
+    "experiments/satsang-mac-app/Support/SatsangGuidancePhone/Info.plist",
+    "experiments/satsang-mac-app/Support/SatsangGuidancePhone/SatsangGuidancePhone.entitlements",
+    "experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift",
+    "form/form-stdlib/satsang-health-memory.fk",
+    "form/form-stdlib/satsang-host-boundary.fk",
+    "form/form-stdlib/tests/satsang-health-memory-band.fk",
+    "form/form-stdlib/tests/satsang-host-boundary-band.fk",
+    "form/fourth-arm-bands.txt",
+    "specs/satsang-mac-guidance-app.md"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pass",
+    "summary": "The shared native app now has a Health tab. On iPhone, the tab routes through HealthKit read authorization, filters sources such as Oura and Oz/O2-style oxygen apps, writes imported samples into local trusted health memory, and includes compact health context in the later guidance request.",
+    "expected_behavior_delta": "The previous native app had room memory only. The app now has health memory as a separate explicit-import lane, a health-samples host resource door, and Form proof for the consent, source, and analysis boundary.",
+    "public_endpoints": [
+      "n/a-local-native-app"
+    ],
+    "test_flows": [
+      "swift test --package-path experiments/satsang-mac-app -> 13 tests passed",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidance -> product built",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone -> product built",
+      "scripts/build_satsang_mac_app.sh -> experiments/satsang-mac-app/dist/Satsang Guidance.app",
+      "xcodebuild -scheme SatsangGuidancePhone -destination 'generic/platform=iOS' -> blocked because iOS 26.2 platform support is not installed",
+      "cd form && ./validate.sh ... satsang-guidance-event-band.fk -> 255 four-way",
+      "cd form && ./validate.sh ... satsang-host-boundary-band.fk -> 2097151 four-way",
+      "cd form && ./validate.sh ... satsang-listen-route-band.fk -> 255 four-way",
+      "cd form && ./validate.sh ... satsang-room-memory-band.fk -> 255 four-way",
+      "cd form && ./validate.sh ... satsang-health-memory-band.fk -> 255 four-way",
+      "python3 scripts/generate_repo_indexes.py --check -> all indexes up to date",
+      "python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.md -> passed",
+      "git diff --check -> passed",
+      "make wellness -> passed; source maps aligned and edited durable docs speak from what IS"
+    ]
+  }
+}

--- a/experiments/satsang-mac-app/Package.swift
+++ b/experiments/satsang-mac-app/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
             dependencies: ["SatsangMacCore"],
             linkerSettings: [
                 .linkedFramework("AVFoundation"),
+                .linkedFramework("HealthKit", .when(platforms: [.iOS])),
                 .linkedFramework("Speech"),
             ]
         ),
@@ -29,6 +30,7 @@ let package = Package(
             dependencies: ["SatsangGuidanceKit"],
             linkerSettings: [
                 .linkedFramework("AVFoundation"),
+                .linkedFramework("HealthKit", .when(platforms: [.iOS])),
                 .linkedFramework("Speech"),
             ]
         ),

--- a/experiments/satsang-mac-app/README.md
+++ b/experiments/satsang-mac-app/README.md
@@ -3,7 +3,7 @@
 SwiftUI native carrier for a satsang guidance session.
 
 The macOS app and iPhone app share one tabbed SwiftUI body: Room, Guidance,
-Memory, Learning, Resources, and Settings. The Room mode listens to the room
+Memory, Health, Learning, Resources, and Settings. The Room mode listens to the room
 microphone after `Start Listening` is pressed, keeps that live capture as the
 primary stream, turns concurrent side-channel speech transcription into editable
 transcript lines, can also follow a local transcript file, shows every line that
@@ -29,6 +29,15 @@ Trusted room memory is stored locally beside the transcript:
 ~/.coherence-network/agent-room-memory/speaker-profiles.json
 ~/.coherence-network/agent-room-memory/sessions/
 ~/.coherence-network/agent-room-memory/latest-context.form
+```
+
+Trusted health memory is stored locally after an explicit Health import:
+
+```text
+~/.coherence-network/health-memory/import-index.jsonl
+~/.coherence-network/health-memory/samples.jsonl
+~/.coherence-network/health-memory/imports/
+~/.coherence-network/health-memory/latest-context.form
 ```
 
 Run from the repo root:
@@ -67,14 +76,21 @@ macOS biometric speaker-identification lane; any future acoustic continuity
 sidecar must share the already-open listening stream. The memory proof lives in
 `form/form-stdlib/satsang-room-memory.fk`.
 
+The Health tab imports wearable samples from iPhone HealthKit after Health
+permission is granted. The default source filter covers Oura, Oz/O2, Wellue,
+ViHealth, oxygen, and oximeter sources. Imported samples are written to local
+health memory and summarized into later guidance context. The health-memory
+proof lives in `form/form-stdlib/satsang-health-memory.fk`.
+
 The app boundary is intentionally small. Shared routing and sufficiency logic is
 Form-native; Swift is the current Apple host carrier for GUI, microphone, speech,
-file, and process resources. The request receipt names a generic host OS
+file, process, and health resources. The request receipt names a generic host OS
 resource interface with resolved macOS, Windows, Android, and iPhone/iOS carrier
 mappings.
 Each Send receipt includes detected host resource doors for file read, file
 append, atomic file write, process stdin/stdout, audio input, and speech
-transcription, plus the cross-platform carrier matrix for those same doors.
+transcription, and health samples, plus the cross-platform carrier matrix for
+those same doors.
 Python, Go, Rust, and TypeScript are not app-boundary runtimes for this carrier.
 Windows and Android are carrier mappings in this package, not full GUI apps yet.
 The iPhone target is native SwiftUI source; a device-signed archive still needs
@@ -82,6 +98,8 @@ an Apple team/profile plus installed iOS SDK support. The permission metadata
 template lives at `Support/SatsangGuidancePhone/Info.plist`, and iOS routes the
 Form process door through an embedded runtime adapter rather than arbitrary
 subprocess spawning.
+The HealthKit entitlement template lives at
+`Support/SatsangGuidancePhone/SatsangGuidancePhone.entitlements`.
 
 Before Send writes the event, the app asks the repo-local native `form-cli`
 for a local body/RAG answer. The resulting route receipt is stored inside the

--- a/experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift
@@ -41,6 +41,11 @@ final class AppModel: ObservableObject {
     @Published var selectedID: TranscriptUtterance.ID?
     @Published var routeSummary: String = "Form route: waiting for request"
     @Published var memoryContextSummary: String = "Trusted memory: waiting for Send"
+    @Published var healthContextSummary: String = "Health memory: waiting for import"
+    @Published var healthSourceHints: String = WearableHealthImporter.defaultSourceHints.joined(separator: ", ")
+    @Published var healthLookbackDays: Int = 7
+    @Published var healthSamples: [TrustedHealthSample] = []
+    @Published var isImportingHealth: Bool = false
     @Published var status: String = "Ready"
 
     private let defaultTranscriptPath: String
@@ -48,6 +53,7 @@ final class AppModel: ObservableObject {
     private let repositoryRoot: URL?
     private let hostResources: FoundationHostResourceInterface
     private let roomMemoryStore: TrustedRoomMemoryStore
+    private let healthMemoryStore: TrustedHealthMemoryStore
     private var timer: Timer?
     private let roomTranscriber = RoomTranscriber()
 
@@ -59,6 +65,10 @@ final class AppModel: ObservableObject {
         defaultQueuePath = home.appendingPathComponent(".coherence-network/satsang-guidance/events.jsonl").path
         roomMemoryStore = TrustedRoomMemoryStore(
             rootURL: home.appendingPathComponent(".coherence-network/agent-room-memory"),
+            host: hostResources
+        )
+        healthMemoryStore = TrustedHealthMemoryStore(
+            rootURL: home.appendingPathComponent(".coherence-network/health-memory"),
             host: hostResources
         )
         repositoryRoot = Self.resolveRepositoryRoot(home: home, host: hostResources)
@@ -78,10 +88,12 @@ final class AppModel: ObservableObject {
             self?.micLevel = level
         }
         reload()
+        reloadHealthContext(silent: true)
         timer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 guard let self, self.followTranscript else { return }
                 self.reload(silent: true)
+                self.reloadHealthContext(silent: true)
             }
         }
     }
@@ -163,8 +175,10 @@ final class AppModel: ObservableObject {
         commitLiveDraftIfNeeded()
         utterances = roomMemoryStore.utterancesWithSpeakerProfiles(utterances)
         let memoryContext = loadMemoryContext()
+        let healthContext = loadHealthContext()
         memoryContextSummary = memoryContext.summaryLine
-        let routeReceipt = makeRouteReceipt(memoryContext: memoryContext)
+        healthContextSummary = healthContext.summaryLine
+        let routeReceipt = makeRouteReceipt(memoryContext: memoryContext, healthContext: healthContext)
         routeSummary = routeReceipt.summary
         let request = GuidanceRequest(
             sessionTitle: sessionTitle,
@@ -174,7 +188,8 @@ final class AppModel: ObservableObject {
             guidanceQuestion: guidanceQuestion,
             utterances: utterances,
             routeReceipt: routeReceipt,
-            memoryContext: memoryContext
+            memoryContext: memoryContext,
+            healthContext: healthContext
         )
         do {
             let sender = GuidanceRequestSender(
@@ -184,7 +199,7 @@ final class AppModel: ObservableObject {
             let result = try sender.send(request)
             let memoryResult = try roomMemoryStore.record(request)
             memoryContextSummary = "\(memoryContext.summaryLine); \(memoryResult.summary)"
-            status = "Sent \(request.utterances.count) lines to \(targetPresence). \(routeReceipt.summary). \(memoryResult.summary). Form envelope: \(result.latestFormURL.path)"
+            status = "Sent \(request.utterances.count) lines to \(targetPresence). \(routeReceipt.summary). \(memoryResult.summary). \(healthContext.summaryLine). Form envelope: \(result.latestFormURL.path)"
         } catch {
             status = "Send failed: \(error.localizedDescription)"
         }
@@ -231,6 +246,34 @@ final class AppModel: ObservableObject {
         }
     }
 
+    func importHealthSamples() {
+        guard !isImportingHealth else { return }
+        isImportingHealth = true
+        status = "Requesting Health access"
+        let daysBack = healthLookbackDays
+        let hints = healthSourceHintList
+        Task {
+            do {
+                let importer = WearableHealthImporter()
+                let samples = try await importer.importRecentSamples(daysBack: daysBack, sourceNameHints: hints)
+                let snapshot = TrustedHealthMemorySnapshot(sourceHints: hints, samples: samples)
+                let result = try healthMemoryStore.record(snapshot)
+                let context = try healthMemoryStore.context()
+                await MainActor.run {
+                    self.healthSamples = samples
+                    self.healthContextSummary = "\(context.summaryLine); \(result.summary)"
+                    self.status = "Imported \(samples.count) health samples. \(result.summary)."
+                    self.isImportingHealth = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.status = "Health import failed: \(error.localizedDescription)"
+                    self.isImportingHealth = false
+                }
+            }
+        }
+    }
+
     private func expanded(_ path: String) -> String {
         if path == "~" { return hostResources.homeDirectory.path }
         if path.hasPrefix("~/") {
@@ -241,12 +284,15 @@ final class AppModel: ObservableObject {
         return path
     }
 
-    private func makeRouteReceipt(memoryContext: TrustedRoomMemoryContext) -> FormNativeRouteReceipt {
+    private func makeRouteReceipt(
+        memoryContext: TrustedRoomMemoryContext,
+        healthContext: TrustedHealthMemoryContext
+    ) -> FormNativeRouteReceipt {
         let bodySources = formBodySources()
         let body = FormNativeLookupSignal.bodyProtocol(sourceIDs: bodySources, sufficient: false)
         let formCLIURL = repositoryRoot.flatMap { resolveFormCLI(repositoryRoot: $0) }
         let hostBoundary = makeHostBoundary(formCLIURL: formCLIURL)
-        let rag = formNativeAskSignal(formCLIURL: formCLIURL, memoryContext: memoryContext)
+        let rag = formNativeAskSignal(formCLIURL: formCLIURL, memoryContext: memoryContext, healthContext: healthContext)
         return FormNativeRouteReceipt(hostBoundary: hostBoundary, bodyLookup: body, ragLookup: rag)
     }
 
@@ -264,15 +310,39 @@ final class AppModel: ObservableObject {
         }
     }
 
+    private func loadHealthContext() -> TrustedHealthMemoryContext {
+        do {
+            return try healthMemoryStore.context()
+        } catch {
+            return TrustedHealthMemoryContext(
+                priorImportCount: 0,
+                recentSampleCount: 0,
+                sourceSummary: "health memory read failed",
+                metricSummary: "health memory read failed",
+                recentObservationSummary: error.localizedDescription
+            )
+        }
+    }
+
+    func reloadHealthContext(silent: Bool = false) {
+        let context = loadHealthContext()
+        healthContextSummary = context.summaryLine
+        if !silent, context.recentSampleCount > 0 {
+            status = context.summaryLine
+        }
+    }
+
     private func formBodySources() -> [String] {
         guard let repositoryRoot else { return [] }
         let candidates = [
             "form/form-stdlib/satsang-guidance-event.fk",
             "form/form-stdlib/form-cli-sufficiency.fk",
             "form/form-stdlib/satsang-room-memory.fk",
+            "form/form-stdlib/satsang-health-memory.fk",
             "form/form-stdlib/rag-ask.fk",
             "docs/coherence-substrate/satsang-guidance-event.form",
             "docs/coherence-substrate/satsang-room-memory.form",
+            "docs/coherence-substrate/satsang-health-memory.form",
             "docs/coherence-substrate/form-first-reasoning.form"
         ]
         return candidates.filter {
@@ -286,10 +356,14 @@ final class AppModel: ObservableObject {
             queueURL: URL(fileURLWithPath: expanded(queuePath)),
             formCLIURL: formCLIURL
         )
-        return FormHostBoundaryReceipt(resourceDoors: fileProcessDoors + RoomTranscriber.detectResourceDoors())
+        return FormHostBoundaryReceipt(resourceDoors: fileProcessDoors + RoomTranscriber.detectResourceDoors() + WearableHealthImporter.detectResourceDoors())
     }
 
-    private func formNativeAskSignal(formCLIURL: URL?, memoryContext: TrustedRoomMemoryContext) -> FormNativeLookupSignal {
+    private func formNativeAskSignal(
+        formCLIURL: URL?,
+        memoryContext: TrustedRoomMemoryContext,
+        healthContext: TrustedHealthMemoryContext
+    ) -> FormNativeLookupSignal {
         guard let repositoryRoot else {
             return .unavailable("form-native-rag-local-llm", reason: "repository root not found")
         }
@@ -298,7 +372,10 @@ final class AppModel: ObservableObject {
         }
         let memoryText = [
             memoryContext.speakerSummary,
-            memoryContext.recentExchangeSummary
+            memoryContext.recentExchangeSummary,
+            healthContext.sourceSummary,
+            healthContext.metricSummary,
+            healthContext.recentObservationSummary
         ].joined(separator: "\n")
         let query = [guidanceQuestion, memoryText, transcriptText]
             .joined(separator: "\n")
@@ -337,6 +414,13 @@ final class AppModel: ObservableObject {
 
     private func isLikelyFilePath(_ path: String) -> Bool {
         path.hasPrefix("/") || path.hasPrefix("~/") || path.hasPrefix("./") || path.hasPrefix("../")
+    }
+
+    private var healthSourceHintList: [String] {
+        healthSourceHints
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
     }
 
     private func upsertLiveDraft(_ text: String) {
@@ -406,6 +490,9 @@ public struct SatsangGuidanceRootView: View {
                 memoryTab
                     .tabItem { Label("Memory", systemImage: "archivebox") }
                     .tag(SatsangNativeAppMode.memory)
+                healthTab
+                    .tabItem { Label("Health", systemImage: "heart.text.square") }
+                    .tag(SatsangNativeAppMode.health)
                 learningTab
                     .tabItem { Label("Learning", systemImage: "arrow.triangle.2.circlepath") }
                     .tag(SatsangNativeAppMode.learning)
@@ -552,8 +639,43 @@ public struct SatsangGuidanceRootView: View {
             VStack(alignment: .leading, spacing: 14) {
                 metricRow("Sessions", model.memoryContextSummary)
                 metricRow("Speakers", "\(model.utterances.compactMap(\.speakerProfileID).filter { !$0.isEmpty }.count)")
+                metricRow("Health", model.healthContextSummary)
                 routeSummary
                 transcriptPreview
+            }
+            .padding(16)
+        }
+    }
+
+    private var healthTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 8) {
+                    GridRow {
+                        Text("Sources")
+                        TextField("Oura, Oz, O2, Wellue", text: $model.healthSourceHints)
+                    }
+                    GridRow {
+                        Text("Days")
+                        Stepper("\(model.healthLookbackDays)", value: $model.healthLookbackDays, in: 1...30)
+                    }
+                }
+                .textFieldStyle(.roundedBorder)
+
+                HStack {
+                    Button { model.importHealthSamples() } label: {
+                        Label(model.isImportingHealth ? "Importing" : "Import", systemImage: "heart.text.square")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(model.isImportingHealth)
+                    Spacer()
+                    Button { model.reloadHealthContext() } label: {
+                        Label("Reload", systemImage: "arrow.clockwise")
+                    }
+                }
+
+                metricRow("Health memory", model.healthContextSummary)
+                healthSampleList
             }
             .padding(16)
         }
@@ -564,6 +686,7 @@ public struct SatsangGuidanceRootView: View {
             VStack(alignment: .leading, spacing: 14) {
                 metricRow("Route", model.routeSummary)
                 metricRow("Memory", model.memoryContextSummary)
+                metricRow("Health", model.healthContextSummary)
                 metricRow("Edited turns", "\(model.utterances.filter(\.wasEdited).count)")
                 metricRow("Transcript turns", "\(model.utterances.count)")
             }
@@ -756,6 +879,40 @@ public struct SatsangGuidanceRootView: View {
             }
             .frame(minHeight: 180)
             .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+        }
+    }
+
+    private var healthSampleList: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Latest imported samples")
+                .font(.headline)
+            if model.healthSamples.isEmpty {
+                Text("No samples imported.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(model.healthSamples.suffix(24)) { sample in
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(sample.kind)
+                                .font(.caption.weight(.semibold))
+                            Spacer()
+                            Text(sample.endDate)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        Text("\(sample.value, specifier: "%.2f") \(sample.unit) · \(sample.sourceName)")
+                            .font(.callout)
+                        if let stage = sample.metadata["stage"] {
+                            Text(stage)
+                                .font(.caption2.monospaced())
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 4)
+                }
+            }
         }
     }
 

--- a/experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift
@@ -1,0 +1,343 @@
+import Foundation
+import SatsangMacCore
+
+#if canImport(HealthKit)
+import HealthKit
+#endif
+
+enum WearableHealthImportError: Error, LocalizedError {
+    case unavailable(String)
+    case authorizationDenied
+    case missingSampleType(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let reason):
+            return reason
+        case .authorizationDenied:
+            return "Health access was not granted."
+        case .missingSampleType(let identifier):
+            return "HealthKit sample type is unavailable: \(identifier)."
+        }
+    }
+}
+
+final class WearableHealthImporter {
+    static let defaultSourceHints = [
+        "Oura",
+        "Oz",
+        "O2",
+        "Wellue",
+        "ViHealth",
+        "oxygen",
+        "oximeter",
+    ]
+
+    static func detectResourceDoors() -> [HostResourceDoor] {
+        #if canImport(HealthKit) && os(iOS)
+        let available = HKHealthStore.isHealthDataAvailable()
+        return [
+            HostResourceDoor(
+                kind: "health-samples",
+                state: available ? "available" : "unavailable",
+                carrier: "ios-healthkit",
+                detail: "explicit read authorization for wearable samples"
+            )
+        ]
+        #else
+        return [
+            HostResourceDoor(
+                kind: "health-samples",
+                state: "unavailable",
+                carrier: "healthkit-unavailable-on-this-host",
+                detail: "iPhone HealthKit carrier required"
+            )
+        ]
+        #endif
+    }
+
+    func importRecentSamples(daysBack: Int, sourceNameHints: [String]) async throws -> [TrustedHealthSample] {
+        #if canImport(HealthKit) && os(iOS)
+        guard HKHealthStore.isHealthDataAvailable() else {
+            throw WearableHealthImportError.unavailable("Health data is not available on this device.")
+        }
+        let healthStore = HKHealthStore()
+        let specs = Self.quantitySpecs()
+        let categoryTypes = try Self.categoryTypes()
+        var readTypes = Set<HKObjectType>()
+        specs.forEach { readTypes.insert($0.type) }
+        categoryTypes.forEach { readTypes.insert($0) }
+        readTypes.insert(HKObjectType.workoutType())
+        try await requestAuthorization(healthStore: healthStore, readTypes: readTypes)
+
+        let end = Date()
+        let start = Calendar.current.date(byAdding: .day, value: -max(daysBack, 1), to: end) ?? end
+        let hints = sourceNameHints.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        var samples: [TrustedHealthSample] = []
+        for spec in specs {
+            samples += try await fetchQuantitySamples(
+                healthStore: healthStore,
+                spec: spec,
+                start: start,
+                end: end,
+                sourceNameHints: hints
+            )
+        }
+        samples += try await fetchSleepSamples(
+            healthStore: healthStore,
+            start: start,
+            end: end,
+            sourceNameHints: hints
+        )
+        samples += try await fetchWorkoutSamples(
+            healthStore: healthStore,
+            start: start,
+            end: end,
+            sourceNameHints: hints
+        )
+        return samples.sorted { $0.endDate < $1.endDate }
+        #else
+        throw WearableHealthImportError.unavailable("HealthKit import is available only in the native iPhone carrier.")
+        #endif
+    }
+}
+
+#if canImport(HealthKit) && os(iOS)
+private struct QuantitySpec {
+    var identifier: HKQuantityTypeIdentifier
+    var type: HKQuantityType
+    var kind: String
+    var unit: HKUnit
+    var displayUnit: String
+    var transform: @Sendable (Double) -> Double
+}
+
+private extension WearableHealthImporter {
+    static func quantitySpecs() -> [QuantitySpec] {
+        [
+            quantitySpec(.heartRate, kind: "heart-rate", unit: HKUnit.count().unitDivided(by: .minute()), displayUnit: "count/min"),
+            quantitySpec(.restingHeartRate, kind: "resting-heart-rate", unit: HKUnit.count().unitDivided(by: .minute()), displayUnit: "count/min"),
+            quantitySpec(.heartRateVariabilitySDNN, kind: "hrv-sdnn", unit: HKUnit.secondUnit(with: .milli), displayUnit: "ms"),
+            quantitySpec(.oxygenSaturation, kind: "spo2", unit: .percent(), displayUnit: "%", transform: { $0 <= 1.5 ? $0 * 100.0 : $0 }),
+            quantitySpec(.respiratoryRate, kind: "respiratory-rate", unit: HKUnit.count().unitDivided(by: .minute()), displayUnit: "count/min"),
+            quantitySpec(.stepCount, kind: "steps", unit: .count(), displayUnit: "count"),
+            quantitySpec(.activeEnergyBurned, kind: "active-energy", unit: .kilocalorie(), displayUnit: "kcal"),
+            quantitySpec(.bodyTemperature, kind: "body-temperature", unit: .degreeCelsius(), displayUnit: "degC"),
+        ]
+    }
+
+    static func quantitySpec(
+        _ identifier: HKQuantityTypeIdentifier,
+        kind: String,
+        unit: HKUnit,
+        displayUnit: String,
+        transform: @escaping @Sendable (Double) -> Double = { $0 }
+    ) -> QuantitySpec {
+        guard let type = HKObjectType.quantityType(forIdentifier: identifier) else {
+            fatalError("Missing HealthKit quantity type \(identifier.rawValue)")
+        }
+        return QuantitySpec(
+            identifier: identifier,
+            type: type,
+            kind: kind,
+            unit: unit,
+            displayUnit: displayUnit,
+            transform: transform
+        )
+    }
+
+    static func categoryTypes() throws -> [HKSampleType] {
+        guard let sleep = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else {
+            throw WearableHealthImportError.missingSampleType("sleepAnalysis")
+        }
+        return [sleep]
+    }
+
+    func requestAuthorization(healthStore: HKHealthStore, readTypes: Set<HKObjectType>) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            healthStore.requestAuthorization(toShare: Set<HKSampleType>(), read: readTypes) { success, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard success else {
+                    continuation.resume(throwing: WearableHealthImportError.authorizationDenied)
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+        }
+    }
+
+    func fetchQuantitySamples(
+        healthStore: HKHealthStore,
+        spec: QuantitySpec,
+        start: Date,
+        end: Date,
+        sourceNameHints: [String]
+    ) async throws -> [TrustedHealthSample] {
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+        return try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: spec.type,
+                predicate: predicate,
+                limit: 500,
+                sortDescriptors: [sort]
+            ) { _, rawSamples, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                let rows = (rawSamples as? [HKQuantitySample] ?? [])
+                    .filter { Self.matchesSource($0, hints: sourceNameHints) }
+                    .map { sample in
+                        Self.healthSample(
+                            sample: sample,
+                            kind: spec.kind,
+                            value: spec.transform(sample.quantity.doubleValue(for: spec.unit)),
+                            unit: spec.displayUnit
+                        )
+                    }
+                continuation.resume(returning: rows)
+            }
+            healthStore.execute(query)
+        }
+    }
+
+    func fetchSleepSamples(
+        healthStore: HKHealthStore,
+        start: Date,
+        end: Date,
+        sourceNameHints: [String]
+    ) async throws -> [TrustedHealthSample] {
+        guard let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else {
+            throw WearableHealthImportError.missingSampleType("sleepAnalysis")
+        }
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+        return try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: sleepType,
+                predicate: predicate,
+                limit: 500,
+                sortDescriptors: [sort]
+            ) { _, rawSamples, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                let rows = (rawSamples as? [HKCategorySample] ?? [])
+                    .filter { Self.matchesSource($0, hints: sourceNameHints) }
+                    .map { sample in
+                        Self.healthSample(
+                            sample: sample,
+                            kind: "sleep-analysis",
+                            value: sample.endDate.timeIntervalSince(sample.startDate) / 60.0,
+                            unit: "minutes",
+                            metadata: ["stage": Self.sleepStageName(sample.value)]
+                        )
+                    }
+                continuation.resume(returning: rows)
+            }
+            healthStore.execute(query)
+        }
+    }
+
+    func fetchWorkoutSamples(
+        healthStore: HKHealthStore,
+        start: Date,
+        end: Date,
+        sourceNameHints: [String]
+    ) async throws -> [TrustedHealthSample] {
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: end)
+        let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+        return try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: HKObjectType.workoutType(),
+                predicate: predicate,
+                limit: 200,
+                sortDescriptors: [sort]
+            ) { _, rawSamples, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                let rows = (rawSamples as? [HKWorkout] ?? [])
+                    .filter { Self.matchesSource($0, hints: sourceNameHints) }
+                    .map { workout in
+                        var metadata: [String: String] = [
+                            "activity-type": "\(workout.workoutActivityType.rawValue)"
+                        ]
+                        if let energy = workout.totalEnergyBurned?.doubleValue(for: .kilocalorie()) {
+                            metadata["active-energy-kcal"] = String(format: "%.2f", energy)
+                        }
+                        if let distance = workout.totalDistance?.doubleValue(for: .meter()) {
+                            metadata["distance-m"] = String(format: "%.2f", distance)
+                        }
+                        return Self.healthSample(
+                            sample: workout,
+                            kind: "workout",
+                            value: workout.duration / 60.0,
+                            unit: "minutes",
+                            metadata: metadata
+                        )
+                    }
+                continuation.resume(returning: rows)
+            }
+            healthStore.execute(query)
+        }
+    }
+
+    static func matchesSource(_ sample: HKSample, hints: [String]) -> Bool {
+        guard !hints.isEmpty else { return true }
+        let fields = [
+            sample.sourceRevision.source.name,
+            sample.sourceRevision.source.bundleIdentifier,
+            sample.device?.name,
+            sample.device?.manufacturer,
+            sample.device?.model,
+        ].compactMap { $0 }
+        return hints.contains { hint in
+            fields.contains { field in field.localizedCaseInsensitiveContains(hint) }
+        }
+    }
+
+    static func healthSample(
+        sample: HKSample,
+        kind: String,
+        value: Double,
+        unit: String,
+        metadata: [String: String] = [:]
+    ) -> TrustedHealthSample {
+        let formatter = ISO8601DateFormatter()
+        return TrustedHealthSample(
+            id: sample.uuid.uuidString,
+            kind: kind,
+            value: value,
+            unit: unit,
+            startDate: formatter.string(from: sample.startDate),
+            endDate: formatter.string(from: sample.endDate),
+            sourceName: sample.sourceRevision.source.name,
+            sourceBundleIdentifier: sample.sourceRevision.source.bundleIdentifier,
+            deviceName: sample.device?.name,
+            metadata: metadata
+        )
+    }
+
+    static func sleepStageName(_ value: Int) -> String {
+        if value == HKCategoryValueSleepAnalysis.inBed.rawValue { return "in-bed" }
+        if value == HKCategoryValueSleepAnalysis.asleep.rawValue { return "asleep" }
+        if value == HKCategoryValueSleepAnalysis.awake.rawValue { return "awake" }
+        if #available(iOS 16.0, *) {
+            if value == HKCategoryValueSleepAnalysis.asleepCore.rawValue { return "asleep-core" }
+            if value == HKCategoryValueSleepAnalysis.asleepDeep.rawValue { return "asleep-deep" }
+            if value == HKCategoryValueSleepAnalysis.asleepREM.rawValue { return "asleep-rem" }
+            if value == HKCategoryValueSleepAnalysis.asleepUnspecified.rawValue { return "asleep-unspecified" }
+        }
+        return "sleep-stage-\(value)"
+    }
+}
+#endif

--- a/experiments/satsang-mac-app/Sources/SatsangMacCore/GuidanceRequest.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangMacCore/GuidanceRequest.swift
@@ -12,6 +12,7 @@ public struct GuidanceRequest: Codable, Equatable, Sendable {
     public var utterances: [TranscriptUtterance]
     public var routeReceipt: FormNativeRouteReceipt?
     public var memoryContext: TrustedRoomMemoryContext?
+    public var healthContext: TrustedHealthMemoryContext?
 
     public init(
         id: String = UUID().uuidString,
@@ -23,7 +24,8 @@ public struct GuidanceRequest: Codable, Equatable, Sendable {
         guidanceQuestion: String,
         utterances: [TranscriptUtterance],
         routeReceipt: FormNativeRouteReceipt? = nil,
-        memoryContext: TrustedRoomMemoryContext? = nil
+        memoryContext: TrustedRoomMemoryContext? = nil,
+        healthContext: TrustedHealthMemoryContext? = nil
     ) {
         self.kind = "satsang-guidance-request"
         self.id = id
@@ -36,6 +38,7 @@ public struct GuidanceRequest: Codable, Equatable, Sendable {
         self.utterances = utterances
         self.routeReceipt = routeReceipt
         self.memoryContext = memoryContext
+        self.healthContext = healthContext
     }
 
     public var editedCount: Int {
@@ -58,6 +61,9 @@ public struct GuidanceRequest: Codable, Equatable, Sendable {
         }
         if let memoryContext {
             rows.append(TrustedRoomMemoryStore.formEnvelope(memoryContext, indent: "  "))
+        }
+        if let healthContext {
+            rows.append(TrustedHealthMemoryStore.formEnvelope(healthContext, indent: "  "))
         }
         rows.append("  (utterances")
         for utterance in utterances {

--- a/experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift
@@ -76,6 +76,7 @@ public struct HostPlatformCarrier: Codable, Equatable, Sendable {
                     HostResourceDoor(kind: "file-append", state: "declared", carrier: "macos-foundation-filehandle", detail: "FileHandle append"),
                     HostResourceDoor(kind: "file-write-atomic", state: "declared", carrier: "macos-foundation-data-atomic", detail: "Data.write atomic"),
                     HostResourceDoor(kind: "process-stdin-stdout", state: "declared", carrier: "macos-foundation-process", detail: "Process with pipes"),
+                    HostResourceDoor(kind: "health-samples", state: "declared", carrier: "macos-healthkit-unavailable", detail: "iPhone HealthKit carrier records direct wearable samples"),
                 ]
             ),
             HostPlatformCarrier(
@@ -89,6 +90,7 @@ public struct HostPlatformCarrier: Codable, Equatable, Sendable {
                     HostResourceDoor(kind: "file-append", state: "declared", carrier: "windows-known-folder-filesystem", detail: "LocalAppData append"),
                     HostResourceDoor(kind: "file-write-atomic", state: "declared", carrier: "windows-replacefile-atomic", detail: "atomic replace"),
                     HostResourceDoor(kind: "process-stdin-stdout", state: "declared", carrier: "windows-createprocess-stdin-stdout", detail: "CreateProcessW pipes"),
+                    HostResourceDoor(kind: "health-samples", state: "declared", carrier: "windows-health-export-import", detail: "bounded local import/export carrier until a native health store exists"),
                 ]
             ),
             HostPlatformCarrier(
@@ -102,6 +104,7 @@ public struct HostPlatformCarrier: Codable, Equatable, Sendable {
                     HostResourceDoor(kind: "file-append", state: "declared", carrier: "android-app-private-files", detail: "Context.filesDir append"),
                     HostResourceDoor(kind: "file-write-atomic", state: "declared", carrier: "android-atomic-file", detail: "AtomicFile or rename"),
                     HostResourceDoor(kind: "process-stdin-stdout", state: "declared", carrier: "android-packaged-form-cli-process", detail: "packaged native form-cli with bounded pipes"),
+                    HostResourceDoor(kind: "health-samples", state: "declared", carrier: "android-health-connect", detail: "Health Connect read door after explicit permission"),
                 ]
             ),
             HostPlatformCarrier(
@@ -115,6 +118,7 @@ public struct HostPlatformCarrier: Codable, Equatable, Sendable {
                     HostResourceDoor(kind: "file-append", state: "declared", carrier: "ios-app-sandbox-files", detail: "FileHandle append in app container"),
                     HostResourceDoor(kind: "file-write-atomic", state: "declared", carrier: "ios-foundation-data-atomic", detail: "Data.write atomic in app container"),
                     HostResourceDoor(kind: "process-stdin-stdout", state: "declared", carrier: "ios-embedded-form-cli-adapter", detail: "same protocol via embedded Form runtime adapter; arbitrary subprocess unavailable"),
+                    HostResourceDoor(kind: "health-samples", state: "declared", carrier: "ios-healthkit", detail: "HealthKit read door for Oura/Oz/O2 wearable samples after explicit permission"),
                 ]
             ),
         ]
@@ -244,7 +248,8 @@ public struct FormHostBoundaryReceipt: Codable, Equatable, Sendable {
             "file-read",
             "file-append",
             "file-write-atomic",
-            "process-stdin-stdout"
+            "process-stdin-stdout",
+            "health-samples"
         ],
         resourceDoors: [HostResourceDoor]? = nil,
         platformCarriers: [HostPlatformCarrier]? = nil,

--- a/experiments/satsang-mac-app/Sources/SatsangMacCore/SatsangNativeAppMode.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangMacCore/SatsangNativeAppMode.swift
@@ -4,6 +4,7 @@ public enum SatsangNativeAppMode: String, CaseIterable, Codable, Identifiable, S
     case room
     case guidance
     case memory
+    case health
     case learning
     case resources
     case settings
@@ -18,6 +19,8 @@ public enum SatsangNativeAppMode: String, CaseIterable, Codable, Identifiable, S
             return "Guidance"
         case .memory:
             return "Memory"
+        case .health:
+            return "Health"
         case .learning:
             return "Learning"
         case .resources:

--- a/experiments/satsang-mac-app/Sources/SatsangMacCore/TrustedHealthMemory.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangMacCore/TrustedHealthMemory.swift
@@ -1,0 +1,298 @@
+import Foundation
+
+public struct TrustedHealthMemoryTrustReceipt: Codable, Equatable, Sendable {
+    public var kind: String
+    public var captureBoundary: String
+    public var storageCarrier: String
+    public var retrievalScope: String
+    public var sourceCarrier: String
+    public var hiddenCapture: Bool
+    public var canFeedLaterContext: Bool
+    public var analysisBoundary: String
+
+    public init(
+        captureBoundary: String = "explicit-import",
+        storageCarrier: String = "local-json-file",
+        retrievalScope: String = "same-holder-local-health-memory",
+        sourceCarrier: String = "ios-healthkit-source-filter",
+        hiddenCapture: Bool = false,
+        canFeedLaterContext: Bool = true,
+        analysisBoundary: String = "reference-memory-reasoning-analysis-not-diagnosis"
+    ) {
+        self.kind = "trusted-health-memory-trust-receipt"
+        self.captureBoundary = captureBoundary
+        self.storageCarrier = storageCarrier
+        self.retrievalScope = retrievalScope
+        self.sourceCarrier = sourceCarrier
+        self.hiddenCapture = hiddenCapture
+        self.canFeedLaterContext = canFeedLaterContext
+        self.analysisBoundary = analysisBoundary
+    }
+}
+
+public struct TrustedHealthSample: Codable, Equatable, Identifiable, Sendable {
+    public var id: String
+    public var kind: String
+    public var value: Double
+    public var unit: String
+    public var startDate: String
+    public var endDate: String
+    public var sourceName: String
+    public var sourceBundleIdentifier: String
+    public var deviceName: String?
+    public var metadata: [String: String]
+
+    public init(
+        id: String,
+        kind: String,
+        value: Double,
+        unit: String,
+        startDate: String,
+        endDate: String,
+        sourceName: String,
+        sourceBundleIdentifier: String = "",
+        deviceName: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.id = id
+        self.kind = kind
+        self.value = value
+        self.unit = unit
+        self.startDate = startDate
+        self.endDate = endDate
+        self.sourceName = sourceName
+        self.sourceBundleIdentifier = sourceBundleIdentifier
+        self.deviceName = deviceName
+        self.metadata = metadata
+    }
+
+    public var compactSummary: String {
+        let rounded = String(format: "%.2f", value)
+        let source = sourceName.isEmpty ? "unknown-source" : sourceName
+        return "\(kind)=\(rounded) \(unit) from \(source) at \(endDate)"
+    }
+}
+
+public struct TrustedHealthMemorySnapshot: Codable, Equatable, Identifiable, Sendable {
+    public var kind: String
+    public var id: String
+    public var createdAt: String
+    public var sourceHints: [String]
+    public var sampleCount: Int
+    public var samples: [TrustedHealthSample]
+    public var trustReceipt: TrustedHealthMemoryTrustReceipt
+
+    public init(
+        id: String = UUID().uuidString,
+        createdAt: String = ISO8601DateFormatter().string(from: Date()),
+        sourceHints: [String],
+        samples: [TrustedHealthSample],
+        trustReceipt: TrustedHealthMemoryTrustReceipt = TrustedHealthMemoryTrustReceipt()
+    ) {
+        self.kind = "trusted-health-memory-import"
+        self.id = id
+        self.createdAt = createdAt
+        self.sourceHints = sourceHints
+        self.sampleCount = samples.count
+        self.samples = samples
+        self.trustReceipt = trustReceipt
+    }
+}
+
+public struct TrustedHealthMemoryIndexEntry: Codable, Equatable, Sendable {
+    public var importID: String
+    public var createdAt: String
+    public var sourceHints: [String]
+    public var sampleCount: Int
+    public var importPath: String
+}
+
+public struct TrustedHealthMemoryContext: Codable, Equatable, Sendable {
+    public var kind: String
+    public var priorImportCount: Int
+    public var recentSampleCount: Int
+    public var sourceSummary: String
+    public var metricSummary: String
+    public var recentObservationSummary: String
+    public var trustReceipt: TrustedHealthMemoryTrustReceipt
+
+    public init(
+        priorImportCount: Int,
+        recentSampleCount: Int,
+        sourceSummary: String,
+        metricSummary: String,
+        recentObservationSummary: String,
+        trustReceipt: TrustedHealthMemoryTrustReceipt = TrustedHealthMemoryTrustReceipt()
+    ) {
+        self.kind = "trusted-health-memory-context"
+        self.priorImportCount = priorImportCount
+        self.recentSampleCount = recentSampleCount
+        self.sourceSummary = sourceSummary
+        self.metricSummary = metricSummary
+        self.recentObservationSummary = recentObservationSummary
+        self.trustReceipt = trustReceipt
+    }
+
+    public static func empty() -> TrustedHealthMemoryContext {
+        TrustedHealthMemoryContext(
+            priorImportCount: 0,
+            recentSampleCount: 0,
+            sourceSummary: "no health sources",
+            metricSummary: "no health metrics",
+            recentObservationSummary: "no health samples"
+        )
+    }
+
+    public var summaryLine: String {
+        "Health memory: \(priorImportCount) imports, \(recentSampleCount) recent samples"
+    }
+}
+
+public struct TrustedHealthMemoryRecordResult: Codable, Equatable, Sendable {
+    public var importURL: URL
+    public var indexURL: URL
+    public var sampleLogURL: URL
+    public var contextJSONURL: URL
+    public var contextFormURL: URL
+    public var sampleCount: Int
+
+    public var summary: String {
+        "stored \(sampleCount) health samples"
+    }
+}
+
+public final class TrustedHealthMemoryStore: @unchecked Sendable {
+    public var rootURL: URL
+    public var host: any HostResourceInterface
+
+    private var importsURL: URL { rootURL.appendingPathComponent("imports") }
+    private var indexURL: URL { rootURL.appendingPathComponent("import-index.jsonl") }
+    private var sampleLogURL: URL { rootURL.appendingPathComponent("samples.jsonl") }
+    private var latestContextJSONURL: URL { rootURL.appendingPathComponent("latest-context.json") }
+    private var latestContextFormURL: URL { rootURL.appendingPathComponent("latest-context.form") }
+
+    public init(rootURL: URL, host: any HostResourceInterface = FoundationHostResourceInterface()) {
+        self.rootURL = rootURL
+        self.host = host
+    }
+
+    @discardableResult
+    public func record(_ snapshot: TrustedHealthMemorySnapshot) throws -> TrustedHealthMemoryRecordResult {
+        try host.createDirectory(at: importsURL)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let importURL = importsURL.appendingPathComponent("\(Self.fileSafe(snapshot.id)).json")
+        try host.writeData(try encoder.encode(snapshot), to: importURL, options: .atomic)
+
+        let indexEntry = TrustedHealthMemoryIndexEntry(
+            importID: snapshot.id,
+            createdAt: snapshot.createdAt,
+            sourceHints: snapshot.sourceHints,
+            sampleCount: snapshot.sampleCount,
+            importPath: importURL.path
+        )
+        let lineEncoder = JSONEncoder()
+        lineEncoder.outputFormatting = [.sortedKeys]
+        try host.appendLine(try lineEncoder.encode(indexEntry), to: indexURL)
+        for sample in snapshot.samples {
+            try host.appendLine(try lineEncoder.encode(sample), to: sampleLogURL)
+        }
+
+        let latestContext = try context()
+        try host.writeData(try encoder.encode(latestContext), to: latestContextJSONURL, options: .atomic)
+        try host.writeData(Data(Self.formEnvelope(latestContext).utf8), to: latestContextFormURL, options: .atomic)
+
+        return TrustedHealthMemoryRecordResult(
+            importURL: importURL,
+            indexURL: indexURL,
+            sampleLogURL: sampleLogURL,
+            contextJSONURL: latestContextJSONURL,
+            contextFormURL: latestContextFormURL,
+            sampleCount: snapshot.sampleCount
+        )
+    }
+
+    public func context(maxImports: Int = 5, maxSamples: Int = 24) throws -> TrustedHealthMemoryContext {
+        let entries = try loadIndex()
+        let selectedEntries = Array(entries.suffix(maxImports))
+        let snapshots = try selectedEntries.compactMap { try loadSnapshot(path: $0.importPath) }
+        let samples = Array(Self.deduplicated(snapshots.flatMap(\.samples)).suffix(maxSamples))
+        let sourceSummary = Self.countSummary(samples.map { $0.sourceName.isEmpty ? "unknown-source" : $0.sourceName })
+        let metricSummary = Self.countSummary(samples.map(\.kind))
+        let recentSummary = samples.suffix(10)
+            .map(\.compactSummary)
+            .joined(separator: " | ")
+
+        return TrustedHealthMemoryContext(
+            priorImportCount: entries.count,
+            recentSampleCount: samples.count,
+            sourceSummary: sourceSummary.isEmpty ? "no health sources" : sourceSummary,
+            metricSummary: metricSummary.isEmpty ? "no health metrics" : metricSummary,
+            recentObservationSummary: recentSummary.isEmpty ? "no health samples" : recentSummary
+        )
+    }
+
+    public static func formEnvelope(_ context: TrustedHealthMemoryContext, indent: String = "") -> String {
+        [
+            "\(indent)(trusted-health-memory-context",
+            "\(indent)  (prior-import-count \(context.priorImportCount))",
+            "\(indent)  (recent-sample-count \(context.recentSampleCount))",
+            "\(indent)  (source-summary \"\(escape(context.sourceSummary))\")",
+            "\(indent)  (metric-summary \"\(escape(context.metricSummary))\")",
+            "\(indent)  (recent-observation-summary \"\(escape(context.recentObservationSummary))\")",
+            "\(indent)  (capture-boundary \"\(escape(context.trustReceipt.captureBoundary))\")",
+            "\(indent)  (storage-carrier \"\(escape(context.trustReceipt.storageCarrier))\")",
+            "\(indent)  (retrieval-scope \"\(escape(context.trustReceipt.retrievalScope))\")",
+            "\(indent)  (source-carrier \"\(escape(context.trustReceipt.sourceCarrier))\")",
+            "\(indent)  (analysis-boundary \"\(escape(context.trustReceipt.analysisBoundary))\")",
+            "\(indent)  (hidden-capture \(context.trustReceipt.hiddenCapture ? 1 : 0))",
+            "\(indent)  (feeds-later-context \(context.trustReceipt.canFeedLaterContext ? 1 : 0)))",
+        ].joined(separator: "\n")
+    }
+
+    private func loadIndex() throws -> [TrustedHealthMemoryIndexEntry] {
+        guard let data = try host.readData(from: indexURL) else { return [] }
+        return String(decoding: data, as: UTF8.self)
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line in
+                guard let data = String(line).data(using: .utf8) else { return nil }
+                return try? JSONDecoder().decode(TrustedHealthMemoryIndexEntry.self, from: data)
+            }
+    }
+
+    private func loadSnapshot(path: String) throws -> TrustedHealthMemorySnapshot? {
+        guard let data = try host.readData(from: URL(fileURLWithPath: path)) else { return nil }
+        return try JSONDecoder().decode(TrustedHealthMemorySnapshot.self, from: data)
+    }
+
+    private static func deduplicated(_ samples: [TrustedHealthSample]) -> [TrustedHealthSample] {
+        var seen: Set<String> = []
+        var rows: [TrustedHealthSample] = []
+        for sample in samples.sorted(by: { $0.endDate < $1.endDate }) {
+            if seen.insert(sample.id).inserted {
+                rows.append(sample)
+            }
+        }
+        return rows
+    }
+
+    private static func countSummary(_ values: [String]) -> String {
+        Dictionary(grouping: values.filter { !$0.isEmpty }, by: { $0 })
+            .map { "\($0.key)=\($0.value.count)" }
+            .sorted()
+            .joined(separator: "; ")
+    }
+
+    private static func fileSafe(_ value: String) -> String {
+        value.map { character in
+            character.isLetter || character.isNumber || character == "-" ? character : "-"
+        }.reduce(into: "") { $0.append($1) }
+    }
+
+    private static func escape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+    }
+}

--- a/experiments/satsang-mac-app/Support/SatsangGuidancePhone/Info.plist
+++ b/experiments/satsang-mac-app/Support/SatsangGuidancePhone/Info.plist
@@ -8,5 +8,7 @@
 	<string>Room listening uses the microphone after Start Listening is pressed.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Speech recognition turns live room audio into editable transcript lines.</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>Health import reads wearable samples you choose to share for local memory and guidance context.</string>
 </dict>
 </plist>

--- a/experiments/satsang-mac-app/Support/SatsangGuidancePhone/SatsangGuidancePhone.entitlements
+++ b/experiments/satsang-mac-app/Support/SatsangGuidancePhone/SatsangGuidancePhone.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+</dict>
+</plist>

--- a/experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift
+++ b/experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift
@@ -52,6 +52,13 @@ final class SatsangMacCoreTests: XCTestCase {
                 speakerCount: 1,
                 speakerSummary: "Voz 1[speaker-1] turns=2",
                 recentExchangeSummary: "Voz 1: prior exchange"
+            ),
+            healthContext: TrustedHealthMemoryContext(
+                priorImportCount: 1,
+                recentSampleCount: 2,
+                sourceSummary: "Oura=1; Wellue=1",
+                metricSummary: "heart-rate=1; spo2=1",
+                recentObservationSummary: "spo2=97.00 % from Wellue"
             )
         )
 
@@ -65,17 +72,23 @@ final class SatsangMacCoreTests: XCTestCase {
         XCTAssertTrue(form.contains("(listen-receipt \"primary-live-room-capture-receipt\")"))
         XCTAssertTrue(form.contains("(transcribe-route \"speech-side-channel-during-live-capture\")"))
         XCTAssertTrue(form.contains("(host-resource-interface \"host-os-generic-resource-interface\")"))
-        XCTAssertTrue(form.contains("(host-resource-door-count 6)"))
+        XCTAssertTrue(form.contains("(host-resource-door-count 7)"))
         XCTAssertTrue(form.contains("(host-resource-door-summary \"audio-input:declared:host-os-generic-resource-interface"))
+        XCTAssertTrue(form.contains("health-samples:declared:host-os-generic-resource-interface"))
         XCTAssertTrue(form.contains("(host-platform-carrier-count 4)"))
         XCTAssertTrue(form.contains("windows:windows-minimal-host-carrier"))
         XCTAssertTrue(form.contains("android:android-minimal-host-carrier"))
         XCTAssertTrue(form.contains("ios:iphone-minimal-host-carrier"))
+        XCTAssertTrue(form.contains("ios-healthkit"))
         XCTAssertTrue(form.contains("(forbidden-runtime-carriers \"python,go,rust,typescript\")"))
         XCTAssertTrue(form.contains("(remote-oracle-requested 1)"))
         XCTAssertTrue(form.contains("(trusted-room-memory-context"))
         XCTAssertTrue(form.contains("(prior-session-count 1)"))
         XCTAssertTrue(form.contains("(hidden-capture 0)"))
+        XCTAssertTrue(form.contains("(trusted-health-memory-context"))
+        XCTAssertTrue(form.contains("(prior-import-count 1)"))
+        XCTAssertTrue(form.contains("(source-carrier \"ios-healthkit-source-filter\")"))
+        XCTAssertTrue(form.contains("(analysis-boundary \"reference-memory-reasoning-analysis-not-diagnosis\")"))
         XCTAssertTrue(form.contains("speaker-1"))
         XCTAssertTrue(form.contains("hello edited"))
     }
@@ -176,8 +189,8 @@ final class SatsangMacCoreTests: XCTestCase {
         XCTAssertEqual(receipt.kind, "satsang-native-tabbed-app")
         XCTAssertEqual(receipt.singleAppBody, "form-native-satsang-guidance-body")
         XCTAssertEqual(receipt.defaultMode, "room")
-        XCTAssertEqual(receipt.modes, ["room", "guidance", "memory", "learning", "resources", "settings"])
-        XCTAssertEqual(SatsangNativeAppMode.allCases.map(\.title), ["Room", "Guidance", "Memory", "Learning", "Resources", "Settings"])
+        XCTAssertEqual(receipt.modes, ["room", "guidance", "memory", "health", "learning", "resources", "settings"])
+        XCTAssertEqual(SatsangNativeAppMode.allCases.map(\.title), ["Room", "Guidance", "Memory", "Health", "Learning", "Resources", "Settings"])
     }
 
     func testTrustedRoomMemoryStoresSessionAndFeedsLaterContext() throws {
@@ -247,6 +260,57 @@ final class SatsangMacCoreTests: XCTestCase {
         XCTAssertTrue(next.formEnvelope.contains("(prior-session-count 1)"))
         XCTAssertTrue(next.formEnvelope.contains("first exchange"))
         XCTAssertTrue(next.formEnvelope.contains(firstProfile ?? "missing"))
+    }
+
+    func testTrustedHealthMemoryStoresWearableSamplesAndFeedsLaterContext() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let store = TrustedHealthMemoryStore(rootURL: dir)
+        let snapshot = TrustedHealthMemorySnapshot(
+            id: "health-1",
+            createdAt: "2026-06-26T18:00:00Z",
+            sourceHints: ["Oura", "O2"],
+            samples: [
+                TrustedHealthSample(
+                    id: "s1",
+                    kind: "heart-rate",
+                    value: 61,
+                    unit: "count/min",
+                    startDate: "2026-06-26T17:59:00Z",
+                    endDate: "2026-06-26T18:00:00Z",
+                    sourceName: "Oura",
+                    sourceBundleIdentifier: "com.ouraring.oura"
+                ),
+                TrustedHealthSample(
+                    id: "s2",
+                    kind: "spo2",
+                    value: 97,
+                    unit: "%",
+                    startDate: "2026-06-26T17:50:00Z",
+                    endDate: "2026-06-26T18:00:00Z",
+                    sourceName: "Wellue O2",
+                    sourceBundleIdentifier: "com.viatom.vihealth",
+                    metadata: ["stage": "sleep"]
+                )
+            ]
+        )
+
+        XCTAssertEqual(try store.context().priorImportCount, 0)
+        let result = try store.record(snapshot)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.importURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.indexURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.sampleLogURL.path))
+
+        let context = try store.context()
+        XCTAssertEqual(context.priorImportCount, 1)
+        XCTAssertEqual(context.recentSampleCount, 2)
+        XCTAssertTrue(context.sourceSummary.contains("Oura=1"))
+        XCTAssertTrue(context.sourceSummary.contains("Wellue O2=1"))
+        XCTAssertTrue(context.metricSummary.contains("heart-rate=1"))
+        XCTAssertTrue(context.metricSummary.contains("spo2=1"))
+        XCTAssertTrue(context.recentObservationSummary.contains("spo2=97.00 % from Wellue O2"))
+        XCTAssertEqual(context.trustReceipt.captureBoundary, "explicit-import")
+        XCTAssertFalse(context.trustReceipt.hiddenCapture)
+        XCTAssertTrue(TrustedHealthMemoryStore.formEnvelope(context).contains("(trusted-health-memory-context"))
     }
 
     func testDetectedHostResourceDoorsStayGeneric() {

--- a/form/form-stdlib/satsang-health-memory.fk
+++ b/form/form-stdlib/satsang-health-memory.fk
@@ -1,0 +1,71 @@
+; satsang-health-memory.fk — explicit local health memory for wearable samples.
+;
+; Health samples enter memory only by explicit import from a user-consented
+; source carrier. The memory can feed later context, reasoning, and analysis;
+; it is not a diagnostic authority and it does not hide background capture.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn shm-import-boundary? (boundary)
+        (if (str_eq boundary "explicit-import") 1 0))
+
+    (defn shm-source-carrier? (carrier)
+        (if (str_eq carrier "ios-healthkit") 1
+            (if (str_eq carrier "oura-apple-health") 1
+                (if (str_eq carrier "oz-o2-healthkit") 1
+                    (if (str_eq carrier "manual-health-export") 1 0)))))
+
+    (defn shm-metric-kind? (kind)
+        (if (str_eq kind "heart-rate") 1
+            (if (str_eq kind "resting-heart-rate") 1
+                (if (str_eq kind "hrv-sdnn") 1
+                    (if (str_eq kind "spo2") 1
+                        (if (str_eq kind "respiratory-rate") 1
+                            (if (str_eq kind "sleep-analysis") 1
+                                (if (str_eq kind "steps") 1
+                                    (if (str_eq kind "active-energy") 1
+                                        (if (str_eq kind "workout") 1
+                                            (if (str_eq kind "body-temperature") 1 0)))))))))))
+
+    (defn shm-source-filter? (source)
+        (if (str_eq source "oura") 1
+            (if (str_eq source "oz") 1
+                (if (str_eq source "o2") 1
+                    (if (str_eq source "wellue") 1
+                        (if (str_eq source "vihealth") 1
+                            (if (str_eq source "oxygen") 1
+                                (if (str_eq source "oximeter") 1
+                                    (if (str_eq source "all") 1 0)))))))))
+
+    (defn shm-analysis-boundary? (boundary)
+        (if (str_eq boundary "reference-memory-reasoning-analysis-not-diagnosis") 1 0))
+
+    (defn shm-trust-ok? (import-boundary source-carrier metric hidden feeds analysis-boundary)
+        (if (and (eq (shm-import-boundary? import-boundary) 1)
+                 (and (eq (shm-source-carrier? source-carrier) 1)
+                      (and (eq (shm-metric-kind? metric) 1)
+                           (and (eq hidden 0)
+                                (and (eq feeds 1)
+                                     (eq (shm-analysis-boundary? analysis-boundary) 1)))))) 1 0))
+
+    (defn shm-receipt (import-boundary source-carrier metric hidden feeds analysis-boundary)
+        (list "satsang-health-memory"
+              import-boundary
+              source-carrier
+              metric
+              hidden
+              feeds
+              analysis-boundary
+              (shm-trust-ok? import-boundary source-carrier metric hidden feeds analysis-boundary)))
+
+    (defn shm-rec-kind      (r) (nth r 0))
+    (defn shm-rec-boundary  (r) (nth r 1))
+    (defn shm-rec-carrier   (r) (nth r 2))
+    (defn shm-rec-metric    (r) (nth r 3))
+    (defn shm-rec-hidden    (r) (nth r 4))
+    (defn shm-rec-feeds     (r) (nth r 5))
+    (defn shm-rec-analysis  (r) (nth r 6))
+    (defn shm-rec-ok?       (r) (nth r 7))
+
+    0)

--- a/form/form-stdlib/satsang-host-boundary.fk
+++ b/form/form-stdlib/satsang-host-boundary.fk
@@ -1,7 +1,8 @@
 ; satsang-host-boundary.fk — app logic in Form, host code as a minimal ABI carrier.
 ;
 ; The shared satsang guidance body belongs in Form. Platform apps may carry the
-; smallest OS adapter needed for microphone, speech, file, and process resources.
+; smallest OS adapter needed for microphone, speech, file, process, and health
+; sample resources.
 ; macOS and iPhone are SwiftUI carriers now; Windows and Android are resolved
 ; host-carrier doors pending real GUI packaging. Python, Go, Rust, and TypeScript
 ; are not app-boundary runtimes.
@@ -25,7 +26,8 @@
                 (if (str_eq kind "file-read") 1
                     (if (str_eq kind "file-append") 1
                         (if (str_eq kind "file-write-atomic") 1
-                            (if (str_eq kind "process-stdin-stdout") 1 0)))))))
+                            (if (str_eq kind "process-stdin-stdout") 1
+                                (if (str_eq kind "health-samples") 1 0))))))))
 
     (defn shb-platform-target? (platform)
         (if (str_eq platform "macos") 1
@@ -69,28 +71,32 @@
                     (if (str_eq kind "file-read") "macos-foundation-filemanager"
                         (if (str_eq kind "file-append") "macos-foundation-filehandle"
                             (if (str_eq kind "file-write-atomic") "macos-foundation-data-atomic"
-                                (if (str_eq kind "process-stdin-stdout") "macos-foundation-process" ""))))))
+                                (if (str_eq kind "process-stdin-stdout") "macos-foundation-process"
+                                    (if (str_eq kind "health-samples") "macos-healthkit-unavailable" "")))))))
             (if (str_eq platform "windows")
                 (if (str_eq kind "audio-input") "windows-wasapi-capture"
                     (if (str_eq kind "speech-transcript") "windows-speechrecognizer"
                         (if (str_eq kind "file-read") "windows-known-folder-filesystem"
                             (if (str_eq kind "file-append") "windows-known-folder-filesystem"
                                 (if (str_eq kind "file-write-atomic") "windows-replacefile-atomic"
-                                    (if (str_eq kind "process-stdin-stdout") "windows-createprocess-stdin-stdout" ""))))))
+                                    (if (str_eq kind "process-stdin-stdout") "windows-createprocess-stdin-stdout"
+                                        (if (str_eq kind "health-samples") "windows-health-export-import" "")))))))
                 (if (str_eq platform "android")
                     (if (str_eq kind "audio-input") "android-audiorecord"
                         (if (str_eq kind "speech-transcript") "android-speechrecognizer"
                             (if (str_eq kind "file-read") "android-app-private-files"
                                 (if (str_eq kind "file-append") "android-app-private-files"
                                     (if (str_eq kind "file-write-atomic") "android-atomic-file"
-                                        (if (str_eq kind "process-stdin-stdout") "android-packaged-form-cli-process" ""))))))
+                                        (if (str_eq kind "process-stdin-stdout") "android-packaged-form-cli-process"
+                                            (if (str_eq kind "health-samples") "android-health-connect" "")))))))
                     (if (eq (shb-ios-platform? platform) 1)
                         (if (str_eq kind "audio-input") "ios-avfoundation"
                             (if (str_eq kind "speech-transcript") "ios-speech"
                                 (if (str_eq kind "file-read") "ios-app-sandbox-files"
                                     (if (str_eq kind "file-append") "ios-app-sandbox-files"
                                         (if (str_eq kind "file-write-atomic") "ios-foundation-data-atomic"
-                                            (if (str_eq kind "process-stdin-stdout") "ios-embedded-form-cli-adapter" ""))))))
+                                            (if (str_eq kind "process-stdin-stdout") "ios-embedded-form-cli-adapter"
+                                                (if (str_eq kind "health-samples") "ios-healthkit" "")))))))
                         "")))))
 
     (defn shb-carrier-resolved? (platform kind)
@@ -106,7 +112,8 @@
                       (and (eq (shb-carrier-resolved? platform "file-read") 1)
                            (and (eq (shb-carrier-resolved? platform "file-append") 1)
                                 (and (eq (shb-carrier-resolved? platform "file-write-atomic") 1)
-                                     (eq (shb-carrier-resolved? platform "process-stdin-stdout") 1)))))) 1 0))
+                                     (and (eq (shb-carrier-resolved? platform "process-stdin-stdout") 1)
+                                          (eq (shb-carrier-resolved? platform "health-samples") 1))))))) 1 0))
 
     (defn shb-boundary-ok? (runtime resource platform)
         (if (and (eq (shb-app-runtime-allowed? runtime) 1)

--- a/form/form-stdlib/tests/satsang-health-memory-band.fk
+++ b/form/form-stdlib/tests/satsang-health-memory-band.fk
@@ -1,0 +1,39 @@
+; preludes: form-stdlib/core.fk form-stdlib/satsang-health-memory.fk
+;
+; satsang-health-memory-band — wearable samples enter local health memory only
+; by explicit import, with source filters and non-diagnostic analysis boundary.
+;
+; Verdict 255:
+;   1   explicit import is accepted
+;   2   iOS HealthKit is an accepted source carrier
+;   4   Oura source filter is accepted
+;   8   Oz/O2 source filter is accepted
+;   16  heart-rate metric is accepted
+;   32  SpO2 metric is accepted
+;   64  hidden capture is rejected by trust receipt
+;   128 receipt can feed later context under analysis-not-diagnosis boundary
+(do
+    (let receipt (shm-receipt "explicit-import"
+                              "ios-healthkit"
+                              "spo2"
+                              0
+                              1
+                              "reference-memory-reasoning-analysis-not-diagnosis"))
+
+    (let c0 (if (eq (shm-import-boundary? "explicit-import") 1) 1 0))
+    (let c1 (if (eq (shm-source-carrier? "ios-healthkit") 1) 2 0))
+    (let c2 (if (eq (shm-source-filter? "oura") 1) 4 0))
+    (let c3 (if (and (eq (shm-source-filter? "oz") 1)
+                     (eq (shm-source-filter? "o2") 1)) 8 0))
+    (let c4 (if (eq (shm-metric-kind? "heart-rate") 1) 16 0))
+    (let c5 (if (eq (shm-metric-kind? "spo2") 1) 32 0))
+    (let c6 (if (eq (shm-trust-ok? "explicit-import"
+                                   "ios-healthkit"
+                                   "spo2"
+                                   1
+                                   1
+                                   "reference-memory-reasoning-analysis-not-diagnosis") 0) 64 0))
+    (let c7 (if (and (eq (shm-rec-ok? receipt) 1)
+                     (eq (shm-rec-hidden receipt) 0)) 128 0))
+
+    (sum (list c0 c1 c2 c3 c4 c5 c6 c7)))

--- a/form/form-stdlib/tests/satsang-host-boundary-band.fk
+++ b/form/form-stdlib/tests/satsang-host-boundary-band.fk
@@ -3,7 +3,7 @@
 ; satsang-host-boundary-band — shared Form body, minimal host ABI, no app
 ; boundary Python/Go/Rust/TypeScript.
 ;
-; Verdict 1048575:
+; Verdict 2097151:
 ;   1   Form is an allowed app runtime
 ;   2   Swift is only the minimal host carrier
 ;   4   Python is forbidden at the app boundary
@@ -24,6 +24,7 @@
 ;   65536 Windows process door is CreateProcess stdin/stdout
 ;   262144 iPhone/iOS carrier matrix resolves every resource door
 ;   524288 iPhone speech carrier is the native Speech side channel
+;   1048576 iPhone health samples use HealthKit
 (do
     (let rec (shb-receipt "swift-minimal-host-carrier" "process-stdin-stdout" "macos"))
     (let audio-door (shb-door-receipt "audio-input" "open" "macos-avfoundation"))
@@ -52,5 +53,6 @@
     (let c17 (if (eq (shb-platform-target? "ios") 1) 131072 0))
     (let c18 (if (eq (shb-platform-carriers-complete? "ios") 1) 262144 0))
     (let c19 (if (str_eq (shb-carrier-for "ios" "speech-transcript") "ios-speech") 524288 0))
+    (let c20 (if (str_eq (shb-carrier-for "ios" "health-samples") "ios-healthkit") 1048576 0))
 
-    (sum (list c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19)))
+    (sum (list c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 c10 c11 c12 c13 c14 c15 c16 c17 c18 c19 c20)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -950,7 +950,8 @@ research-corpus fks 127
 resid-train-emit fks 7
 satsang-field fks 255
 satsang-guidance-event fks 255
-satsang-host-boundary fks 131071
+satsang-host-boundary fks 2097151
+satsang-health-memory fks 255
 satsang-listen-route fks 255
 satsang-share fks 255
 scheduler fks 511

--- a/specs/satsang-mac-guidance-app.md
+++ b/specs/satsang-mac-guidance-app.md
@@ -10,12 +10,16 @@ source:
     symbols: [SatsangGuidanceRootView, SatsangHostShell, AppModel]
   - file: experiments/satsang-mac-app/Sources/SatsangGuidanceKit/RoomTranscriber.swift
     symbols: [RoomTranscriber]
+  - file: experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift
+    symbols: [WearableHealthImporter]
   - file: experiments/satsang-mac-app/Sources/SatsangMacCore/SatsangNativeAppMode.swift
     symbols: [SatsangNativeAppMode, SatsangNativeAppModeReceipt]
   - file: experiments/satsang-mac-app/Sources/SatsangMacCore/Transcript.swift
     symbols: [TranscriptUtterance, TranscriptParser]
   - file: experiments/satsang-mac-app/Sources/SatsangMacCore/TrustedRoomMemory.swift
     symbols: [TrustedRoomMemoryStore, TrustedRoomMemoryContext, TrustedRoomSpeakerProfile, TrustedRoomMemorySessionRecord]
+  - file: experiments/satsang-mac-app/Sources/SatsangMacCore/TrustedHealthMemory.swift
+    symbols: [TrustedHealthMemoryStore, TrustedHealthMemoryContext, TrustedHealthSample, TrustedHealthMemorySnapshot]
   - file: experiments/satsang-mac-app/Sources/SatsangMacCore/TranscriptMerger.swift
     symbols: [TranscriptMerger]
   - file: experiments/satsang-mac-app/Sources/SatsangMacCore/GuidanceRequest.swift
@@ -32,10 +36,15 @@ source:
     symbols: [slr-decision, slr-remote-oracle?, slr-live-capture-receipt?, slr-side-channel-transcribe?, slr-receipt]
   - file: form/form-stdlib/satsang-room-memory.fk
     symbols: [srm-mic-exclusive-carrier?, srm-trust-ok?, srm-speaker-match?, srm-context-ready?, srm-receipt]
+  - file: form/form-stdlib/satsang-health-memory.fk
+    symbols: [shm-import-boundary?, shm-source-carrier?, shm-metric-kind?, shm-source-filter?, shm-trust-ok?, shm-receipt]
 requirements:
   - "Mac desktop GUI can listen to the room microphone after explicit Start Listening"
   - "iPhone native SwiftUI GUI is present as a first-class app target"
-  - "Mac and iPhone carriers share one tabbed native app body with Room, Guidance, Memory, Learning, Resources, and Settings modes"
+  - "Mac and iPhone carriers share one tabbed native app body with Room, Guidance, Memory, Health, Learning, Resources, and Settings modes"
+  - "The shared native app body includes a Health mode for explicit iPhone wearable import"
+  - "The iPhone carrier reads HealthKit samples after Health permission and source filtering for Oura, Oz/O2, Wellue, ViHealth, oxygen, or oximeter sources"
+  - "Imported health samples are stored in local health memory and summarized into later guidance context"
   - "Live room capture is the primary stream; speech transcription is only a side channel fed during that capture"
   - "Speech Recognition is never a before-recording or after-recording pass over stored audio"
   - "No-speech intervals do not stop the active room listener"
@@ -48,18 +57,19 @@ requirements:
   - "The send path records Form-native body/RAG lookup before any remote oracle request"
   - "Remote LLM oracle routing is only an explicit request when the native sufficiency gate fails"
   - "Shared app logic is declared Form-native and host access crosses a generic host OS resource interface"
-  - "The request records detected host resource doors for file, process, audio-input, and speech-transcript access"
+  - "The request records detected host resource doors for file, process, audio-input, speech-transcript, and health-samples access"
   - "The request records resolved macOS, Windows, Android, and iPhone/iOS carrier mappings for every host resource door"
   - "The request records local trusted room-memory context from prior explicitly sent sessions"
   - "The send path stores a local session record, session index, and speaker-profile continuity receipt"
+  - "The health import path stores a local import record, sample log, and latest health-memory context receipt"
   - "Recurring unnamed speakers match by stable voice_id/speaker_id when supplied; channel-only room mic continuity is not claimed as verified identity"
   - "Speaker continuity never uses macOS biometric speaker identification or any exclusive-mic biometric carrier"
   - "Python, Go, Rust, and TypeScript are rejected as app-boundary runtimes for this carrier"
 done_when:
-  - "Swift package tests pass for parsing, request writing, trusted room-memory, host-boundary, and route-gate receipts"
+  - "Swift package tests pass for parsing, request writing, trusted room-memory, trusted health-memory, host-boundary, and route-gate receipts"
   - "Swift package builds the GUI executable"
-  - "satsang-guidance-event, satsang-listen-route, and satsang-room-memory Form bands cross four-way with verdict 255; satsang-host-boundary crosses four-way with verdict 1048575"
-test: "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-guidance-event.fk form-stdlib/tests/satsang-guidance-event-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/satsang-listen-route.fk form-stdlib/tests/satsang-listen-route-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-room-memory.fk form-stdlib/tests/satsang-room-memory-band.fk"
+  - "satsang-guidance-event, satsang-listen-route, satsang-room-memory, and satsang-health-memory Form bands cross four-way with verdict 255; satsang-host-boundary crosses four-way with verdict 2097151"
+test: "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-guidance-event.fk form-stdlib/tests/satsang-guidance-event-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/satsang-listen-route.fk form-stdlib/tests/satsang-listen-route-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-room-memory.fk form-stdlib/tests/satsang-room-memory-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-health-memory.fk form-stdlib/tests/satsang-health-memory-band.fk"
 constraints:
   - "Do not auto-send hidden transcripts; the user presses Send"
   - "The GUI edits local event payloads only; speech capture starts only from explicit user action"
@@ -73,17 +83,18 @@ constraints:
 
 This spec creates the native satsang companion app surface. macOS and iPhone
 share one SwiftUI/Form-native body with tabs for Room, Guidance, Memory,
-Learning, Resources, and Settings. Room speech and detected transcript files are
-visible, editable, and sent as an explicit guidance request to Sema or another
-invoked presence only when a turn is offered. The carrier listens only after
-explicit user action, reads local transcript files, and writes a local protocol
-event queue.
+Health, Learning, Resources, and Settings. Room speech and detected transcript
+files are visible, editable, and sent as an explicit guidance request to Sema or
+another invoked presence only when a turn is offered. The carrier listens only
+after explicit user action, reads local transcript files, imports iPhone
+HealthKit wearable samples after explicit permission, and writes local protocol
+memory.
 
 ## Requirements
 
 - [x] The GUI loads detected transcript lines from a JSONL or JSON-array file.
 - [x] The GUI is a single tabbed native app surface with Room, Guidance,
-      Memory, Learning, Resources, and Settings modes.
+      Memory, Health, Learning, Resources, and Settings modes.
 - [x] The GUI starts/stops native macOS microphone transcription with explicit
       user action.
 - [x] The iPhone SwiftUI app target uses the same shared GUI/body and has the
@@ -105,6 +116,14 @@ event queue.
       speaker profiles, and latest context receipt after explicit Send.
 - [x] Later sends include prior-session context and speaker-profile summary in
       the request.
+- [x] The iPhone Health mode requests HealthKit read permission and imports
+      source-filtered wearable samples into local health memory.
+- [x] The source filter defaults cover Oura, Oz/O2, Wellue, ViHealth, oxygen,
+      and oximeter sources while allowing the holder to edit the source list.
+- [x] Imported health memory writes a local import record, sample log, JSON
+      context, and Form context.
+- [x] Later sends include compact health-memory context in the local Form/RAG
+      request.
 - [x] Recurring unnamed speakers can match by stable `voice_id` / `speaker_id`
       when supplied by a transcript producer; `room mic` without a voice id is
       carried as channel continuity, not verified identity.
@@ -122,8 +141,8 @@ event queue.
       host OS resource interface, Swift as the minimal host carrier, and
       Python/Go/Rust/TypeScript forbidden at the app boundary.
 - [x] The request records detected host resource doors for file read, file
-      append, atomic file write, process stdin/stdout, audio input, and speech
-      transcription.
+      append, atomic file write, process stdin/stdout, audio input, speech
+      transcription, and health samples.
 - [x] The request records a complete macOS/Windows/Android/iPhone carrier
       matrix for those same resource doors.
 - [x] A Form proof names the valid event/protocol boundary.
@@ -139,9 +158,11 @@ event queue.
 - `experiments/satsang-mac-app/Support/SatsangGuidancePhone/Info.plist` - iPhone permission metadata template.
 - `experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift` - shared tabbed SwiftUI GUI.
 - `experiments/satsang-mac-app/Sources/SatsangGuidanceKit/RoomTranscriber.swift` - native Apple room microphone capture with speech transcription as a side channel.
+- `experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift` - conditional iPhone HealthKit importer for source-filtered wearable samples.
 - `experiments/satsang-mac-app/Sources/SatsangMacCore/SatsangNativeAppMode.swift` - shared tab/mode receipt.
 - `experiments/satsang-mac-app/Sources/SatsangMacCore/Transcript.swift` - transcript parser.
 - `experiments/satsang-mac-app/Sources/SatsangMacCore/TrustedRoomMemory.swift` - local session index, speaker-profile, and prior-context memory store.
+- `experiments/satsang-mac-app/Sources/SatsangMacCore/TrustedHealthMemory.swift` - local health import index, sample log, and prior-context memory store.
 - `experiments/satsang-mac-app/Sources/SatsangMacCore/TranscriptMerger.swift` - transcript reload merge policy.
 - `experiments/satsang-mac-app/Sources/SatsangMacCore/GuidanceRequest.swift` - event writer.
 - `experiments/satsang-mac-app/Sources/SatsangMacCore/FormNativeRouting.swift` - local Form/RAG route receipt writer.
@@ -156,8 +177,11 @@ event queue.
 - `form/form-stdlib/tests/satsang-listen-route-band.fk` - remote-last route proof.
 - `form/form-stdlib/satsang-room-memory.fk` - explicit local trusted room-memory protocol.
 - `form/form-stdlib/tests/satsang-room-memory-band.fk` - trusted room-memory proof.
+- `form/form-stdlib/satsang-health-memory.fk` - explicit local trusted health-memory protocol.
+- `form/form-stdlib/tests/satsang-health-memory-band.fk` - trusted health-memory proof.
 - `docs/coherence-substrate/satsang-guidance-event.form` - teaching.
 - `docs/coherence-substrate/satsang-room-memory.form` - room-memory teaching.
+- `docs/coherence-substrate/satsang-health-memory.form` - health-memory teaching.
 
 ## Acceptance Tests
 
@@ -165,9 +189,10 @@ event queue.
 - `swift build --package-path experiments/satsang-mac-app --product SatsangGuidance` passes.
 - `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-guidance-event.fk form-stdlib/tests/satsang-guidance-event-band.fk` returns `255`.
 - `swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone` passes.
-- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk` returns `1048575`.
+- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk` returns `2097151`.
 - `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/satsang-listen-route.fk form-stdlib/tests/satsang-listen-route-band.fk` returns `255`.
 - `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-room-memory.fk form-stdlib/tests/satsang-room-memory-band.fk` returns `255`.
+- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-health-memory.fk form-stdlib/tests/satsang-health-memory-band.fk` returns `255`.
 - Manual validation: launch the app, press Start Listening, allow macOS
   microphone/speech prompts, speak into the room, edit a transcript line, press
   Send, and see a JSON/Form event under
@@ -182,6 +207,9 @@ event queue.
 - Manual validation: while Speech Recognition attaches, cycles, or waits through
   silence, confirm the live mic level remains active and the listener does not
   restart the capture stream.
+- Manual validation: on an iPhone with HealthKit data from Oura or an Oz/O2
+  source, open Health mode, press Import, grant Health permission, and confirm
+  local files appear under `~/.coherence-network/health-memory/`.
 
 ## Verification
 
@@ -194,6 +222,7 @@ cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-guidance-event.
 cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk
 cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/satsang-listen-route.fk form-stdlib/tests/satsang-listen-route-band.fk
 cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-room-memory.fk form-stdlib/tests/satsang-room-memory-band.fk
+cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-health-memory.fk form-stdlib/tests/satsang-health-memory-band.fk
 python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.md
 ```
 
@@ -201,6 +230,7 @@ python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.m
 
 - Autonomous interruption by Sema or another presence.
 - Invoking a remote LLM directly from the GUI.
+- Direct Oura Cloud OAuth or direct Oz/O2 Bluetooth pairing in this PR.
 - Replacing macOS Speech with a fully Form-native acoustic decoder.
 - Using macOS biometric speaker identification or any exclusive-mic biometric
   carrier for room-memory speaker continuity.
@@ -237,12 +267,18 @@ python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.m
   support outside this source patch. iOS cannot spawn arbitrary subprocesses, so
   the process stdin/stdout resource door is declared as an embedded Form runtime
   adapter until fkwu is packaged in-process.
+- HealthKit only returns data types and sources the holder grants. Oura can
+  reach this lane through its Apple Health export; Oz/O2 devices reach it when
+  their companion app writes compatible Apple Health samples. Device-specific
+  Bluetooth or vendor-cloud routes require their own consent and protocol work.
 
 ## Known Gaps and Follow-up Tasks
 
 - Follow-up task: add a signed notarized macOS bundle once the app surface settles.
 - Follow-up task: add a signed iPhone archive/TestFlight lane once the Apple
   team/profile is available.
+- Follow-up task: add direct Oura OAuth and direct Oz/O2 Bluetooth carriers when
+  the holder wants source-native data beyond Apple Health.
 - Follow-up task: wire a live Sema presence process to consume the event queue and
   return a visible transmission inside the GUI.
 - Follow-up task: add a passive shared-audio continuity sidecar only if it can


### PR DESCRIPTION
## Summary

- Adds a shared native Health tab that imports wearable samples from iPhone HealthKit after explicit Health permission.
- Stores imported Oura/Oz/O2-style source-filtered samples in local trusted health memory and includes compact health context in later Form/RAG guidance requests.
- Extends the host-resource door matrix with `health-samples` and adds a four-way Form proof for the health-memory trust boundary.

## Validation

- `swift test --package-path experiments/satsang-mac-app`
- `swift build --package-path experiments/satsang-mac-app --product SatsangGuidance`
- `swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone`
- `scripts/build_satsang_mac_app.sh`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-guidance-event.fk form-stdlib/tests/satsang-guidance-event-band.fk`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk` -> `2097151`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/satsang-listen-route.fk form-stdlib/tests/satsang-listen-route-band.fk`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-room-memory.fk form-stdlib/tests/satsang-room-memory-band.fk`
- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-health-memory.fk form-stdlib/tests/satsang-health-memory-band.fk`
- `python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-26_iphone_health_wearable_memory.json`
- `python3 scripts/generate_repo_indexes.py --check`
- `python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.md`
- `git diff --check`
- `make wellness`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`
- `python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict`

## Known boundary

`xcodebuild -scheme SatsangGuidancePhone -destination 'generic/platform=iOS' -derivedDataPath .build/xcode-derived build` is blocked on this host because iOS 26.2 platform support is not installed. The iPhone HealthKit source path is present, but device-signed HealthKit validation still needs an Apple team/profile and installed iOS SDK.
