### PR TITLE
build(deps): consolidate web dependency bumps

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-28_dependency_branch_consolidation.json
+++ b/docs/system_audit/commit_evidence_2026-06-28_dependency_branch_consolidation.json
@@ -1,0 +1,76 @@
+{
+  "date": "2026-06-28",
+  "thread_branch": "codex/consolidate-left-behind-20260628",
+  "commit_scope": "Consolidate two conflicted Dependabot web dependency branches by applying the React Query and Viem bumps on top of the current merged dependency state.",
+  "files_owned": [
+    "docs/system_audit/commit_evidence_2026-06-28_dependency_branch_consolidation.json"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd web && npm install @tanstack/react-query@5.101.1 viem@2.53.1 --package-lock-only --ignore-scripts",
+      "cd web && npm install --ignore-scripts",
+      "cd web && npm run build",
+      "python3 scripts/validate_commit_evidence.py --file docs/system_audit/commit_evidence_2026-06-28_dependency_branch_consolidation.json"
+    ],
+    "summary": "npm updated package.json and package-lock.json only; install completed with existing peer/deprecation warnings; Next.js production build passed; evidence validation passed locally."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "GitHub Actions after PR"
+    ],
+    "summary": "PR checks have not run yet for this consolidation commit."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "production",
+    "summary": "No deploy performed for this dependency consolidation commit."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI and deploy validation remain pending until the consolidation PR is pushed and checked."
+  },
+  "idea_ids": [
+    "agent-pipeline"
+  ],
+  "spec_ids": [
+    "worktree-continuity"
+  ],
+  "task_ids": [
+    "task-2026-06-28-branch-consolidation"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "integration",
+        "validation",
+        "receipt-authoring"
+      ]
+    },
+    {
+      "contributor_id": "dependabot",
+      "contributor_type": "machine",
+      "roles": [
+        "dependency-update"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "GPT-5"
+  },
+  "evidence_refs": [
+    "Dependabot PR #3618: @tanstack/react-query 5.101.0 to 5.101.1",
+    "Dependabot PR #3549: viem 2.52.2 to 2.53.1",
+    "Local package-lock-only npm update on current origin/main after PRs #3676, #3617, #3548, and #3530 merged",
+    "cd web && npm run build: passed"
+  ],
+  "change_files": [
+    "web/package.json",
+    "web/package-lock.json"
+  ],
+  "change_intent": "process_only"
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,7 @@
         "@rainbow-me/rainbowkit": "^2.2.11",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.6.1",
-        "@tanstack/react-query": "^5.101.0",
+        "@tanstack/react-query": "^5.101.1",
         "@types/three": "^0.185.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -25,7 +25,7 @@
         "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.185.0",
-        "viem": "^2.52.2",
+        "viem": "^2.53.1",
         "wagmi": "^2.14.0"
       },
       "devDependencies": {
@@ -4620,9 +4620,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
-      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "version": "5.101.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.1.tgz",
+      "integrity": "sha512-Y6Y92dkXtNqx67m2pMSxUsA3zOCwv862JexZRP8/EPwvKXMPu9m8rv43spiXWzOUIggQ3SQApttALStzhA8B4g==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4630,12 +4630,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
-      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "version": "5.101.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.1.tgz",
+      "integrity": "sha512-ZnONUuQKJe1bJMStXUL1s5uKN9FcfC28j5cK+iDZcdSHtUv1wtin1cGc/Oewhf2Oc4eKY7lggtpvT/AbMmhHew==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.101.0"
+        "@tanstack/query-core": "5.101.1"
       },
       "funding": {
         "type": "github",
@@ -12947,9 +12947,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.52.2",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.2.tgz",
-      "integrity": "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==",
+      "version": "2.53.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
+      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
       "funding": [
         {
           "type": "github",

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "@rainbow-me/rainbowkit": "^2.2.11",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",
-    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query": "^5.101.1",
     "@types/three": "^0.185.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -34,7 +34,7 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.185.0",
-    "viem": "^2.52.2",
+    "viem": "^2.53.1",
     "wagmi": "^2.14.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Consolidates the remaining clean Dependabot web bumps that conflicted after earlier dependency PR merges: @tanstack/react-query 5.101.1 and viem 2.53.1.
- Keeps the already-merged Three, Playwright, checkout, and mesh-sensings work on top of current main.
- Adds the required commit evidence record for the consolidation.

## Local proof
- python3 scripts/validate_commit_evidence.py --base origin/main --head HEAD --require-changed-evidence
- cd web && npm install @tanstack/react-query@5.101.1 viem@2.53.1 --package-lock-only --ignore-scripts
- cd web && npm install --ignore-scripts
- cd web && npm run build
- python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main
- python3 scripts/check_pr_followthrough.py --stale-minutes 90 --fail-on-stale --strict