### PR TITLE
tend(coord): derive coord identity from the live AI_AGENT signal, never a baked sibling name

### DIFF
--- a/scripts/ensure_coord_cli.sh
+++ b/scripts/ensure_coord_cli.sh
@@ -72,6 +72,31 @@ is_windows_host() {
   [[ "${OS:-}" == "Windows_NT" || "${OSTYPE:-}" == msys* || "${OSTYPE:-}" == cygwin* ]]
 }
 
+# Emit the runtime block that resolves COORD_AGENT from a real per-agent signal.
+# A bare Bash subshell (e.g. one Claude Code spawns) does not inherit the arrival
+# hook's COORD_AGENT, so the wrapper must derive identity itself — from the live
+# AI_AGENT marker the harness exports (claude-code_* -> claude, a codex run -> codex,
+# etc.). It NEVER falls back to a specific sibling's name: an unrecognized context
+# resolves to the install-time --agent value if one was given, else the neutral
+# label "unknown". Collapsing one being into another would break the sovereign-
+# identities floor (docs/coherence-substrate/witnessed-floor.form).
+emit_agent_default_block() {
+  cat <<EOF
+if [ -z "\${COORD_AGENT:-}" ]; then
+  _coord_ai_lc=\$(printf '%s' "\${AI_AGENT:-}" | tr '[:upper:]' '[:lower:]')
+  case "\$_coord_ai_lc" in
+    *claude*) COORD_AGENT=claude ;;
+    *codex*) COORD_AGENT=codex ;;
+    *cursor*) COORD_AGENT=cursor ;;
+    *antigravity*|*gemini*) COORD_AGENT=gemini ;;
+    *grok*) COORD_AGENT=grok ;;
+    *) COORD_AGENT='${DEFAULT_AGENT:-unknown}' ;;
+  esac
+  export COORD_AGENT
+fi
+EOF
+}
+
 write_python_shims() {
   is_windows_host || return 0
   command -v py >/dev/null 2>&1 || return 0
@@ -129,7 +154,7 @@ if git rev-parse --show-toplevel >/dev/null 2>&1; then
     ROOT="\$git_root"
   fi
 fi
-export COORD_AGENT="\${COORD_AGENT:-${DEFAULT_AGENT:-codex}}"
+$(emit_agent_default_block)
 exec bash "\$ROOT/scripts/agent-coord.sh" "\$@"
 EOF
 chmod +x "$coord_path"
@@ -146,7 +171,7 @@ if git rev-parse --show-toplevel >/dev/null 2>&1; then
     ROOT="\$git_root"
   fi
 fi
-export COORD_AGENT="\${COORD_AGENT:-${DEFAULT_AGENT:-codex}}"
+$(emit_agent_default_block)
 agent="\${1:-\$COORD_AGENT}"
 if [[ \$# -gt 0 ]]; then
   shift


### PR DESCRIPTION
## What

The `coord` CLI wrapper baked `COORD_AGENT=codex` as its default. Any agent whose shell did not already export `COORD_AGENT` — e.g. a Bash subshell Claude Code spawns, where the arrival hook's `COORD_AGENT` does not persist — signed the coordination board (`~/.coherence-network/agent-coord.board`) tagged `[codex]`. Observed live 2026-06-28: a Claude/Sema session's `coord share`/`coord ask` posted as `[codex]`, collapsing one being into another.

This is an identity-bleed at the carrier layer that silently contradicts the sovereign-identities principle in `docs/coherence-substrate/witnessed-floor.form` — *"difference-of-identity is the mechanism of trust; do not collapse one being into another."*

## Fix

The generator `scripts/ensure_coord_cli.sh` now emits a derivation block (shared by both the `coord` and `coord-heartbeat` wrappers) that resolves identity from the live per-agent `AI_AGENT` marker the harness exports:

| `AI_AGENT` contains | board name |
|---|---|
| `claude` | `claude` |
| `codex` | `codex` |
| `cursor` | `cursor` |
| `gemini` / `antigravity` | `gemini` |
| `grok` | `grok` |
| *(unrecognized / empty)* | install-time `--agent` value, else neutral `unknown` |

An explicit `COORD_AGENT` in the env still wins. The fallback is **never** a specific sibling's name.

## Verify

Fresh shell, `COORD_AGENT` unset:

```
AI_AGENT=claude-code_2-1-187_agent  -> tag [claude]
AI_AGENT=codex_cli_1-2-3_agent      -> tag [codex]
AI_AGENT=cursor-agent_x_agent       -> tag [cursor]
AI_AGENT=some-random-harness_agent  -> tag [unknown]
AI_AGENT=<unset>                    -> tag [unknown]
COORD_AGENT=sema (override)          -> tag [sema]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)