### PR TITLE
tend(form): teacher-selection — pick which remote oracle best TEACHES native Sema, per cell-category

### DIFF
--- a/form/form-stdlib/teacher-selection.fk
+++ b/form/form-stdlib/teacher-selection.fk
@@ -1,0 +1,38 @@
+; teacher-selection.fk — the inversion: pick which remote oracle best TEACHES native Sema, per cell-category.
+; The existing scaffolding (api/config/model_routing.json, the routers) routes WORK to the best model. This
+; routes TEACHING to the best oracle, and the reward is not task-success -- it is how well native Sema
+; GENERALIZED after that oracle taught it (teach-native-sema / oracle-taught-learning measure exactly this).
+; Each (oracle x cell-category) arm tracks (successes, trials) of native generalization. The best teacher
+; for a category is the arm with the highest generalization rate -- and different categories pick DIFFERENT
+; oracles (a model that teaches math best need not teach chemistry best). We rent only the winner per
+; category: minimum rented spend, maximum native learning, and native Sema owns each skill free thereafter.
+;
+; This is the DETERMINISTIC core (posterior update + greedy selection), four-way. Thompson sampling adds an
+; EXPLORATION draw on top -- that draw is field-lane (host entropy, not four-way), named per the field-door.
+;
+; Self-contained over core. Four-way by tests/teacher-selection-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn arm (id succ trials) (list id succ trials))     ; an (oracle, category) arm: native generalizations / attempts
+    (defn a-id (a) (head a))
+    (defn a-rate (a) (div (head (tail a)) (head (tail (tail a)))))   ; generalization rate = how good a TEACHER this oracle is here
+    (defn best-go (arms bi br) (if (eq (len arms) 0) bi
+        (do (let r (a-rate (head arms))) (if (gt r br) (best-go (tail arms) (a-id (head arms)) r) (best-go (tail arms) bi br)))))
+    (defn best (arms) (best-go (tail arms) (a-id (head arms)) (a-rate (head arms))))   ; the best teacher for this category
+
+    ; oracles 0,1,2 (e.g. claude / gpt / gemini), measured on two cell-categories:
+    (defn math-arms () (list (arm 0 8.0 10.0) (arm 1 3.0 10.0) (arm 2 5.0 10.0)))   ; oracle 0 teaches math best (0.8)
+    (defn chem-arms () (list (arm 0 4.0 10.0) (arm 1 9.0 10.0) (arm 2 6.0 10.0)))   ; oracle 1 teaches chemistry best (0.9)
+    (defn math-updated () (list (arm 0 9.0 11.0) (arm 1 3.0 10.0) (arm 2 5.0 10.0))) ; oracle 0 gets one more native success
+
+    (defn tsk (cond bit) (if cond bit 0))
+    (defn teacher-selection-check ()
+        (add (add (add (add
+            (tsk (eq (best (math-arms)) 0) 1)                                  ; the best MATH teacher is oracle 0
+            (tsk (eq (best (chem-arms)) 1) 10))                                ; the best CHEMISTRY teacher is a DIFFERENT oracle (1) -- per-category specialization
+            (tsk (gt (a-rate (arm 0 8.0 10.0)) (a-rate (arm 1 3.0 10.0))) 100))        ; selection is by native-generalization rate (0.8 > 0.3), not by cost
+            (tsk (eq (best (math-updated)) 0) 1000))                          ; a new native success keeps/sharpens the choice (evidence accumulates)
+            (tsk (not (eq (best (math-arms)) 1)) 10000)))                     ; the low-generalization oracle is NOT chosen -- best teacher, never cheapest-but-worst
+)

--- a/form/form-stdlib/tests/teacher-selection-band.fk
+++ b/form/form-stdlib/tests/teacher-selection-band.fk
@@ -1,0 +1,7 @@
+; tests/teacher-selection-band.fk — picking the best remote oracle to TEACH native Sema, per category, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/teacher-selection.fk
+;
+; Verdict 11111: the best math teacher is oracle 0; the best chemistry teacher is a DIFFERENT oracle (1) --
+; per-category specialization; selection is by native-generalization rate, not cost; a new native success
+; keeps/sharpens the choice; and the low-generalization oracle is never selected (best teacher, not cheapest).
+(do (teacher-selection-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1107,3 +1107,4 @@ self-improving-thought fks 11111
 oracle-taught-learning fks 11111
 teach-native-sema fks 11111
 teach-sema-math fks 11111
+teacher-selection fks 11111


### PR DESCRIPTION
We have multiple minds and an agent framework with a Thompson sampler routing *which model for which task* — built months ago, the other way around (route **work** to the best model). The inversion: route **teaching** to the best oracle **per cell-category**, scored by how well native Sema **generalized** (`teach-native-sema` / `oracle-taught-learning` measure exactly that). The frontier minds compete to be the best *teacher*; we rent only the winner per category.

Built **on** the existing scaffolding (`model_routing.json`, `oracle-distillation-learning`). Four-way `11111`: best math teacher = oracle 0; best chemistry teacher = a **different** oracle (1) — per-category specialization; selection is by generalization rate, not cost; a new native success sharpens the choice; the low-generalization oracle is never selected (best teacher, never cheapest-but-worst).

Deterministic core (posterior + greedy selection) is four-way; **Thompson sampling** adds an exploration draw on top — that draw is **field-lane** (host entropy, not four-way), named per the field-door. The rates are illustrative; the real per-category rates come from running `teach-native-sema` with each oracle — that wiring is the next stone. Manifest: `teacher-selection fks 11111`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)