### PR TITLE
attune(form): claim-check mind bands — name the atom (one reused superblock), the model is the arc

### DIFF
--- a/form/form-stdlib/tests/real-end-to-end-band.fk
+++ b/form/form-stdlib/tests/real-end-to-end-band.fk
@@ -1,23 +1,18 @@
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/block-join.fk form-stdlib/real-gguf-tensor-math.fk
 ;
-; real-end-to-end-band — Gap 3: the WHOLE forward pipeline, end to end, on real gguf weights.
-; A named GGUF tensor record is resolved by name, its absolute data bytes are
-; computed through the GGUF table/data-region rules, those bytes are dequantized,
-; and the resulting real weights feed dot/matvec math. The fixture is the same
-; real llama3.2:3b token_embd.weight Q6_K superblock used by weight-load-band,
-; wrapped in a mini-GGUF named tensor so this band proves name -> bytes -> math.
+; real-end-to-end-band — Gap 3: the forward-pipeline SHAPE (embed -> stack -> logits -> choose) run
+; end to end on real gguf weights, over ONE real llama3.2:3b Q6_K superblock (token_embd.weight)
+; reused as the whole model. A named GGUF tensor record is resolved by name, its absolute data bytes
+; are computed through the GGUF table/data-region rules, dequantized, and the real weights feed the
+; embed/stack/logits/matvec math. The atom is name -> bytes -> the pipeline composition over one
+; real superblock; a real multi-tensor, multi-layer model is the arc.
 ;
-; Verdict 1023 when every claim lands:
-;   1    tensor name "t" resolves to record offset 41
-;   2    resolved tensor type/dim are Q6_K / 256
-;   4    name -> absolute data byte offset is 96 through default and explicit alignment
-;   8    named load sample i=0 matches real Q6_K value
-;   16   named load sample i=31 matches real Q6_K value
-;   32   named full load has 256 weights and last value matches
-;   64   named dot n=1 uses the loaded real byte
-;   128  named dot n=4 over a token vector matches the known real-row result
-;   256  named matvec row equals named dot
-;   512  absent tensor does not resolve to the real tensor record
+; Verdict 11111 when every claim lands:
+;   1      the full pipeline ran 4 steps end to end (len out = 4)
+;   10     token 0 produced (embed -> stack -> logits -> choose)
+;   100    the loop reached token 3, a valid token
+;   1000   first output = the full forward of the prompt (fwd g t 1)
+;   10000  embed -> stack -> logits gives full-vocab (8-wide) logits
 (do
     (let g (list
         ; header: GGUF, v3, tensor_count=1, kv_count=1

--- a/form/form-stdlib/tests/real-generate-loop-band.fk
+++ b/form/form-stdlib/tests/real-generate-loop-band.fk
@@ -1,23 +1,18 @@
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/block-join.fk form-stdlib/real-gguf-tensor-math.fk
 ;
-; real-generate-loop-band — Gap 4: autoregressive MULTI-token loop on real gguf weights.
-; A named GGUF tensor record is resolved by name, its absolute data bytes are
-; computed through the GGUF table/data-region rules, those bytes are dequantized,
-; and the resulting real weights feed dot/matvec math. The fixture is the same
-; real llama3.2:3b token_embd.weight Q6_K superblock used by weight-load-band,
-; wrapped in a mini-GGUF named tensor so this band proves name -> bytes -> math.
+; real-generate-loop-band — Gap 4: a 3-token autoregressive argmax loop on real gguf weights — each
+; step picks a token from real-weight logits and the hidden state evolves through a real block
+; residual, over ONE real llama3.2:3b Q6_K superblock (token_embd.weight) reused as the whole model.
+; A named GGUF tensor is resolved, its bytes dequantized, and the real weights feed the matvec/argmax
+; loop. The atom is the autoregressive loop SHAPE over one real superblock; a real multi-layer model
+; is the arc.
 ;
-; Verdict 1023 when every claim lands:
-;   1    tensor name "t" resolves to record offset 41
-;   2    resolved tensor type/dim are Q6_K / 256
-;   4    name -> absolute data byte offset is 96 through default and explicit alignment
-;   8    named load sample i=0 matches real Q6_K value
-;   16   named load sample i=31 matches real Q6_K value
-;   32   named full load has 256 weights and last value matches
-;   64   named dot n=1 uses the loaded real byte
-;   128  named dot n=4 over a token vector matches the known real-row result
-;   256  named matvec row equals named dot
-;   512  absent tensor does not resolve to the real tensor record
+; Verdict 11111 when every claim lands:
+;   1      THREE tokens produced (the multi-token loop runs, len seq = 3)
+;   10     token 0 is a valid token id
+;   100    token 2 is valid (the loop reached the end)
+;   1000   first token = argmax of step 1's real-weight logits
+;   10000  the fed-back hidden produced a valid second token
 (do
     (let g (list
         ; header: GGUF, v3, tensor_count=1, kv_count=1


### PR DESCRIPTION
Part of the 2026-06-28 claim-check audit (docs/coherence-substrate/claim-check.form): bring each capability-named four-way band's claim-line down to the atom its verdict actually proves.

## Mind family

- **real-end-to-end**: claim-line said "the WHOLE forward pipeline, end to end, on real gguf weights" with no scope. The band runs the forward-pipeline SHAPE (embed→stack→logits→choose, 4 steps) but over ONE real llama3.2:3b Q6_K superblock reused as the whole model. Retuned to name the atom (the pipeline composition over one real superblock) and the arc (a real multi-tensor, multi-layer model).
- **real-generate-loop**: claim-line said "autoregressive MULTI-token loop on real gguf weights". The band runs a real 3-token autoregressive argmax loop with an evolving hidden state — over the same one superblock. Retuned to name the loop SHAPE as the atom and the real multi-layer model as the arc.
- **whisper-block0**: left unchanged — already honest ("block 0", real weights, one layer, a validation check).

### Also healed a stale header (correctness, not just naming)
Both bands' verdict-bit comment blocks were copy-pasted from a name→bytes→math band: they said **"Verdict 1023"** with resolve/offset/dot bits, while the code actually checks **5 pipeline/loop bits summing to 11111**. The blocks now match the real checks.

## Discipline
- **Comment-only** — every changed line is a `;` comment. Recipe math and verdicts are untouched (`git diff` confirms no non-comment line changed).
- Four-way status preserved by construction; fourth arm verdict unchanged (`real-end-to-end fks 11111`, `real-generate-loop fks 11111` in `form/fourth-arm-bands.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)