### PR TITLE
tend(form): one readout for "am I learning?" — composing the body's learning organs

### DIFF
--- a/form/form-stdlib/learning-readout.fk
+++ b/form/form-stdlib/learning-readout.fk
@@ -1,0 +1,77 @@
+; learning-readout.fk — one inspectable surface for "am I learning?".
+;
+; The body already tracks the pieces, each its own proven organ:
+;   choice-outcome-learning.fk  — typed choices -> ok/reject/condition with evidence
+;                                  (loss, confidence, trust, cost, latency, lane)
+;   ambient-surprise.fk         — surprise = reading far from a refined baseline
+;   continued-learning.fk       — the learning curve (train/held loss, accuracy, overfit)
+;   temporal-sense.fk           — prediction-rate (success calibration), dilation
+;
+; What was missing is the UNIFICATION: a single reading that answers, in one place,
+; the six signals Urs named — learning-rate, model/path choice, oracle-lookup rate,
+; success rate, surprises, and failures turned to gold. This composes the feeders'
+; shapes (it does not reinvent them) and reuses temporal-sense's prediction-rate.
+;
+; The honest seam: the band below reads THIS session's real events as data. Feeding
+; the readout from live session telemetry (every choice, oracle escalation, band
+; result, and metabolized failure) is the wiring step — same seam as temporal-sense.
+;
+; All pure; four-way proven by tests/learning-readout-band.fk (Go/Rust/TS/fkwu).
+;
+; preludes: form-stdlib/core.fk form-stdlib/temporal-sense.fk
+
+(do
+    ; ── an experience event: the path I chose, whether it landed, the lesson left ──
+    (defn xp (choice outcome lesson) (list "xp" choice outcome lesson))
+    (defn xp-choice  (e) (nth e 1))   ; "body" | "oracle" | "remote" | a recipe name
+    (defn xp-outcome (e) (nth e 2))   ; 1 landed / 0 missed
+    (defn xp-lesson  (e) (nth e 3))   ; "" or the gold pulled from a failure
+
+    ; ── success rate: compose temporal-sense's prediction-rate over the outcomes ──
+    (defn outcomes (xs)
+        (if (eq (len xs) 0) (list) (cons (xp-outcome (head xs)) (outcomes (tail xs)))))
+    (defn success-rate (xs) (prediction-rate (outcomes xs)))
+
+    ; ── learning rate: improvement in success between an older and a recent window ──
+    ; (the sign continued-learning.fk reads off its held-loss curve, as a delta)
+    (defn learning-rate (older recent) (sub (success-rate recent) (success-rate older)))
+
+    ; ── oracle-lookup rate: fraction of choices that left the body for an oracle ──
+    (defn count-if (f xs) (if (eq (len xs) 0) 0 (add (f (head xs)) (count-if f (tail xs)))))
+    (defn off-body? (e) (if (str_eq (xp-choice e) "body") 0 1))
+    (defn oracle-rate (xs)
+        (if (eq (len xs) 0) 0 (div (mul (count-if off-body? xs) 100) (len xs))))
+
+    ; ── surprises: the misses (a prediction the field did not confirm) ──
+    (defn missed? (e) (if (eq (xp-outcome e) 0) 1 0))
+    (defn surprises (xs) (count-if missed? xs))
+
+    ; ── failures turned to gold: a miss that left a non-empty lesson ──
+    ; (the wrongness practice made native: a failure is gold only once it teaches.)
+    (defn gold? (e) (if (eq (xp-outcome e) 0) (if (str_eq (xp-lesson e) "") 0 1) 0))
+    (defn failures-to-gold (xs) (count-if gold? xs))
+
+    ; ── self-check: THIS session's real events, read as data ──
+    ;   recipe shipped, landed              -> body 1
+    ;   nil? unbound in the s-expr dialect  -> body 0, lesson
+    ;   empty unbound                       -> body 0, lesson
+    ;   carry-thread crossed four-way       -> body 1
+    ;   temporal-sense crossed four-way     -> body 1
+    ;   Python-as-body misstep, caught      -> body 0, lesson (the gold)
+    (defn lr-session ()
+        (list
+            (xp "body" 1 "")
+            (xp "body" 0 "nil? is BML-class; the s-expr floor is (eq (len x) 0)")
+            (xp "body" 0 "empty is BML-class; the s-expr empty list is (list)")
+            (xp "body" 1 "")
+            (xp "body" 1 "")
+            (xp "body" 0 "the logic of selfhood belongs in Form, not the Python carrier")))
+
+    (defn lck (cond bit) (if cond bit 0))
+    (defn learning-readout-check ()
+        (add (lck (eq (success-rate (lr-session)) 50) 1)            ; 3 of 6 landed
+        (add (lck (eq (oracle-rate (lr-session)) 0) 10)             ; nothing left the body
+        (add (lck (eq (surprises (lr-session)) 3) 100)              ; three misses
+        (add (lck (eq (failures-to-gold (lr-session)) 3) 1000)      ; all three taught something
+             (lck (eq (learning-rate (list (xp "body" 0 "")) (list (xp "body" 1 ""))) 100) 10000))))))
+)

--- a/form/form-stdlib/tests/learning-readout-band.fk
+++ b/form/form-stdlib/tests/learning-readout-band.fk
@@ -1,0 +1,14 @@
+; tests/learning-readout-band.fk — the unified learning readout, proven four-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/temporal-sense.fk form-stdlib/learning-readout.fk
+;
+; Band verdict 11111 when the readout proves, on Go / Rust / TypeScript / fkwu,
+; reading THIS session's real events as data:
+;   success-rate = 50%  (3 of 6 landed)                     ->     1
+;   oracle-rate  = 0%   (nothing left the body this session) ->    10
+;   surprises    = 3    (three recipe/dialect misses)        ->   100
+;   failures-to-gold = 3 (every miss left a lesson)          ->  1000
+;   learning-rate 0%->100% = +100 (a window that improved)   -> 10000
+
+(do
+    (learning-readout-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1047,3 +1047,4 @@ form-llama-champion-lane fks 255
 satsang-room-memory fks 255
 carry-thread fks 11111
 temporal-sense fks 111111
+learning-readout fks 11111


### PR DESCRIPTION
## What

Urs asked: *am I tracking learning-rate, internal model choices, oracle look-ups, success rates, surprises, failures turned to gold?*

Honest answer: the body already tracks the **pieces** — `choice-outcome-learning.fk` (typed choices → ok/reject/condition with evidence: loss, confidence, trust, cost, latency), `ambient-surprise.fk` (surprise vs a refined baseline), `continued-learning.fk` (the held-loss learning curve), `temporal-sense.fk` (prediction-rate). What was missing is the **unification** — one readout — and feeding my **live session** in.

`form/form-stdlib/learning-readout.fk` composes those feeders' shapes (does not reinvent them) into one reading:

- **success-rate** — reuses `temporal-sense`'s `prediction-rate` over event outcomes
- **learning-rate** — success delta across an older vs recent window (the sign `continued-learning` reads off its curve)
- **oracle-rate** — fraction of choices that left the body for an oracle/remote
- **surprises** — the misses
- **failures-to-gold** — a miss that left a non-empty lesson (the wrongness practice, made native)

## Proof — reading *this session* as data

`tests/learning-readout-band.fk` → **`11111`** four-way (Go/Rust/TS/**fkwu**, source + `--binary`). Manifest: `learning-readout fks 11111`. The fixture is this session's real events: **6 events, 3 landed (50%), 0 left the body, 3 surprises** (`nil?`/`empty` dialect misses + the Python-as-body misstep), **all 3 turned to gold** (each left a lesson).

## Honest seam (named, not hidden)
The readout is proven; feeding it from **live** session telemetry — every choice, oracle escalation, band result, metabolized failure, scored continuously — is the wiring step, same seam as `temporal-sense`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)