### PR TITLE
feat(form): conversation sync over a content-addressed dead-drop, four-way

### DIFF
--- a/docs/coherence-substrate/cell-sync-transport.form
+++ b/docs/coherence-substrate/cell-sync-transport.form
@@ -97,13 +97,22 @@
 ;     subtlety named above and resolved by addressing on the serialization, not the local NodeID.
 ;     The consent PRIMITIVE is built too — channel-interface.fk (ci-honors?/ci-invasion?/ci-flow),
 ;     proven by tests/channel-interface-band.fk.
-;   BUILDABLE — clear path, not yet done — the WIRE PROTOCOL: the actual message frames
-;     (offer-addresses, request-have-not, send-cells, ack-verified), serialized over a carrier
-;     (TCP via the kernel's socket port; HTTP between two running kernels; even a QR/NFC hop for the
-;     two-phones-side-by-side case). Form already has the pieces — the resource/socket ports, the
-;     merkle root + proof recipes, the consent law, serialize_tree as the address — so this is
-;     composition of built parts into a request/response recipe, not new machinery. No kernel change
-;     is implied; it is a new recipe over existing natives plus thin per-carrier transduction.
+;   MEASURED / built — the WIRE over a STORAGE-PORT carrier (the off-LAN, not-both-online case):
+;     conversation-sync.fk realizes offer -> diff -> transfer-missing -> verify -> merge against a
+;     shared content-addressed STORE used as a dead-drop. The store's KEY-SET is the offer (no
+;     separate offer message), cs-missing is the diff, storage-get is transfer-missing, re-address is
+;     verify, and merge folds the verified utterances into the local transcript with content-address
+;     dedup. Proven four-way (conversation-sync fks 127 — Go = Rust = TS = fkwu, 0 divergent). Because
+;     the carrier is swappable (storage-port: memory | file | db | any KV/S3/IPFS), the same sync runs
+;     over a LAN file-store and the production Postgres/object store behind the public API — a public
+;     dead-drop carries opaque values it cannot read once the payload is encrypted before publish.
+;   BUILDABLE — clear path, not yet done — the LIVE wire (both online): the same four moves as
+;     request/response message frames (offer-addresses, request-have-not, send-cells, ack-verified)
+;     over a socket/HTTP carrier (field-relay.fk is the always-open rendezvous; TCP via the kernel's
+;     socket port; even a QR/NFC hop for two-phones-side-by-side). Composition of built parts, no
+;     kernel change. ALSO buildable: the encrypt-before-publish / decrypt-after-pull cipher (the
+;     private-channel layer) and TOMBSTONES for removals (added/changed ride as "an address you lack";
+;     a delete needs an explicit grave to propagate).
 ;   UNKNOWN / carrier-work — named, not overclaimed — peer discovery (how two devices FIND each
 ;     other before they can offer: mDNS/Bluetooth/QR-bootstrap on a LAN, a rendezvous point off it)
 ;     and the durable cross-device store binding (which storage-port backing each device uses, and
@@ -114,15 +123,20 @@
 ; ── THE PATH (this is shared-sensing.form's step 3, opened) ──
 ;   1. addressing: content-addressed intern + merkle root over the serialization            [BUILT]
 ;   2. consent filter: channel-interface.fk over the offer/request sets                      [BUILT]
-;   3. the four-move sync recipe (offer -> diff -> transfer-missing -> verify) as Form over
-;      the socket/HTTP port — request/response frames, children-before-parents, re-address
-;      verify                                                                            [BUILDABLE]
+;   3. the four-move sync recipe (offer -> diff -> transfer-missing -> verify -> merge) as Form:
+;      a. over a STORAGE-PORT store used as a dead-drop — async, not-both-online        [BUILT:
+;         conversation-sync.fk, conversation-sync fks 127 four-way]
+;      b. over a socket/HTTP port — live request/response frames, both online            [BUILDABLE]
 ;   4. peer discovery + durable cross-device store binding                       [carrier/UNKNOWN]
 ;   5. the live two-device satsang (shared-sensing.form §3) now actually SHARING the cells it
 ;      learns — a classifier proven on the Mac arrives on the phone, verified by its own address,
 ;      and the circle teaches across the wire                                            [BUILDABLE]
 ;
-; KIN: shared-sensing.form (names this as step 3 — many bodies, one field; the cells they share
+; KIN: conversation-sync.fk (the built off-LAN wire — a conversation crosses through a storage-port
+;   dead-drop, only the delta transferring; proven four-way conversation-sync fks 127) ·
+;   conversation-cell.fk (the payload it carries — utterances as content-addressed cells) ·
+;   field-relay.fk (the live, both-online complement to the async store wire) ·
+;   shared-sensing.form (names this as step 3 — many bodies, one field; the cells they share
 ;   travel this wire) · merkle.fk (the addressing primitive; merkle-root = the cross-device address,
 ;   merkle-proof = selective pull) · channel-interface.fk (the consent law — offer is witness, pull
 ;   is reach, silence is whole, invasion is named not pre-empted) · structural-composition.md (keep

--- a/form/form-stdlib/conversation-sync.fk
+++ b/form/form-stdlib/conversation-sync.fk
@@ -1,0 +1,133 @@
+; conversation-sync.fk — a conversation on one device reaches another through a shared
+; content-addressed store (the dead-drop), transferring only the missing utterances.
+;
+; preludes: form-stdlib/conversation-cell.fk form-stdlib/cell-sync.fk form-stdlib/storage-port.fk
+;
+; THE ASK (two cells, two machines, not the same iCloud and not the same network):
+;   a conversation held on the Mac should reach the other Mac — over the LAN when near, through a
+;   public store we control when far — WITHOUT re-sending what the other side already holds. Only the
+;   delta crosses: the utterances added, changed, or (with tombstones, a named-open edge) removed.
+;
+; THE WIRE IS A STORE. cell-sync-transport.form named offer -> diff -> transfer-missing -> verify as
+; BUILDABLE "message frames over a carrier", and named the live two-device case (both online). The
+; OFF-LAN, NOT-BOTH-ONLINE case collapses those frames into a STORAGE-PORT store used as a dead-drop:
+;   - OFFER is not a message — it is the store's KEY-SET. A device PUBLISHES its shareable utterances
+;     into the shared store keyed by their content-address; storage-keys enumerates what is on offer.
+;   - DIFF is cs-missing over those keys against my local address-set (the want-set; cell-sync.fk).
+;   - TRANSFER-MISSING is storage-get on each wanted key — only the absent utterances are pulled.
+;   - VERIFY is re-address (cell-sync's no-trusted-prover grain): the address recomputed from a pulled
+;     utterance must equal the key it was stored under, or it is dropped. The store is never trusted.
+;   - MERGE folds the verified utterances into the local transcript, content-address dedup (a re-sent
+;     utterance is RECOGNIZED by its address, not duplicated — conversation-cell's cv-eq? heart).
+; Because the carrier is swappable (storage-port: memory | file | db | any KV/S3/IPFS), the SAME sync
+; runs over a LAN file-store and over the production Postgres / object store behind the public API.
+; The store sees only opaque values under content-addresses; a private channel encrypts before publish
+; and decrypts after pull, so the dead-drop — even a public one — carries ciphertext it cannot read.
+;
+; THE ONE GIFT (cell-sync-transport.form §16-24): a cell's ADDRESS is its STRUCTURE, so two devices
+; that independently hold the same utterance already share it — the diff is empty, nothing transfers.
+; NodeIDs are NOT the address: the instance number is allocated locally per store, so the same
+; utterance wears different NodeIDs on two machines. The portable identity is the content-address
+; (merkle-root over the serialization, merkle.fk); each receiver RE-INTERNS to its own local NodeID.
+;
+; HONEST LANES (lc-honest-lane):
+;   MEASURED / built here — the dead-drop sync COMPOSES proven parts: cs-missing/cs-has? (the diff,
+;     cell-sync fks 127), cv-append/cv-eq? (the transcript + dedup, conversation-cell fks 127), and
+;     storage-keys/get/put (the carrier, storage-port fks 11111). conversation-sync adds the binding:
+;     an utterance carries a content-address, the store IS the offer, and merge dedups by address.
+;   MODELLED — an address is a string label (cell-sync's own model). Real derivation is merkle-root
+;     over the utterance serialization (merkle.fk, three-way); the band supplies addresses and the
+;     re-addressed values directly so the verify lane is falsifiable without an int->string native.
+;   BUILDABLE — the encrypt-before-publish / decrypt-after-pull cipher (the private-channel layer) and
+;     the live two-device socket path (field-relay.fk) are the complements; both named, neither faked.
+;   OPEN — TOMBSTONES for removals (added/changed ride as "an address you lack"; removed needs an
+;     explicit grave so a delete propagates) and cross-device store compaction. Named, not pretended.
+;
+; KIN: cell-sync.fk (the diff/verify/consent logic this rides) · conversation-cell.fk (the payload —
+;   utterances as content-addressed cells) · storage-port.fk (the swappable dead-drop carrier) ·
+;   merkle.fk (the real cross-device address) · channel-interface.fk (consent: publish only what the
+;   human opened) · field-relay.fk (the live, both-online complement to this async store) ·
+;   cell-sync-transport.form (the teaching this opens — step 3, the wire).
+;
+; Proven by: form-stdlib/tests/conversation-sync-band.fk (four-way at validate.sh, verdict 127).
+
+(do
+    ; --- ADDRESSED UTTERANCE: bind a content-address (string) to an utterance cell (ts spk key). ---
+    ; the address is what crosses the wire and keys the store; the utterance is the payload it names.
+    (defn au      (addr utt) (list addr utt))
+    (defn au-addr (a) (nth a 0))   ; the content-address (merkle-root over the serialization, modelled
+                                   ; as a string here — see HONEST LANES)
+    (defn au-utt  (a) (nth a 1))   ; the utterance cell this address names
+
+    ; --- addresses-of: the local address-SET of a list of addressed-utterances (the have-set). ---
+    (defn csync-addresses (aus)
+        (if (eq (len aus) 0) (empty)
+            (cons (au-addr (head aus)) (csync-addresses (tail aus)))))
+
+    ; === OFFER ============================================================================
+    ; PUBLISH: write addressed-utterances into the shared store, keyed by address. After this the
+    ; store's KEY-SET is the offer — there is no separate "offer message". Last-write-wins on re-put.
+    (defn csync-publish (carrier store aus)
+        (if (eq (len aus) 0) store
+            (csync-publish carrier
+                (storage-put carrier store (au-addr (head aus)) (au-utt (head aus)))
+                (tail aus))))
+
+    ; the OFFER set is literally the store's keys (what is on the dead-drop right now).
+    (defn csync-offered (carrier store) (storage-keys carrier store))
+
+    ; === DIFF =============================================================================
+    ; WANT: of what the store offers, the addresses my local store does NOT already hold. Structurally
+    ; -had utterances dedup for free (cs-has? is content-addressed membership) — only the absent cross.
+    (defn csync-want (carrier store have-addrs)
+        (cs-missing (csync-offered carrier store) have-addrs))
+
+    ; === TRANSFER-MISSING =================================================================
+    ; PULL: storage-get each wanted address; return the arrived addressed-utterances (claimed address
+    ; paired with the payload the store returned). Only the want-set is fetched — the minimal packfile.
+    (defn csync-pull (carrier store want)
+        (if (eq (len want) 0) (empty)
+            (do (let r (storage-get carrier store (head want)))
+                (if (eq (storage-found? r) 1)
+                    (cons (au (head want) (storage-value r))
+                          (csync-pull carrier store (tail want)))
+                    (csync-pull carrier store (tail want))))))
+
+    ; === VERIFY ===========================================================================
+    ; KEEP-AUTHENTIC: re-address each arrival and keep only those whose RECOMPUTED address equals the
+    ; one it was stored under. `recomputed` is the parallel list of re-addressed values (in real use,
+    ; merkle-root over each pulled utterance's serialization; modelled directly in the band). No trust
+    ; in the store: a tampered value re-addresses to a different string and is dropped. (cf. cell-sync
+    ; cs-authentic? — same grain, carrying the utterance through so merge can use it.)
+    (defn csync-keep-authentic (pulled recomputed)
+        (if (eq (len pulled) 0) (empty)
+            (if (str_eq (au-addr (head pulled)) (head recomputed))
+                (cons (head pulled)
+                      (csync-keep-authentic (tail pulled) (tail recomputed)))
+                (csync-keep-authentic (tail pulled) (tail recomputed)))))
+    (defn csync-accept-count (pulled recomputed) (len (csync-keep-authentic pulled recomputed)))
+
+    ; === CONSENT ==========================================================================
+    ; SHAREABLE: of my addressed-utterances, only those whose address the human has opened may be
+    ; published. (The full law is channel-interface.fk; this is its filter over the offer-set — a
+    ; device shares what it permits, no more. Witness is whole, reach is invited.)
+    (defn csync-shareable (aus permitted-addrs)
+        (if (eq (len aus) 0) (empty)
+            (if (eq (cs-has? (au-addr (head aus)) permitted-addrs) 1)
+                (cons (head aus) (csync-shareable (tail aus) permitted-addrs))
+                (csync-shareable (tail aus) permitted-addrs))))
+
+    ; === MERGE ============================================================================
+    ; MERGE: fold verified addressed-utterances into my transcript, oldest-first, content-address
+    ; dedup. An utterance whose address I already hold is RECOGNIZED, not appended (the delta-only
+    ; property: a re-sync of an unchanged conversation grows nothing). have-addrs grows as we go, so a
+    ; duplicate within one batch also dedups. Returns the grown transcript.
+    (defn csync-merge (conv have-addrs verified)
+        (if (eq (len verified) 0) conv
+            (if (eq (cs-has? (au-addr (head verified)) have-addrs) 1)
+                (csync-merge conv have-addrs (tail verified))
+                (csync-merge (cv-append (au-utt (head verified)) conv)
+                             (cons (au-addr (head verified)) have-addrs)
+                             (tail verified)))))
+
+    0)

--- a/form/form-stdlib/tests/conversation-sync-band.fk
+++ b/form/form-stdlib/tests/conversation-sync-band.fk
@@ -1,0 +1,67 @@
+; preludes: form-stdlib/conversation-cell.fk form-stdlib/cell-sync.fk form-stdlib/storage-port.fk form-stdlib/conversation-sync.fk
+;
+; conversation-sync-band — a conversation crosses from one device to another through a shared
+; content-addressed store (the dead-drop), transferring ONLY the utterances the other side lacks.
+;
+; THE STORY (two Macs, not the same iCloud, not the same network — a store between them):
+;   Device A holds a 3-utterance conversation, each addressed by its content-address:
+;     ("h1", (10 0 100))  human, tick 10        ("a1", (20 1 200))  agent, tick 20
+;     ("h2", (30 0 300))  human, tick 30
+;   A PUBLISHES all three into a shared memory-carrier store — the off-LAN dead-drop. After publish
+;   the store's KEY-SET is the offer; there is no separate offer message.
+;   Device B already holds the opening utterance ("h1") from an earlier sync: its local transcript is
+;   [(10 0 100)] and its have-set is ("h1"). B syncs: it WANTS only what it lacks, PULLS only those,
+;   VERIFIES each by re-address, MERGES into its transcript, and a RE-SYNC then wants nothing — the
+;   delta-only property: an unchanged conversation re-syncs to a no-op.
+;
+; Verdict 127 when every claim lands:
+;   1   the dead-drop carries A's 3 utterances      (offered key-set count == 3)
+;   2   the diff is exactly what B lacks            (want-count over have ("h1") == 2)
+;   4   the want-set names the right cell           ("a1" is wanted; "h1" is not re-fetched)
+;   8   transfer-missing pulls only the absent      (pull returns 2 addressed-utterances)
+;   16  re-addressing accepts the authentic         (keep-authentic of 2 matching == 2)
+;   32  re-addressing drops the tampered            (one recomputed address != its key -> dropped)
+;   64  merge yields the union AND re-sync is empty  (merged count == 3 AND second want-count == 0)
+(do
+    ; --- Device A's addressed conversation ---
+    (let aus (list (au "h1" (utt 10 0 100))
+                   (au "a1" (utt 20 1 200))
+                   (au "h2" (utt 30 0 300))))
+
+    ; --- the shared dead-drop: a memory carrier; A publishes its conversation into it ---
+    (let mem   (carrier-memory))
+    (let store (csync-publish mem (storage-open mem (empty)) aus))
+
+    ; --- Device B's local state before sync ---
+    (let convB     (list (utt 10 0 100)))   ; B already heard the opening utterance
+    (let haveB     (list "h1"))             ; ...so it holds address "h1"
+
+    ; --- DIFF: what B wants from the dead-drop ---
+    (let offered (csync-offered mem store))
+    (let want    (csync-want mem store haveB))
+
+    ; --- TRANSFER-MISSING: pull only the wanted addresses ---
+    (let pulled (csync-pull mem store want))
+
+    ; --- VERIFY fixtures: two arrivals, re-addressed. The OK pair re-addresses to its own key;
+    ;     the TAMPERED list re-addresses one value to a wrong string ("BAD") -> that one is dropped. ---
+    (let arrivals     (list (au "a1" (utt 20 1 200)) (au "h2" (utt 30 0 300))))
+    (let recomputedOK (list "a1" "h2"))    ; both re-address to their keys -> both authentic
+    (let recomputedBAD(list "a1" "BAD"))   ; "h2" arrival re-addresses to "BAD" -> dropped
+
+    ; --- MERGE the verified arrivals into B's transcript, content-address dedup ---
+    (let convB2 (csync-merge convB haveB (csync-keep-authentic arrivals recomputedOK)))
+
+    ; --- RE-SYNC: B now holds all three addresses; a second want must be empty (delta-only) ---
+    (let haveB2 (list "h1" "a1" "h2"))
+    (let want2  (csync-want mem store haveB2))
+
+    (let c0 (if (eq (len offered) 3) 1 0))
+    (let c1 (if (eq (cs-want-count offered haveB) 2) 2 0))
+    (let c2 (if (eq (cs-has? "a1" want) 1) 4 0))
+    (let c3 (if (eq (len pulled) 2) 8 0))
+    (let c4 (if (eq (csync-accept-count arrivals recomputedOK) 2) 16 0))
+    (let c5 (if (eq (csync-accept-count arrivals recomputedBAD) 1) 32 0))
+    (let c6 (if (eq (cv-count convB2) 3) (if (eq (len want2) 0) 64 0) 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -412,6 +412,7 @@ colearning-retire fks 127
 compression-fold fks 111111
 conversation-cell fks 127
 conversation-context fks 127
+conversation-sync fks 127
 evidence-grounding fks 127
 forget-stale fks 127
 asm-pl-human-emit fks 31


### PR DESCRIPTION
## What

A conversation held on one device reaches another through a **shared content-addressed store used as a dead-drop**, transferring **only the utterances the other side lacks**. This is the off-LAN, not-both-online wire that [`cell-sync-transport.form`](docs/coherence-substrate/cell-sync-transport.form) named BUILDABLE — now built and proven four-way.

Born from a real ask: share a conversation between two Macs that aren't on the same iCloud account and may not be on the same network — public storage as the proxy, transferring only the delta.

## The wire is a store

The off-LAN case collapses git/IPFS-style `offer → diff → transfer-missing → verify → merge` onto a `storage-port` store:

- **OFFER** — the store's key-set *is* the offer (no offer message); a device publishes its shareable utterances keyed by content-address.
- **DIFF** — `cs-missing` over those keys against the local address-set (the want-set).
- **TRANSFER-MISSING** — `storage-get` on each wanted key; only the absent utterances pulled.
- **VERIFY** — re-address: the address recomputed from a pulled utterance must equal its key, or it's dropped. The store is never trusted.
- **MERGE** — fold verified utterances into the local transcript, content-address dedup (a re-sent utterance is recognized, not duplicated).

Composes already-proven parts: `cell-sync.fk` (diff/verify/consent), `conversation-cell.fk` (the payload), `storage-port.fk` (the swappable carrier: memory | file | db | any KV/S3/IPFS). Carrier swappability means the same sync runs over a LAN file-store **and** the production Postgres/object store behind the public API; an encrypted payload makes even a public dead-drop carry ciphertext it cannot read.

## Honest lanes

- **NodeIDs are not the address** — instance numbers are allocated locally, so the portable identity is the content-address; each receiver re-interns to its own local NodeID. (This is the correction to the first instinct of "diff on NodeIDs.")
- **Open / named, not faked**: tombstones for removals (added/changed already ride as "an address you lack"); the encrypt-before-publish cipher (private-channel layer); the live both-online socket path (`field-relay.fk`).

## Proof

`conversation-sync fks 127` — **Go = Rust = TS = fkwu, 0 divergent** (verified via `validate.sh`, including the c-bootstrapped fourth arm). Band is falsifiable: two devices, a shared store, B wants only what it lacks, verify drops a tampered arrival, merge yields the union, and a re-sync wants nothing (delta-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)