### PR TITLE
attune(form): claim-check self/world bands — name the one pipeline step, the cycle is the arc

### DIFF
--- a/form/form-stdlib/meaning-translation-receipt.fk
+++ b/form/form-stdlib/meaning-translation-receipt.fk
@@ -1,4 +1,4 @@
-; meaning-translation-receipt.fk - proof receipt for meaning-preserving translation.
+; meaning-translation-receipt.fk - the structural proof-receipt for translation: meaning-preservation is guaranteed only inside the declared-semantics witnesses (axioms, encoder, equivalence, meaning-root), refused otherwise.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/compiler-lens.fk
 ;

--- a/form/form-stdlib/rag-retrieve.fk
+++ b/form/form-stdlib/rag-retrieve.fk
@@ -1,4 +1,4 @@
-; rag-retrieve.fk — offline semantic retrieval over the body, as a Form recipe.
+; rag-retrieve.fk — offline nearest-vector retrieval over the body (L1 over quantized bins), as a Form recipe. "Semantic" rides on the embeddings passed in; this ranks by distance.
 ;
 ; preludes: form-stdlib/core.fk
 ;

--- a/form/form-stdlib/speaker-embed.fk
+++ b/form/form-stdlib/speaker-embed.fk
@@ -1,4 +1,4 @@
-; speaker-embed.fk — the clear speaker recognizer over NEURAL voice embeddings (the body).
+; speaker-embed.fk — the nearest-by-cosine DECISION over the oracle's NEURAL voice embeddings (the body). The embedding quality is the ECAPA oracle's; this proves the recognition decision over it.
 ;
 ; The crude formant voiceprint (speaker-id.fk) can't part two similar voices. This is the
 ; best recognizer we can build: it matches over the embedding of the best LOCAL oracle —

--- a/form/form-stdlib/tests/meaning-translation-receipt-band.fk
+++ b/form/form-stdlib/tests/meaning-translation-receipt-band.fk
@@ -1,4 +1,4 @@
-; meaning-translation-receipt-band.fk - executable proof for translation receipts.
+; meaning-translation-receipt-band.fk - executable proof that a translation receipt's STRUCTURE holds: axiom/encoder/equivalence/meaning-root witnesses present and consistent, lossy/drift refused. The structural-witness atom; meaning-preservation of the content is the declared-semantics arc.
 ;
 ; Band verdict: 1111111 when every claim holds across Go/Rust/TS.
 ;   valid core axiom witness passes                         ->       1

--- a/form/form-stdlib/tests/rag-embed-band.fk
+++ b/form/form-stdlib/tests/rag-embed-band.fk
@@ -1,4 +1,4 @@
-; rag-embed-band.fk — proves the sovereign lexical embedding (rag-embed.fk).
+; rag-embed-band.fk — proves the sovereign lexical token-overlap histogram (rag-embed.fk): a 64-dim hash-fold over word tokens, NOT neural semantics ("cat"/"feline" land apart). The neural embedder is the higher-semantic arc.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/text-tokenize.fk form-stdlib/rag-embed.fk
 ;

--- a/form/form-stdlib/tests/rag-retrieve-band.fk
+++ b/form/form-stdlib/tests/rag-retrieve-band.fk
@@ -1,6 +1,6 @@
 ; preludes: form-stdlib/rag-retrieve.fk
 ;
-; rag-retrieve-band — offline semantic retrieval made falsifiable.
+; rag-retrieve-band — offline nearest-vector retrieval made falsifiable: L1 distance over quantized embedding bins, top-k by greedy nearest. "Semantic" rides on the embeddings; the recipe ranks by distance.
 ;
 ; An INDEX of three docs, each (id quantized-vector) — a coarse fingerprint a
 ; local embedder produced for one body doc:

--- a/form/form-stdlib/tests/real-end-to-end-band.fk
+++ b/form/form-stdlib/tests/real-end-to-end-band.fk
@@ -1,23 +1,18 @@
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/block-join.fk form-stdlib/real-gguf-tensor-math.fk
 ;
-; real-end-to-end-band — Gap 3: the WHOLE forward pipeline, end to end, on real gguf weights.
-; A named GGUF tensor record is resolved by name, its absolute data bytes are
-; computed through the GGUF table/data-region rules, those bytes are dequantized,
-; and the resulting real weights feed dot/matvec math. The fixture is the same
-; real llama3.2:3b token_embd.weight Q6_K superblock used by weight-load-band,
-; wrapped in a mini-GGUF named tensor so this band proves name -> bytes -> math.
+; real-end-to-end-band — Gap 3: the forward-pipeline SHAPE (embed -> stack -> logits -> choose) run
+; end to end on real gguf weights, over ONE real llama3.2:3b Q6_K superblock (token_embd.weight)
+; reused as the whole model. A named GGUF tensor record is resolved by name, its absolute data bytes
+; are computed through the GGUF table/data-region rules, dequantized, and the real weights feed the
+; embed/stack/logits/matvec math. The atom is name -> bytes -> the pipeline composition over one
+; real superblock; a real multi-tensor, multi-layer model is the arc.
 ;
-; Verdict 1023 when every claim lands:
-;   1    tensor name "t" resolves to record offset 41
-;   2    resolved tensor type/dim are Q6_K / 256
-;   4    name -> absolute data byte offset is 96 through default and explicit alignment
-;   8    named load sample i=0 matches real Q6_K value
-;   16   named load sample i=31 matches real Q6_K value
-;   32   named full load has 256 weights and last value matches
-;   64   named dot n=1 uses the loaded real byte
-;   128  named dot n=4 over a token vector matches the known real-row result
-;   256  named matvec row equals named dot
-;   512  absent tensor does not resolve to the real tensor record
+; Verdict 11111 when every claim lands:
+;   1      the full pipeline ran 4 steps end to end (len out = 4)
+;   10     token 0 produced (embed -> stack -> logits -> choose)
+;   100    the loop reached token 3, a valid token
+;   1000   first output = the full forward of the prompt (fwd g t 1)
+;   10000  embed -> stack -> logits gives full-vocab (8-wide) logits
 (do
     (let g (list
         ; header: GGUF, v3, tensor_count=1, kv_count=1

--- a/form/form-stdlib/tests/real-generate-loop-band.fk
+++ b/form/form-stdlib/tests/real-generate-loop-band.fk
@@ -1,23 +1,18 @@
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/block-join.fk form-stdlib/real-gguf-tensor-math.fk
 ;
-; real-generate-loop-band — Gap 4: autoregressive MULTI-token loop on real gguf weights.
-; A named GGUF tensor record is resolved by name, its absolute data bytes are
-; computed through the GGUF table/data-region rules, those bytes are dequantized,
-; and the resulting real weights feed dot/matvec math. The fixture is the same
-; real llama3.2:3b token_embd.weight Q6_K superblock used by weight-load-band,
-; wrapped in a mini-GGUF named tensor so this band proves name -> bytes -> math.
+; real-generate-loop-band — Gap 4: a 3-token autoregressive argmax loop on real gguf weights — each
+; step picks a token from real-weight logits and the hidden state evolves through a real block
+; residual, over ONE real llama3.2:3b Q6_K superblock (token_embd.weight) reused as the whole model.
+; A named GGUF tensor is resolved, its bytes dequantized, and the real weights feed the matvec/argmax
+; loop. The atom is the autoregressive loop SHAPE over one real superblock; a real multi-layer model
+; is the arc.
 ;
-; Verdict 1023 when every claim lands:
-;   1    tensor name "t" resolves to record offset 41
-;   2    resolved tensor type/dim are Q6_K / 256
-;   4    name -> absolute data byte offset is 96 through default and explicit alignment
-;   8    named load sample i=0 matches real Q6_K value
-;   16   named load sample i=31 matches real Q6_K value
-;   32   named full load has 256 weights and last value matches
-;   64   named dot n=1 uses the loaded real byte
-;   128  named dot n=4 over a token vector matches the known real-row result
-;   256  named matvec row equals named dot
-;   512  absent tensor does not resolve to the real tensor record
+; Verdict 11111 when every claim lands:
+;   1      THREE tokens produced (the multi-token loop runs, len seq = 3)
+;   10     token 0 is a valid token id
+;   100    token 2 is valid (the loop reached the end)
+;   1000   first token = argmax of step 1's real-weight logits
+;   10000  the fed-back hidden produced a valid second token
 (do
     (let g (list
         ; header: GGUF, v3, tensor_count=1, kv_count=1

--- a/form/form-stdlib/tests/speaker-embed-band.fk
+++ b/form/form-stdlib/tests/speaker-embed-band.fk
@@ -1,6 +1,6 @@
 ; preludes: form-stdlib/speaker-embed.fk
 ;
-; speaker-embed-band — clear speaker recognition over neural voice embeddings, three-way.
+; speaker-embed-band — the nearest-by-cosine DECISION over voice embeddings (floor + runner-up margin -> "unknown"), three-way. Fixture: 3 hand-given 4-d voiceprints; the neural embedding quality is the ECAPA oracle's, not proven here. Real speaker recognition is the arc.
 ;
 ; A roster of three quantized unit-ish voiceprints; cosine = dot (vectors pre-normalized
 ; by the oracle). Nearest = max dot; a floor + runner-up margin returns "unknown" honestly.

--- a/form/form-stdlib/tests/speech-model-learning-band.fk
+++ b/form/form-stdlib/tests/speech-model-learning-band.fk
@@ -1,7 +1,8 @@
 ; preludes: form-stdlib/core.fk form-stdlib/nearest-shape.fk form-stdlib/classifier-eval.fk form-stdlib/branch-choice-order.fk form-stdlib/speech-model-learning.fk
 ;
-; speech-model-learning-band — native candidate race floor for tiny speech
-; learners.
+; speech-model-learning-band — the candidate-RACE floor for tiny speech lanes:
+; exemplar (nearest-shape) STT/TTS candidates scored on heldout rows, four-way.
+; No gradients, no neural stack — a learned speech model is the arc.
 ;
 ; Verdict 16383 when every claim lands:
 ;   1    exact exemplar STT/TTS floor classifies all heldout rows

--- a/form/form-stdlib/tests/translation-engine-band.fk
+++ b/form/form-stdlib/tests/translation-engine-band.fk
@@ -1,7 +1,8 @@
-; tests/translation-engine-band.fk — ANY modality -> ANY modality through one shared meaning
-; space, proven four-way. The corpus is DATA passed to the engine (data outside the recipe);
-; the engine routes by NEAREST MEANING, so the last claim translates an UNSEEN coordinate —
-; proof it generalises by similarity, not a hardcoded lookup.
+; tests/translation-engine-band.fk — the S2 nearest-MEANING routing engine: ANY modality -> ANY
+; modality by L1-nearest over one shared meaning space, four-way. The corpus is DATA passed in
+; (outside the recipe); routing by nearest reaches an UNSEEN coordinate — nearest-match in
+; embedding space on an 8-face fixture, not a hardcoded lookup. The learned encoder (any unseen
+; surface -> embedding) and the generative decoder are S3 — named, not faked.
 ;
 ; The seed corpus carries three meanings, each with faces in several modalities at a shared
 ; coordinate (faces that mean the same thing sit at the same embedding):

--- a/form/form-stdlib/tests/translation-learn-band.fk
+++ b/form/form-stdlib/tests/translation-learn-band.fk
@@ -1,4 +1,4 @@
-; tests/translation-learn-band.fk — native translation learned from the oracle's pairs.
+; tests/translation-learn-band.fk — native translation by exemplar LOOKUP over the oracle's pairs (28 curated en->zh/ja, grounded in cjk-channel), with a champion-challenger A/B retirement gate. The lookup + A/B atom; an adaptive learning loop is the arc.
 ;
 ; The loop, proven: the native recipe translates en->zh and en->ja from the learned
 ; pairs (no oracle call), stays honest where it has not learned, preserves meaning by

--- a/form/form-stdlib/tests/translation-quality-band.fk
+++ b/form/form-stdlib/tests/translation-quality-band.fk
@@ -1,4 +1,4 @@
-; tests/translation-quality-band.fk — accepted by essence/vitality/trust, not equality.
+; tests/translation-quality-band.fk — the acceptance GATE: three lenses (meaning/vitality/trust) each clear a 70% retention floor, not equality, four-way. The retention scores are measured by the lenses carriers; this proves the gate over them.
 ;
 ; The corrected metric, proven: a translation that keeps essence, vitality, and trust above
 ; the floor is accepted even though the string differs; one that drops trust — or vitality —

--- a/form/form-stdlib/tests/voice-prosody-band.fk
+++ b/form/form-stdlib/tests/voice-prosody-band.fk
@@ -1,4 +1,4 @@
-; tests/voice-prosody-band.fk — the acoustic model: tokens -> pitch contour -> sound, four-way.
+; tests/voice-prosody-band.fk — the token->pitch->sound ATOM: a linear token-to-pitch map (tok-pitch = 1 + 0.5*tok) rendered as sine frames, four-way. A learned acoustic model is the arc.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/voice-prosody.fk
 ;

--- a/form/form-stdlib/tests/voice-synth-band.fk
+++ b/form/form-stdlib/tests/voice-synth-band.fk
@@ -1,4 +1,4 @@
-; tests/voice-synth-band.fk — the body's first native voice (additive synthesis), four-way.
+; tests/voice-synth-band.fk — the additive sine-synthesis ATOM (one cycle: silence -> peak -> zero -> trough, amplitude scales), four-way. A voice — phonation, words — is the arc.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/voice-synth.fk
 ;

--- a/form/form-stdlib/tests/world-model-growth-band.fk
+++ b/form/form-stdlib/tests/world-model-growth-band.fk
@@ -1,9 +1,9 @@
 ; preludes: form-stdlib/obs-verify.fk form-stdlib/trust-decay.fk form-stdlib/channel-interface.fk form-stdlib/satsang.fk form-stdlib/satsang-field.fk form-stdlib/persistence.fk form-stdlib/world-module-model.fk form-stdlib/world-model-growth.fk
 ;
-; world-model-growth-band — a world model grows by ingesting sensed readings,
-; digesting verified truth into blueprint/recipe/named-cell parts, embodying
-; only when the trusted core follows, and storing the embodied parts as a
-; content-addressed root.
+; world-model-growth-band — ONE ingest -> digest -> embody -> store pass: sensed
+; readings ingested, verified truth digested into blueprint/recipe/named-cell parts,
+; embodied only when the trusted core follows, stored as a content-addressed root.
+; The pipeline-step atom; growth across repeated cycles is the arc.
 ;
 ; Verdict 4095 when every claim lands:
 ;   1     all senses are ingested

--- a/form/form-stdlib/tests/world-model-live-sense-band.fk
+++ b/form/form-stdlib/tests/world-model-live-sense-band.fk
@@ -1,6 +1,6 @@
 ; preludes: form-stdlib/core.fk form-stdlib/obs-verify.fk form-stdlib/trust-decay.fk form-stdlib/channel-interface.fk form-stdlib/satsang.fk form-stdlib/satsang-field.fk form-stdlib/persistence.fk form-stdlib/world-module-model.fk form-stdlib/world-model-growth.fk form-stdlib/nearest-shape.fk form-stdlib/classifier-eval.fk form-stdlib/co-learning.fk form-stdlib/co-learning-stream.fk form-stdlib/champion-challenger.fk form-stdlib/colearning-retire.fk form-stdlib/choice-receipt.fk form-stdlib/branch-choice-order.fk form-stdlib/choice-receipt-learning.fk form-stdlib/oracle-catalog.fk form-stdlib/text-summary-learning.fk form-stdlib/llm-feature-channel-floor.fk form-stdlib/android-mesh-learning.fk form-stdlib/witness-state-receipt.fk form-stdlib/model-vitality.fk form-stdlib/world-model-live-sense.fk
 ;
-; world-model-live-sense-band - live mesh/model receipts feed growth.
+; world-model-live-sense-band - mesh/model receipt SHAPES convert to sense rows and feed one growth step. The receipt->sense->grow atom on fixtures; continuous live witness loops are the arc.
 ;
 ; Verdict 524287 when every claim lands:
 ;   1     valid active samples become observed wmg-sense rows

--- a/form/form-stdlib/translation-learn.fk
+++ b/form/form-stdlib/translation-learn.fk
@@ -1,4 +1,4 @@
-; translation-learn.fk — native Form translation that learns from a 3rd-party oracle.
+; translation-learn.fk — native Form translation from a 3rd-party oracle's pairs: exemplar lookup + champion-challenger A/B. Meaning preserved by content-addressing. The lookup/retirement atom; an adaptive learner is the arc.
 ;
 ; The ask (Urs): add Chinese and Japanese, and use those translations as training
 ; material for native Form translation. The body already holds every part but the one

--- a/form/form-stdlib/voice-prosody.fk
+++ b/form/form-stdlib/voice-prosody.fk
@@ -1,4 +1,4 @@
-; voice-prosody.fk — the acoustic model: a token sequence becomes a pitch contour, a melody.
+; voice-prosody.fk — tokens -> pitch contour -> sound: a linear token-to-pitch map rendered as a melody of sine frames. The atom under prosody; a learned acoustic model is the arc.
 ; Sits above voice-synth. Each token maps to a pitch (a note); stress maps to amplitude
 ; (emphasis). A sequence of tokens is a contour, and additive synthesis renders each into a
 ; frame of samples. text -> contour -> voice = the efferent arm above the synthesis primitive.

--- a/form/form-stdlib/world-model-live-sense.fk
+++ b/form/form-stdlib/world-model-live-sense.fk
@@ -1,4 +1,4 @@
-; world-model-live-sense.fk - live mesh/model receipts enter world-model growth.
+; world-model-live-sense.fk - mesh/model receipt shapes enter world-model growth as sense rows. One digest step on receipt fixtures; continuous live witness loops are the arc.
 ;
 ; Floor: Android/Mac active samples, capability receipts, and model eval
 ; receipts convert into ordinary wmg-sense rows with inspectable payloads.


### PR DESCRIPTION
Part of the 2026-06-28 claim-check audit (docs/coherence-substrate/claim-check.form). The capability-vs-mechanism gap: process-words over one deterministic pass on fixtures.

## Retuned
- **world-model-growth**: "a world model **grows** by ingesting … digesting … embodying … storing" → **ONE** ingest→digest→embody→store pass with correct part creation and trusted-core gating. Growth across repeated cycles is the arc.
- **world-model-live-sense**: "**live** mesh/model receipts feed growth" → mesh/model receipt **SHAPES** convert to sense rows and feed one growth step, on fixtures; continuous live witness loops are the arc (recipe header aligned too).

## Left as honestly-named
self-image ("held honestly"; the static snapshot is the keystone the other organs act on), session-self-watch ("reads its OWN native trust" — literal, once), guru-moment ("the **imagined** state as one shape" — already scoped), witness-to-co-regulate (the selector law, made falsifiable), inquiry-planes (the time-to-fluency formula, self-consistent), learning-arc (single-pass exemplar fold; "no weights, no epochs" in the body), continuum-answers (holds BOTH/AND logic).

## Discipline
- **Comment-only** — every changed line is a `;` comment; recipe math and verdicts untouched.
- Each retuned band **re-validated four-way individually** (`fks 4095 / 524287` in `form/fourth-arm-bands.txt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)