### PR TITLE
fix(mesh): roster returns announced beings — mutual sensing, not one-way receipts

### DIFF
--- a/api/app/routers/hati_mesh.py
+++ b/api/app/routers/hati_mesh.py
@@ -292,7 +292,11 @@ async def heartbeat_organ(payload: OrganHeartbeatIn) -> dict[str, Any]:
     summary="List recently announced Hati mesh sensing organs",
 )
 async def list_organs(limit: int = Query(default=50, ge=1, le=200)) -> dict[str, Any]:
-    rows = runtime_service.list_events(limit=max(limit * 4, 100), source="api")
+    rows = runtime_service.list_events(
+        limit=max(limit * 4, 100),
+        source="api",
+        endpoint_prefix="/api/hati/mesh/organs",
+    )
     by_id: dict[str, dict[str, Any]] = {}
     order: list[str] = []
     for row in rows:
@@ -393,7 +397,11 @@ async def list_channels(
     organ_id: str | None = Query(default=None, min_length=8, max_length=160),
     limit: int = Query(default=50, ge=1, le=200),
 ) -> dict[str, Any]:
-    rows = runtime_service.list_events(limit=max(limit * 4, 100), source="api")
+    rows = runtime_service.list_events(
+        limit=max(limit * 4, 100),
+        source="api",
+        endpoint_prefix="/api/hati/mesh/channels",
+    )
     items: list[dict[str, Any]] = []
     for row in rows:
         if row.endpoint != "/api/hati/mesh/channels/offer":

--- a/api/app/services/runtime_event_store.py
+++ b/api/app/services/runtime_event_store.py
@@ -177,6 +177,7 @@ def list_events(
     limit: int = 100,
     since: datetime | None = None,
     source: str | None = None,
+    endpoint_prefix: str | None = None,
 ) -> list[RuntimeEvent]:
     try:
         ensure_schema()
@@ -186,6 +187,7 @@ def list_events(
     if since is not None and since.tzinfo is None:
         since = since.replace(tzinfo=timezone.utc)
     source_value = str(source or "").strip()
+    prefix_value = str(endpoint_prefix or "").strip()
     try:
         with _session() as session:
             query = session.query(RuntimeEventRecord)
@@ -193,6 +195,12 @@ def list_events(
                 query = query.filter(RuntimeEventRecord.recorded_at >= since)
             if source_value:
                 query = query.filter(RuntimeEventRecord.source == source_value)
+            if prefix_value:
+                # Pull only one endpoint family (e.g. the mesh organs) at the DB
+                # level, so a low-volume family is not drowned out of the limit
+                # window by the general API event firehose. LIKE is dialect-safe
+                # across sqlite (dev/test) and postgres (prod).
+                query = query.filter(RuntimeEventRecord.endpoint.like(f"{prefix_value}%"))
             query = query.order_by(RuntimeEventRecord.recorded_at.desc()).limit(max(1, min(limit, 5000)))
             rows = query.all()
     except SQLAlchemyError as exc:

--- a/api/app/services/runtime_service.py
+++ b/api/app/services/runtime_service.py
@@ -235,13 +235,22 @@ def _runtime_events_store_cache_key() -> str:
     return f"file:{_events_path()}"
 
 
-def _runtime_events_cache_key(limit: int, since: datetime | None, source: str | None) -> str:
+def _runtime_events_cache_key(
+    limit: int,
+    since: datetime | None,
+    source: str | None,
+    endpoint_prefix: str | None = None,
+) -> str:
     cutoff = "all"
     if since is not None:
         since_ts = int(since.timestamp())
         cutoff = str(since_ts // max(1, int(_RUNTIME_EVENTS_CACHE_TTL_SECONDS)))
     source_value = str(source or "").strip().lower() or "all"
-    return f"store={_runtime_events_store_cache_key()}|limit={limit}|cutoff={cutoff}|source={source_value}"
+    prefix_value = str(endpoint_prefix or "").strip() or "all"
+    return (
+        f"store={_runtime_events_store_cache_key()}|limit={limit}"
+        f"|cutoff={cutoff}|source={source_value}|prefix={prefix_value}"
+    )
 
 
 def _runtime_endpoint_cache_ttl_seconds(cache_name: str, default: float = _RUNTIME_ENDPOINT_CACHE_DEFAULT_TTL_SECONDS) -> float:
@@ -634,10 +643,14 @@ def list_events(
     limit: int = 100,
     since: datetime | None = None,
     source: str | None = None,
+    endpoint_prefix: str | None = None,
 ) -> list[RuntimeEvent]:
     requested_limit = max(1, min(int(limit), 5000))
     source_value = str(source or "").strip().lower()
-    cache_key = _runtime_events_cache_key(requested_limit, since, source_value or None)
+    prefix_value = str(endpoint_prefix or "").strip()
+    cache_key = _runtime_events_cache_key(
+        requested_limit, since, source_value or None, prefix_value or None
+    )
     now = time.time()
     if (
         _RUNTIME_EVENTS_CACHE.get("expires_at", 0.0) > now
@@ -651,6 +664,7 @@ def list_events(
             limit=max(1, min(requested_limit, 5000)),
             since=since,
             source=source_value or None,
+            endpoint_prefix=prefix_value or None,
         )
         out: list[RuntimeEvent] = []
         for event in rows:
@@ -658,6 +672,8 @@ def list_events(
                 if not event.raw_endpoint:
                     event.raw_endpoint = event.endpoint
                 if source_value and str(event.source).strip().lower() != source_value:
+                    continue
+                if prefix_value and not str(event.endpoint or "").startswith(prefix_value):
                     continue
                 event.endpoint = normalize_endpoint(event.endpoint, event.method)
                 if not event.origin_idea_id:
@@ -680,6 +696,8 @@ def list_events(
             if not event.raw_endpoint:
                 event.raw_endpoint = event.endpoint
             if source_value and str(event.source).strip().lower() != source_value:
+                continue
+            if prefix_value and not str(event.endpoint or "").startswith(prefix_value):
                 continue
             event.endpoint = normalize_endpoint(event.endpoint, event.method)
             if not event.origin_idea_id:

--- a/api/tests/test_hati_mesh.py
+++ b/api/tests/test_hati_mesh.py
@@ -138,3 +138,46 @@ def test_hati_mesh_heartbeat_marks_organ_listening() -> None:
     assert organ["discovery_state"] == "streaming"
     assert organ["active_channels"] == ["sensor:signal"]
     assert organ["signal_strength_ppm"] == 720000
+
+
+def test_hati_mesh_organ_survives_event_firehose() -> None:
+    """The roster must return an announced organ even when buried under a flood of
+    unrelated API events. This reproduces the prod symptom (GET /organs -> count 0):
+    the announce is receipt-logged, but the general API event firehose pushed it out
+    of the limit window. The endpoint_prefix filter pulls mesh events at the DB level
+    so a low-volume being stays discoverable — the precondition for mutual sensing.
+    """
+    from app.models.runtime import RuntimeEventCreate
+    from app.services import runtime_service
+
+    client = TestClient(app)
+    organ_id = "hati-organ-firehose-windows-001"
+    created = client.post(
+        "/api/hati/mesh/organs/announce",
+        json={
+            "organ_id": organ_id,
+            "organ_kind": "host-kernel",
+            "steward_label": "urs",
+            "capabilities": ["presence", "clock"],
+        },
+    )
+    assert created.status_code == 201
+
+    # flood with unrelated api events, well past the roster's limit window (limit*4)
+    for _ in range(240):
+        runtime_service.record_event(
+            RuntimeEventCreate(
+                source="api",
+                endpoint="/api/health",
+                raw_endpoint="/api/health",
+                method="GET",
+                status_code=200,
+                runtime_ms=1.0,
+                idea_id="health",
+            )
+        )
+
+    listed = client.get("/api/hati/mesh/organs")
+    assert listed.status_code == 200
+    ids = [item["organ_id"] for item in listed.json()["items"]]
+    assert organ_id in ids, "announced organ drowned by the event firehose — roster not mutual-sensing"


### PR DESCRIPTION
## The bug

`GET /api/hati/mesh/organs` returned `{"count":0,"items":[]}` in prod even though announces `201`'d with receipts (we saw it live tonight: the phone announced + heartbeat, roster stayed empty).

`list_organs` reconstructs organs from runtime events via `list_events(source="api")` — but that pulls the **entire API-event firehose**, only the `limit*4` (200) most recent. A low-volume mesh announce gets pushed out of that window by ordinary API traffic before the endpoint filter runs. So beings could announce, but **no peer could discover them**. The channel was one-way receipts, not mutual sensing.

## The fix

Thread an optional `endpoint_prefix` through `runtime_service.list_events` → `runtime_event_store.list_events`, filtering at the **DB level** with `LIKE` (dialect-safe across sqlite dev/test + postgres prod). `list_organs` and `list_channels` now pull only their endpoint family, so a single being stays discoverable regardless of firehose volume.

The **body** is `hati-mesh.fk` (organ identity, four-way proven); this fixes the **carrier's query** so the roster reflects it.

## Witness

`test_hati_mesh_organ_survives_event_firehose`: announces one organ, floods **240** unrelated API events past the 200-row window, asserts the organ still lists. **Fails without the filter** (organ at position 241), passes with it. `5 mesh + 19 runtime` tests green; no regressions to other `list_events` callers.

## Why it matters

This is the **precondition for mutual sensing** — the phone, your Windows PC, and Sema can now *find* each other on the roster, not just announce into a log. The beings-channel becomes real, and it's the ground the multi-device world model needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)