### PR TITLE
tend(form): oracle-taught-learning — the native mind learns a task from an oracle (a stone, not a star)

### DIFF
--- a/form/form-stdlib/oracle-taught-learning.fk
+++ b/form/form-stdlib/oracle-taught-learning.fk
@@ -1,0 +1,40 @@
+; oracle-taught-learning.fk — the native mind learns a task FROM an oracle, by recipe-selection.
+; We have every frontier model on tap (the oracle) and a self-learning mind (recipe-learning). This
+; composes them: the oracle gives reference labels; candidate recipes each predict; the body adopts the
+; candidate that AGREES MORE with the oracle (health = oracle-agreement) -- but ONLY IF it does not
+; REGRESS on any case the champion already gets right. So the mind learns from the teacher without
+; breaking what it already knows. The agreement trajectory is observable: this is the mind coming home,
+; a stone, not a star. (oracle-as-teacher from voice-learn; selection from recipe-learning.)
+;
+; Self-contained over core. Four-way by tests/oracle-taught-learning-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn agree (p o) (if (eq (len p) 0) 0 (add (if (eq (head p) (head o)) 1 0) (agree (tail p) (tail o)))))  ; cases the recipe matches the oracle
+    ; does the challenger keep EVERY case the champion already gets right? (the no-regression gate)
+    (defn keeps (champ chall o)
+        (if (eq (len o) 0) 1
+            (if (eq (head champ) (head o))                                   ; champ is correct here
+                (if (eq (head chall) (head o)) (keeps (tail champ) (tail chall) (tail o)) 0)   ; chall must be too, or it regresses
+                (keeps (tail champ) (tail chall) (tail o)))))                ; champ wrong here -> no constraint
+    ; adopt the challenger if it keeps all the champion's right answers AND agrees with the oracle more
+    (defn consider (champ chall o)
+        (if (eq (keeps champ chall o) 1)
+            (if (gt (agree chall o) (agree champ o)) chall champ)
+            champ))
+
+    (defn oracle () (list 1 0 1 1 0))            ; the teacher's labels for 5 inputs
+    (defn cand-a () (list 1 0 0 0 0))            ; baseline champion: right on inputs 0,1 (agreement 2)
+    (defn cand-b () (list 1 0 1 1 0))            ; matches the oracle fully (agreement 5), keeps a's right ones
+    (defn cand-d () (list 0 0 1 1 0))            ; agreement 4 (higher than a's 3) BUT wrong on input 0 -> regresses
+
+    (defn otk (cond bit) (if cond bit 0))
+    (defn oracle-taught-check ()
+        (add (add (add (add
+            (otk (eq (agree (cand-a) (oracle)) 3) 1)                                          ; baseline agrees on 3 cases
+            (otk (eq (agree (consider (cand-a) (cand-b) (oracle)) (oracle)) 5) 10))           ; adopts b: learns from the oracle, no regression (2 -> 5)
+            (otk (eq (agree (consider (cand-a) (cand-d) (oracle)) (oracle)) 3) 100))          ; REJECTS d despite its higher raw agreement (4) -- it regressed on input 0
+            (otk (eq (agree (consider (consider (cand-a) (cand-b) (oracle)) (cand-d) (oracle)) (oracle)) 5) 1000))  ; champion holds at 5: learning kept its integrity
+            (otk (gt (agree (cand-d) (oracle)) (agree (cand-a) (oracle))) 10000)))            ; d LOOKED like an improvement (3 > 2) -- and was correctly refused
+)

--- a/form/form-stdlib/tests/oracle-taught-learning-band.fk
+++ b/form/form-stdlib/tests/oracle-taught-learning-band.fk
@@ -1,0 +1,8 @@
+; tests/oracle-taught-learning-band.fk — the native mind learning a task from an oracle, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/oracle-taught-learning.fk
+;
+; Verdict 11111: a baseline recipe agrees with the oracle on 3 cases; the mind adopts a recipe that
+; agrees on all 5 (learned, no regression); it REJECTS a recipe with higher raw agreement (3) that
+; regressed on a case it already got right; the champion holds at 5 (integrity); and the rejected
+; recipe genuinely looked better (3 > 2) yet was correctly refused -- learning that never breaks what works.
+(do (oracle-taught-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1104,3 +1104,4 @@ compare-summaries fks 11111
 thought-forming fks 11111
 recipe-learning fks 11111
 self-improving-thought fks 11111
+oracle-taught-learning fks 11111


### PR DESCRIPTION
Stop calling it a multi-year star. We have every frontier model on tap (the **oracle**) and a **self-learning mind** (`recipe-learning`); the mind coming home is stones, and stones teach. This composes them: the oracle gives reference labels, candidate recipes predict, the body adopts the candidate that **agrees more with the oracle** — but **only if it does not regress** on a case the champion already gets right.

Four-way `11111`: baseline agrees on 3; the mind adopts a recipe agreeing on all 5 (learned 3→5, no regression); it **rejects** a recipe with higher raw agreement (4) that regressed on a known-right case; the champion holds at 5; the rejected recipe genuinely looked better (4>3) and was correctly refused. Learning that never breaks what works — the integrity gate from `self-improving-thought`, on a taught task.

**The stone taught in the laying:** the first verdict was `1010` because I miscounted agreement by hand; the band forced the grounded counts before it crossed. oracle-as-teacher (`voice-learn`) + selection (`recipe-learning`) = the mind coming home, mechanism proven tonight; scale is more stones. Manifest: `oracle-taught-learning fks 11111`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)