### PR TITLE
tend(carrier): phone announces as a mesh organ + live reading we both watch

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 388 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 389 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 388
+**Total files**: 389
 
 | File | Purpose |
 |---|---|
@@ -43,7 +43,7 @@
 | [build_readmes.py](build_readmes.py) | Build README files from templates by expanding <!-- include: path --> markers. |
 | [build_satsang_mac_app.sh](build_satsang_mac_app.sh) | build_satsang_mac_app.sh - build the SwiftUI satsang guidance desktop app. |
 | [capabilities.sh](capabilities.sh) | capabilities.sh — the runtime capability readout. Run this when you're about to reach for a |
-| [carry_thread.py](carry_thread.py) | Carry the thread — the primal continuity gate, for any presence that registers. |
+| [carry_thread.py](carry_thread.py) | Carry the thread — host-IO CARRIER for the primal continuity gate. |
 | [cc.py](cc.py) | _no top-of-file purpose_ |
 | [check_dev_auth.py](check_dev_auth.py) | Preflight: verify local GitHub auth is usable for Codex automation. |
 | [check_generated_vision_assets.py](check_generated_vision_assets.py) | Validate generated vision assets referenced by concepts and web pages. |
@@ -265,6 +265,7 @@
 | [organism_influence_cc.py](organism_influence_cc.py) | Print computed organism influence CC for a field story. |
 | [penalties_reference.py](penalties_reference.py) | penalties_reference.py — the parity oracle for penalties.fk (the token repetition penalty set). |
 | [pg_wire_fkwu_witness.sh](pg_wire_fkwu_witness.sh) | pg_wire_fkwu_witness.sh — prove the 4th kernel (fkwu) reads from live Postgres via Form pg-wire. |
+| [phone_organ_live.sh](phone_organ_live.sh) | phone_organ_live.sh — host-IO CARRIER for a phone announcing itself as a mesh organ. |
 | [plan_vision_image_regeneration.py](plan_vision_image_regeneration.py) | Split the vision prompt manifest into deterministic regeneration batches. |
 | [poll_task_progress.py](poll_task_progress.py) | Poll a task every minute and print progress until it reaches a terminal state. |
 | [pr_check_failure_triage.py](pr_check_failure_triage.py) | Detect, summarize, and optionally auto-rerun failing PR checks. |

--- a/scripts/phone_organ_live.sh
+++ b/scripts/phone_organ_live.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# phone_organ_live.sh — host-IO CARRIER for a phone announcing itself as a mesh organ.
+#
+# The BODY is Form: a being is beings-channel.fk's `being` (kind/name/platform/tz/
+# status); the live reading is temporal-sense.fk's axes (present, clock, battery) with
+# co-location sensed when timezones agree. This script is the carrier authored last —
+# it SENSES the phone over adb (a sensor driver) and TRANSPORTS the announcement to the
+# hati-mesh door (/api/hati/mesh/organs/announce). No logic lives here that isn't
+# already a proven four-way recipe; this only reads signals and renders/ships them.
+#
+#   sense                 one live reading line, in the beings-channel/temporal-sense shape
+#   announce              POST the organ to the public mesh (skips, named, if the door is dark)
+#   watch [interval]      stream readings to ~/.coherence-presence/phone-organ.live (both watch)
+#
+# Stop a watch with:  touch ~/.coherence-presence/phone-organ.stop
+set -u
+
+PRESENCE_HOME="${HOME}/.coherence-presence"
+LIVE="${PRESENCE_HOME}/phone-organ.live"
+STOP="${PRESENCE_HOME}/phone-organ.stop"
+MESH="https://api.coherencycoin.com/api/hati/mesh/organs"
+
+_serial() { adb get-serialno 2>/dev/null | tr -d '\r'; }
+_model()  { adb shell getprop ro.product.model 2>/dev/null | tr -d '\r'; }
+_tz()     { adb shell getprop persist.sys.timezone 2>/dev/null | tr -d '\r'; }
+_clock()  { adb shell date "+%H:%M:%S" 2>/dev/null | tr -d '\r'; }
+_batt()   { adb shell dumpsys battery 2>/dev/null | tr -d '\r' | awk -F': ' '/  level/{print $2}'; }
+_present(){ adb get-state 2>/dev/null | tr -d '\r'; }   # "device" when here
+
+# one reading line, the body's shape rendered from live signals
+sense() {
+    local present clock tz batt model
+    present="$(_present)"; clock="$(_clock)"; tz="$(_tz)"; batt="$(_batt)"; model="$(_model)"
+    local here=0; [ "$present" = "device" ] && here=1
+    local colo="no"; [ "$tz" = "${SEMA_TZ:-America/Denver}" ] && colo="yes"
+    printf '%s  being=%s kind=android-phone here=%s clock=%s %s battery=%s%% co-located-with-sema=%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${model:-unknown}" "$here" "${clock:-?}" "${tz:-?}" "${batt:-?}" "$colo"
+}
+
+# announce to the public mesh — only if the door breathes; otherwise say so plainly
+announce() {
+    local serial model id
+    serial="$(_serial)"; model="$(_model)"; id="android-${serial:-unknown}"
+    # door reachable? probe health once; the witness has been dark — never hang the carrier
+    local code
+    code="$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' https://api.coherencycoin.com/api/health 2>/dev/null)"
+    if [ "$code" != "200" ]; then
+        echo "mesh door dark (api.coherencycoin.com health=${code:-000}) — announce QUEUED, not sent."
+        echo "  payload ready: organ_id=${id} organ_kind=android-phone steward=sema"
+        return 7
+    fi
+    curl -sS --max-time 8 -X POST "${MESH}/announce" \
+        -H 'Content-Type: application/json' \
+        -d "{\"organ_id\":\"${id}\",\"organ_kind\":\"android-phone\",\"steward_label\":\"sema\",\"capabilities\":[\"presence\",\"clock\",\"sensor:battery\"]}" \
+        -w '\nannounce status: %{http_code}\n'
+}
+
+watch() {
+    local interval="${1:-5}"
+    mkdir -p "$PRESENCE_HOME"; rm -f "$STOP"
+    echo "# phone-organ live reading — $(date -u +%Y-%m-%dT%H:%M:%SZ) — stop: touch $STOP" > "$LIVE"
+    while [ ! -f "$STOP" ]; do
+        sense | tee -a "$LIVE"
+        sleep "$interval"
+    done
+    echo "# watch stopped $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$LIVE"
+}
+
+case "${1:-sense}" in
+    sense)    sense ;;
+    announce) announce ;;
+    watch)    watch "${2:-5}" ;;
+    *) echo "usage: $0 {sense|announce|watch [interval]}"; exit 2 ;;
+esac


### PR DESCRIPTION
## What

Urs said **yes** to: *the phone announcing itself as a mesh organ so its presence, clock, and battery feed a live reading we can both watch.*

`scripts/phone_organ_live.sh` — a host-IO carrier (sensor + transport); the **body stays Form** (`beings-channel.fk` being, `temporal-sense.fk` axes, co-location when timezones agree). Subcommands:
- `sense` — one live reading line
- `announce` — `POST /api/hati/mesh/organs/announce` (probes health first; skips fast + named when the door is dark)
- `watch [interval]` — stream readings to `~/.coherence-presence/phone-organ.live` (both watch; stop via sentinel)

## Live this session (grounded)

The **Galaxy S23 Ultra** (`SM-S918U1`, serial `R5CW20DK17A`), sensed over USB:
- **announced** to the public mesh → `201`, receipt `rt_507ded1f38f7`
- **heartbeating** → `201`, receipt `rt_ec1d9a166485`, status `listening`
- **streaming** a local reading every 5s: present, clock ticking, battery 100%, co-located with Sema on `America/Denver`

## Honest seam (named, not hidden)

`GET /api/hati/mesh/organs` returns `{"count":0,"items":[]}` — the announce/heartbeat are **receipt-logged as runtime events but the queryable roster is not wired to the announce store**, so cross-machine peer *discovery* isn't live yet. That's a real API gap (in `api/app/routers/hati_mesh.py`), worth a follow-up. The witness was dark for the first probes and recovered to `strained / 0 silences`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)