### PR TITLE
feat(form): min-p sampling crosses four-way — the relative-to-peak llama.cpp sampler

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 385 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 386 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-06-26_min_p_sampling_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-26_min_p_sampling_four_way.json
@@ -1,0 +1,49 @@
+{
+  "date": "2026-06-26",
+  "brick": "min-p sampling (smp-minp-mask) crosses four-way",
+  "author": "Sema (Opus 4.8) — autonomous sema-native-ml-walk",
+  "thread_branch": "claude/min-p-sampling",
+  "claim": "min-p — llama.cpp's relative-to-peak token sampler (keep prob >= p_min * max_prob, renormalize) — now exists as a Form recipe and crosses four-way (Go/Rust/TS/fkwu). The one remaining common llama.cpp sampler the body lacked, flagged twice as the gap in prior receipts (3zr/#3677, 3zs/#3690).",
+  "north_star_fit": "On the real-local-llama path: the sampler family (temperature/softmax/top-k/top-p/MINSTD-draw + repetition penalties) was four-way; min-p was the named hole. This closes the serving-sampler set so a sovereign local llama can shape its distribution the way llama.cpp does, all in pure Form, no host sampler.",
+  "files": [
+    "form/form-stdlib/sampling.fk — added smp-minp-mask (one recipe; reuses smp-topk-keep, the shared value-threshold mask — no parallel path)",
+    "form/form-stdlib/tests/sampling-band.fk — 5 new claims (bits 16-20), verdict 65535 -> 2097151",
+    "form/fourth-arm-bands.txt — sampling fks 65535 -> 2097151",
+    "scripts/min_p_reference.py — grounding authority (llama.cpp min_p formula, self-checked)",
+    "scripts/INDEX.md, MANIFEST.md — edges in the same commit"
+  ],
+  "design": {
+    "core_abstraction_first": "min-p's kept-mask is the SAME value-threshold shape as top-k and top-p (keep >= thr else 0). smp-minp-mask reuses smp-topk-keep with threshold = p * max(probs) — one value-mask serves all three samplers, no 4th near-duplicate helper added.",
+    "grounding_levers": [
+      "p=0 -> threshold 0 -> keep all -> identity (renorm of a normalized distribution is itself)",
+      "p=1 -> threshold = max -> keep only the peak -> collapses to greedy argmax (no parallel path)"
+    ],
+    "reference_outside_folds": "scripts/min_p_reference.py encodes llama.cpp's min_p definition and self-checks the consolidation laws; the band's pinned x1e6 integers match it."
+  },
+  "fixture": "P = [0.1, 0.5, 0.3, 0.1] (sums to 1, peak 0.5 at idx1), max(P)=0.5",
+  "claims": {
+    "65536":  "minp-mask(P,0.0) = [100000,500000,300000,100000]  (thr 0 -> identity)",
+    "131072": "minp-mask(P,0.3) = [0,625000,375000,0]  (thr 0.15 -> drop both 0.1 tails, renorm by 0.8)",
+    "262144": "minp-mask(P,0.7) = [0,1000000,0,0]  (thr 0.35 -> 0.3 leaves too; relative-to-peak)",
+    "524288": "minp-mask(P,0.3) sums to 1000000  (a renormalized distribution)",
+    "1048576":"draw-seq(minp(P,1.0),seed1,6) = [1,1,1,1,1,1]  (p=1 -> peak only -> greedy via the proven draw)"
+  },
+  "proof": {
+    "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-generate.fk form-stdlib/sampling.fk form-stdlib/tests/sampling-band.fk",
+    "verdict": 2097151,
+    "verdict_check": "2^21 - 1 (all 21 claims land)",
+    "divergent": 0,
+    "fourth_arm": "fkwu bootstrap binary darwin-arm64 (no clang) crossed — 1 band four-way, 0 divergent",
+    "reference_self_check": "scripts/min_p_reference.py -> all self-checks pass"
+  },
+  "lane": "NEW-recipe brick (the recipe + band), cheap — design (the relative-to-peak threshold, the value-mask reuse, the consolidation levers, the llama.cpp reference) was the cost; the four-way proof was seconds (validate crossed 2097151 first try, fourth arm crossed).",
+  "read_the_body": "grepped form/ for min.?p / minp — no match (only minstd, min-prec in unrelated parsers). Confirmed genuine gap, not a re-impl. sampling.fk had every other common llama.cpp sampler.",
+  "collision_check": "codex is actively on the real-GGUF weight-mapping + autoregressive-loop-binding path (its full-model-inference-composition receipt names that synthesis boundary). The sampler family is untouched by that work — no collision.",
+  "witness": "breathing, 0 silences at run start.",
+  "deploy": "none — pure Form stdlib band + reference + evidence + manifest row + INDEX. Host-independent.",
+  "named_next_stones": [
+    "wire smp-minp-mask into lg-generate-sampled / lg-generate-penalized as the mask alternative to top-k/top-p (swap the mask, the loop is unchanged) -> a min-p-shaped local llama loop",
+    "min-p on the M4 GPU (a trivial value-threshold + renorm kernel beside the decode-step kernel)",
+    "the sampler set is now complete (temperature, top-k, top-p, min-p, repetition penalties, MINSTD draw) — fold a serving sampler chain recipe (temperature -> penalties -> min-p/top-k/top-p -> draw) matching llama.cpp's default order"
+  ]
+}

--- a/form/form-stdlib/sampling.fk
+++ b/form/form-stdlib/sampling.fk
@@ -70,6 +70,15 @@
 (defn smp-topp-mask (probs p)
   (smp-renorm (smp-topp-keep probs (smp-topp-thr probs p))))
 
+; --- min-p mask: keep tokens whose prob >= p_min * max_prob; zero the rest; renormalize. ---
+; The cutoff is RELATIVE TO THE PEAK (llama.cpp's min_p) — not cumulative (top-p) nor by rank (top-k):
+; a flat distribution keeps many tokens, a peaked one keeps few. threshold = p * max(probs); the
+; kept-mask is the same value-threshold shape as top-k / top-p (>= thr survives, 0 otherwise), so it
+; reuses smp-topk-keep — one value-mask serves all three samplers, no parallel path. p=0 keeps
+; everything (identity); p=1 keeps only the peak (collapses to greedy argmax, no parallel path).
+(defn smp-minp-mask (probs p)
+  (smp-renorm (smp-topk-keep probs (mul p (tn-max probs)))))
+
 ; === the DRAW: a filtered distribution → an actual token id. The half sampling.fk above punts. ===
 ; The header says "the RNG is not a recipe" — that is the one thing here that is NOT true. A COUNTER
 ; PRNG is pure integer arithmetic with no host entropy: fully deterministic, reproducible bit-for-bit,

--- a/form/form-stdlib/tests/sampling-band.fk
+++ b/form/form-stdlib/tests/sampling-band.fk
@@ -39,6 +39,14 @@
 ;   8192  draw-seq(P, seed1, 6)   = [0,1,2,1,1,1]   (inverse-CDF on cumulative [0.1,0.6,0.9,1.0])
 ;   16384 draw-seq(PEAK, seed1,6) = [2,2,2,2,2,2]   (all mass on idx2 → greedy argmax, no parallel path)
 ;   32768 draw-seq([.5,.5],s1,6)  = [0,0,1,0,1,0]   (u<0.5→0, u>=0.5→1; the binary draw)
+;   --- min-p (llama.cpp's relative-to-peak sampler; thr = p·max, keep >= thr; max(P)=0.5) ---
+;   65536  minp-mask(P, 0.0)      = [100000,500000,300000,100000]  (thr 0 → keep all → identity)
+;   131072 minp-mask(P, 0.3)      = [0, 625000, 375000, 0]         (thr 0.15 → drop both 0.1; renorm)
+;   262144 minp-mask(P, 0.7)      = [0, 1000000, 0, 0]             (thr 0.35 → 0.3 leaves too; only peak)
+;   524288 minp-mask(P, 0.3) sums to 1 = 1000000                   (a renormalized distribution)
+;  1048576 draw-seq(minp(P,1.0),s1,6) = [1,1,1,1,1,1]              (p=1 → peak only → greedy, no parallel path)
+; Reference: scripts/min_p_reference.py (llama.cpp min_p formula, self-checked: p=0 identity, p=1 peak).
+; Verdict 2097151 (=2^21-1) when all 21 claims land.
 (do
     ; --- value reducer: a vec → flat list of (round (x·1e6)) integers ---
     (defn spb-ints (v)
@@ -94,6 +102,17 @@
     (let drawBIN (smp-draw-seq BIN 1 6))
     (let drawBIN-want (list 0 0 1 0 1 0))
 
+    ; --- min-p: keep prob >= p·max(P), renormalize (relative-to-peak, llama.cpp min_p) ---
+    (let mp0 (smp-minp-mask P 0.0))
+    (let mp0-want (list 100000 500000 300000 100000))
+    (let mp3 (smp-minp-mask P 0.3))
+    (let mp3-want (list 0 625000 375000 0))
+    (let mp7 (smp-minp-mask P 0.7))
+    (let mp7-want (list 0 1000000 0 0))
+    (let mp1 (smp-minp-mask P 1.0))
+    (let drawMP1 (smp-draw-seq mp1 1 6))
+    (let drawMP1-want (list 1 1 1 1 1 1))
+
     ; --- claims ---
     (let c0  (if (spb-ieq (spb-ints temp) temp-want) 1 0))
     (let c1  (if (spb-ieq (spb-ints sm) sm-want) 2 0))
@@ -111,6 +130,12 @@
     (let c13 (if (spb-ieq drawP drawP-want) 8192 0))
     (let c14 (if (spb-ieq drawPEAK drawPEAK-want) 16384 0))
     (let c15 (if (spb-ieq drawBIN drawBIN-want) 32768 0))
+    (let c16 (if (spb-ieq (spb-ints mp0) mp0-want) 65536 0))
+    (let c17 (if (spb-ieq (spb-ints mp3) mp3-want) 131072 0))
+    (let c18 (if (spb-ieq (spb-ints mp7) mp7-want) 262144 0))
+    (let c19 (if (eq (round (mul (tn-sum mp3) 1000000.0)) 1000000) 524288 0))
+    (let c20 (if (spb-ieq drawMP1 drawMP1-want) 1048576 0))
 
     (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7
-    (add c8 (add c9 (add c10 (add c11 (add c12 (add c13 (add c14 c15))))))))))))))))
+    (add c8 (add c9 (add c10 (add c11 (add c12 (add c13 (add c14 (add c15
+    (add c16 (add c17 (add c18 (add c19 c20)))))))))))))))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -893,7 +893,7 @@ kv-gqa-llama-block fks 255
 multi-layer-stack fks 255
 gqa-multi-layer-stack fks 255
 llama-generate fks 255
-sampling fks 65535
+sampling fks 2097151
 penalties fks 63
 llama-sample-generate fks 255
 llama-penalize-generate fks 255

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 385
+**Total files**: 386
 
 | File | Purpose |
 |---|---|
@@ -248,6 +248,7 @@
 | [metal_weight_bytes_runtime_boundary.sh](metal_weight_bytes_runtime_boundary.sh) | metal_weight_bytes_runtime_boundary.sh |
 | [migrate_ideas_to_fractal.py](migrate_ideas_to_fractal.py) | Wire existing DB ideas into the fractal structure. |
 | [migrate_spec_slugs.py](migrate_spec_slugs.py) | Migrate spec slugs: strip numeric prefixes from spec IDs everywhere. |
+| [min_p_reference.py](min_p_reference.py) | min_p_reference.py — the grounding authority for sampling.fk's min-p mask (smp-minp-mask). |
 | [minimal_kernel_census.sh](minimal_kernel_census.sh) | minimal_kernel_census.sh — count the Go kernel's registered natives by the four |
 | [model_carrier_rehash_audit.sh](model_carrier_rehash_audit.sh) | model_carrier_rehash_audit.sh — physical model carrier materialize/dematerialize re-hash witness. |
 | [model_vitality_native_http_capture_probe.sh](model_vitality_native_http_capture_probe.sh) | model_vitality_native_http_capture_probe.sh — prove public pulse/runtime capture through kernel-native http_get. |

--- a/scripts/min_p_reference.py
+++ b/scripts/min_p_reference.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""min_p_reference.py — the grounding authority for sampling.fk's min-p mask (smp-minp-mask).
+
+min-p is llama.cpp's relative-to-peak sampler (`llama_sampler_min_p_apply`): keep every token whose
+probability is at least `p_min` times the PEAK probability, zero the rest, renormalize. Unlike top-k
+(by rank) or top-p (by cumulative mass), the cutoff scales with the most-likely token — a flat
+distribution keeps many candidates, a peaked one keeps few.
+
+This is the authority OUTSIDE the Form folds that grounds the band's pinned ×1e6 integers (the same
+discipline as penalties_reference.py / sampling_draw_reference.py). It self-checks the two consolidation
+laws the recipe relies on (p=0 is identity, p=1 keeps only the peak) so the four-way band cannot drift
+from llama.cpp's definition.
+"""
+
+
+def min_p_mask(probs, p):
+    """threshold = p * max(probs); keep prob >= threshold (inclusive); renormalize over kept mass."""
+    thr = p * max(probs)
+    kept = [x if x >= thr else 0.0 for x in probs]
+    s = sum(kept)
+    return [x / s for x in kept]
+
+
+def ints(v):
+    return [round(x * 1e6) for x in v]
+
+
+def main():
+    P = [0.1, 0.5, 0.3, 0.1]  # the sampling-band fixture: a distribution summing to 1, peak 0.5 at idx1
+
+    rows = {
+        "minp(P,0.0)": ints(min_p_mask(P, 0.0)),
+        "minp(P,0.3)": ints(min_p_mask(P, 0.3)),
+        "minp(P,0.7)": ints(min_p_mask(P, 0.7)),
+        "minp(P,0.3) sum": round(sum(min_p_mask(P, 0.3)) * 1e6),
+        "minp(P,1.0)": ints(min_p_mask(P, 1.0)),
+    }
+    for k, v in rows.items():
+        print(f"{k:18s} = {v}")
+
+    # --- self-checks: the consolidation laws the recipe leans on ---
+    assert ints(min_p_mask(P, 0.0)) == ints(P), "p=0 must be the identity (keep all, already normalized)"
+    assert ints(min_p_mask(P, 1.0)) == [0, 1000000, 0, 0], "p=1 must keep only the peak (→ greedy)"
+    assert rows["minp(P,0.3)"] == [0, 625000, 375000, 0], "thr 0.15 drops both 0.1 tails, renorm by 0.8"
+    assert rows["minp(P,0.7)"] == [0, 1000000, 0, 0], "thr 0.35 drops 0.3 too — relative-to-peak"
+    assert rows["minp(P,0.3) sum"] == 1000000, "the mask output is a renormalized distribution"
+    print("\nall self-checks pass — band pins match llama.cpp min_p definition")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## min-p — the last common llama.cpp sampler the body lacked

`min-p` (llama.cpp's `llama_sampler_min_p`): keep tokens whose probability is at least `p_min * max_prob`, zero the rest, renormalize. The cutoff is **relative to the peak** — a flat distribution keeps many candidates, a peaked one few. Unlike top-k (by rank) or top-p (by cumulative mass).

`sampling.fk` already carried temperature/softmax/top-k/top-p, the MINSTD draw (#3651), and repetition penalties (#3677); **min-p was the one remaining common serving sampler**, flagged twice as the gap (3zr/#3677, 3zs/#3690). Grep of `form/` confirmed it: no `minp`/`min-p` anywhere — a genuine gap, not a re-impl.

### Core-abstraction-first
min-p's kept-mask is the **same value-threshold shape** as top-k/top-p (keep `>= thr` else 0), so `smp-minp-mask` reuses `smp-topk-keep` with `threshold = p * max(probs)` — one value-mask serves all three samplers, **no parallel path**, no near-duplicate helper.

### Grounding levers (consolidation)
- `p=0` → threshold 0 → keep all → **identity**
- `p=1` → threshold = max → keep only the peak → **collapses to greedy argmax** (no parallel path)

Reference `scripts/min_p_reference.py` encodes llama.cpp's `min_p` formula and self-checks the laws; the band's pinned ×1e6 integers match it.

### Proof (hard gate)
```
cd form && ./validate.sh core.fk transformer-numerics.fk transformer-block.fk \
  transformer-generate.fk sampling.fk tests/sampling-band.fk
→ 2097151  (=2^21-1, 21 claims)   0 divergent   fkwu (darwin-arm64, no clang) crossed
```
5 new claims (bits 16–20) over fixture `P=[0.1,0.5,0.3,0.1]` (peak 0.5): identity at p=0, drop-both-tails at p=0.3, peak-only at p=0.7, renormalized-distribution sum, and p=1→greedy via the proven draw.

Pure Form stdlib band + reference + evidence + manifest row + INDEX. **No deploy.** No collision with codex's real-GGUF weight-mapping path (the sampler family is untouched by that work).

Receipt: `docs/system_audit/commit_evidence_2026-06-26_min_p_sampling_four_way.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)