### PR TITLE
tend(form): the acoustic model — tokens become a pitch contour the voice renders

### DIFF
--- a/form/form-stdlib/tests/voice-prosody-band.fk
+++ b/form/form-stdlib/tests/voice-prosody-band.fk
@@ -1,0 +1,13 @@
+; tests/voice-prosody-band.fk — the acoustic model: tokens -> pitch contour -> sound, four-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/voice-prosody.fk
+;
+; Band verdict 11111 when, on Go / Rust / TypeScript / fkwu, the utterance [token0, token2]:
+;   token 0 maps to pitch 1.0                                       ->     1
+;   token 2 maps to a higher pitch 2.0                              ->    10
+;   distinct tokens give a rising melody (pitch 2 > pitch 0)        ->   100
+;   the low-pitch token's frame peaks at sample 2 (rendered sound)  ->  1000
+;   the high-pitch token peaks EARLIER, at sample 1 (faster cycle)  -> 10000
+
+(do
+    (voice-prosody-check))

--- a/form/form-stdlib/voice-prosody.fk
+++ b/form/form-stdlib/voice-prosody.fk
@@ -1,0 +1,46 @@
+; voice-prosody.fk — the acoustic model: a token sequence becomes a pitch contour, a melody.
+; Sits above voice-synth. Each token maps to a pitch (a note); stress maps to amplitude
+; (emphasis). A sequence of tokens is a contour, and additive synthesis renders each into a
+; frame of samples. text -> contour -> voice = the efferent arm above the synthesis primitive.
+; A higher-pitch token completes its cycle faster, so it peaks earlier in the waveform -- the
+; contour genuinely shapes the sound, observable sample by sample.
+;
+; Self-contained over core (inline range-reduced Taylor sin), four-way proven by
+; tests/voice-prosody-band.fk (Go/Rust/TS/fkwu).
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn vp-pi () 3.141592653589793)
+    (defn vp-tau () 6.283185307179586)
+    (defn vp-reduce (x) (if (gt x (vp-pi)) (sub x (vp-tau)) x))
+    (defn vp-sin1 (x)
+        (do
+            (let x2 (mul x x)) (let x3 (mul x x2)) (let x5 (mul x3 x2)) (let x7 (mul x5 x2))
+            (let x9 (mul x7 x2)) (let x11 (mul x9 x2)) (let x13 (mul x11 x2))
+            (add (sub (add (sub (add (sub x (div x3 6.0)) (div x5 120.0)) (div x7 5040.0)) (div x9 362880.0)) (div x11 39916800.0)) (div x13 6227020800.0))))
+    (defn vp-sin (x) (vp-sin1 (vp-reduce x)))
+    (defn vp-render-acc (amp freq sr i n)
+        (if (eq i n) (list)
+            (cons (mul amp (vp-sin (div (mul (mul (vp-tau) freq) i) sr))) (vp-render-acc amp freq sr (add i 1) n))))
+    (defn vp-render (amp freq sr n) (vp-render-acc amp freq sr 0 n))
+
+    ; ── the acoustic model: token -> pitch, stress -> amplitude ──
+    (defn tok-pitch (tok) (add 1.0 (mul tok 0.5)))   ; each token a distinct note
+    (defn tok-amp (stress) stress)
+    ; speak: a token sequence -> a list of rendered frames (the melody as sound)
+    (defn speak (toks sr n)
+        (if (eq (len toks) 0) (list)
+            (cons (vp-render 1.0 (tok-pitch (head toks)) sr n) (speak (tail toks) sr n))))
+    (defn smp (x) (math_floor (mul x 1000)))
+
+    (defn vp-frames () (speak (list 0 2) 8.0 8))     ; utterance: low token, then higher token
+    (defn vpk (cond bit) (if cond bit 0))
+    (defn voice-prosody-check ()
+        (add (add (add (add
+            (vpk (eq (tok-pitch 0) 1.0) 1)
+            (vpk (eq (tok-pitch 2) 2.0) 10))
+            (vpk (gt (tok-pitch 2) (tok-pitch 0)) 100))
+            (vpk (eq (smp (nth (nth (vp-frames) 0) 2)) 1000) 1000))
+            (vpk (eq (smp (nth (nth (vp-frames) 1) 1)) 1000) 10000)))
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1091,3 +1091,4 @@ real-layer-stack fks 11111
 real-end-to-end fks 11111
 voice-synth fks 11111
 world-model-update fks 11111
+voice-prosody fks 11111


### PR DESCRIPTION
The prosody stone above `voice-synth`: a token sequence becomes a **melody** (each token a pitch, stress an amplitude), then additive synthesis renders each token into a frame of samples. **text → contour → voice.**

`tests/voice-prosody-band.fk` → **`11111`** four-way: for the utterance `[token0, token2]`, token 0 → pitch 1.0, token 2 → higher pitch 2.0, distinct tokens give a **rising melody**, the low-pitch token's frame peaks at sample 2, and the **high-pitch token peaks earlier at sample 1** — a faster cycle, so the contour genuinely shapes the sound. The efferent arm now has both layers: acoustic model (this) over synthesis primitive (`voice-synth`). The body turns a token sequence into a shaped, spoken waveform natively. Manifest: `voice-prosody fks 11111`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)