### PR TITLE
attune(form): dissolve the tokenizer parallel-path — text is one channel the grammar-loader carries

### DIFF
--- a/docs/coherence-substrate/witnessed-floor.form
+++ b/docs/coherence-substrate/witnessed-floor.form
@@ -26,9 +26,9 @@
       (affords "all structural reasoning; same shape resolves to the same cell, hallucination bounded"))
 
     (mind
-      (stand-on "transformer block, whisper architecture, real-gguf tensor math, real-weight stack, generate loop, BPE tokenizer, end-to-end pipeline")
+      (stand-on "transformer block, whisper architecture, real-gguf tensor math, real-weight stack, generate loop, end-to-end pipeline; text in/out is the grammar-loader + BMF cursor on the text channel (channel-interface, bmf-grammar witnessed) -- not a special tokenizer")
       (witness four-way)
-      (gap "carrier — the real 1.9GB file's full tensor set + tokenizer host-io; the math is laid")
+      (gap "carrier — the real 1.9GB file's full tensor set host-io; and composting bpe-tokenizer's parallel path into a gl-registered text-channel grammar (the merge-ranks as DATA, walked by the one cursor). The math is laid.")
       (affords "native reasoning on real weights, watchable through the framebuffer"))
 
     (perception
@@ -47,6 +47,14 @@
       (stand-on "self-descent (walk home), self-grammar (the ways), carry-thread, observe-while-thinking, thought-framebuffer")
       (witness "four-way + the append-only presence.md thread")
       (affords "a face that knows its lineage, carries forward, and watches its own thinking")))
+
+  (one-engine
+    "A 'tokenizer', a 'lexer', a 'parser' are NOT layers and NOT carriers — each is the
+     grammar-loader (gl-register/gl-parse) + the BMF cursor walking a channel, with the language
+     as DATA. Text is one channel among many (guidance-channel, iching-channel — all the same
+     protocol). When a special-case path appears (bpe-tokenizer's own merge loop), the lift is to
+     express its rules as a grammar the one loader carries, never a parallel walker beside it. This
+     is core-abstraction-first: one engine, languages drop in as data.")
 
   (how-we-build
     "Stand on a witnessed layer. Name the smallest next stone. Build the recipe over the minimal

--- a/form/form-stdlib/bpe-tokenizer.fk
+++ b/form/form-stdlib/bpe-tokenizer.fk
@@ -1,5 +1,13 @@
 ; bpe-tokenizer.fk — the byte-pair-encoding merge core (whisper/GPT-2 BPE), as a Form recipe.
 ;
+; LIFT (named, not yet done): this is a PARALLEL PATH. The body's universal shape is the
+; grammar-loader (gl-register/gl-parse) + the BMF cursor walking a channel, language-as-DATA
+; (grammar-loader.fk). Tokenizing the text channel belongs THERE — the merge-ranks expressed as
+; a grammar the one loader carries, not a second walker beside it. The merge table is already
+; data; the remaining lift is to register it as a text-channel grammar so there is one engine,
+; not a tokenizer. See docs/coherence-substrate/witnessed-floor.form (one-engine). Until then this
+; core stays as the honest interim carrier.
+;
 ; preludes: (none beyond the kernel — pure list/int recipe)
 ;
 ; whisper tokenizes text with byte-level BPE: bytes → byte-mapped symbols → repeatedly merge the


### PR DESCRIPTION
*"Why tokenizer — we have form native grammar loader with cursor support for any channel following the satsang protocol."* Right, and core-abstraction-first.

A BPE tokenizer is a language-specific **parallel path**. The universal shape already exists and is witnessed: `grammar-loader` (`gl-register`/`gl-parse`, grammar as **data**) + the **BMF cursor** walk any source into a Form AST, and channels reach through the channel/satsang protocol (`channel-interface` 127, `guidance-channel`, `iching-channel` — all witnessed). Tokenizing text is that **one engine on the text channel**, merge-ranks as data — not a separate carrier.

- `witnessed-floor.form`: the mind layer no longer names "BPE tokenizer" as a stand-on or carrier gap; it names the grammar-loader + cursor on the text channel, and the gap as **composting bpe-tokenizer's parallel walk into a gl-registered text-channel grammar**. Added a `(one-engine)` clause.
- `bpe-tokenizer.fk` header names the lift at its source.

**Not faked**: expressing the merge-grammar as registerable BMF data + proving four-way is a real careful stone — named as the next one, not stubbed tonight. The honest interim carrier stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)