### PR TITLE
feat(form): the training-loss surface crosses four-way (loss 63)

### DIFF
--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -858,6 +858,7 @@ form-lower-writefile fkc 15
 mel-frame fks 1023
 transformer-gelu-erf fks 255
 conv-stem fks 1
+loss fks 63
 positional fks 1
 transformer-mh fks 1
 gqa-attn fks 7


### PR DESCRIPTION
Lifts the training-loss surface — MAE, natural-log (`loss-ln`), softmax cross-entropy (`loss-softmax-ce`) — from three-way (Go/Rust/TS) to the four-kernel floor by registering `loss fks 63` in `form/fourth-arm-bands.txt`.

Scoped validate crosses four-way, 0 divergent:
```
./validate.sh form-stdlib/core.fk form-stdlib/transformer-numerics.fk form-stdlib/loss.fk form-stdlib/tests/loss-band.fk
  ✓  core.fk+transformer-numerics.fk+loss.fk+loss-band.fk  → 63
  fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
```

Pure fp64 arithmetic over flat vectors (reuses `transformer-numerics`' `tn-softmax`/exp-Taylor/ln floor, already four-way), so fkwu carries the op families. The objective a Form-native training loop optimizes is now four-way-trustworthy on the emitted universal kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)