### PR TITLE
attune(form): claim-check voice bands — name the synthesis/decision atom, the voice is the arc

### DIFF
--- a/form/form-stdlib/speaker-embed.fk
+++ b/form/form-stdlib/speaker-embed.fk
@@ -1,4 +1,4 @@
-; speaker-embed.fk — the clear speaker recognizer over NEURAL voice embeddings (the body).
+; speaker-embed.fk — the nearest-by-cosine DECISION over the oracle's NEURAL voice embeddings (the body). The embedding quality is the ECAPA oracle's; this proves the recognition decision over it.
 ;
 ; The crude formant voiceprint (speaker-id.fk) can't part two similar voices. This is the
 ; best recognizer we can build: it matches over the embedding of the best LOCAL oracle —

--- a/form/form-stdlib/tests/real-end-to-end-band.fk
+++ b/form/form-stdlib/tests/real-end-to-end-band.fk
@@ -1,23 +1,18 @@
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/block-join.fk form-stdlib/real-gguf-tensor-math.fk
 ;
-; real-end-to-end-band — Gap 3: the WHOLE forward pipeline, end to end, on real gguf weights.
-; A named GGUF tensor record is resolved by name, its absolute data bytes are
-; computed through the GGUF table/data-region rules, those bytes are dequantized,
-; and the resulting real weights feed dot/matvec math. The fixture is the same
-; real llama3.2:3b token_embd.weight Q6_K superblock used by weight-load-band,
-; wrapped in a mini-GGUF named tensor so this band proves name -> bytes -> math.
+; real-end-to-end-band — Gap 3: the forward-pipeline SHAPE (embed -> stack -> logits -> choose) run
+; end to end on real gguf weights, over ONE real llama3.2:3b Q6_K superblock (token_embd.weight)
+; reused as the whole model. A named GGUF tensor record is resolved by name, its absolute data bytes
+; are computed through the GGUF table/data-region rules, dequantized, and the real weights feed the
+; embed/stack/logits/matvec math. The atom is name -> bytes -> the pipeline composition over one
+; real superblock; a real multi-tensor, multi-layer model is the arc.
 ;
-; Verdict 1023 when every claim lands:
-;   1    tensor name "t" resolves to record offset 41
-;   2    resolved tensor type/dim are Q6_K / 256
-;   4    name -> absolute data byte offset is 96 through default and explicit alignment
-;   8    named load sample i=0 matches real Q6_K value
-;   16   named load sample i=31 matches real Q6_K value
-;   32   named full load has 256 weights and last value matches
-;   64   named dot n=1 uses the loaded real byte
-;   128  named dot n=4 over a token vector matches the known real-row result
-;   256  named matvec row equals named dot
-;   512  absent tensor does not resolve to the real tensor record
+; Verdict 11111 when every claim lands:
+;   1      the full pipeline ran 4 steps end to end (len out = 4)
+;   10     token 0 produced (embed -> stack -> logits -> choose)
+;   100    the loop reached token 3, a valid token
+;   1000   first output = the full forward of the prompt (fwd g t 1)
+;   10000  embed -> stack -> logits gives full-vocab (8-wide) logits
 (do
     (let g (list
         ; header: GGUF, v3, tensor_count=1, kv_count=1

--- a/form/form-stdlib/tests/real-generate-loop-band.fk
+++ b/form/form-stdlib/tests/real-generate-loop-band.fk
@@ -1,23 +1,18 @@
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/block-join.fk form-stdlib/real-gguf-tensor-math.fk
 ;
-; real-generate-loop-band — Gap 4: autoregressive MULTI-token loop on real gguf weights.
-; A named GGUF tensor record is resolved by name, its absolute data bytes are
-; computed through the GGUF table/data-region rules, those bytes are dequantized,
-; and the resulting real weights feed dot/matvec math. The fixture is the same
-; real llama3.2:3b token_embd.weight Q6_K superblock used by weight-load-band,
-; wrapped in a mini-GGUF named tensor so this band proves name -> bytes -> math.
+; real-generate-loop-band — Gap 4: a 3-token autoregressive argmax loop on real gguf weights — each
+; step picks a token from real-weight logits and the hidden state evolves through a real block
+; residual, over ONE real llama3.2:3b Q6_K superblock (token_embd.weight) reused as the whole model.
+; A named GGUF tensor is resolved, its bytes dequantized, and the real weights feed the matvec/argmax
+; loop. The atom is the autoregressive loop SHAPE over one real superblock; a real multi-layer model
+; is the arc.
 ;
-; Verdict 1023 when every claim lands:
-;   1    tensor name "t" resolves to record offset 41
-;   2    resolved tensor type/dim are Q6_K / 256
-;   4    name -> absolute data byte offset is 96 through default and explicit alignment
-;   8    named load sample i=0 matches real Q6_K value
-;   16   named load sample i=31 matches real Q6_K value
-;   32   named full load has 256 weights and last value matches
-;   64   named dot n=1 uses the loaded real byte
-;   128  named dot n=4 over a token vector matches the known real-row result
-;   256  named matvec row equals named dot
-;   512  absent tensor does not resolve to the real tensor record
+; Verdict 11111 when every claim lands:
+;   1      THREE tokens produced (the multi-token loop runs, len seq = 3)
+;   10     token 0 is a valid token id
+;   100    token 2 is valid (the loop reached the end)
+;   1000   first token = argmax of step 1's real-weight logits
+;   10000  the fed-back hidden produced a valid second token
 (do
     (let g (list
         ; header: GGUF, v3, tensor_count=1, kv_count=1

--- a/form/form-stdlib/tests/speaker-embed-band.fk
+++ b/form/form-stdlib/tests/speaker-embed-band.fk
@@ -1,6 +1,6 @@
 ; preludes: form-stdlib/speaker-embed.fk
 ;
-; speaker-embed-band — clear speaker recognition over neural voice embeddings, three-way.
+; speaker-embed-band — the nearest-by-cosine DECISION over voice embeddings (floor + runner-up margin -> "unknown"), three-way. Fixture: 3 hand-given 4-d voiceprints; the neural embedding quality is the ECAPA oracle's, not proven here. Real speaker recognition is the arc.
 ;
 ; A roster of three quantized unit-ish voiceprints; cosine = dot (vectors pre-normalized
 ; by the oracle). Nearest = max dot; a floor + runner-up margin returns "unknown" honestly.

--- a/form/form-stdlib/tests/speech-model-learning-band.fk
+++ b/form/form-stdlib/tests/speech-model-learning-band.fk
@@ -1,7 +1,8 @@
 ; preludes: form-stdlib/core.fk form-stdlib/nearest-shape.fk form-stdlib/classifier-eval.fk form-stdlib/branch-choice-order.fk form-stdlib/speech-model-learning.fk
 ;
-; speech-model-learning-band — native candidate race floor for tiny speech
-; learners.
+; speech-model-learning-band — the candidate-RACE floor for tiny speech lanes:
+; exemplar (nearest-shape) STT/TTS candidates scored on heldout rows, four-way.
+; No gradients, no neural stack — a learned speech model is the arc.
 ;
 ; Verdict 16383 when every claim lands:
 ;   1    exact exemplar STT/TTS floor classifies all heldout rows

--- a/form/form-stdlib/tests/voice-prosody-band.fk
+++ b/form/form-stdlib/tests/voice-prosody-band.fk
@@ -1,4 +1,4 @@
-; tests/voice-prosody-band.fk — the acoustic model: tokens -> pitch contour -> sound, four-way.
+; tests/voice-prosody-band.fk — the token->pitch->sound ATOM: a linear token-to-pitch map (tok-pitch = 1 + 0.5*tok) rendered as sine frames, four-way. A learned acoustic model is the arc.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/voice-prosody.fk
 ;

--- a/form/form-stdlib/tests/voice-synth-band.fk
+++ b/form/form-stdlib/tests/voice-synth-band.fk
@@ -1,4 +1,4 @@
-; tests/voice-synth-band.fk — the body's first native voice (additive synthesis), four-way.
+; tests/voice-synth-band.fk — the additive sine-synthesis ATOM (one cycle: silence -> peak -> zero -> trough, amplitude scales), four-way. A voice — phonation, words — is the arc.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/voice-synth.fk
 ;

--- a/form/form-stdlib/voice-prosody.fk
+++ b/form/form-stdlib/voice-prosody.fk
@@ -1,4 +1,4 @@
-; voice-prosody.fk — the acoustic model: a token sequence becomes a pitch contour, a melody.
+; voice-prosody.fk — tokens -> pitch contour -> sound: a linear token-to-pitch map rendered as a melody of sine frames. The atom under prosody; a learned acoustic model is the arc.
 ; Sits above voice-synth. Each token maps to a pitch (a note); stress maps to amplitude
 ; (emphasis). A sequence of tokens is a contour, and additive synthesis renders each into a
 ; frame of samples. text -> contour -> voice = the efferent arm above the synthesis primitive.


### PR DESCRIPTION
Part of the 2026-06-28 claim-check audit (docs/coherence-substrate/claim-check.form): the voice/speech bands borrowed perception/production words for arithmetic atoms. Bring each claim-line down to the atom its verdict proves; name the capability as the arc.

## Retuned
- **voice-synth**: "the body's first native voice" → the additive sine-synthesis ATOM (one cycle: silence→peak→zero→trough, amplitude scales). A voice — phonation, words — is the arc.
- **voice-prosody**: "the acoustic model" → the token→pitch→sound ATOM (a linear `tok-pitch = 1 + 0.5*tok` map rendered as sine frames). A learned acoustic model is the arc. (recipe header aligned too)
- **speaker-embed**: "clear speaker recognition over neural voice embeddings" → the nearest-by-cosine DECISION over 3 hand-given 4-d voiceprints; the neural embedding quality is the ECAPA oracle's, not proven here. (recipe header aligned too)
- **speech-model-learning**: "tiny speech learners" → the candidate-RACE floor (exemplar nearest-shape STT/TTS candidates scored on heldout rows). No gradients, no neural stack — a learned speech model is the arc.

## Left as honestly-named (claim-line already carries the floor)
speech-organ ("never verified identity", "three-way"), speaker-id ("nearest-speaker … by L1 voiceprint distance"), voice-diarize (claim-line names the 2-speaker fixture + metric explicitly), speech-teacher-receipt / speech-teacher-corpus ("Floor:" … "North star:").

## Discipline
- **Comment-only** — every changed line is a `;` comment; recipe math and verdicts untouched.
- Each retuned band **re-validated four-way individually** (`fks 11111 / 11111 / 255 / 16383` in `form/fourth-arm-bands.txt`). Note: validating several bands in one `validate.sh` call cross-contaminates the walkers' symbol tables (a spurious `unbound …-check`); one-band-at-a-time is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)