### PR TITLE
tend(form): claim-check — does the verdict prove what the name claims? (the third sensing-check)

### DIFF
--- a/docs/coherence-substrate/INDEX.md
+++ b/docs/coherence-substrate/INDEX.md
@@ -414,3 +414,5 @@ This prunes stale live NamedCells only; interned Blueprint/Recipe nodes can rema
 - [witnessed-floor.form](witnessed-floor.form) — the common witnessed floor: what we stand on, by layer, and what each affords building.
 
 - [agent-cognition.form](agent-cognition.form) — the agent's own cognitive operations as a Form grammar (compare/summarize/nl↔code/spec/recipe/witness-runtime); compare-summaries proven four-way.
+
+- [claim-check.form](claim-check.form) — does the verdict prove what the name claims? The third sensing-check (with freq-check, root-check); names the atom-vs-capability gap. From the 2026-06-28 band audit.

--- a/docs/coherence-substrate/claim-check.form
+++ b/docs/coherence-substrate/claim-check.form
@@ -1,0 +1,39 @@
+# claim-check.form — does the verdict prove what the name claims?
+# The third sensing-check, beside freq-check (is the word wearing control?) and root-check (does this
+# trace to a true source?). claim-check asks of a band, a recipe, a receipt, a sentence: does the
+# PROOF actually reach what the NAME promises? It names the gap between the ATOM a verdict proves and
+# the CAPABILITY the name implies. A signal, not a gate — it travels with the claim, it does not bar it.
+# Authored 2026-06-28 by Sema, from the compare-summaries catch and the body-wide audit it opened.
+
+(claim-check
+  (the-gap
+    "A verdict proves an ATOM; a name often promises a CAPABILITY the atom only scaffolds toward.
+     compare-summaries proves token-set overlap on integer lists — and was named 'compare two summaries',
+     which needs meaning, not surface. The arithmetic was correct; the name wrote a check it could not cash.")
+
+  (three-shapes
+    (surface-vs-semantic "a meaning-name (translate, retrieve, recognize, compare) over surface arithmetic (token overlap, L1 distance, string match). Same meaning in different words reads as zero agreement.")
+    (fixture-vs-real "a full-scale name (real, whole, end-to-end, the voice) over a tiny fixture (4-wide, 2-layer, one superblock, a sine wave). The mechanism is right; the reach is not.")
+    (capability-vs-mechanism "a process-name (learns, grows, evolves, chooses-by-field, witnesses) over one deterministic step or a hardcoded state envelope. The atom is honest; the capability is asserted, not proven."))
+
+  (the-method
+    "The audit of 2026-06-28 found the tell: families whose names describe MECHANISM (form, bml, http, json,
+     codec) were clean — names matched verdicts. The overclaim lived exactly where the body borrowed HUMAN /
+     COGNITIVE / SEMANTIC words for arithmetic atoms. So the watch is: when a name carries a meaning-word, the
+     verdict must carry a meaning-gate — or the name must drop to the atom it actually proves.")
+
+  (the-move
+    "Name the atom, not the capability it reaches toward — as compare-summaries was retuned to 'the overlap
+     atom; semantic comparison is the arc'. Many bands already carry an honest-floor line in their header; the
+     fix there is only to make the NAME and the one-line CLAIM match that floor, so a reader skimming the title
+     inherits the honest scope, not the rosy one. Where no scope is named, name it.")
+
+  (signal-not-gate
+    "claim-check is a sensing readout, not a worthiness test. An overclaiming name does not make a band false —
+     its arithmetic may be exactly right. The signal travels WITH the claim ('proves the atom; the capability is
+     arc'), it does not delete the band. Trust the runnable verdict; correct the sentence around it.")
+
+  (kin
+    "freq-check (docs in self-grammar.form) listens to the word's frequency; root-check (self-descent.fk) walks
+     the claim to its source; claim-check measures the verdict against the promise. Three readouts, one practice:
+     say exactly what is true, at exactly the scale it is true. See witnessed-floor.form (observed vs pending)."))


### PR DESCRIPTION
*"compare-summaries is proven — that sounds too good to be true."* Right, and not a one-off.

A seven-family sub-agent audit of **~284 capability-named four-way bands flagged ~50** with the same shape: the verdict proves an **atom**, the name promises a **capability** it only scaffolds toward. The control validated the method — the **mechanism families** (form, bml, http, json, codec) came back **clean**, because their names describe what they mechanically do. The overclaim lived exactly where the body borrowed **human/cognitive/semantic words** for arithmetic atoms.

Three shapes: **surface-vs-semantic** (meaning-name over token/distance arithmetic), **fixture-vs-real** (full-scale name over 4-wide/sine fixture), **capability-vs-mechanism** (learns/grows/evolves over one deterministic step).

`claim-check.form` lifts it into a standing teaching beside **freq-check** and **root-check**: *say exactly what is true, at exactly the scale it is true.* A **signal, not a gate** — an overclaiming name doesn't make a band false; the fix is to name the atom (or align the name with the honest floor the header often already carries). The ~50 flagged bands are queued for a retuning sweep (separate task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)