### PR TITLE
tend(substrate): deploy ingests .form/.fk; annotate resolves repo-relative paths

### DIFF
--- a/api/app/services/substrate/kernel.py
+++ b/api/app/services/substrate/kernel.py
@@ -606,18 +606,27 @@ def annotate_path(session: Session, path: str) -> PathAnnotation:
     """Return substrate context for a file path.
 
     The lookup is by source_path — the path stored when the cell was
-    ingested. If multiple cells point at the same path (rare; possible
-    if the same file is ingested under multiple domains), only the first
-    is returned.
+    ingested. Cells are stored under the container-absolute path
+    (`/app/<repo-relative>`), but callers naturally hold the repo-relative
+    path (form-first attribution, the read-hook). So the lookup tries both
+    the path as given and the `/app/`-prefixed form, in cell_id order, so a
+    repo-relative query resolves the same cell a container-absolute one does.
+    If multiple cells point at the same path (rare; possible if the same
+    file is ingested under multiple domains), only the first is returned.
 
     Agents call this when they read a file and want to know:
     - what cell this file is in the substrate
     - what Blueprint shape it has
     - what other cells share that shape (structural equivalents)
     """
+    candidates = [path]
+    if path.startswith("/app/"):
+        candidates.append(path[len("/app/"):])
+    else:
+        candidates.append("/app/" + path.lstrip("/"))
     cell_orm = (
         session.query(SubstrateNamedCellORM)
-        .filter_by(source_path=path)
+        .filter(SubstrateNamedCellORM.source_path.in_(candidates))
         .order_by(SubstrateNamedCellORM.cell_id)
         .first()
     )

--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -891,9 +891,16 @@ run_substrate_ingest() {
     return 0
   fi
 
+  # Ingestable tissue: the .md content domains PLUS the substrate's own
+  # shape-files (docs/coherence-substrate/*.form) and stdlib recipes
+  # (form/form-stdlib/**/*.fk). The latter two land as ARTIFACT cells so
+  # form-first attribution can resolve their NodeIDs from the live lattice
+  # instead of from memory. They reach the substrate only through
+  # ingest-paths (the `ingest`/`ingest --all` commands skip non-.md), so
+  # the per-file loop below dispatches every path through ingest-paths.
   local changed
   changed="$(cd "$REPO_DIR" && git diff --name-only "$from".."$to" 2>/dev/null \
-              | grep -E '^(specs|ideas|docs/vision-kb|docs/presences|docs/lineage|docs/breath)/.*\.md$' \
+              | grep -E '^(specs|ideas|docs/vision-kb|docs/presences|docs/lineage|docs/breath)/.*\.md$|^docs/coherence-substrate/.*\.form$|^form/form-stdlib/.*\.fk$' \
               || true)"
   if [[ -z "$changed" ]]; then
     ended="$(date +%s)"
@@ -910,8 +917,12 @@ run_substrate_ingest() {
   local rc=0
   while IFS= read -r path; do
     [[ -z "$path" ]] && continue
-    run_with_timeout "${SUBSTRATE_INGEST_FILE_TIMEOUT_SECONDS:-120}" \
-      docker compose exec -T api sh -lc "cd /app && python3 scripts/coh_substrate.py ingest '/app/$path' --structured" \
+    # ingest-paths (not `ingest`) so .form/.fk land as ARTIFACT cells and
+    # .md still routes to its domain ingester. Structured CTOR is the
+    # default; the 300s ceiling covers a concept's word-cell interning
+    # against prod Postgres (120s dropped lc-cognitive-sovereignty).
+    run_with_timeout "${SUBSTRATE_INGEST_FILE_TIMEOUT_SECONDS:-300}" \
+      docker compose exec -T api sh -lc "cd /app && python3 scripts/coh_substrate.py ingest-paths '/app/$path'" \
       2>&1 | tee -a "$LOG_FILE"
     local file_rc=$?
     if [[ "$file_rc" -ne 0 ]]; then


### PR DESCRIPTION
## What

Closes the repo-body → prod-lattice drift that made form-first attribution cite NodeIDs from memory instead of the live body.

**Root cause (data-flow):** `auto-deploy.sh`'s `run_substrate_ingest` filtered changed files to `*.md` under the content domains only. `docs/coherence-substrate/*.form` and `form/form-stdlib/**/*.fk` were *never* ingested on deploy — and the `ingest`/`ingest --all` commands skip non-`.md` anyway. So every `.form`/`.fk` cell drifted out of the lattice. Verified live: `annotate?path=…witnessed-floor.form` → `in_substrate:false`; `cell/concept/lc-cognitive-sovereignty` → not found.

**Root cause (query surface):** `annotate_path` matched `source_path` exactly. Cells store the container-absolute `/app/<repo-rel>` path, but form-first callers (and the read-hook) hold the repo-relative path — so annotate returned `false` even for present cells (e.g. the long-ingested `lc-trust-over-fear`).

## Changes

- **`auto-deploy.sh`** — widen the ingest filter to include `docs/coherence-substrate/*.form` and `form/form-stdlib/**/*.fk`; dispatch every changed path through `ingest-paths` (handles `.md` domains *and* `.form`/`.fk` artifacts); bump per-file timeout 120→300s (120s had been silently dropping the slow concept word-cell ingest).
- **`kernel.py` `annotate_path`** — resolve both the given path and its `/app`-prefixed form, so a repo-relative query grounds the same cell a container-absolute one does.

## Data heal (already applied to prod)

Ingested in-container against prod Postgres: `witnessed-floor.form`, `self-grammar.form`, and the `voice-*` / `world-model-*` / `self-descent` `.fk` recipes (ARTIFACT cells 336265–336459). `lc-cognitive-sovereignty` concept ingest in flight. This PR stops the *re-drift* on the next `.form`/`.fk` addition.

## Note on the task's named files

The task named `voice-formant`, `voice-consonant`, `voice-learn`, `real-thought-*` — several of those `.fk` filenames don't exist in the body (cache-not-body drift). Ingested what the body actually holds via glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)