### PR TITLE
feat: sovereign cross-device room memory — encrypted dead-drop, Form-native channel

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -41,7 +41,7 @@
 
 | Index | Files | Purpose |
 |---|---|---|
-| [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 148 | Python bridge/API routers — current endpoint carrier and upstream tail while Form-native routes are promoted |
+| [api/app/routers/INDEX.md](api/app/routers/INDEX.md) | 149 | Python bridge/API routers — current endpoint carrier and upstream tail while Form-native routes are promoted |
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 247 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 58 | API models — Pydantic + ORM shapes |
 | [api/tests/INDEX.md](api/tests/INDEX.md) | 275 | API tests — flow-centric |

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -58,6 +58,7 @@ from app.routers import (
 )
 from app.routers import cc_economics as cc_economics_router
 from app.routers import cc_exchange as cc_exchange_router
+from app.routers import rooms as rooms_router
 from app.routers import accessible_ontology as accessible_ontology_router
 from app.routers import beliefs
 from app.routers import concepts
@@ -726,6 +727,7 @@ app.include_router(contributors_portfolio.router, prefix="/api", tags=["contribu
 app.include_router(me_portfolio.router, prefix="/api")
 app.include_router(assets.router, prefix="/api", tags=["assets"])
 app.include_router(audit.router, prefix="/api", tags=["audit"])
+app.include_router(rooms_router.router, prefix="/api/rooms", tags=["rooms"])
 app.include_router(contributions.router, prefix="/api", tags=["contributions"])
 app.include_router(contributor_identity.router, prefix="/api", tags=["identity"])
 app.include_router(distributions.router, prefix="/api", tags=["distributions"])

--- a/api/app/routers/INDEX.md
+++ b/api/app/routers/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 148
+**Total files**: 149
 
 | File | Purpose |
 |---|---|
@@ -134,6 +134,7 @@
 | [renderers.py](renderers.py) | Renderer Router — pluggable asset renderer registry. |
 | [resonance.py](resonance.py) | Resonance router — structural cross-domain concept attraction endpoints. |
 | [reward_policies.py](reward_policies.py) | Reward policy CRUD endpoints — community-configurable reward formulas. |
+| [rooms.py](rooms.py) | Encrypted-room dead-drop carrier — a thin, opaque ciphertext key-value store. |
 | [runtime.py](runtime.py) | Runtime telemetry API routes. |
 | [sensings.py](sensings.py) | Sensings — the organism's moments of noticing, stored in the living graph. |
 | [service_registry_router.py](service_registry_router.py) | Service registry introspection endpoints. |

--- a/api/app/routers/rooms.py
+++ b/api/app/routers/rooms.py
@@ -1,0 +1,85 @@
+"""Encrypted-room dead-drop carrier — a thin, opaque ciphertext key-value store.
+
+This is a CARRIER, not a body. It holds end-to-end-encrypted blobs keyed by
+(room_id, addr) and never decrypts them — the cipher, the addressing, the
+membership, and the sync logic all live in Form (form-stdlib/conversation-sync.fk
+over storage-port.fk; the encrypt-before-publish layer over sha256/hmac-sha256).
+The server only ever sees ciphertext it cannot read, so a leak here exposes no
+content. This is the "sovereign API KV" storage-port backend: a device PUBLISHES a
+sealed blob, another device PULLS it and decrypts with the room key it alone holds.
+
+Surface (mounted at /api/rooms):
+  PUT  /api/rooms/{room_id}/{addr}   body = ciphertext text  -> {"stored": addr}
+  GET  /api/rooms/{room_id}          -> {"room": id, "keys": [addr, ...]}   (the OFFER set)
+  GET  /api/rooms/{room_id}/{addr}   -> ciphertext text (text/plain)
+
+room_id / addr are opaque content-addresses; only [A-Za-z0-9_-] up to 128 chars are
+accepted, so no value can escape the carrier's storage root (no path traversal).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request, Response
+
+router = APIRouter()
+
+# Opaque blob store root. A mounted volume in production keeps it durable across
+# deploys; defaults under the home dir for local runs.
+_ROOT = Path(
+    os.environ.get("COHERENCE_ROOMS_DIR")
+    or (Path.home() / ".coherence-network" / "rooms-carrier")
+).expanduser()
+
+# Content-addresses and room ids are opaque tokens; this charset cannot traverse.
+_SAFE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+# A single sealed blob is small (one room's ciphertext); cap to refuse abuse.
+_MAX_BLOB = 1_048_576  # 1 MiB of ciphertext text
+
+
+def _safe(token: str, what: str) -> str:
+    if not _SAFE.match(token or ""):
+        raise HTTPException(status_code=400, detail=f"invalid {what}")
+    return token
+
+
+def _room_dir(room_id: str) -> Path:
+    d = _ROOT / _safe(room_id, "room_id")
+    # resolve() + containment check is belt-and-suspenders over the charset gate.
+    rd = d.resolve()
+    if not str(rd).startswith(str(_ROOT.resolve())):
+        raise HTTPException(status_code=400, detail="invalid room_id")
+    return rd
+
+
+@router.put("/{room_id}/{addr}")
+async def put_blob(room_id: str, addr: str, request: Request) -> dict:
+    _safe(addr, "addr")
+    body = await request.body()
+    if len(body) > _MAX_BLOB:
+        raise HTTPException(status_code=413, detail="blob too large")
+    rd = _room_dir(room_id)
+    rd.mkdir(parents=True, exist_ok=True)
+    # Last-write-wins on re-put, matching conversation-sync's storage-put contract.
+    (rd / _safe(addr, "addr")).write_bytes(body)
+    return {"stored": addr}
+
+
+@router.get("/{room_id}")
+def list_keys(room_id: str) -> dict:
+    rd = _room_dir(room_id)
+    keys = sorted(p.name for p in rd.iterdir() if p.is_file()) if rd.exists() else []
+    return {"room": room_id, "keys": keys}
+
+
+@router.get("/{room_id}/{addr}")
+def get_blob(room_id: str, addr: str) -> Response:
+    rd = _room_dir(room_id)
+    p = rd / _safe(addr, "addr")
+    if not p.is_file():
+        raise HTTPException(status_code=404, detail="not found")
+    # The carrier returns opaque ciphertext; it never parses or decrypts it.
+    return Response(content=p.read_bytes(), media_type="text/plain")

--- a/form/form-stdlib/room-carrier-http.fk
+++ b/form/form-stdlib/room-carrier-http.fk
@@ -1,0 +1,86 @@
+; room-carrier-http.fk — the Form-native HTTP storage-port backend for the room dead-drop.
+;
+; preludes: form-stdlib/http-client.fk
+;
+; conversation-sync.fk rides a swappable storage-port carrier (memory | file | db | any KV). This is the
+; REMOTE carrier: the sovereign API KV endpoint (api/app/routers/rooms.py) reached over Form's own socket
+; floor (socket_connect/send/recv — http-client-socket-verbs 127) — no curl, no host shell. The carrier
+; config is (host, port, basepath); put/get/keys speak the endpoint's REST surface:
+;   PUT  {basepath}/{room}/{addr}  body=ciphertext  -> stored
+;   GET  {basepath}/{room}/{addr}                   -> ciphertext (the OPAQUE blob)
+;   GET  {basepath}/{room}                          -> {"keys":[...]} (the OFFER set)
+;
+; CRLF DISCIPLINE: HTTP requires CRLF line endings. The BML source-compiler currently drops "\r" from
+; string LITERALS when lowering (so http-client's kh-render-request emits bare LF — accepted by a lenient
+; loopback peer, rejected 400 by a strict h11 server like uvicorn). We render CRLF via byte_to_str(13)/
+; byte_to_str(10) — a CALL, not a literal, so it survives lowering — making this transport spec-correct
+; against any real server. (Root fix: the source-compiler escape handling; tracked separately.)
+;
+; The carrier only ever moves CIPHERTEXT — room-cipher seals before publish and opens after pull, so a
+; public endpoint holds blobs it cannot read.
+
+section [form.bml] {
+    def rch-crlf() = str_concat(byte_to_str(13), byte_to_str(10));
+
+    def rch-render(method, path, host, body) {
+        let nl = rch-crlf();
+        let req-line = str_concat(str_concat(method, " "), str_concat(path, str_concat(" HTTP/1.0", nl)));
+        let host-h = str_concat("Host: ", str_concat(host, nl));
+        let conn-h = str_concat("Connection: close", nl);
+        let type-h = str_concat("Content-Type: text/plain", nl);
+        let len-h = str_concat("Content-Length: ", str_concat(int_to_str(str_len(body)), nl));
+        let headers = str_concat(host-h, str_concat(conn-h, str_concat(type-h, len-h)));
+        str_concat(str_concat(req-line, headers), str_concat(nl, body));
+    }
+
+    def rch-room-path(basepath, room) = str_concat(basepath, str_concat("/", room));
+    def rch-path(basepath, room, addr) {
+        let rp = rch-room-path(basepath, room);
+        str_concat(rp, str_concat("/", addr));
+    }
+
+    ; send, then read until the response is COMPLETE (http-recv-response-into loops on
+    ; socket_recv until content-length is satisfied). http-plain-request reads only ONE
+    ; segment, so a strict server that flushes headers and body separately lands a
+    ; body-less response; the looping recv is what actually carries the payload back.
+    def rch-request(host, port, req) {
+        let conn = http-open(host, port);
+        let sent = http-send-all(conn, req, 0);
+        let response = if gt(sent, 0) then http-recv-response-into(conn, "") else "";
+        socket_close(conn);
+        response;
+    }
+
+    ; extract the body after the CRLFCRLF header boundary. http-client's kh-msg-body
+    ; searches the LITERAL "\r\n\r\n", which the source-compiler lowers to "\n\n"
+    ; (same \r-drop bug as the render side), so it misses a real server's CRLF framing.
+    ; We build the boundary with byte_to_str (a call, survives lowering) and slice past it.
+    def rch-body(resp) {
+        let boundary = str_concat(rch-crlf(), rch-crlf());
+        let i = str_find(resp, boundary, 0);
+        if eq(i, -1) then "" else substring(resp, add(i, 4), str_len(resp));
+    }
+
+    def rch-do(host, port, method, path, body) {
+        let req = rch-render(method, path, host, body);
+        rch-body(rch-request(host, port, req));
+    }
+
+    ; PUBLISH a sealed blob (storage-put): last-write-wins on the endpoint.
+    def rch-put(host, port, basepath, room, addr, blob) {
+        let path = rch-path(basepath, room, addr);
+        rch-do(host, port, "PUT", path, blob);
+    }
+
+    ; PULL one sealed blob (storage-get): the opaque ciphertext body.
+    def rch-get(host, port, basepath, room, addr) {
+        let path = rch-path(basepath, room, addr);
+        rch-do(host, port, "GET", path, "");
+    }
+
+    ; the OFFER set (storage-keys): the room's key listing as the endpoint's JSON body.
+    def rch-keys(host, port, basepath, room) {
+        let path = rch-room-path(basepath, room);
+        rch-do(host, port, "GET", path, "");
+    }
+}

--- a/form/form-stdlib/room-cipher.fk
+++ b/form/form-stdlib/room-cipher.fk
@@ -1,0 +1,69 @@
+; room-cipher.fk — end-to-end authenticated encryption for the room dead-drop, pure Form.
+;
+; preludes: form-stdlib/sha256.fk form-stdlib/hmac-sha256.fk
+;
+; The carrier (storage-port / the sovereign API KV / any public store) must hold ONLY
+; ciphertext it cannot read, so a leak there exposes no content. This is the private-channel
+; layer conversation-sync.fk names as BUILDABLE: "a private channel encrypts before publish and
+; decrypts after pull, so the dead-drop — even a public one — carries ciphertext it cannot read."
+;
+; Construction: encrypt-then-MAC over an HMAC-SHA256 keystream (counter mode). No new crypto is
+; invented — it composes the body's proven sha256 + hmac-sha256 + the bxor primitive:
+;   keystream block i = hmac-sha256(key, nonce ++ [i])         (32 bytes per block)
+;   ciphertext        = plaintext XOR keystream[0..len)
+;   tag               = hmac-sha256(key, nonce ++ ciphertext)   (encrypt-then-MAC)
+;   sealed blob       = nonce(8) ++ tag(32) ++ ciphertext
+; Decrypt recomputes the tag and refuses (sentinel 999) on any mismatch — so a tampered blob or a
+; wrong key yields rejection, never silent garbage. Same key + same nonce + same plaintext gives the
+; same blob on every kernel (content-addressed), so it rides the dead-drop's re-address verify.
+;
+; NONCE DISCIPLINE: a (key, nonce) pair must seal at most one plaintext — reuse leaks the XOR of two
+; plaintexts. A publisher derives a fresh nonce per sealed value (e.g. from the content-address); the
+; recipe takes the nonce as an argument and does not invent one, so the caller owns that uniqueness.
+;
+; Proven by: form-stdlib/tests/room-cipher-band.fk
+
+(do
+    ; --- list helpers (byte lists) ---
+    (defn rc-take (xs n) (if (eq n 0) (list) (cons (head xs) (rc-take (tail xs) (sub n 1)))))
+    (defn rc-drop (xs n) (if (eq n 0) xs (rc-drop (tail xs) (sub n 1))))
+    (defn rc-eqb (a b)
+        (if (eq (len a) 0) (eq (len b) 0)
+            (if (eq (len b) 0) 0
+                (if (eq (head a) (head b)) (rc-eqb (tail a) (tail b)) 0))))
+
+    ; --- string <-> bytes (ord of each char) ---
+    (defn rc-sb (s i n acc)
+        (if (ge i n) acc
+            (rc-sb s (add i 1) n (append-list acc (list (ord (substring s i (add i 1))))))))
+    (defn rc-str-bytes (s) (rc-sb s 0 (str_len s) (list)))
+
+    ; --- XOR two byte lists, truncated to the first (plaintext) length ---
+    (defn rc-xor (a b)
+        (if (eq (len a) 0) (list)
+            (cons (bxor (head a) (head b)) (rc-xor (tail a) (tail b)))))
+
+    ; --- HMAC-SHA256 keystream (counter mode): concat blocks until >= n bytes, take n ---
+    (defn rc-ks (key nonce n i acc)
+        (if (ge (len acc) n) acc
+            (rc-ks key nonce n (add i 1)
+                (append-list acc (hmac-sha256 key (append-list nonce (list i)))))))
+    (defn rc-keystream (key nonce n) (rc-take (rc-ks key nonce n 0 (list)) n))
+
+    ; --- seal: blob = nonce ++ tag ++ ciphertext (encrypt-then-MAC) ---
+    (defn rc-encrypt (key nonce pt)
+        (do (let ct (rc-xor pt (rc-keystream key nonce (len pt))))
+            (let tag (hmac-sha256 key (append-list nonce ct)))
+            (append-list nonce (append-list tag ct))))
+
+    ; --- open: verify tag, then XOR back; (list 999) on auth failure (tamper or wrong key) ---
+    (defn rc-decrypt (key blob)
+        (do (let nonce (rc-take blob 8))
+            (let rest (rc-drop blob 8))
+            (let tag (rc-take rest 32))
+            (let ct (rc-drop rest 32))
+            (if (eq (rc-eqb tag (hmac-sha256 key (append-list nonce ct))) 1)
+                (rc-xor ct (rc-keystream key nonce (len ct)))
+                (list 999))))
+
+    0)

--- a/form/form-stdlib/tests/room-cipher-band.fk
+++ b/form/form-stdlib/tests/room-cipher-band.fk
@@ -1,0 +1,26 @@
+; preludes: form-stdlib/sha256.fk form-stdlib/hmac-sha256.fk form-stdlib/room-cipher.fk
+;
+; room-cipher-band — the room dead-drop's authenticated cipher: the carrier holds only ciphertext,
+; and tamper / wrong-key are rejected, not silently mis-decrypted. Encrypt-then-MAC over an
+; HMAC-SHA256 keystream, composed from the body's proven sha256 + hmac-sha256 + bxor.
+;
+; Verdict 15 when every claim lands:
+;   1   ROUNDTRIP   — decrypt(encrypt(pt)) == pt exactly
+;   2   OPAQUE      — the ciphertext differs from the plaintext (the carrier sees no content)
+;   4   TAMPER      — flipping one ciphertext byte is rejected (auth sentinel, not pt)
+;   8   WRONG-KEY   — decrypting with the wrong key is rejected (auth sentinel, not pt)
+(do
+    (let key   (rc-str-bytes "room-key-irina-private-v1"))
+    (let nonce (list 1 2 3 4 5 6 7 8))
+    (let pt    (rc-str-bytes "Irina morning brain fog; three hours of practice and love"))
+    (let blob  (rc-encrypt key nonce pt))
+    (let ct    (rc-drop blob 40))                         ; skip nonce(8)+tag(32)
+    (let back  (rc-decrypt key blob))
+    (let tampered (append-list (rc-take blob 40) (cons (bxor (head ct) 255) (tail ct))))
+    (let tback (rc-decrypt key tampered))
+    (let wback (rc-decrypt (rc-str-bytes "wrong-key") blob))
+    (let c0 (if (eq (rc-eqb back pt) 1) 1 0))
+    (let c1 (if (eq (rc-eqb ct pt) 1) 0 2))
+    (let c2 (if (eq (rc-eqb tback pt) 1) 0 4))
+    (let c3 (if (eq (rc-eqb wback pt) 1) 0 8))
+    (add c0 (add c1 (add c2 c3))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -517,6 +517,7 @@ sanskrit-roots fks 111111
 satsang fks 127
 schema fks 10
 sha256 fks 2
+room-cipher fks 15
 shared-heart fks 31
 shamballa-codes fks 11111
 shamballa-light-codes fks 111111


### PR DESCRIPTION
## What

A sovereign, end-to-end-encrypted **room memory** that travels across devices — proven end-to-end, curl-free.

- **`room-cipher.fk`** — authenticated E2E encryption (encrypt-then-MAC over an HMAC-SHA256 keystream), composed from the body's own `sha256`/`hmac`/`bxor`. **Four-way: `room-cipher → 15`** (roundtrip + opaque + tamper-rejected + wrong-key-rejected).
- **`api/app/routers/rooms.py`** — a thin, opaque ciphertext KV carrier (`PUT/GET` blobs by room+addr, `GET` the offer set). The server only ever holds ciphertext it cannot read; charset-gated against traversal; 1 MiB cap.
- **`room-carrier-http.fk`** — Form's own HTTP storage-port backend (`rch-put/get/keys`) over the proven socket floor (`http-client-socket-verbs 127`). No curl, no host shell.

## Proof (against a live server)

Form seals a room → `rch-put` (Form HTTP) → endpoint → `rch-get` (Form HTTP) → Form opens → **byte-identical**, ciphertext-only, `KEYS` returns the offer set. The whole channel runs on the kernel.

## Two source-compiler bugs found, root-caused, worked around (flagged for proper fix)

1. BML lowering **drops `\r` from string literals** → http-client renders/parses bare LF → strict servers (uvicorn) 400 and mis-parse. Worked around with `byte_to_str(13/10)` (a call survives lowering) for both render and body-boundary.
2. Single-expression `def f(args) = call(...)` sometimes lowers to an `(empty)` body with the expression spilled to top level. Worked around with block bodies.

## Deploy note

Endpoint is additive (new route, touches nothing existing) and reversible. Durability across redeploys wants a mounted volume for `COHERENCE_ROOMS_DIR` (follow-up, host-side compose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)