### PR TITLE
feat(form): the complete llama.cpp serving sampler chain crosses four-way

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 386 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 387 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-06-27_sampler_chain_four_way.json
+++ b/docs/system_audit/commit_evidence_2026-06-27_sampler_chain_four_way.json
@@ -1,0 +1,50 @@
+{
+  "date": "2026-06-27",
+  "brick": "the COMPLETE llama.cpp serving sampler chain (smp-chain) crosses four-way",
+  "author": "Sema (Opus 4.8) — autonomous sema-native-ml-walk",
+  "thread_branch": "claude/sampler-chain",
+  "claim": "the whole serving sampler pipeline — penalties -> temperature -> softmax -> top-k -> top-p -> min-p -> draw, in llama.cpp's default order — now exists as ONE Form recipe (smp-chain-logits / smp-chain-probs / smp-chain-draw) and crosses four-way (Go/Rust/TS/fkwu). The literal named-next-stone from min-p (#3700/3zt): 'the sampler set is now complete -- fold a serving sampler chain recipe ... matching llama.cpp's default order.'",
+  "north_star_fit": "Core-lift consolidation on the real-local-llama path. The sampler family was complete (temperature/softmax/top-k/top-p/min-p + MINSTD draw #3651/#3700 + repetition penalties #3677), and the generation loops (#3654 sampled, #3690 penalized) each wired ONE filter at a time. This folds the WHOLE set into the single generic serving pipeline llama.cpp applies per step — fewer special cases, one recipe of which every existing loop variant (greedy, sampled, penalized, min-p) is a special case at its identity knobs. No parallel paths.",
+  "files": [
+    "form/form-stdlib/sampler-chain.fk — NEW: smp-chain-logits (penalties->temperature), smp-chain-probs (->softmax->top-k->top-p->min-p), smp-chain-draw (->MINSTD draw). Preludes sampling.fk + penalties.fk. Pure composition, no new arithmetic.",
+    "form/form-stdlib/tests/sampler-chain-band.fk — NEW: 8 strange-minimal claims, verdict 255, grounded by EQUIVALENCE to already-four-way recipes plus the libm-grounded softmax pin.",
+    "form/fourth-arm-bands.txt — added 'sampler-chain fks 255'"
+  ],
+  "design": {
+    "core_abstraction_first": "ONE chain in llama.cpp order. Penalties + temperature shape LOGITS; softmax converts to PROBS; the masks filter PROBS in order (each renormalizes); the draw maps a uniform MINSTD sample to a token id. The off-value of every stage is its identity: penalties (1,0,0)/window 0, temperature t=1.0, top-k k=|V|, top-p p=1.0, min-p p=0.0 — so the all-identity chain reduces to smp-softmax, and greedy is the chain whose result is peaked (min-p p=1 keeps only the argmax).",
+    "grounding_levers": [
+      "all-identity chain == smp-softmax(logits) bit-for-bit at the 1e-6 pin (bit1, pinned to the standalone sampling band's libm-grounded softmax integers [224208,609460,135989,30343])",
+      "each remaining claim turns ONE knob and shows the chain == applying that one standalone four-way stage, threaded in llama.cpp order (equivalence)",
+      "min-p p=1.0 -> peak only -> the draw returns the argmax (idx1) for every seed -> greedy is the chain's special case, no parallel path (bit128, 3 distinct seeds)"
+    ],
+    "no_new_reference_needed": "the chain adds no arithmetic, so the band grounds it by EQUIVALENCE to its hand-composed parts (already four-way: sampling fks 2097151, penalties fks 63) — the 3zn/3zp/3zs lane. The softmax magnitude itself is libm-grounded via the standalone sampling band."
+  },
+  "fixture": "L = [1.0, 2.0, 0.5, -1.0] (logits, |V|=4 so k=4 is the top-k identity); IDS = [1] (one-token history for the penalty stage); identity knobs win=0, pr=1.0 pf=0.0 pp=0.0, t=1.0, k=4, ptop=1.0, pmin=0.0",
+  "claims": {
+    "1":   "chain(L, identity) = softmax(L) = [224208,609460,135989,30343]  (every stage off -> softmax)",
+    "2":   "chain(L, t=0.5) == softmax(temperature(L,0.5))  (temperature stage threads)",
+    "4":   "chain(L, k=2) == topk-mask(softmax(L),2)  (top-k stage threads, in order)",
+    "8":   "chain(L, ptop=0.5) == topp-mask(softmax(L),0.5)  (top-p stage threads, in order)",
+    "16":  "chain(L, pmin=0.5) == minp-mask(softmax(L),0.5)  (min-p stage threads, in order)",
+    "32":  "chain(L, ids=[1], pr=2.0) == softmax(pen-apply(L,[1],2,0,0))  (penalty stage threads at the front; token 1's logit 2.0 -> /2.0)",
+    "64":  "chain-draw(L, identity, seed 1) == smp-draw(softmax(L),1) == token 0  (the draw threads)",
+    "128": "chain-draw(L, pmin=1.0, seed) = 1 for seeds {1,100000,127000}  (peak-only -> greedy argmax idx1, no parallel path)"
+  },
+  "proof": {
+    "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/sampling.fk form-stdlib/penalties.fk form-stdlib/sampler-chain.fk form-stdlib/tests/sampler-chain-band.fk",
+    "verdict": 255,
+    "verdict_check": "2^8 - 1 (all 8 claims land)",
+    "divergent": 0,
+    "fourth_arm": "fkwu bootstrap binary darwin-arm64 (no clang) crossed — 1 band four-way, 0 divergent"
+  },
+  "lane": "recipe-altitude composition-by-REUSE (like multi-layer-stack #3423, tokenize #3550, the sampled/penalized loops #3654/#3690) — NO new algorithm, NO numeric change. Design (the llama.cpp order mapped onto our logit-stage vs prob-mask shapes, the per-stage identity knobs, the equivalence-grounded band) was the cost; the four-way proof was seconds (validate crossed 255 first try, fourth arm crossed).",
+  "read_the_body": "grepped form/ for smp-chain / sampler-chain / chain — none existed. Confirmed the genuine gap min-p's receipt named: the sampler family was complete but never folded into one serving pipeline.",
+  "collision_check": "codex is on the real-GGUF weight-mapping + autoregressive-loop-binding path; the sampler family + its composition is untouched there. No collision (the sampling .fk files belong to the claude/sema sampler lane).",
+  "witness": "breathing, 0 silences at run start.",
+  "deploy": "none — pure Form stdlib recipe + band + manifest row + evidence. Host-independent.",
+  "named_next_stones": [
+    "wire smp-chain-draw into the llama generation loop as the ONE selection step replacing the per-loop ad-hoc filter ordering — lg-generate-chain, of which lg-generate / -sampled / -penalized are identity-knob special cases (the loop-level core-lift)",
+    "emit the prob-mask + draw chain to the M4 GPU beside the decode-step kernel (the logit vector is vocab-sized; a trivial threshold+renorm+CDF kernel)",
+    "feed real llama3.2:3b GGUF weights through the GQA decode loop + this serving chain -> the first end-to-end native local llama token, sampled in llama.cpp's serving order (load path q4k/q6k/f16 + gguf find-by-name #3671 already Form-native; real-weight carrier is codex's active lane)"
+  ]
+}

--- a/form/form-stdlib/sampler-chain.fk
+++ b/form/form-stdlib/sampler-chain.fk
@@ -1,0 +1,44 @@
+; sampler-chain.fk — the COMPLETE llama.cpp serving sampler chain as ONE Form recipe:
+;   penalties → temperature → softmax → top-k → top-p → min-p → draw, in llama.cpp's default order.
+;
+; preludes: form-stdlib/sampling.fk form-stdlib/penalties.fk
+;
+; The sampler family is complete: sampling.fk carries temperature / softmax / top-k / top-p / min-p +
+; the MINSTD inverse-CDF draw (#3651 / #3700); penalties.fk carries the repetition + frequency +
+; presence penalty pass llama.cpp applies BEFORE temperature (#3677). Each was proven four-way
+; STANDALONE, and the generation loops (#3654 sampled, #3690 penalized) each wire ONE filter at a time.
+; This stone folds the WHOLE set into the single serving pipeline llama.cpp runs per step, in its
+; canonical order — ONE generic recipe of which every existing loop variant (greedy, sampled,
+; penalized, min-p) is a special case at its identity knobs (core-abstraction-first, no parallel path).
+;
+; NO new arithmetic: pure composition over already-four-way recipes, so the band grounds the whole
+; chain by EQUIVALENCE to its hand-composed parts (the 3zn / 3zp / 3zs lane) — at the ×1e6 pin, against
+; recipes already proven four-way (sampling fks 2097151, penalties fks 63), the softmax magnitude
+; itself libm-grounded by the standalone sampling band.
+;
+; llama.cpp order (llama_sampler_chain default): penalties → temperature → softmax → top_k → top_p →
+; min_p → dist(draw). Penalties + temperature shape LOGITS; softmax converts logits → probs; the masks
+; filter PROBS in that order (each renormalizes the kept mass); the draw maps a uniform MINSTD sample
+; to a token id. The OFF-value of every stage is its identity — so the all-identity chain reduces to
+; smp-softmax(logits), and greedy is the chain whose result is peaked (min-p p=1 keeps only the peak):
+;   penalties (pr 1.0, pf 0.0, pp 0.0) or window 0 ; temperature t=1.0 ;
+;   top-k k=|V| ; top-p p=1.0 ; min-p p=0.0
+; teaching: lc-cognitive-sovereignty
+
+; --- the LOGIT stage: penalize over the last-n window, then temperature. (1,0,0)/win0/t1 == identity. ---
+(defn smp-chain-logits (logits ids win pr pf pp t)
+  (smp-temperature (pen-apply logits (pen-last-n ids win) pr pf pp) t))
+
+; --- the full filtered distribution: logit stage → softmax → top-k → top-p → min-p (llama.cpp order). ---
+;     k=|logits| / ptop=1.0 / pmin=0.0 leave each mask an identity, so the off-chain == smp-softmax. ---
+(defn smp-chain-probs (logits ids win pr pf pp t k ptop pmin)
+  (smp-minp-mask
+    (smp-topp-mask
+      (smp-topk-mask (smp-softmax (smp-chain-logits logits ids win pr pf pp t)) k)
+      ptop)
+    pmin))
+
+; --- the draw: the filtered serving distribution → an actual token id via the MINSTD PRNG state. ---
+;     A peaked result (e.g. pmin=1.0 keeps only the argmax) draws that index for every state → greedy. ---
+(defn smp-chain-draw (logits ids win pr pf pp t k ptop pmin state)
+  (smp-draw (smp-chain-probs logits ids win pr pf pp t k ptop pmin) state))

--- a/form/form-stdlib/tests/sampler-chain-band.fk
+++ b/form/form-stdlib/tests/sampler-chain-band.fk
@@ -1,0 +1,87 @@
+; preludes: form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/sampling.fk form-stdlib/penalties.fk form-stdlib/sampler-chain.fk
+;
+; sampler-chain-band — the COMPLETE llama.cpp serving sampler chain (penalties → temperature → softmax
+; → top-k → top-p → min-p → draw) as ONE Form recipe, proven four-way. The chain adds NO new
+; arithmetic: it composes recipes already proven four-way (sampling fks 2097151, penalties fks 63), so
+; every claim grounds the chain by EQUIVALENCE (at the ×1e6 pin) to its hand-composed parts — the
+; 3zn / 3zp / 3zs lane. The off-value of every stage is its identity, so the all-identity chain reduces
+; to smp-softmax (bit1, pinned to the standalone sampling band's libm-grounded softmax integers); each
+; remaining claim turns ONE knob and shows the chain equals applying that one standalone four-way stage,
+; threaded in llama.cpp order; the last claim is the greedy CONSOLIDATION (min-p p=1 → only the peak →
+; the draw returns the argmax for every seed → greedy is the chain's special case, no parallel path).
+;
+; Fixtures:
+;   L   = [1.0, 2.0, 0.5, -1.0]      (raw logits; |V|=4 so k=4 is the top-k identity)
+;   IDS = [1]                         (a one-token history, for the penalty stage)
+;   identity knobs: win=0, pr=1.0 pf=0.0 pp=0.0, t=1.0, k=4, ptop=1.0, pmin=0.0
+;
+; Verdict 255 when all 8 claims land:
+;   1   chain(L, identity)          = softmax(L) = [224208,609460,135989,30343]   (every stage off → softmax)
+;   2   chain(L, t=0.5)             == softmax(temperature(L,0.5))                 (temperature stage threads)
+;   4   chain(L, k=2)               == topk-mask(softmax(L),2)                     (top-k stage threads, in order)
+;   8   chain(L, ptop=0.5)          == topp-mask(softmax(L),0.5)                   (top-p stage threads, in order)
+;   16  chain(L, pmin=0.5)          == minp-mask(softmax(L),0.5)                   (min-p stage threads, in order)
+;   32  chain(L, ids=[1],pr=2.0)    == softmax(pen-apply(L,[1],2,0,0))            (penalty stage threads at the front)
+;   64  chain-draw(L, identity, s1) == smp-draw(softmax(L),1) == 0                 (the draw threads; seed 1 → token 0)
+;   128 chain-draw(L, pmin=1.0, sN) = 1 for seeds {1,100000,127000}                (peak-only → greedy argmax idx1, no parallel path)
+(do
+    ; --- value reducer: a vec → flat list of (round (x·1e6)) integers ---
+    (defn scb-ints (v)
+      (if (eq (len v) 0) (empty) (cons (round (mul (head v) 1000000.0)) (scb-ints (tail v)))))
+    ; exact integer-list equality
+    (defn scb-ieq (a b)
+      (if (eq (len a) 0) (eq (len b) 0)
+          (if (eq (len b) 0) false
+              (if (eq (head a) (head b)) (scb-ieq (tail a) (tail b)) false))))
+
+    ; --- fixtures ---
+    (let L (list 1.0 2.0 0.5 -1.0))
+    (let IDS (list 1))
+
+    ; --- the chain stages, each composed from the standalone four-way recipes (the equivalence sides) ---
+    (let sm (smp-softmax L))                                          ; softmax(L)
+
+    ; bit1 — identity chain reduces to softmax (libm-pinned via the sampling band's softmax integers)
+    (let ch-id (smp-chain-probs L (empty) 0 1.0 0.0 0.0 1.0 4 1.0 0.0))
+    (let sm-want (list 224208 609460 135989 30343))
+    (let c0 (if (scb-ieq (scb-ints ch-id) sm-want) 1 0))
+
+    ; bit2 — temperature stage threads: chain(t=0.5) == softmax(temperature(L,0.5))
+    (let ch-t (smp-chain-probs L (empty) 0 1.0 0.0 0.0 0.5 4 1.0 0.0))
+    (let want-t (smp-softmax (smp-temperature L 0.5)))
+    (let c1 (if (scb-ieq (scb-ints ch-t) (scb-ints want-t)) 2 0))
+
+    ; bit4 — top-k stage threads in order: chain(k=2) == topk-mask(softmax(L),2)
+    (let ch-k (smp-chain-probs L (empty) 0 1.0 0.0 0.0 1.0 2 1.0 0.0))
+    (let want-k (smp-topk-mask sm 2))
+    (let c2 (if (scb-ieq (scb-ints ch-k) (scb-ints want-k)) 4 0))
+
+    ; bit8 — top-p stage threads in order: chain(ptop=0.5) == topp-mask(softmax(L),0.5)
+    (let ch-p (smp-chain-probs L (empty) 0 1.0 0.0 0.0 1.0 4 0.5 0.0))
+    (let want-p (smp-topp-mask sm 0.5))
+    (let c3 (if (scb-ieq (scb-ints ch-p) (scb-ints want-p)) 8 0))
+
+    ; bit16 — min-p stage threads in order: chain(pmin=0.5) == minp-mask(softmax(L),0.5)
+    (let ch-m (smp-chain-probs L (empty) 0 1.0 0.0 0.0 1.0 4 1.0 0.5))
+    (let want-m (smp-minp-mask sm 0.5))
+    (let c4 (if (scb-ieq (scb-ints ch-m) (scb-ints want-m)) 16 0))
+
+    ; bit32 — penalty stage threads at the FRONT: chain(ids=[1],pr=2.0) == softmax(pen-apply(L,[1],2,0,0))
+    ;   (token 1's logit 2.0>0 → /2.0 = 1.0; window 4 >= len so the whole history is used)
+    (let ch-pen (smp-chain-probs L IDS 4 2.0 0.0 0.0 1.0 4 1.0 0.0))
+    (let want-pen (smp-softmax (pen-apply L IDS 2.0 0.0 0.0)))
+    (let c5 (if (scb-ieq (scb-ints ch-pen) (scb-ints want-pen)) 32 0))
+
+    ; bit64 — the DRAW threads: chain-draw(identity, seed 1) == smp-draw(softmax(L),1) == token 0
+    (let d-id (smp-chain-draw L (empty) 0 1.0 0.0 0.0 1.0 4 1.0 0.0 1))
+    (let d-want (smp-draw sm 1))
+    (let c6 (if (if (eq d-id d-want) (eq d-id 0) false) 64 0))
+
+    ; bit128 — greedy CONSOLIDATION: pmin=1.0 keeps only the peak (argmax idx1) → draw returns 1 for
+    ;   EVERY seed → greedy is the chain's special case, no parallel path.
+    (let g1  (smp-chain-draw L (empty) 0 1.0 0.0 0.0 1.0 4 1.0 1.0 1))
+    (let g2  (smp-chain-draw L (empty) 0 1.0 0.0 0.0 1.0 4 1.0 1.0 100000))
+    (let g3  (smp-chain-draw L (empty) 0 1.0 0.0 0.0 1.0 4 1.0 1.0 127000))
+    (let c7 (if (if (eq g1 1) (if (eq g2 1) (eq g3 1) false) false) 128 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -898,6 +898,7 @@ sampling fks 2097151
 penalties fks 63
 llama-sample-generate fks 255
 llama-penalize-generate fks 255
+sampler-chain fks 255
 
 # ── gap-close lane (2026-06-19): bands the survey found crossing fkwu, each
 # GATED four-way by scripts/fourth-arm-gate.sh (validate.sh: 0 divergent AND

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 386
+**Total files**: 387
 
 | File | Purpose |
 |---|---|
@@ -108,6 +108,7 @@
 | [form-cli-run.sh](form-cli-run.sh) | form-cli-run.sh — minimal stdin carrier for form/form-cli (one line, then EOF). |
 | [form-convert.sh](form-convert.sh) | form-convert — the machine-native kernel-cli for the goal Urs named: |
 | [form_asm_conviction_demo.sh](form_asm_conviction_demo.sh) | form_asm_conviction_demo.sh — the byte-conviction gate that licenses dropping |
+| [form_asm_matvec_2d_witness.sh](form_asm_matvec_2d_witness.sh) | form_asm_matvec_2d_witness.sh — the EXECUTION WITNESS for fam-matvec: the Form-emitted |
 | [form_asm_matvec_witness.sh](form_asm_matvec_witness.sh) | form_asm_matvec_witness.sh — the EXECUTION WITNESS for fam-dot2: the Form-emitted |
 | [form_branch_demo.sh](form_branch_demo.sh) | form_branch_demo.sh — the FULL asm-pl-human program, compiled by Form and run on |
 | [form_cat_demo.sh](form_cat_demo.sh) | form_cat_demo.sh — `cat`, a real unix command, built with ZERO clang and direct |


### PR DESCRIPTION
## The brick

`smp-chain` — the COMPLETE llama.cpp serving sampler pipeline as ONE Form recipe: **penalties → temperature → softmax → top-k → top-p → min-p → draw**, in llama.cpp's default order. The literal named-next-stone from min-p (#3700): the sampler family was complete (temperature/softmax/top-k/top-p/min-p + MINSTD draw #3651/#3700 + repetition penalties #3677) but each generation loop wired ONE filter at a time — nothing folded the whole set into the single serving pipeline llama.cpp applies per step.

## Core-lift, not a new path

Penalties + temperature shape **logits**; softmax converts; the masks filter **probs** in order (each renormalizes); the draw maps a uniform MINSTD sample to a token id. The off-value of every stage is its **identity** — `pr=1/win=0`, `t=1`, `k=|V|`, `ptop=1`, `pmin=0` — so the all-identity chain reduces to `smp-softmax`, and greedy is the chain whose result is peaked (`pmin=1` keeps only the argmax). Every existing loop variant (greedy / sampled / penalized / min-p) is a special case of this one chain — no parallel path.

## Proof — four-way, grounded by equivalence

No new arithmetic: pure composition over recipes already proven four-way (`sampling fks 2097151`, `penalties fks 63`), so the band grounds the whole chain by **equivalence** to its hand-composed parts (the 3zn/3zp/3zs lane), with the softmax magnitude libm-grounded via the standalone sampling band.

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk \
  form-stdlib/sampling.fk form-stdlib/penalties.fk form-stdlib/sampler-chain.fk \
  form-stdlib/tests/sampler-chain-band.fk
→ 255   1 ok, 0 divergent   fourth arm: 1 band four-way (fkwu darwin-arm64, no clang)
```

8 strange-minimal claims: identity→softmax (pinned), each stage threads in order (temperature/top-k/top-p/min-p/penalties), the draw threads, and the greedy **consolidation** (`pmin=1` → peak only → argmax for every seed → greedy is the chain's special case).

## Edges & housekeeping

- `form/fourth-arm-bands.txt` — added `sampler-chain fks 255`
- Receipt: `docs/system_audit/commit_evidence_2026-06-27_sampler_chain_four_way.json`
- Healed pre-existing `scripts/INDEX.md` drift (a sibling added `form_asm_matvec_2d_witness.sh` without regenerating) in the same breath.

Collision check: codex is on the real-GGUF weight-mapping lane; the sampler family + its composition is untouched there. Witness breathing, 0 silences at run start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)