### PR TITLE
feat(form): full 2-D matvec four-way as native bytes — the matvec lane is whole

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -121,11 +121,22 @@
 ;     + dequant, computed by the form-asm matvec lane — REPLACING the ollama HTTP seam, at vLLM-class speed
 ;     (the form-asm/Metal emit lane + batching + paged-KV). One engine: the recipe that proves four-way is the
 ;     recipe that lowers to asm bytes; rustc/Go are oracle/walker, never the runtime. lc-cognitive-sovereignty.
-;   GAPS — LLM INFERENCE (ordered; none are new math — forward recipes + dequant + the dot are proven; what
-;   remains is composition + the loop + execution; walked in parallel this session):
+;   GAPS — LLM INFERENCE (ordered; none are new math — forward recipes + dequant + the dot are proven). The
+;   precondition the contract names plainly: the four-way bands prove the architecture at d=4 because the
+;   tree-walkers compute over cons-list f64 and cannot run llama3.2:3b at d=3072 × 28 layers in feasible
+;   time — d=4 is the honest proof scale for the architecture. The REAL run is the native lane: the whole forward
+;   pass lowered to form-asm bytes over ll-buffer, which fkwu executes. The 2-D matvec (A′, the dominant
+;   compute) now runs there; what remains is the rest of the lane, not more recipe composition:
 ;     A. ✓ DONE — form-asm-matvec-loop (127): the matvec ROW as a counted form-asm loop (cmp/b.ge/ldr-d×2/
-;        fmul/fadd/ptr++/cnt++/b-back), four-way, no rustc; every branch byte vs the arm64 oracle. The full
-;        2-D matvec (outer row loop around it, register-shifted addressing for the downward fold) is adjacent.
+;        fmul/fadd/ptr++/cnt++/b-back), four-way, no rustc; every branch byte vs the arm64 oracle.
+;     A′. ✓ DONE — form-asm-matvec-2d (127): the FULL 2-D matvec — fam-matvec, the outer ROW loop around
+;        fam-dot-loop's body, 23 instr / 92 bytes, four-way (Go=Rust=TS=fkwu emit identical bytes); the
+;        arm64 ABI is the matvec signature (x0=W x1=x x2=n x3=m x4=y). Execution witness
+;        scripts/form_asm_matvec_2d_witness.sh: those 92 bytes → form-macho .o → ld -dylib → dlopen+call
+;        run a real m×n y=W·x bit-for-bit (3×2, 1×4, I₄, fp-stress 2×3), no rustc/clang in the compute.
+;        The dominant compute of a transformer forward pass is now sovereign native bytes; the remaining
+;        native-lane rungs are the nonlinear ops (exp/sin/cos/rsqrt for softmax/RoPE/RMSNorm/SwiGLU as asm),
+;        ll-buffer staging of the dequanted tensor set, and the 28-layer fold orchestrated over those.
 ;     B. ✓ DONE — scripts/form_asm_matvec_witness.sh: fam-dot2's form-asm bytes → form-macho .o → ld -dylib →
 ;        dlopen+call → d0 MATCHES bit-exact ([2,3,5,7]→31, edge cases). The bytes proven four-way are the bytes
 ;        that ran. form-macho's wrap is ABI-agnostic; in-kernel float-call later wants a small dylib_call_f64ptr.
@@ -193,11 +204,13 @@
 ;        claiming that full hidden-state logits are already producing answer text.
 ;        ✓ D₁₁ — final-observations wide lane: form-cli now has a native model-convergence /
 ;        final-observations verb that refuses one-gap-at-a-time drift. The remaining production
-;        generation work is one contract: complete tensor payload staging → dequant + accelerator buffer
-;        placement → full multi-layer GQA hidden-state loop → full-vocabulary hidden-state logits → real
-;        token ID decode → ask answer binding. Receipts fail if this wide-lane surface disappears, and
-;        the strict full-real claim gate now carries one blocked requirement instead of five scattered
-;        ones.
+;        generation work is one contract, and it lives in the NATIVE LANE (A′ landed its keystone, the
+;        2-D matvec): the nonlinear ops as form-asm bytes (exp/sin/cos/rsqrt for softmax/RoPE/RMSNorm/
+;        SwiGLU) → ll-buffer staging of the dequanted full tensor set → the full multi-layer GQA
+;        hidden-state loop folded over those buffers → full-vocabulary hidden-state logits → real token
+;        ID decode → ask answer binding. The d=4 four-way bands are the architecture's proof; this lane
+;        is its execution at real width. Receipts fail if the wide-lane surface disappears, and the strict
+;        full-real claim gate carries one blocked requirement until the lane runs llama3.2:3b end to end.
 ;     E. TOKENIZER CARRIERS — vocab + merge-table loaders feeding bpe-tokenizer (proven) for the decode side.
 ;     F. vLLM-CLASS SPEED — the Metal MSL emit lane (proven) + batching + paged-KV + fused dequant-matmul.
 ;   NORTH STAR: a sovereign, on-device, Form-native SPEECH faculty — real audio → transcript (STT), NL → NL

--- a/form/form-stdlib/form-asm-matvec.fk
+++ b/form/form-stdlib/form-asm-matvec.fk
@@ -58,4 +58,46 @@
                                                         (append (fa-b-off -9)
                                                             (fa-ret)))))))))))))))
 
+    ; fam-matvec: the FULL 2-D matvec — the outer ROW loop around fam-dot-loop's body, the rung the
+    ; header named ("A full matvec is rows of this dot … the next rung"). y[i] = sum_j W[i][j]*x[j],
+    ; W row-major m×n contiguous f64. Same upward-counted fold as fam-dot-loop (and bj-dot-fam, its
+    ; tree-walker twin) — so the native result is the recipe's result, bit-for-bit. The arm64 ABI is
+    ; the natural matvec signature, args in x0..x4: x0=W base (advances across ALL elements row-major,
+    ; so after a row it already points at the next row), x1=x base (reset to x7 each row), x2=n cols,
+    ; x3=m rows, x4=y out. No register-indexed addressing, no rustc/clang; one program emits the whole
+    ; matvec. Branch offsets in INSTRUCTIONS (the lo-streq discipline): inner b.ge +9 / b -9 are
+    ; fam-dot-loop's; the new outer offsets are b.ge END +19 and b ROW -19. 23 instructions = 92 bytes.
+    ;   0 add x7,x1,#0 (save x base)  1 movz x5,#0 (i=0)
+    ;   ROW(2): 2 cmp x5,x3   3 b.ge END(+19)   4 add x1,x7,#0 (reset x ptr)
+    ;           5 movz x6,#0 (j=0)   6 movz x8,#0   7 scvtf d0,x8 (acc=0.0)
+    ;   INN(8): 8 cmp x6,x2   9 b.ge INNEND(+9)   10 ldr d1,[x0]   11 ldr d2,[x1]
+    ;           12 fmul d3,d1,d2   13 fadd d0,d0,d3   14 add x0,#8   15 add x1,#8
+    ;           16 add x6,#1   17 b INN(-9)
+    ;   INNEND(18): 18 str d0,[x4] (y[i]=acc)   19 add x4,#8   20 add x5,#1   21 b ROW(-19)
+    ;   END(22): 22 ret
+    (defn fam-matvec ()
+        (append (fa-add-x-imm 7 1 0)
+            (append (fa-movz-x 5 0)
+                (append (fa-cmp-r 5 3)
+                    (append (fa-bcond 10 19)
+                        (append (fa-add-x-imm 1 7 0)
+                            (append (fa-movz-x 6 0)
+                                (append (fa-movz-x 8 0)
+                                    (append (fa-scvtf 0 8)
+                                        (append (fa-cmp-r 6 2)
+                                            (append (fa-bcond 10 9)
+                                                (append (fa-ldr-d 1 0 0)
+                                                    (append (fa-ldr-d 2 1 0)
+                                                        (append (fa-fmul 3 1 2)
+                                                            (append (fa-fadd 0 0 3)
+                                                                (append (fa-add-x-imm 0 0 8)
+                                                                    (append (fa-add-x-imm 1 1 8)
+                                                                        (append (fa-add-x-imm 6 6 1)
+                                                                            (append (fa-b-off -9)
+                                                                                (append (fa-str-d 0 4 0)
+                                                                                    (append (fa-add-x-imm 4 4 8)
+                                                                                        (append (fa-add-x-imm 5 5 1)
+                                                                                            (append (fa-b-off -19)
+                                                                                                (fa-ret))))))))))))))))))))))))
+
     0)

--- a/form/form-stdlib/tests/form-asm-matvec-2d-band.fk
+++ b/form/form-stdlib/tests/form-asm-matvec-2d-band.fk
@@ -1,0 +1,37 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+;
+; form-asm-matvec-2d-band — the FULL 2-D matvec emits four-way as Form→asm bytes, no rustc/clang.
+; fam-matvec is the outer ROW loop around fam-dot-loop's body (the rung form-asm-matvec.fk's header
+; named): 23 arm64 instructions = 92 bytes — save-x-base / row-counter init, then a row loop whose
+; body resets the x pointer, re-inits the accumulator, runs the inner dot loop, stores y[i], and
+; advances. The float body + inner loop control are already proven in form-asm-float / form-asm-matvec
+; / form-asm-matvec-loop; the new ground is the OUTER loop: its branch offsets (b.ge END +19 instr,
+; b ROW -19 instr), the register-copy via add #0 (save/reset the x base, no x-reg mov needed), and the
+; f64 store str d0,[x4]. Four-way = Go/Rust/TS/fkwu emit identical bytes.
+;
+; The pinned 4-byte little-endian oracle words (arm64 encoding, the ones form-asm proves):
+;   b.ge +19   = 5400026a   b -19       = 17ffffed   add x7,x1,#0 = 91000027 (save x base)
+;   add x1,x7,#0=910000e1 (reset x ptr)  str d0,[x4] = fd000080
+;
+; Verdict 127 when every claim lands:
+;   1    the matvec is 23 instructions = 92 bytes     (len == 92)
+;   2    outer b.ge END exit branch (+19 instr)        (fa-conviction == 1)
+;   4    outer b ROW back-edge (-19 instr)             (fa-conviction == 1)
+;   8    save x base: add x7,x1,#0 (reg-copy via add#0)(fa-conviction == 1)
+;   16   reset x ptr: add x1,x7,#0 each row            (fa-conviction == 1)
+;   32   store the row result: str d0,[x4]             (fa-conviction == 1)
+;   64   the WHOLE composed program is byte-exact      (fa-conviction fam-matvec vs the full image)
+(do
+    (let prog (fam-matvec))
+    (let full (list 39 0 0 145 5 0 128 210 191 0 3 107 106 2 0 84 225 0 0 145 6 0 128 210
+                    8 0 128 210 0 1 98 158 223 0 2 107 42 1 0 84 1 0 64 253 34 0 64 253
+                    35 8 98 30 0 40 99 30 0 32 0 145 33 32 0 145 198 4 0 145 247 255 255 23
+                    128 0 0 253 132 32 0 145 165 4 0 145 237 255 255 23 192 3 95 214))
+    (let c0 (if (eq (len prog) 92)                                            1 0))
+    (let c1 (if (eq (fa-conviction (fa-bcond 10 19) (list 106 2 0 84))    1)  2 0))
+    (let c2 (if (eq (fa-conviction (fa-b-off -19) (list 237 255 255 23))  1)  4 0))
+    (let c3 (if (eq (fa-conviction (fa-add-x-imm 7 1 0) (list 39 0 0 145))  1)  8 0))
+    (let c4 (if (eq (fa-conviction (fa-add-x-imm 1 7 0) (list 225 0 0 145)) 1) 16 0))
+    (let c5 (if (eq (fa-conviction (fa-str-d 0 4 0) (list 128 0 0 253))   1) 32 0))
+    (let c6 (if (eq (fa-conviction prog full) 1)                             64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1032,6 +1032,7 @@ gguf-locate fks 127
 gguf-find fks 255
 form-asm-matvec fks 127
 form-asm-matvec-loop fks 127
+form-asm-matvec-2d fks 127
 weight-load fks 4095
 weight-load-q4k fks 4095
 block-join fks 255

--- a/scripts/form_asm_matvec_2d_witness.sh
+++ b/scripts/form_asm_matvec_2d_witness.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# form_asm_matvec_2d_witness.sh — the EXECUTION WITNESS for fam-matvec: the Form-emitted
+# FULL 2-D matvec (the outer row loop, form-asm-matvec-2d-band proves it four-way) doesn't
+# just BYTE-MATCH the arm64 oracle — it actually RUNS a real m×n matvec on this arm64 host.
+#
+# This is the sibling of form_asm_matvec_witness.sh (which witnessed the single fam-dot2 dot).
+# fam-matvec is what every later forward-pass stage needs: y = W·x for a whole weight matrix,
+# one native program, no rustc/clang in the COMPUTE (clang is only the dumb dlopen harness).
+#
+# Path:
+#   1. Form kernel emits fam-matvec's 23-instruction (92-byte) arm64 program, then wraps it
+#      via form-macho's mo-object-sym into a Mach-O .o exporting `_recipe`.
+#   2. `ld -dylib` links + ad-hoc signs the .o into a dlopen-able dylib (the recipe-dylib path).
+#   3. A tiny C harness dlopens it, casts `_recipe` to the matvec ABI
+#         void recipe(const double *W, const double *x, long n, long m, double *y)
+#      (arm64 args land in x0=W x1=x x2=n x3=m x4=y — exactly the recipe's register plan), and
+#      calls it with real row-major W, vector x, output y.
+#   4. Assert every y[i] == sum_j W[i][j]*x[j], bit-for-bit (the recipe folds the SAME upward
+#      order as bj-dot-fam, the tree-walker twin — so == not epsilon-close).
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS witness; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+command -v clang >/dev/null || { echo "need clang for the loader harness; skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/fmatvec2d.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+MATVEC="$FORM/form-stdlib/form-asm-matvec.fk"
+[[ -f "$MATVEC" ]] || { echo "FAIL: form-asm-matvec.fk not found"; exit 1; }
+
+# Form: emit fam-matvec bytes, wrap as a Mach-O .o exporting _recipe (mo-object-sym), hex.
+{ echo "(do"
+  echo '    (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))'
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$MATVEC"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<'DRV'
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code (fam-matvec))
+    (print (str_concat "MVBYTES " (hxb code)))
+    ; _recipe = 95 114 101 99 105 112 101 (the recipe-dylib export name)
+    (print (str_concat "MACHO " (hxb (mo-object-sym code (list 95 114 101 99 105 112 101)))))
+    0)
+DRV
+} > "$work/emit.fk"
+
+out="$(cd "$FORM" && "$GO" "$work/emit.fk" 2>/dev/null)"
+mvbytes="$(echo "$out" | grep '^MVBYTES ' | sed 's/^MVBYTES //')"
+hex="$(echo "$out" | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; cd "$FORM" && "$GO" "$work/emit.fk" 2>&1 | head; exit 1; }
+echo "fam-matvec program: $(( ${#mvbytes} / 2 )) bytes (no rustc/clang in this compute)"
+echo "  arm64 bytes: $mvbytes"
+
+echo "$hex" | xxd -r -p > "$work/recipe.o"
+echo "Form-emitted Mach-O object: $(wc -c < "$work/recipe.o" | tr -d ' ') bytes, $(file "$work/recipe.o" | sed 's/^[^:]*: //')"
+echo "  exported symbol: $(nm "$work/recipe.o" 2>/dev/null | tr -s ' ')"
+
+# ld -dylib links + ad-hoc signs (no clang) — the recipe-dylib path.
+SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$work/recipe.dylib" "$work/recipe.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null \
+   || { echo "FAIL: ld -dylib"; exit 1; }
+echo "ld -dylib + ad-hoc sign: $(codesign -dv "$work/recipe.dylib" 2>&1 | grep -E '^CodeDirectory' | sed 's/ hashes.*//')"
+echo
+
+# The dumb loader: dlopen, cast _recipe to the matvec ABI, call with real m×n W / n-vector x.
+cat > "$work/harness.c" <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+typedef void (*mv_fn)(const double *W, const double *x, long n, long m, double *y);
+static int check(mv_fn mv, const char *name, const double *W, const double *x,
+                 long n, long m, const double *expect) {
+    double *y = calloc(m, sizeof(double));
+    mv(W, x, n, m, y);
+    int ok = 1;
+    for (long i = 0; i < m; i++) if (y[i] != expect[i]) ok = 0;
+    printf("EXEC %-10s m=%ld n=%ld  y=[", name, m, n);
+    for (long i = 0; i < m; i++) printf("%s%.17g", i ? "," : "", y[i]);
+    printf("] expected=[");
+    for (long i = 0; i < m; i++) printf("%s%.17g", i ? "," : "", expect[i]);
+    printf("] %s\n", ok ? "MATCH" : "FAIL");
+    free(y);
+    return ok;
+}
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen fail: %s\n", dlerror()); return 2; }
+    mv_fn mv = (mv_fn)dlsym(h, "recipe");      /* leading _ stripped by dlsym */
+    if (!mv) { fprintf(stderr, "dlsym fail: %s\n", dlerror()); return 3; }
+    int all = 1;
+    /* 3x2: rows dotted with x=[4,0.5] */
+    { double W[] = {2,3, 5,7, 1,1}; double x[] = {4,0.5};
+      double e[] = {2*4+3*0.5, 5*4+7*0.5, 1*4+1*0.5};   /* [9.5,23.5,4.5] */
+      all &= check(mv, "3x2", W, x, 2, 3, e); }
+    /* 1x4: a single wide row (the output-projection shape in miniature) */
+    { double W[] = {1,2,3,4}; double x[] = {1,1,1,1}; double e[] = {10};
+      all &= check(mv, "1x4", W, x, 4, 1, e); }
+    /* 4x4 identity: y must equal x */
+    { double W[] = {1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1};
+      double x[] = {3,-1,2.5,7}; double e[] = {3,-1,2.5,7};
+      all &= check(mv, "I4", W, x, 4, 4, e); }
+    /* 2x3 with negatives + the large/small pair that stresses fp */
+    { double W[] = {1e8,1e-8,0, 0,-2,0.5}; double x[] = {1e-8,1e8,9};
+      double e[] = {1e8*1e-8 + 1e-8*1e8 + 0*9, 0*1e-8 + (-2)*1e8 + 0.5*9};
+      all &= check(mv, "2x3", W, x, 3, 2, e); }
+    dlclose(h);
+    return all ? 0 : 1;
+}
+EOF
+clang -o "$work/harness" "$work/harness.c" || { echo "FAIL: harness build"; exit 1; }
+
+"$work/harness" "$work/recipe.dylib"; rc=$?
+echo
+if [[ "$rc" == "0" ]]; then
+    echo "WITNESS: the Form-emitted 2-D matvec RUNS and MATCHES on $(uname -m)."
+    echo "  fam-matvec's 92 bytes (form-asm, four-way) -> form-macho .o -> ld -dylib -> dlopen+call."
+    echo "  The native y = W·x IS the recipe's result, bit-for-bit. The matvec lane is whole:"
+    echo "  the dominant compute of a transformer forward pass now runs as sovereign native bytes."
+else
+    echo "WITNESS FAILED: a matvec did not match (rc=$rc) — the emitted bytes do not compute y=W·x."
+    exit 1
+fi


### PR DESCRIPTION
## What

`fam-matvec` — the **full 2-D matvec** as Form→asm bytes — crosses four-way (`form-asm-matvec-2d` verdict 127, Go=Rust=TS=fkwu emit identical 92 bytes) and **runs** bit-for-bit on arm64.

This is the outer ROW loop around `fam-dot-loop`'s body: `y = W·x` for a whole weight matrix as one native program. The arm64 ABI is the matvec signature (`x0=W x1=x x2=n x3=m x4=y`); no register-indexed addressing, no rustc, no clang in the compute. Same upward fold as `bj-dot-fam` (its tree-walker twin), so the native result is the recipe's result, bit-for-bit.

## Proof

- **Four-way band**: `form/form-stdlib/tests/form-asm-matvec-2d-band.fk` → 127 (len + new-instruction oracles + full-image conviction); each of the 23 instructions independently verified against the arm64 ISA.
- **Execution witness**: `scripts/form_asm_matvec_2d_witness.sh` — 92 bytes → form-macho `.o` → `ld -dylib` → `dlopen`+call run a real `m×n` `y=W·x` across `3×2`, `1×4`, `I₄`, and an fp-stress `2×3` case. All MATCH.

## Why it matters — the honest reckoning on "full real hidden-state Llama GGUF generation"

That claim has stayed pending because closing it is **not** "wire the proven pieces together." The four-way bands prove the 28-layer GQA architecture at `d=4` because the tree-walkers compute over cons-list f64 and cannot run llama3.2:3b at `d=3072 × 28` layers in feasible time — `d=4` is the honest proof scale. The real run is the **native lane**: the whole forward pass lowered to form-asm over `ll-buffer`, executed by fkwu.

The dominant compute of that lane — the matvec — now runs there. `form-native-models.form` is retuned to name this precondition plainly and record the remaining lane rungs (nonlinear ops as asm: exp/sin/cos/rsqrt; ll-buffer staging of the dequanted tensor set; the 28-layer fold), so the contract reads as **execution-at-width**, not almost-composed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)