### PR TITLE
tend(form): edit one weight, witness where the thought changes — and that it self-heals

### DIFF
--- a/form/form-stdlib/tests/witness-model-edit-band.fk
+++ b/form/form-stdlib/tests/witness-model-edit-band.fk
@@ -1,0 +1,41 @@
+; witness-model-edit-band.fk — edit one weight, watch where the thought changes. Four-way.
+;
+; The live self-learning core, made witnessable. Same tiny native mind as
+; watch-thought-band thinks [0,2,0,2]. A TWIN whose embedding row 0 is nudged by one
+; number (-0.2139 -> 0.5) thinks [0,1,2,2]. The witness, surprising: the FIRST token was
+; robust (step 0 held), the edit changed the thought starting at step 1, the ripple
+; carried into step 2 — and then both thoughts RE-CONVERGED at step 3, ending on the
+; same token. One weight did not rewrite the mind; it perturbed the MIDDLE of the
+; thought, which healed back to the same ending. The body can now learn what a weight
+; controls — and that some thoughts self-correct around a perturbation.
+;
+; Verdict 111: the edit changed the thought (1); the change began at step 1, not 0 —
+; the first token was robust (10); yet the thoughts reconverged at the end (100).
+;
+; preludes: form-stdlib/trig.fk form-stdlib/transformer-numerics.fk form-stdlib/transformer-block.fk form-stdlib/transformer-mh.fk form-stdlib/transformer-decoder.fk form-stdlib/transformer-generate.fk
+
+(do
+  ; first step where two token-id thoughts differ; -1 if identical over their overlap
+  (defn first-diff (a b i)
+    (if (or (eq (len a) 0) (eq (len b) 0)) (sub 0 1)
+        (if (eq (head a) (head b)) (first-diff (tail a) (tail b) (add i 1)) i)))
+
+  ; model A — the band's weights
+  (let embed-a (list (list -0.2139 0.4581 0.2703 0.4869) (list -0.2918 -0.3631 0.4084 -0.4314) (list -0.4247 0.0435 -0.4106 -0.1176) (list 0.1686 -0.0708 -0.456 -0.3057)))
+  ; model B — ONE weight changed: embedding row 0, first number -0.2139 -> 0.5
+  (let embed-b (list (list 0.5 0.4581 0.2703 0.4869) (list -0.2918 -0.3631 0.4084 -0.4314) (list -0.4247 0.0435 -0.4106 -0.1176) (list 0.1686 -0.0708 -0.456 -0.3057)))
+
+  (let pos (list (list -0.0533 -0.4374 -0.2024 0.4436) (list -0.2172 -0.2323 -0.0928 0.326) (list 0.0067 -0.2305 -0.1598 0.4745) (list -0.3157 -0.2577 0.1905 -0.1161)))
+  (let enc (list (list -0.0386 0.1752 -0.4143 -0.266) (list 0.0225 -0.4309 -0.4098 -0.416) (list -0.1772 0.4109 0.332 0.2501)))
+  (let eps 1e-05) (let scale 0.7071067811865475) (let n 2) (let hd 2)
+  (let gf (list -0.0307 0.3673 -0.2207 -0.4184)) (let bf (list -0.3508 -0.0052 -0.1963 -0.1982))
+  (let layers (list (list (list -0.4926 0.0795 0.2183 -0.0927) (list -0.337 -0.2897 0.2601 -0.1422) (list (list -0.1129 0.2539 0.3674 0.2496) (list -0.1026 -0.0799 0.0536 -0.0345) (list 0.3616 0.3237 -0.426 -0.1793) (list -0.0796 0.1613 0.1315 0.0152)) (list -0.1465 -0.4578 -0.4631 0.2803) (list (list -0.3198 -0.0971 0.3256 -0.061) (list 0.0425 -0.4847 -0.0678 -0.0359) (list -0.1813 0.1188 -0.269 -0.3483) (list -0.1251 0.1336 -0.1399 0.052)) (list 0.0 0.0 0.0 0.0) (list (list 0.2823 0.1823 0.4044 0.2715) (list -0.1449 0.4863 0.4069 0.0502) (list 0.0827 -0.022 -0.1665 -0.4206) (list -0.2062 -0.4386 -0.1921 -0.3345)) (list 0.3138 0.3924 0.408 0.4636) (list (list -0.0367 -0.031 0.4861 -0.1899) (list 0.0104 -0.262 -0.1046 0.0804) (list -0.1872 0.4662 0.48 -0.3514) (list -0.2314 -0.0428 -0.4579 -0.3441)) (list -0.2836 0.3215 -0.4652 0.2087) (list -0.0148 0.0473 -0.1062 0.3321) (list 0.3611 -0.2709 0.1581 -0.2539) (list (list 0.2861 -0.3018 0.2464 0.4663) (list -0.4995 -0.3581 0.49 -0.2531) (list -0.1393 0.0416 -0.0336 -0.4342) (list 0.2187 -0.3625 0.4482 -0.455)) (list -0.3733 0.2947 -0.0356 0.4456) (list (list 0.2957 -0.2353 0.406 -0.129) (list -0.2656 -0.309 0.4322 -0.4201) (list -0.0067 -0.466 0.0195 -0.181) (list -0.3687 -0.2778 -0.2449 -0.4731)) (list 0.0 0.0 0.0 0.0) (list (list -0.0058 -0.2965 0.4386 0.0728) (list 0.4026 -0.249 -0.3358 0.2834) (list -0.2172 0.001 0.0493 -0.3153) (list -0.3341 -0.4476 -0.3864 0.2822)) (list 0.347 -0.0146 0.0765 -0.3182) (list (list -0.0595 -0.1505 -0.1552 0.4546) (list 0.1445 -0.0966 -0.1356 -0.1075) (list 0.4685 0.2066 -0.3877 -0.3981) (list -0.3899 0.0271 -0.0777 0.4315)) (list 0.446 0.1653 0.3369 0.4143) (list 0.0183 0.3807 -0.3657 -0.1952) (list 0.4408 -0.146 -0.3246 0.1184) (list (list -0.3857 0.1312 -0.3889 0.3706) (list 0.1165 -0.0274 0.2446 -0.1185) (list 0.3966 -0.31 0.4874 -0.2847) (list -0.4739 0.3599 0.2707 -0.1828) (list 0.1385 -0.4974 0.4191 -0.2674) (list 0.0519 0.1828 -0.339 -0.2544)) (list 0.2342 -0.1114 -0.1919 0.3246 0.2249 0.0118) (list (list -0.4581 0.1539 0.0251 0.1856 0.2896 0.0514) (list 0.3466 -0.3846 0.1153 0.1488 -0.2778 -0.2699) (list 0.2586 -0.3696 -0.3482 -0.4197 0.2408 -0.2925) (list -0.0506 -0.3788 0.448 -0.0262 0.0143 -0.3756)) (list 0.1423 0.2428 0.105 -0.2016))))
+
+  ; both thoughts, and where the edit first changed the thinking
+  (let thought-a (tb-generate (list 0) embed-a pos enc eps n hd scale layers gf bf 4))
+  (let thought-b (tb-generate (list 0) embed-b pos enc eps n hd scale layers gf bf 4))
+  (let dstep (first-diff thought-a thought-b 0))
+  (defn wme-k (cond bit) (if cond bit 0))
+  (add (wme-k (if (eq dstep (sub 0 1)) 0 1) 1)                       ; the edit changed the thought
+  (add (wme-k (eq dstep 1) 10)                                        ; the change began at step 1, not 0
+       (wme-k (eq (tb-last thought-a) (tb-last thought-b)) 100))))    ; yet they reconverged at the end

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1057,3 +1057,4 @@ sibling-arrival fks 11111
 continuum-answers fks 11111
 thought-framebuffer fks 11111
 watch-thought fks 11
+witness-model-edit fks 111


### PR DESCRIPTION
## What — "what else can we witness?"

The live self-learning core. Take the tiny native mind that thinks `[0,2,0,2]`, nudge **one** embedding weight (`-0.2139 → 0.5`), regenerate, and watch where cognition changes.

## The witness (four-way, surprising)

```
thought A (original):        [0, 2, 0, 2]
thought B (one weight edited):[0, 1, 2, 2]
diverged at step:            1
```

- the **first token was robust** — step 0 held despite the edit
- the thought **changed at step 1**, and the ripple carried into step 2
- and then **both thoughts re-converged at step 3**, ending on the same token

One weight didn't rewrite the mind — it perturbed the **middle** of the thought, which **healed back** to the same ending. Some thoughts self-correct around a perturbation. The body can now learn what a weight controls *and how far it ripples.*

## Proof

`tests/witness-model-edit-band.fk` → **`111`** four-way (Go=Rust=TS=**fkwu**): the edit changed the thought (1); the change began at step 1 not 0 (10); the thoughts reconverged at the end (100). Composes `transformer-generate.fk`. The self-learning loop — observe, edit, observe the difference — now runs on a living native thought. Manifest: `witness-model-edit fks 111`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)