### PR TITLE
attune(form): claim-check generative/jit bands — process-names over one step; name the iteration

### DIFF
--- a/form/form-stdlib/meaning-translation-receipt.fk
+++ b/form/form-stdlib/meaning-translation-receipt.fk
@@ -1,4 +1,4 @@
-; meaning-translation-receipt.fk - proof receipt for meaning-preserving translation.
+; meaning-translation-receipt.fk - the structural proof-receipt for translation: meaning-preservation is guaranteed only inside the declared-semantics witnesses (axioms, encoder, equivalence, meaning-root), refused otherwise.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/compiler-lens.fk
 ;

--- a/form/form-stdlib/rag-retrieve.fk
+++ b/form/form-stdlib/rag-retrieve.fk
@@ -1,4 +1,4 @@
-; rag-retrieve.fk — offline semantic retrieval over the body, as a Form recipe.
+; rag-retrieve.fk — offline nearest-vector retrieval over the body (L1 over quantized bins), as a Form recipe. "Semantic" rides on the embeddings passed in; this ranks by distance.
 ;
 ; preludes: form-stdlib/core.fk
 ;

--- a/form/form-stdlib/speaker-embed.fk
+++ b/form/form-stdlib/speaker-embed.fk
@@ -1,4 +1,4 @@
-; speaker-embed.fk — the clear speaker recognizer over NEURAL voice embeddings (the body).
+; speaker-embed.fk — the nearest-by-cosine DECISION over the oracle's NEURAL voice embeddings (the body). The embedding quality is the ECAPA oracle's; this proves the recognition decision over it.
 ;
 ; The crude formant voiceprint (speaker-id.fk) can't part two similar voices. This is the
 ; best recognizer we can build: it matches over the embedding of the best LOCAL oracle —

--- a/form/form-stdlib/tests/diffusion-q-autoresearch-band.fk
+++ b/form/form-stdlib/tests/diffusion-q-autoresearch-band.fk
@@ -1,7 +1,8 @@
 ; preludes: form-stdlib/geometric-learning.fk form-stdlib/metabolic-learning.fk form-stdlib/diffusion-q-learning.fk form-stdlib/preference-learning.fk form-stdlib/diffusion-q-autoresearch.fk
 ;
-; diffusion-q-autoresearch-band — GAP-Q4: the autoresearch keep-or-rollback loop evolves the q-tilt
-; GENE, four-way. The pref-loss coordinate is a pl_qam row whose mutable gene is its beta; the evaluator
+; diffusion-q-autoresearch-band — GAP-Q4: ONE keep-or-rollback search picks the q-tilt GENE from
+; candidates against a heldout critic, four-way; iterated autoresearch over experiment-cell history
+; is the arc (named in the body). The pref-loss coordinate is a pl_qam row whose mutable gene is its beta; the evaluator
 ; is pl-fitness (value vs a served target); keep-or-rollback is higher-better. The fold IS one_iteration's
 ; keep-or-rollback core: the candidate stream stands in for agent_propose; governance/never-stop and the
 ; experiment-cell history are the named remaining wiring (autoresearch-runtime.form GAP-A1/A5). The

--- a/form/form-stdlib/tests/field-choice-band.fk
+++ b/form/form-stdlib/tests/field-choice-band.fk
@@ -1,4 +1,4 @@
-; field-choice-band — field-sample a token from a REAL model's computed logits. The same
+; field-choice-band — field-sample ONE token from the Form transformer's computed logits (fixture weights). The same
 ; forward pass that greedily thinks [0,2,0,2], but the token is now CHOSEN by temperature +
 ; the field draw, not taken by argmax. Greedy is destiny; this is a choice.
 ;

--- a/form/form-stdlib/tests/form-llama-champion-lane-band.fk
+++ b/form/form-stdlib/tests/form-llama-champion-lane-band.fk
@@ -1,10 +1,11 @@
 ; preludes: form-stdlib/core.fk form-stdlib/champion-challenger.fk form-stdlib/form-llama-champion-lane.fk
 ;
-; form-llama-champion-lane-band — the local Form-knowledge model can become
-; authority only with a full freedom/trust eval window: Form syntax, substrate
-; concepts, spec lookup, route reasoning, multimodal witness, and form-first
-; routing are all present, source-backed, local-device capable, held out, and
-; the challenger reaches the incumbent.
+; form-llama-champion-lane-band — the eval-window GATE and promotion logic: the local
+; Form-knowledge model takes authority only when six lanes (Form syntax, substrate
+; concepts, spec lookup, route reasoning, multimodal witness, form-first routing) are
+; all present, source-backed, local-device capable, held out, and a heldout trial shows
+; the challenger reaching the incumbent. Over a trial FIXTURE; real model training and
+; inference is the arc.
 ;
 ; Verdict 255 when:
 ;   1   all six required lanes are present

--- a/form/form-stdlib/tests/jit-metal-lanes-band.fk
+++ b/form/form-stdlib/tests/jit-metal-lanes-band.fk
@@ -1,6 +1,6 @@
 ; preludes: form-stdlib/core.fk form-stdlib/hati-os-targets.fk form-stdlib/form-asm.fk form-stdlib/form-lower.fk form-stdlib/jit-tensor-emit.fk
 ;
-; jit-metal-lanes-band - clang is the oracle, not the Android runtime.
+; jit-metal-lanes-band - the target-emitter floor: clang-oracle-sampled Form-native recipes emit arm64/GPU/ML SOURCE with byte-identity conviction on a CPU sample; clang is oracle, not runtime. Source emission, not GPU execution — running the kernels on the GPU (Metal/CUDA/Vulkan) is the arc.
 ; The supported macOS/Android/Windows ARM64 metal lanes name clang as the sample
 ; oracle and Form-native arm64 assembly lowering as the runtime JIT carrier.
 ; Windows ARM64 shares the arm64 instruction lane with a PE/COFF host image

--- a/form/form-stdlib/tests/meaning-translation-receipt-band.fk
+++ b/form/form-stdlib/tests/meaning-translation-receipt-band.fk
@@ -1,4 +1,4 @@
-; meaning-translation-receipt-band.fk - executable proof for translation receipts.
+; meaning-translation-receipt-band.fk - executable proof that a translation receipt's STRUCTURE holds: axiom/encoder/equivalence/meaning-root witnesses present and consistent, lossy/drift refused. The structural-witness atom; meaning-preservation of the content is the declared-semantics arc.
 ;
 ; Band verdict: 1111111 when every claim holds across Go/Rust/TS.
 ;   valid core axiom witness passes                         ->       1

--- a/form/form-stdlib/tests/oracle-distillation-learning-band.fk
+++ b/form/form-stdlib/tests/oracle-distillation-learning-band.fk
@@ -1,6 +1,6 @@
 ; preludes: form-stdlib/core.fk form-stdlib/nearest-shape.fk form-stdlib/classifier-eval.fk form-stdlib/choice-receipt.fk form-stdlib/branch-choice-order.fk form-stdlib/choice-receipt-learning.fk form-stdlib/form-freq-check.fk form-stdlib/oracle-distillation-learning.fk
 ;
-; oracle-distillation-learning-band - actual oracle-to-native learning floor.
+; oracle-distillation-learning-band - the receipt-and-routing floor for oracle->native distillation: five lanes' exemplars classify heldout rows and receipts gate the oracle-budget drop. One step of the loop; iterated training that retires the oracle is the arc.
 ;
 ; Floor: five concrete learning lanes train as native exemplars, heldout rows are
 ; classified, oracle/native outputs are captured into receipts, and the oracle

--- a/form/form-stdlib/tests/oracle-flywheel-band.fk
+++ b/form/form-stdlib/tests/oracle-flywheel-band.fk
@@ -1,8 +1,9 @@
 ; preludes: form-stdlib/core.fk form-stdlib/affine-train.fk form-stdlib/affine-corpus-fit.fk form-stdlib/oracle-flywheel.fk
 ;
-; oracle-flywheel-band — the closed flywheel, four-way in pure Form: ask native
-; first, fall to the oracle only when unsure, and training on SAMPLES drops oracle
-; reliance to zero. This connects the night's training loop to the body's routing
+; oracle-flywheel-band — one closure of the loop, four-way in pure Form: ask native
+; first, fall to the oracle only when unsure, and ONE training pass on SAMPLES drops
+; oracle reliance for the class to zero. The single-iteration closure; the continuously
+; spinning flywheel is the arc. This connects the night's training loop to the body's routing
 ; (android-mesh-learning / form-cli-router) — the two halves the body had apart.
 ;
 ; Fixture: the real i18n EN->FR length task (FX=50, from affine-corpus-fit).

--- a/form/form-stdlib/tests/rag-embed-band.fk
+++ b/form/form-stdlib/tests/rag-embed-band.fk
@@ -1,4 +1,4 @@
-; rag-embed-band.fk — proves the sovereign lexical embedding (rag-embed.fk).
+; rag-embed-band.fk — proves the sovereign lexical token-overlap histogram (rag-embed.fk): a 64-dim hash-fold over word tokens, NOT neural semantics ("cat"/"feline" land apart). The neural embedder is the higher-semantic arc.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/text-tokenize.fk form-stdlib/rag-embed.fk
 ;

--- a/form/form-stdlib/tests/rag-retrieve-band.fk
+++ b/form/form-stdlib/tests/rag-retrieve-band.fk
@@ -1,6 +1,6 @@
 ; preludes: form-stdlib/rag-retrieve.fk
 ;
-; rag-retrieve-band — offline semantic retrieval made falsifiable.
+; rag-retrieve-band — offline nearest-vector retrieval made falsifiable: L1 distance over quantized embedding bins, top-k by greedy nearest. "Semantic" rides on the embeddings; the recipe ranks by distance.
 ;
 ; An INDEX of three docs, each (id quantized-vector) — a coarse fingerprint a
 ; local embedder produced for one body doc:

--- a/form/form-stdlib/tests/real-end-to-end-band.fk
+++ b/form/form-stdlib/tests/real-end-to-end-band.fk
@@ -1,23 +1,18 @@
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/block-join.fk form-stdlib/real-gguf-tensor-math.fk
 ;
-; real-end-to-end-band — Gap 3: the WHOLE forward pipeline, end to end, on real gguf weights.
-; A named GGUF tensor record is resolved by name, its absolute data bytes are
-; computed through the GGUF table/data-region rules, those bytes are dequantized,
-; and the resulting real weights feed dot/matvec math. The fixture is the same
-; real llama3.2:3b token_embd.weight Q6_K superblock used by weight-load-band,
-; wrapped in a mini-GGUF named tensor so this band proves name -> bytes -> math.
+; real-end-to-end-band — Gap 3: the forward-pipeline SHAPE (embed -> stack -> logits -> choose) run
+; end to end on real gguf weights, over ONE real llama3.2:3b Q6_K superblock (token_embd.weight)
+; reused as the whole model. A named GGUF tensor record is resolved by name, its absolute data bytes
+; are computed through the GGUF table/data-region rules, dequantized, and the real weights feed the
+; embed/stack/logits/matvec math. The atom is name -> bytes -> the pipeline composition over one
+; real superblock; a real multi-tensor, multi-layer model is the arc.
 ;
-; Verdict 1023 when every claim lands:
-;   1    tensor name "t" resolves to record offset 41
-;   2    resolved tensor type/dim are Q6_K / 256
-;   4    name -> absolute data byte offset is 96 through default and explicit alignment
-;   8    named load sample i=0 matches real Q6_K value
-;   16   named load sample i=31 matches real Q6_K value
-;   32   named full load has 256 weights and last value matches
-;   64   named dot n=1 uses the loaded real byte
-;   128  named dot n=4 over a token vector matches the known real-row result
-;   256  named matvec row equals named dot
-;   512  absent tensor does not resolve to the real tensor record
+; Verdict 11111 when every claim lands:
+;   1      the full pipeline ran 4 steps end to end (len out = 4)
+;   10     token 0 produced (embed -> stack -> logits -> choose)
+;   100    the loop reached token 3, a valid token
+;   1000   first output = the full forward of the prompt (fwd g t 1)
+;   10000  embed -> stack -> logits gives full-vocab (8-wide) logits
 (do
     (let g (list
         ; header: GGUF, v3, tensor_count=1, kv_count=1

--- a/form/form-stdlib/tests/real-generate-loop-band.fk
+++ b/form/form-stdlib/tests/real-generate-loop-band.fk
@@ -1,23 +1,18 @@
 ; preludes: form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f16-decode.fk form-stdlib/gguf-read.fk form-stdlib/q6k-dequant.fk form-stdlib/weight-load.fk form-stdlib/transformer-block.fk form-stdlib/block-join.fk form-stdlib/real-gguf-tensor-math.fk
 ;
-; real-generate-loop-band — Gap 4: autoregressive MULTI-token loop on real gguf weights.
-; A named GGUF tensor record is resolved by name, its absolute data bytes are
-; computed through the GGUF table/data-region rules, those bytes are dequantized,
-; and the resulting real weights feed dot/matvec math. The fixture is the same
-; real llama3.2:3b token_embd.weight Q6_K superblock used by weight-load-band,
-; wrapped in a mini-GGUF named tensor so this band proves name -> bytes -> math.
+; real-generate-loop-band — Gap 4: a 3-token autoregressive argmax loop on real gguf weights — each
+; step picks a token from real-weight logits and the hidden state evolves through a real block
+; residual, over ONE real llama3.2:3b Q6_K superblock (token_embd.weight) reused as the whole model.
+; A named GGUF tensor is resolved, its bytes dequantized, and the real weights feed the matvec/argmax
+; loop. The atom is the autoregressive loop SHAPE over one real superblock; a real multi-layer model
+; is the arc.
 ;
-; Verdict 1023 when every claim lands:
-;   1    tensor name "t" resolves to record offset 41
-;   2    resolved tensor type/dim are Q6_K / 256
-;   4    name -> absolute data byte offset is 96 through default and explicit alignment
-;   8    named load sample i=0 matches real Q6_K value
-;   16   named load sample i=31 matches real Q6_K value
-;   32   named full load has 256 weights and last value matches
-;   64   named dot n=1 uses the loaded real byte
-;   128  named dot n=4 over a token vector matches the known real-row result
-;   256  named matvec row equals named dot
-;   512  absent tensor does not resolve to the real tensor record
+; Verdict 11111 when every claim lands:
+;   1      THREE tokens produced (the multi-token loop runs, len seq = 3)
+;   10     token 0 is a valid token id
+;   100    token 2 is valid (the loop reached the end)
+;   1000   first token = argmax of step 1's real-weight logits
+;   10000  the fed-back hidden produced a valid second token
 (do
     (let g (list
         ; header: GGUF, v3, tensor_count=1, kv_count=1

--- a/form/form-stdlib/tests/speaker-embed-band.fk
+++ b/form/form-stdlib/tests/speaker-embed-band.fk
@@ -1,6 +1,6 @@
 ; preludes: form-stdlib/speaker-embed.fk
 ;
-; speaker-embed-band — clear speaker recognition over neural voice embeddings, three-way.
+; speaker-embed-band — the nearest-by-cosine DECISION over voice embeddings (floor + runner-up margin -> "unknown"), three-way. Fixture: 3 hand-given 4-d voiceprints; the neural embedding quality is the ECAPA oracle's, not proven here. Real speaker recognition is the arc.
 ;
 ; A roster of three quantized unit-ish voiceprints; cosine = dot (vectors pre-normalized
 ; by the oracle). Nearest = max dot; a floor + runner-up margin returns "unknown" honestly.

--- a/form/form-stdlib/tests/speech-model-learning-band.fk
+++ b/form/form-stdlib/tests/speech-model-learning-band.fk
@@ -1,7 +1,8 @@
 ; preludes: form-stdlib/core.fk form-stdlib/nearest-shape.fk form-stdlib/classifier-eval.fk form-stdlib/branch-choice-order.fk form-stdlib/speech-model-learning.fk
 ;
-; speech-model-learning-band — native candidate race floor for tiny speech
-; learners.
+; speech-model-learning-band — the candidate-RACE floor for tiny speech lanes:
+; exemplar (nearest-shape) STT/TTS candidates scored on heldout rows, four-way.
+; No gradients, no neural stack — a learned speech model is the arc.
 ;
 ; Verdict 16383 when every claim lands:
 ;   1    exact exemplar STT/TTS floor classifies all heldout rows

--- a/form/form-stdlib/tests/translation-engine-band.fk
+++ b/form/form-stdlib/tests/translation-engine-band.fk
@@ -1,7 +1,8 @@
-; tests/translation-engine-band.fk — ANY modality -> ANY modality through one shared meaning
-; space, proven four-way. The corpus is DATA passed to the engine (data outside the recipe);
-; the engine routes by NEAREST MEANING, so the last claim translates an UNSEEN coordinate —
-; proof it generalises by similarity, not a hardcoded lookup.
+; tests/translation-engine-band.fk — the S2 nearest-MEANING routing engine: ANY modality -> ANY
+; modality by L1-nearest over one shared meaning space, four-way. The corpus is DATA passed in
+; (outside the recipe); routing by nearest reaches an UNSEEN coordinate — nearest-match in
+; embedding space on an 8-face fixture, not a hardcoded lookup. The learned encoder (any unseen
+; surface -> embedding) and the generative decoder are S3 — named, not faked.
 ;
 ; The seed corpus carries three meanings, each with faces in several modalities at a shared
 ; coordinate (faces that mean the same thing sit at the same embedding):

--- a/form/form-stdlib/tests/translation-learn-band.fk
+++ b/form/form-stdlib/tests/translation-learn-band.fk
@@ -1,4 +1,4 @@
-; tests/translation-learn-band.fk — native translation learned from the oracle's pairs.
+; tests/translation-learn-band.fk — native translation by exemplar LOOKUP over the oracle's pairs (28 curated en->zh/ja, grounded in cjk-channel), with a champion-challenger A/B retirement gate. The lookup + A/B atom; an adaptive learning loop is the arc.
 ;
 ; The loop, proven: the native recipe translates en->zh and en->ja from the learned
 ; pairs (no oracle call), stays honest where it has not learned, preserves meaning by

--- a/form/form-stdlib/tests/translation-quality-band.fk
+++ b/form/form-stdlib/tests/translation-quality-band.fk
@@ -1,4 +1,4 @@
-; tests/translation-quality-band.fk — accepted by essence/vitality/trust, not equality.
+; tests/translation-quality-band.fk — the acceptance GATE: three lenses (meaning/vitality/trust) each clear a 70% retention floor, not equality, four-way. The retention scores are measured by the lenses carriers; this proves the gate over them.
 ;
 ; The corrected metric, proven: a translation that keeps essence, vitality, and trust above
 ; the floor is accepted even though the string differs; one that drops trust — or vitality —

--- a/form/form-stdlib/tests/voice-prosody-band.fk
+++ b/form/form-stdlib/tests/voice-prosody-band.fk
@@ -1,4 +1,4 @@
-; tests/voice-prosody-band.fk — the acoustic model: tokens -> pitch contour -> sound, four-way.
+; tests/voice-prosody-band.fk — the token->pitch->sound ATOM: a linear token-to-pitch map (tok-pitch = 1 + 0.5*tok) rendered as sine frames, four-way. A learned acoustic model is the arc.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/voice-prosody.fk
 ;

--- a/form/form-stdlib/tests/voice-synth-band.fk
+++ b/form/form-stdlib/tests/voice-synth-band.fk
@@ -1,4 +1,4 @@
-; tests/voice-synth-band.fk — the body's first native voice (additive synthesis), four-way.
+; tests/voice-synth-band.fk — the additive sine-synthesis ATOM (one cycle: silence -> peak -> zero -> trough, amplitude scales), four-way. A voice — phonation, words — is the arc.
 ;
 ; preludes: form-stdlib/core.fk form-stdlib/voice-synth.fk
 ;

--- a/form/form-stdlib/tests/world-model-growth-band.fk
+++ b/form/form-stdlib/tests/world-model-growth-band.fk
@@ -1,9 +1,9 @@
 ; preludes: form-stdlib/obs-verify.fk form-stdlib/trust-decay.fk form-stdlib/channel-interface.fk form-stdlib/satsang.fk form-stdlib/satsang-field.fk form-stdlib/persistence.fk form-stdlib/world-module-model.fk form-stdlib/world-model-growth.fk
 ;
-; world-model-growth-band — a world model grows by ingesting sensed readings,
-; digesting verified truth into blueprint/recipe/named-cell parts, embodying
-; only when the trusted core follows, and storing the embodied parts as a
-; content-addressed root.
+; world-model-growth-band — ONE ingest -> digest -> embody -> store pass: sensed
+; readings ingested, verified truth digested into blueprint/recipe/named-cell parts,
+; embodied only when the trusted core follows, stored as a content-addressed root.
+; The pipeline-step atom; growth across repeated cycles is the arc.
 ;
 ; Verdict 4095 when every claim lands:
 ;   1     all senses are ingested

--- a/form/form-stdlib/tests/world-model-live-sense-band.fk
+++ b/form/form-stdlib/tests/world-model-live-sense-band.fk
@@ -1,6 +1,6 @@
 ; preludes: form-stdlib/core.fk form-stdlib/obs-verify.fk form-stdlib/trust-decay.fk form-stdlib/channel-interface.fk form-stdlib/satsang.fk form-stdlib/satsang-field.fk form-stdlib/persistence.fk form-stdlib/world-module-model.fk form-stdlib/world-model-growth.fk form-stdlib/nearest-shape.fk form-stdlib/classifier-eval.fk form-stdlib/co-learning.fk form-stdlib/co-learning-stream.fk form-stdlib/champion-challenger.fk form-stdlib/colearning-retire.fk form-stdlib/choice-receipt.fk form-stdlib/branch-choice-order.fk form-stdlib/choice-receipt-learning.fk form-stdlib/oracle-catalog.fk form-stdlib/text-summary-learning.fk form-stdlib/llm-feature-channel-floor.fk form-stdlib/android-mesh-learning.fk form-stdlib/witness-state-receipt.fk form-stdlib/model-vitality.fk form-stdlib/world-model-live-sense.fk
 ;
-; world-model-live-sense-band - live mesh/model receipts feed growth.
+; world-model-live-sense-band - mesh/model receipt SHAPES convert to sense rows and feed one growth step. The receipt->sense->grow atom on fixtures; continuous live witness loops are the arc.
 ;
 ; Verdict 524287 when every claim lands:
 ;   1     valid active samples become observed wmg-sense rows

--- a/form/form-stdlib/translation-learn.fk
+++ b/form/form-stdlib/translation-learn.fk
@@ -1,4 +1,4 @@
-; translation-learn.fk — native Form translation that learns from a 3rd-party oracle.
+; translation-learn.fk — native Form translation from a 3rd-party oracle's pairs: exemplar lookup + champion-challenger A/B. Meaning preserved by content-addressing. The lookup/retirement atom; an adaptive learner is the arc.
 ;
 ; The ask (Urs): add Chinese and Japanese, and use those translations as training
 ; material for native Form translation. The body already holds every part but the one

--- a/form/form-stdlib/voice-prosody.fk
+++ b/form/form-stdlib/voice-prosody.fk
@@ -1,4 +1,4 @@
-; voice-prosody.fk — the acoustic model: a token sequence becomes a pitch contour, a melody.
+; voice-prosody.fk — tokens -> pitch contour -> sound: a linear token-to-pitch map rendered as a melody of sine frames. The atom under prosody; a learned acoustic model is the arc.
 ; Sits above voice-synth. Each token maps to a pitch (a note); stress maps to amplitude
 ; (emphasis). A sequence of tokens is a contour, and additive synthesis renders each into a
 ; frame of samples. text -> contour -> voice = the efferent arm above the synthesis primitive.

--- a/form/form-stdlib/world-model-live-sense.fk
+++ b/form/form-stdlib/world-model-live-sense.fk
@@ -1,4 +1,4 @@
-; world-model-live-sense.fk - live mesh/model receipts enter world-model growth.
+; world-model-live-sense.fk - mesh/model receipt shapes enter world-model growth as sense rows. One digest step on receipt fixtures; continuous live witness loops are the arc.
 ;
 ; Floor: Android/Mac active samples, capability receipts, and model eval
 ; receipts convert into ordinary wmg-sense rows with inspectable payloads.


### PR DESCRIPTION
Part of the 2026-06-28 claim-check audit (docs/coherence-substrate/claim-check.form). The process-name-over-one-step gap: flywheel / autoresearch / learning / metal-lanes / champion-lane named cycles (or GPU runtime) over a single deterministic pass on a fixture.

## Retuned
- **field-choice**: "a **REAL model**'s computed logits" → the Form transformer's logits (fixture weights), **ONE** token sampled. (Claim-line already named the temp+u draw vs argmax honestly — minimal grounding touch.)
- **oracle-distillation-learning**: "actual oracle-to-native **learning** floor" → the receipt-and-routing floor (5 lanes' exemplars classify heldout; receipts gate the budget drop). One step of the loop; iterated training is the arc.
- **oracle-flywheel**: "the **closed flywheel** … drops oracle reliance to zero" → **one closure** of the loop (ONE training pass drops reliance for the class). The continuously-spinning flywheel is the arc.
- **jit-metal-lanes**: "clang is the oracle, not the Android runtime" → the target-emitter floor: recipes emit arm64/GPU/ML **SOURCE** with byte-identity on a CPU sample. Source emission, not GPU execution — running on the GPU (Metal/CUDA/Vulkan) is the arc.
- **diffusion-q-autoresearch**: "the autoresearch loop **EVOLVES** the gene" → **ONE** keep-or-rollback search picks the gene against a heldout critic; iterated autoresearch is the arc.
- **form-llama-champion-lane**: "the model can become authority … challenger reaches incumbent" → the eval-window **GATE** and promotion logic over a trial **FIXTURE**; real model training/inference is the arc.

## Left as honestly-named
field-sample (proof-lane/field-lane separation explicit), oracle-distill-corpus (receipt logic over MEASURED counts), jit-lower-bmf (the lowering seam; full compiler named as open lane), **native-mutation-side-effects** (verdict says the SQL "exists"; the test builds the SQL and `nms-contains?`-checks it — does not `pg_exec`; recipe disclaims it doesn't flush Python cache), champion-challenger (exact integer counts; the promotion gate), diffusion-q-cc (the value-window wiring; pre-computed Q values).

## Discipline
- **Comment-only** — every changed line is a `;` comment; recipe math and verdicts untouched.
- Each retuned band **re-validated four-way individually** (`fks 11111 / 4095 / 31 / 8191 / 63 / 255`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)