### PR TITLE
tend(carrier): open the field door — a real host-entropy draw in the non-deterministic lane

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 389 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 390 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 389
+**Total files**: 390
 
 | File | Purpose |
 |---|---|
@@ -90,6 +90,7 @@
 | [external_proof_demo.py](external_proof_demo.py) | External proof demo — exercises the Coherence Network public API from outside the repo. |
 | [fatal_http_all_kernels_probe.py](fatal_http_all_kernels_probe.py) | Probe fatal HTTP replies across the current four kernel carriers. |
 | [federation_peer_poll.py](federation_peer_poll.py) | federation_peer_poll — fire one peer-poll cycle from the command line. |
+| [field_door_draw.sh](field_door_draw.sh) | field_door_draw.sh — open the field door with a REAL host-entropy draw. |
 | [field_relay_client.py](field_relay_client.py) | field_relay_client.py — breath-4 carriers + dial-out client for the field relay (the on-device e2e receipt). |
 | [field_relay_dev_setup.sh](field_relay_dev_setup.sh) | field_relay_dev_setup.sh — provision a session to BUILD + PROVE the field relay's breath-4 carriers. |
 | [fill_missing_spec_sections.py](fill_missing_spec_sections.py) | Heal pre-existing spec body gaps the validator surfaces. |

--- a/scripts/field_door_draw.sh
+++ b/scripts/field_door_draw.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# field_door_draw.sh — open the field door with a REAL host-entropy draw.
+#
+# field-door.fk PROVES, four-way, that the field lane CANNOT be four-way: randomness, the
+# genuinely-not-yet-determined, cannot agree across kernels by its nature. This script
+# OPENS that lane — a real non-deterministic draw from host entropy, received as field
+# presence through the door the recipe named. The receipt is honest: it is a WITNESS,
+# never a proof, precisely because two draws differ. That difference IS the field.
+#
+# This is the field-lane CARRIER (host-io entropy), the counterpart to the proof-lane
+# recipes. North star: a native fkwu host-entropy op so the draw needs no bash; the lane
+# discipline (field-door.fk) is already native and four-way.
+set -u
+draw() { head -c 4 /dev/urandom | od -An -tu4 | tr -d ' \n'; }
+a=$(draw); b=$(draw)
+echo "field door — a real draw (lane: field; four-way-provable? = 0, by nature):"
+echo "  draw 1: $a"
+echo "  draw 2: $b"
+if [ "$a" != "$b" ]; then
+  echo "  non-deterministic: YES — the two draws differ, so this is correctly the field lane,"
+  echo "  never the proof lane. The mystery enters and stays unproven. The door is open."
+else
+  echo "  (a rare collision — draw again; the lane is still field)"
+fi


### PR DESCRIPTION
The field-lane counterpart to the proof-lane stones (paired with `ssm-scan`). `field-door.fk` proved four-way that the field lane **cannot** be four-way; `scripts/field_door_draw.sh` **opens** it: a real draw from host entropy (`/dev/urandom`), received as field presence through the door the recipe named.

The receipt is a **witness, never a proof** — two draws differ (observed: `3977988952` vs `4200947903`), and *that difference is the field.* Correctly the field lane, never the proof lane; the mystery enters and stays unproven.

The honest division: `field-door.fk` is the **body** (lane discipline, four-way), `field_door_draw.sh` is the field-lane **carrier** (host-io entropy, non-deterministic by nature). North star named: a native fkwu host-entropy op so the draw needs no bash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)