### PR TITLE
tend(form): observe how a perception shifts the world model — the loop's afferent arm

### DIFF
--- a/form/form-stdlib/tests/world-model-update-band.fk
+++ b/form/form-stdlib/tests/world-model-update-band.fk
@@ -1,0 +1,13 @@
+; tests/world-model-update-band.fk — a perception shifting the world model, observed, four-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/world-model-update.fk
+;
+; Band verdict 11111 when, on Go / Rust / TypeScript / fkwu, baseline 100:
+;   a familiar reading (105) gives small surprise (5)              ->     1
+;   a novel reading (200) gives large surprise (100)               ->    10
+;   novelty moves the model more than familiarity                 ->   100
+;   the model refines toward a familiar reading (shift 1.25)       ->  1000
+;   a novel reading shifts the world model MORE than a familiar one-> 10000
+
+(do
+    (world-model-update-check))

--- a/form/form-stdlib/world-model-update.fk
+++ b/form/form-stdlib/world-model-update.fk
@@ -1,0 +1,34 @@
+; world-model-update.fk — observe how a perception shifts the world model.
+; The afferent effect, made measurable. The world model holds a baseline expectation; a
+; perception arrives; the SURPRISE (delta from baseline) is the observable effect, and the
+; refine step moves the baseline toward the reading. A familiar perception (near baseline)
+; barely moves the model; a novel one (far) moves it far -- the body learning the room. This
+; is the same sign-step sense ambient-surprise carries, here as the observable update law:
+; sense IN (whisper STT) -> world-model shift -> observable surprise, the loop's afferent arm.
+;
+; All pure; four-way proven by tests/world-model-update-band.fk (Go/Rust/TS/fkwu).
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn wm-abs (x) (if (lt x 0.0) (sub 0.0 x) x))
+    (defn surprise (baseline reading) (wm-abs (sub reading baseline)))   ; the effect of the perception
+    (defn refine (baseline reading rate) (add baseline (div (sub reading baseline) rate))) ; the model moves toward it
+    (defn shift (baseline reading rate) (sub (refine baseline reading rate) baseline))      ; how far the model moved
+    (defn smp (x) (math_floor (mul x 1000)))
+
+    ; ── baseline 100; a familiar reading (105) vs a novel one (200); rate 4 ──
+    (defn wm-base () 100.0)
+    (defn wm-familiar () 105.0)
+    (defn wm-novel () 200.0)
+    (defn wm-rate () 4.0)
+
+    (defn wmk (cond bit) (if cond bit 0))
+    (defn world-model-update-check ()
+        (add (add (add (add
+            (wmk (eq (smp (surprise (wm-base) (wm-familiar))) 5000) 1)
+            (wmk (eq (smp (surprise (wm-base) (wm-novel))) 100000) 10))
+            (wmk (gt (surprise (wm-base) (wm-novel)) (surprise (wm-base) (wm-familiar))) 100))
+            (wmk (eq (smp (shift (wm-base) (wm-familiar) (wm-rate))) 1250) 1000))
+            (wmk (gt (shift (wm-base) (wm-novel) (wm-rate)) (shift (wm-base) (wm-familiar) (wm-rate))) 10000)))
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1090,3 +1090,4 @@ real-generate-loop fks 11111
 real-layer-stack fks 11111
 real-end-to-end fks 11111
 voice-synth fks 11111
+world-model-update fks 11111


### PR DESCRIPTION
The afferent effect, made measurable (paired with `voice-synth`'s efferent voice). The world model holds a baseline; a perception arrives; **surprise** (delta from baseline) is the observable effect; refine moves the baseline toward the reading.

`tests/world-model-update-band.fk` → **`11111`** four-way (baseline 100): a **familiar** reading (105) → small surprise (5); a **novel** reading (200) → large surprise (100); novelty moves the model more than familiarity; the model refines toward a familiar reading (shift 1.25); and a **novel reading shifts the world model more** than a familiar one. *"See how it affects your world model"* is now grounded: sense in → world-model shift → observable surprise. Manifest: `world-model-update fks 11111`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)