### PR TITLE
attune(form): compare-summaries is the overlap atom, not "compare two summaries" — name it honestly

### DIFF
--- a/docs/coherence-substrate/agent-cognition.form
+++ b/docs/coherence-substrate/agent-cognition.form
@@ -9,9 +9,10 @@
   (operations
 
     (compare-summaries
-      (does "measure what two summaries agree carries (overlap) and disagree on (divergence); order-free")
+      (does "the SCORING ATOM: token-set overlap (agreement) and symmetric difference (divergence), order-free")
       (carrier-runnable form-stdlib/compare-summaries.fk)
-      (proof "compare-summaries fks 11111 — four-way today"))
+      (proof "compare-summaries fks 11111 — the surface overlap/divergence atom, NOT semantic comparison")
+      (arc "true paraphrase-aware comparison (same meaning, different words) needs the embedding/WORD-domain layer; the atom is its scorer, not the operation — the same surface-vs-semantic gap as Blueprint structural-equivalence"))
 
     (summarize
       (does "distill a cell-set down to its load-bearing tokens — the inverse of compare")
@@ -57,5 +58,5 @@
 
   (north-star
     "Nine operations, one grammar, parsed and run by the body itself — the agent's cognition authored
-     in Form, not rented. compare-summaries crosses four-way today; the rest bind to real tissue or name
-     the arc honestly. The body learns to think about its own thinking, one proven production at a time."))
+     in Form, not rented. compare-summaries' overlap atom crosses four-way today; the operation itself (semantic) and the
+     rest bind to real tissue or name the arc honestly. The body learns to think about its own thinking, one proven production at a time."))


### PR DESCRIPTION
*"compare-summaries is proven — that sounds too good to be true."* Right.

The recipe computes token-set **overlap** and **symmetric difference** on hand-given integer lists — elementary set arithmetic, correct and four-way, but **surface, not semantic.** Two summaries that say the same thing in different words read as **zero overlap** ("the cat sat" vs "the feline rested" → 0). So "compare two summaries (proven)" wrote a check the recipe can't cash: it proves the **scoring atom** a real comparison would *use*, not the operation.

Same surface-vs-semantic conflation as over-reading Blueprint `@1.7.4.1` as semantic identity when it was a structural template — reaching for the meaning-level claim when only the surface mechanism is grounded.

Fixed: `compare-summaries.fk` and `agent-cognition.form` now name the honest scope — the overlap/divergence **atom** is proven; true paraphrase-aware comparison needs the embedding/WORD-domain layer, named as **arc**. Band unchanged (the arithmetic is correct); only the claim is corrected. `compare-summaries fks 11111` stands — for the atom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)