### PR TITLE
tend: install Oura Wellue health path

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 381 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 382 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/satsang-guidance-event.form
+++ b/docs/coherence-substrate/satsang-guidance-event.form
@@ -62,7 +62,7 @@
 ;   form/form-stdlib/tests/satsang-room-memory-band.fk -> 255.
 ;   form/form-stdlib/satsang-health-memory.fk names explicit local health memory,
 ;   source-filtered HealthKit import, no-hidden-capture, and analysis boundary.
-;   Proof: form/form-stdlib/tests/satsang-health-memory-band.fk -> 255.
+;   Proof: form/form-stdlib/tests/satsang-health-memory-band.fk -> 1023.
 ;
 ; Boundary:
 ;   The event is an offer, not an interruption. The GUI does not decide that a

--- a/docs/coherence-substrate/satsang-health-memory.form
+++ b/docs/coherence-substrate/satsang-health-memory.form
@@ -3,11 +3,12 @@
 Health memory is a consented local context lane for wearable samples that the
 holder explicitly imports from the iPhone health store.
 
-The first native carrier is iOS HealthKit. Oura, Oz/O2, Wellue, ViHealth, and
-other oxygen or ring sources enter through Apple Health when the holder grants
-read access for the selected categories. The app stores imported samples in the
-local health-memory folder and makes only compact summaries available to the
-guidance request.
+The first native carrier is iOS HealthKit. The built-in essential profiles are
+Oura Ring 4 through the Oura Apple Health integration and Wellue O2Ring S
+through ViHealth Apple Health sharing. Other oxygen or ring sources enter
+through Apple Health when the holder grants read access for the selected
+categories. The app stores imported samples in the local health-memory folder
+and makes only compact summaries available to the guidance request.
 
 The trust receipt is the boundary:
 

--- a/docs/system_audit/commit_evidence_2026-06-26_oura_wellue_install_path.json
+++ b/docs/system_audit/commit_evidence_2026-06-26_oura_wellue_install_path.json
@@ -1,0 +1,130 @@
+{
+  "date": "2026-06-26",
+  "thread_branch": "codex/oura-wellue-install-20260626",
+  "commit_scope": "Install-readiness pass for the iPhone health-memory lane: promote Oura Ring 4 and Wellue O2Ring S/ViHealth into explicit source profiles, prove the exact-device health-memory receipt, and cross-compile the iPhone HealthKit branch.",
+  "files_owned": [
+    "docs/coherence-substrate/satsang-guidance-event.form",
+    "docs/coherence-substrate/satsang-health-memory.form",
+    "docs/system_audit/commit_evidence_2026-06-26_oura_wellue_install_path.json",
+    "experiments/satsang-mac-app/README.md",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/RoomTranscriber.swift",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift",
+    "experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift",
+    "form/form-stdlib/satsang-health-memory.fk",
+    "form/form-stdlib/tests/satsang-health-memory-band.fk",
+    "form/fourth-arm-bands.txt",
+    "specs/satsang-mac-guidance-app.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "make prompt-guide",
+      "curl -sS --max-time 5 https://pulse.coherencycoin.com/pulse/now | jq '{overall, silences: (.ongoing_silences | length), silent_organs: [.organs[] | select(.status != \"breathing\") | .name]}'",
+      "form-cli ask \"Oura Ring 4 Wellue O2Ring S iPhone HealthKit ViHealth trusted health memory install source carrier\"",
+      "xcrun devicectl list devices",
+      "swift test --package-path experiments/satsang-mac-app",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidance",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone --sdk \"$(xcrun --sdk iphoneos --show-sdk-path)\" --triple arm64-apple-ios17.0",
+      "xcodebuild -scheme SatsangGuidancePhone -destination 'generic/platform=iOS' -derivedDataPath .build/xcode-derived CODE_SIGNING_ALLOWED=NO build",
+      "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-health-memory.fk form-stdlib/tests/satsang-health-memory-band.fk",
+      "python3 scripts/generate_repo_indexes.py",
+      "python3 scripts/generate_repo_indexes.py --check",
+      "python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.md"
+    ],
+    "fourth_arm": "satsang-health-memory-band.fk -> 1023; output included 'fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)' and '0 divergent'.",
+    "summary": "Startup gate passed in a fresh worktree and the public witness was breathing with no ongoing silences. form-cli ask observed the native fkwu+Metal model-cell lane but had no grounded/sufficient local RAG hit for the exact Oura Ring 4 / Wellue O2Ring S install query. Swift tests passed with 13 XCTest cases. Both native app products built on macOS. The iPhone target cross-compiled against the iPhoneOS SDK at arm64-apple-ios17.0, exercising the HealthKit branch. Xcode app-bundle/device installation remains blocked locally because no iPhone or simulator destination is visible to devicectl/xctrace and no connected trusted device/signing install path is present in this session."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": []
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "summary": "No PR deploy yet; this commit is ready for PR checks after final local gates."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Local proof and iPhoneOS source compile passed; physical iPhone install still needs a connected trusted device and signing profile."
+  },
+  "idea_ids": [
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "satsang-mac-guidance-app"
+  ],
+  "task_ids": [
+    "oura-wellue-install-path-2026-06-26"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs-muff",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "wearable-device-selection"
+      ]
+    },
+    {
+      "contributor_id": "agent:codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "form-proof",
+        "local-validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "OpenAI GPT-5 Codex"
+  },
+  "evidence_refs": [
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift",
+    "form/form-stdlib/satsang-health-memory.fk",
+    "form/form-stdlib/tests/satsang-health-memory-band.fk",
+    "specs/satsang-mac-guidance-app.md",
+    "docs/coherence-substrate/satsang-health-memory.form"
+  ],
+  "change_files": [
+    "MANIFEST.md",
+    "docs/coherence-substrate/satsang-guidance-event.form",
+    "docs/coherence-substrate/satsang-health-memory.form",
+    "docs/system_audit/commit_evidence_2026-06-26_oura_wellue_install_path.json",
+    "experiments/satsang-mac-app/README.md",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/RoomTranscriber.swift",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift",
+    "experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift",
+    "experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift",
+    "experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift",
+    "form/form-stdlib/satsang-health-memory.fk",
+    "form/form-stdlib/tests/satsang-health-memory-band.fk",
+    "form/fourth-arm-bands.txt",
+    "scripts/INDEX.md",
+    "specs/satsang-mac-guidance-app.md"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "summary": "The app source is ready for Oura Ring 4 and Wellue O2Ring S/ViHealth HealthKit import and the iPhoneOS HealthKit branch compiles. Physical installation and live HealthKit import could not be completed because no trusted iPhone device is connected.",
+    "expected_behavior_delta": "The Health tab now defaults to exact Oura Ring 4 and Wellue O2Ring S source profiles, writes compatible samples into local trusted health memory, and the Form proof names those exact source filters and carrier path.",
+    "public_endpoints": [
+      "n/a-local-native-app"
+    ],
+    "test_flows": [
+      "swift test --package-path experiments/satsang-mac-app -> 13 tests passed",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidance -> product built",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone -> product built",
+      "swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone --sdk \"$(xcrun --sdk iphoneos --show-sdk-path)\" --triple arm64-apple-ios17.0 -> product built",
+      "xcrun devicectl list devices -> No devices found",
+      "xcodebuild -scheme SatsangGuidancePhone -destination 'generic/platform=iOS' ... -> no matching destination; no installable iPhone destination visible",
+      "cd form && ./validate.sh ... satsang-health-memory-band.fk -> 1023 four-way",
+      "python3 scripts/generate_repo_indexes.py --check -> all indexes up to date",
+      "python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.md -> passed"
+    ]
+  }
+}

--- a/experiments/satsang-mac-app/README.md
+++ b/experiments/satsang-mac-app/README.md
@@ -77,8 +77,11 @@ sidecar must share the already-open listening stream. The memory proof lives in
 `form/form-stdlib/satsang-room-memory.fk`.
 
 The Health tab imports wearable samples from iPhone HealthKit after Health
-permission is granted. The default source filter covers Oura, Oz/O2, Wellue,
-ViHealth, oxygen, and oximeter sources. Imported samples are written to local
+permission is granted. The built-in essential source profiles are Oura Ring 4
+through the Oura Apple Health integration and Wellue O2Ring S through ViHealth
+Apple Health sharing. The editable source filter also covers Oura, Oura bundle
+ids, Wellue, O2RingS/O2Ring-S/O2Ring, Viatom, ViHealth, ViHealth bundle ids,
+Oz/O2, oxygen, and oximeter sources. Imported samples are written to local
 health memory and summarized into later guidance context. The health-memory
 proof lives in `form/form-stdlib/satsang-health-memory.fk`.
 
@@ -93,11 +96,11 @@ transcription, and health samples, plus the cross-platform carrier matrix for
 those same doors.
 Python, Go, Rust, and TypeScript are not app-boundary runtimes for this carrier.
 Windows and Android are carrier mappings in this package, not full GUI apps yet.
-The iPhone target is native SwiftUI source; a device-signed archive still needs
-an Apple team/profile plus installed iOS SDK support. The permission metadata
-template lives at `Support/SatsangGuidancePhone/Info.plist`, and iOS routes the
-Form process door through an embedded runtime adapter rather than arbitrary
-subprocess spawning.
+The iPhone target is native SwiftUI source; installing to a physical phone needs
+a connected trusted iPhone plus an Apple team/profile for signing. The permission
+metadata template lives at `Support/SatsangGuidancePhone/Info.plist`, and iOS
+routes the Form process door through an embedded runtime adapter rather than
+arbitrary subprocess spawning.
 The HealthKit entitlement template lives at
 `Support/SatsangGuidancePhone/SatsangGuidancePhone.entitlements`.
 

--- a/experiments/satsang-mac-app/Sources/SatsangGuidanceKit/RoomTranscriber.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangGuidanceKit/RoomTranscriber.swift
@@ -261,7 +261,7 @@ final class RoomTranscriber: @unchecked Sendable {
     private func configureAudioSessionIfNeeded() throws {
         #if os(iOS)
         let session = AVAudioSession.sharedInstance()
-        try session.setCategory(.playAndRecord, mode: .measurement, options: [.allowBluetooth, .defaultToSpeaker])
+        try session.setCategory(.playAndRecord, mode: .measurement, options: [.allowBluetoothHFP, .defaultToSpeaker])
         try session.setActive(true, options: [])
         #endif
     }

--- a/experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangGuidanceKit/SatsangGuidanceRootView.swift
@@ -653,7 +653,7 @@ public struct SatsangGuidanceRootView: View {
                 Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 8) {
                     GridRow {
                         Text("Sources")
-                        TextField("Oura, Oz, O2, Wellue", text: $model.healthSourceHints)
+                        TextField("Oura Ring 4, Wellue O2Ring S", text: $model.healthSourceHints)
                     }
                     GridRow {
                         Text("Days")
@@ -661,6 +661,8 @@ public struct SatsangGuidanceRootView: View {
                     }
                 }
                 .textFieldStyle(.roundedBorder)
+
+                metricRow("Essential sources", WearableHealthImporter.essentialSourceSummary)
 
                 HStack {
                     Button { model.importHealthSamples() } label: {

--- a/experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangGuidanceKit/WearableHealthImporter.swift
@@ -23,15 +23,63 @@ enum WearableHealthImportError: Error, LocalizedError {
 }
 
 final class WearableHealthImporter {
-    static let defaultSourceHints = [
-        "Oura",
-        "Oz",
-        "O2",
-        "Wellue",
-        "ViHealth",
-        "oxygen",
-        "oximeter",
+    struct SourceProfile: Equatable {
+        var displayName: String
+        var sourceHints: [String]
+        var essentialSampleKinds: [String]
+    }
+
+    static let essentialSourceProfiles = [
+        SourceProfile(
+            displayName: "Oura Ring 4",
+            sourceHints: [
+                "Oura Ring 4",
+                "Oura",
+                "com.ouraring.oura",
+            ],
+            essentialSampleKinds: [
+                "sleep-analysis",
+                "heart-rate",
+                "resting-heart-rate",
+                "hrv-sdnn",
+                "respiratory-rate",
+                "steps",
+                "active-energy",
+            ]
+        ),
+        SourceProfile(
+            displayName: "Wellue O2Ring S",
+            sourceHints: [
+                "Wellue O2Ring S",
+                "O2RingS",
+                "O2Ring-S",
+                "O2Ring",
+                "Wellue",
+                "Viatom",
+                "ViHealth",
+                "com.viatom.vihealth",
+                "Oz",
+                "O2",
+                "oxygen",
+                "oximeter",
+            ],
+            essentialSampleKinds: [
+                "spo2",
+                "heart-rate",
+                "sleep-analysis",
+            ]
+        ),
     ]
+
+    static let defaultSourceHints = Array(
+        Set(essentialSourceProfiles.flatMap(\.sourceHints))
+    ).sorted()
+
+    static var essentialSourceSummary: String {
+        essentialSourceProfiles
+            .map { "\($0.displayName): \($0.essentialSampleKinds.joined(separator: ", "))" }
+            .joined(separator: "; ")
+    }
 
     static func detectResourceDoors() -> [HostResourceDoor] {
         #if canImport(HealthKit) && os(iOS)
@@ -156,7 +204,7 @@ private extension WearableHealthImporter {
     }
 
     func requestAuthorization(healthStore: HKHealthStore, readTypes: Set<HKObjectType>) async throws {
-        try await withCheckedThrowingContinuation { continuation in
+        let _: Void = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
             healthStore.requestAuthorization(toShare: Set<HKSampleType>(), read: readTypes) { success, error in
                 if let error {
                     continuation.resume(throwing: error)
@@ -329,13 +377,14 @@ private extension WearableHealthImporter {
 
     static func sleepStageName(_ value: Int) -> String {
         if value == HKCategoryValueSleepAnalysis.inBed.rawValue { return "in-bed" }
-        if value == HKCategoryValueSleepAnalysis.asleep.rawValue { return "asleep" }
         if value == HKCategoryValueSleepAnalysis.awake.rawValue { return "awake" }
         if #available(iOS 16.0, *) {
             if value == HKCategoryValueSleepAnalysis.asleepCore.rawValue { return "asleep-core" }
             if value == HKCategoryValueSleepAnalysis.asleepDeep.rawValue { return "asleep-deep" }
             if value == HKCategoryValueSleepAnalysis.asleepREM.rawValue { return "asleep-rem" }
             if value == HKCategoryValueSleepAnalysis.asleepUnspecified.rawValue { return "asleep-unspecified" }
+        } else if value == 1 {
+            return "asleep"
         }
         return "sleep-stage-\(value)"
     }

--- a/experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift
+++ b/experiments/satsang-mac-app/Sources/SatsangMacCore/HostResourceInterface.swift
@@ -129,7 +129,12 @@ public struct FoundationHostResourceInterface: HostResourceInterface {
     public init() {}
 
     public var homeDirectory: URL {
+        #if os(iOS) || os(tvOS) || os(watchOS)
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        #else
         FileManager.default.homeDirectoryForCurrentUser
+        #endif
     }
 
     public var currentDirectory: URL {

--- a/experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift
+++ b/experiments/satsang-mac-app/Tests/SatsangMacCoreTests/SatsangMacCoreTests.swift
@@ -56,9 +56,9 @@ final class SatsangMacCoreTests: XCTestCase {
             healthContext: TrustedHealthMemoryContext(
                 priorImportCount: 1,
                 recentSampleCount: 2,
-                sourceSummary: "Oura=1; Wellue=1",
+                sourceSummary: "Oura Ring 4=1; Wellue O2Ring S=1",
                 metricSummary: "heart-rate=1; spo2=1",
-                recentObservationSummary: "spo2=97.00 % from Wellue"
+                recentObservationSummary: "spo2=97.00 % from Wellue O2Ring S"
             )
         )
 
@@ -268,7 +268,7 @@ final class SatsangMacCoreTests: XCTestCase {
         let snapshot = TrustedHealthMemorySnapshot(
             id: "health-1",
             createdAt: "2026-06-26T18:00:00Z",
-            sourceHints: ["Oura", "O2"],
+            sourceHints: ["Oura Ring 4", "Wellue O2Ring S", "com.ouraring.oura", "com.viatom.vihealth"],
             samples: [
                 TrustedHealthSample(
                     id: "s1",
@@ -277,7 +277,7 @@ final class SatsangMacCoreTests: XCTestCase {
                     unit: "count/min",
                     startDate: "2026-06-26T17:59:00Z",
                     endDate: "2026-06-26T18:00:00Z",
-                    sourceName: "Oura",
+                    sourceName: "Oura Ring 4",
                     sourceBundleIdentifier: "com.ouraring.oura"
                 ),
                 TrustedHealthSample(
@@ -287,7 +287,7 @@ final class SatsangMacCoreTests: XCTestCase {
                     unit: "%",
                     startDate: "2026-06-26T17:50:00Z",
                     endDate: "2026-06-26T18:00:00Z",
-                    sourceName: "Wellue O2",
+                    sourceName: "Wellue O2Ring S",
                     sourceBundleIdentifier: "com.viatom.vihealth",
                     metadata: ["stage": "sleep"]
                 )
@@ -303,11 +303,11 @@ final class SatsangMacCoreTests: XCTestCase {
         let context = try store.context()
         XCTAssertEqual(context.priorImportCount, 1)
         XCTAssertEqual(context.recentSampleCount, 2)
-        XCTAssertTrue(context.sourceSummary.contains("Oura=1"))
-        XCTAssertTrue(context.sourceSummary.contains("Wellue O2=1"))
+        XCTAssertTrue(context.sourceSummary.contains("Oura Ring 4=1"))
+        XCTAssertTrue(context.sourceSummary.contains("Wellue O2Ring S=1"))
         XCTAssertTrue(context.metricSummary.contains("heart-rate=1"))
         XCTAssertTrue(context.metricSummary.contains("spo2=1"))
-        XCTAssertTrue(context.recentObservationSummary.contains("spo2=97.00 % from Wellue O2"))
+        XCTAssertTrue(context.recentObservationSummary.contains("spo2=97.00 % from Wellue O2Ring S"))
         XCTAssertEqual(context.trustReceipt.captureBoundary, "explicit-import")
         XCTAssertFalse(context.trustReceipt.hiddenCapture)
         XCTAssertTrue(TrustedHealthMemoryStore.formEnvelope(context).contains("(trusted-health-memory-context"))

--- a/form/form-stdlib/satsang-health-memory.fk
+++ b/form/form-stdlib/satsang-health-memory.fk
@@ -14,7 +14,9 @@
         (if (str_eq carrier "ios-healthkit") 1
             (if (str_eq carrier "oura-apple-health") 1
                 (if (str_eq carrier "oz-o2-healthkit") 1
-                    (if (str_eq carrier "manual-health-export") 1 0)))))
+                    (if (str_eq carrier "vihealth-apple-health") 1
+                        (if (str_eq carrier "wellue-vihealth-apple-health") 1
+                            (if (str_eq carrier "manual-health-export") 1 0)))))))
 
     (defn shm-metric-kind? (kind)
         (if (str_eq kind "heart-rate") 1
@@ -30,13 +32,18 @@
 
     (defn shm-source-filter? (source)
         (if (str_eq source "oura") 1
-            (if (str_eq source "oz") 1
-                (if (str_eq source "o2") 1
-                    (if (str_eq source "wellue") 1
-                        (if (str_eq source "vihealth") 1
-                            (if (str_eq source "oxygen") 1
-                                (if (str_eq source "oximeter") 1
-                                    (if (str_eq source "all") 1 0)))))))))
+            (if (str_eq source "oura-ring-4") 1
+                (if (str_eq source "oz") 1
+                    (if (str_eq source "o2") 1
+                        (if (str_eq source "wellue") 1
+                            (if (str_eq source "wellue-o2ring-s") 1
+                                (if (str_eq source "o2rings") 1
+                                    (if (str_eq source "o2ring-s") 1
+                                        (if (str_eq source "viatom") 1
+                                            (if (str_eq source "vihealth") 1
+                                                (if (str_eq source "oxygen") 1
+                                                    (if (str_eq source "oximeter") 1
+                                                        (if (str_eq source "all") 1 0))))))))))))))
 
     (defn shm-analysis-boundary? (boundary)
         (if (str_eq boundary "reference-memory-reasoning-analysis-not-diagnosis") 1 0))

--- a/form/form-stdlib/tests/satsang-health-memory-band.fk
+++ b/form/form-stdlib/tests/satsang-health-memory-band.fk
@@ -3,7 +3,7 @@
 ; satsang-health-memory-band — wearable samples enter local health memory only
 ; by explicit import, with source filters and non-diagnostic analysis boundary.
 ;
-; Verdict 255:
+; Verdict 1023:
 ;   1   explicit import is accepted
 ;   2   iOS HealthKit is an accepted source carrier
 ;   4   Oura source filter is accepted
@@ -12,6 +12,8 @@
 ;   32  SpO2 metric is accepted
 ;   64  hidden capture is rejected by trust receipt
 ;   128 receipt can feed later context under analysis-not-diagnosis boundary
+;   256 Oura Ring 4 source filter is accepted
+;   512 Wellue O2Ring S via ViHealth Apple Health carrier is accepted
 (do
     (let receipt (shm-receipt "explicit-import"
                               "ios-healthkit"
@@ -35,5 +37,9 @@
                                    "reference-memory-reasoning-analysis-not-diagnosis") 0) 64 0))
     (let c7 (if (and (eq (shm-rec-ok? receipt) 1)
                      (eq (shm-rec-hidden receipt) 0)) 128 0))
+    (let c8 (if (eq (shm-source-filter? "oura-ring-4") 1) 256 0))
+    (let c9 (if (and (eq (shm-source-filter? "wellue-o2ring-s") 1)
+                     (and (eq (shm-source-filter? "o2rings") 1)
+                          (eq (shm-source-carrier? "wellue-vihealth-apple-health") 1))) 512 0))
 
-    (sum (list c0 c1 c2 c3 c4 c5 c6 c7)))
+    (sum (list c0 c1 c2 c3 c4 c5 c6 c7 c8 c9)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -951,7 +951,7 @@ resid-train-emit fks 7
 satsang-field fks 255
 satsang-guidance-event fks 255
 satsang-host-boundary fks 2097151
-satsang-health-memory fks 255
+satsang-health-memory fks 1023
 satsang-listen-route fks 255
 satsang-share fks 255
 scheduler fks 511

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 381
+**Total files**: 382
 
 | File | Purpose |
 |---|---|
@@ -94,6 +94,7 @@
 | [fill_missing_spec_sections.py](fill_missing_spec_sections.py) | Heal pre-existing spec body gaps the validator surfaces. |
 | [fkwu_awk.sh](fkwu_awk.sh) | fkwu_awk.sh — run a native awk query over a file ON FKWU (the c-bootstrap |
 | [fkwu_fnri.sh](fkwu_fnri.sh) | fkwu_fnri.sh — fnri witness / resolve / know via fkwu (fc-fnri direct, proven source). |
+| [fkwu_form_cli_full_gguf_tensor_slice_math_receipt.sh](fkwu_form_cli_full_gguf_tensor_slice_math_receipt.sh) | fkwu_form_cli_full_gguf_tensor_slice_math_receipt.sh -- prove a named tensor |
 | [fkwu_form_cli_full_model_inference_composition_receipt.sh](fkwu_form_cli_full_model_inference_composition_receipt.sh) | fkwu_form_cli_full_model_inference_composition_receipt.sh |
 | [fkwu_form_cli_gguf_model_cell_receipt.sh](fkwu_form_cli_gguf_model_cell_receipt.sh) | fkwu_form_cli_gguf_model_cell_receipt.sh -- prove form-cli can verify a |
 | [fkwu_form_cli_metal_direct_receipt.sh](fkwu_form_cli_metal_direct_receipt.sh) | fkwu_form_cli_metal_direct_receipt.sh |

--- a/specs/satsang-mac-guidance-app.md
+++ b/specs/satsang-mac-guidance-app.md
@@ -43,7 +43,7 @@ requirements:
   - "iPhone native SwiftUI GUI is present as a first-class app target"
   - "Mac and iPhone carriers share one tabbed native app body with Room, Guidance, Memory, Health, Learning, Resources, and Settings modes"
   - "The shared native app body includes a Health mode for explicit iPhone wearable import"
-  - "The iPhone carrier reads HealthKit samples after Health permission and source filtering for Oura, Oz/O2, Wellue, ViHealth, oxygen, or oximeter sources"
+  - "The iPhone carrier reads HealthKit samples after Health permission and source filtering for Oura Ring 4, Oura, Oura bundle ids, Wellue O2Ring S, O2RingS/O2Ring-S/O2Ring, Wellue, Viatom, ViHealth, ViHealth bundle ids, Oz/O2, oxygen, or oximeter sources"
   - "Imported health samples are stored in local health memory and summarized into later guidance context"
   - "Live room capture is the primary stream; speech transcription is only a side channel fed during that capture"
   - "Speech Recognition is never a before-recording or after-recording pass over stored audio"
@@ -68,7 +68,8 @@ requirements:
 done_when:
   - "Swift package tests pass for parsing, request writing, trusted room-memory, trusted health-memory, host-boundary, and route-gate receipts"
   - "Swift package builds the GUI executable"
-  - "satsang-guidance-event, satsang-listen-route, satsang-room-memory, and satsang-health-memory Form bands cross four-way with verdict 255; satsang-host-boundary crosses four-way with verdict 2097151"
+  - "Swift package cross-compiles the iPhone HealthKit branch with the iPhoneOS SDK"
+  - "satsang-guidance-event, satsang-listen-route, and satsang-room-memory Form bands cross four-way with verdict 255; satsang-health-memory crosses four-way with verdict 1023; satsang-host-boundary crosses four-way with verdict 2097151"
 test: "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-guidance-event.fk form-stdlib/tests/satsang-guidance-event-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/satsang-listen-route.fk form-stdlib/tests/satsang-listen-route-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-room-memory.fk form-stdlib/tests/satsang-room-memory-band.fk && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-health-memory.fk form-stdlib/tests/satsang-health-memory-band.fk"
 constraints:
   - "Do not auto-send hidden transcripts; the user presses Send"
@@ -118,8 +119,10 @@ memory.
       the request.
 - [x] The iPhone Health mode requests HealthKit read permission and imports
       source-filtered wearable samples into local health memory.
-- [x] The source filter defaults cover Oura, Oz/O2, Wellue, ViHealth, oxygen,
-      and oximeter sources while allowing the holder to edit the source list.
+- [x] The source filter defaults cover Oura Ring 4, Oura, Oura bundle ids,
+      Wellue O2Ring S, O2RingS/O2Ring-S/O2Ring, Wellue, Viatom, ViHealth,
+      ViHealth bundle ids, Oz/O2, oxygen, and oximeter sources while allowing
+      the holder to edit the source list.
 - [x] Imported health memory writes a local import record, sample log, JSON
       context, and Form context.
 - [x] Later sends include compact health-memory context in the local Form/RAG
@@ -189,10 +192,11 @@ memory.
 - `swift build --package-path experiments/satsang-mac-app --product SatsangGuidance` passes.
 - `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-guidance-event.fk form-stdlib/tests/satsang-guidance-event-band.fk` returns `255`.
 - `swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone` passes.
+- `swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone --sdk "$(xcrun --sdk iphoneos --show-sdk-path)" --triple arm64-apple-ios17.0` passes.
 - `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-host-boundary.fk form-stdlib/tests/satsang-host-boundary-band.fk` returns `2097151`.
 - `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-cli-router.fk form-stdlib/form-cli-judge.fk form-stdlib/form-cli-sufficiency.fk form-stdlib/satsang-listen-route.fk form-stdlib/tests/satsang-listen-route-band.fk` returns `255`.
 - `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-room-memory.fk form-stdlib/tests/satsang-room-memory-band.fk` returns `255`.
-- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-health-memory.fk form-stdlib/tests/satsang-health-memory-band.fk` returns `255`.
+- `cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-health-memory.fk form-stdlib/tests/satsang-health-memory-band.fk` returns `1023`.
 - Manual validation: launch the app, press Start Listening, allow macOS
   microphone/speech prompts, speak into the room, edit a transcript line, press
   Send, and see a JSON/Form event under
@@ -207,9 +211,10 @@ memory.
 - Manual validation: while Speech Recognition attaches, cycles, or waits through
   silence, confirm the live mic level remains active and the listener does not
   restart the capture stream.
-- Manual validation: on an iPhone with HealthKit data from Oura or an Oz/O2
-  source, open Health mode, press Import, grant Health permission, and confirm
-  local files appear under `~/.coherence-network/health-memory/`.
+- Manual validation: on an iPhone with HealthKit data from Oura Ring 4 and
+  Wellue O2Ring S/ViHealth, open Health mode, press Import, grant Health
+  permission, and confirm local files appear under
+  `~/.coherence-network/health-memory/`.
 
 ## Verification
 
@@ -263,14 +268,16 @@ python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.m
   this PR; real Windows/Android device builds still need to promote each
   declared door to an observed/open runtime receipt.
 - The iPhone target is native SwiftUI source in the shared Swift package. A
-  device-signed archive still needs an Apple team/profile and installed iOS SDK
-  support outside this source patch. iOS cannot spawn arbitrary subprocesses, so
-  the process stdin/stdout resource door is declared as an embedded Form runtime
-  adapter until fkwu is packaged in-process.
-- HealthKit only returns data types and sources the holder grants. Oura can
-  reach this lane through its Apple Health export; Oz/O2 devices reach it when
-  their companion app writes compatible Apple Health samples. Device-specific
-  Bluetooth or vendor-cloud routes require their own consent and protocol work.
+  physical install needs a connected trusted iPhone and an Apple team/profile
+  for signing. iOS cannot spawn arbitrary subprocesses, so the process
+  stdin/stdout resource door is declared as an embedded Form runtime adapter
+  until fkwu is packaged in-process.
+- HealthKit only returns data types and sources the holder grants. Oura Ring 4
+  reaches this lane through the Oura Apple Health integration. Wellue O2Ring S
+  reaches this lane through ViHealth Apple Health sharing when enabled, and
+  remains eligible for a later local export-file import path for CSV/binary
+  reports. Device-specific Bluetooth or vendor-cloud routes require their own
+  consent and protocol work.
 
 ## Known Gaps and Follow-up Tasks
 


### PR DESCRIPTION
## Summary
- promotes Oura Ring 4 and Wellue O2Ring S/ViHealth into explicit iPhone health-memory source profiles
- adds exact-device Form receipt coverage for Oura Ring 4 and Wellue O2Ring S via ViHealth Apple Health
- fixes iOS host-local storage to use the app container and cross-compiles the HealthKit branch against iPhoneOS

## Validation
- swift test --package-path experiments/satsang-mac-app
- swift build --package-path experiments/satsang-mac-app --product SatsangGuidance
- swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone
- swift build --package-path experiments/satsang-mac-app --product SatsangGuidancePhone --sdk $(xcrun --sdk iphoneos --show-sdk-path) --triple arm64-apple-ios17.0
- cd form && ./validate.sh form-stdlib/core.fk form-stdlib/satsang-health-memory.fk form-stdlib/tests/satsang-health-memory-band.fk -> 1023 four-way
- python3 scripts/generate_repo_indexes.py --check
- python3 scripts/validate_spec_quality.py --file specs/satsang-mac-guidance-app.md
- python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-26_oura_wellue_install_path.json
- git diff --check
- make wellness
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict

## Install note
Physical iPhone installation was attempted up to device discovery. xcrun devicectl list devices returned No devices found, so a connected trusted iPhone plus signing profile is still required before installing and validating live HealthKit data. No personal health data is stored in this PR.