### PR TITLE
attune(form): name the bootstrap bridge — slot_selection_service.py is the carrier teacher-selection heads home from

### DIFF
--- a/form/form-stdlib/teacher-selection.fk
+++ b/form/form-stdlib/teacher-selection.fk
@@ -1,6 +1,7 @@
 ; teacher-selection.fk — the inversion: pick which remote oracle best TEACHES native Sema, per cell-category.
 ; The existing scaffolding (api/config/model_routing.json, the routers) routes WORK to the best model. This
-; routes TEACHING to the best oracle, and the reward is not task-success -- it is how well native Sema
+; routes TEACHING to the best oracle. The inversion needs NO new sampler -- it is slot_selection_service used
+; with slot-key "teach:<category>", slots = oracles, and the reward is not task-ROI -- it is how well native Sema
 ; GENERALIZED after that oracle taught it (teach-native-sema / oracle-taught-learning measure exactly this).
 ; Each (oracle x cell-category) arm tracks (successes, trials) of native generalization. The best teacher
 ; for a category is the arm with the highest generalization rate -- and different categories pick DIFFERENT


### PR DESCRIPTION
Urs grounded the framework he meant: the Python one under `api/` — specifically **`api/app/services/slot_selection_service.py`**, a *generic* Thompson-Sampling slot selector (Beta posterior + recency, select/record, version-invalidation) already wired into provider selection, prompt A/B, and idea selection. It routes **work** to the best model (ROI) — built months ago, the other way around.

`teacher-selection.fk` is the **native destination** of that exact logic, and the inversion needs **no new sampler**: it's `slot_selection_service` used with slot-key `teach:<cell-category>`, slots = the oracles, and `value_score` = native **generalization gain** (not task ROI). Same Beta posterior, same select/record — only the reward and slot-meaning change. *One engine, objective as data.*

The framework can run the inversion **today** in the bootstrap (Python) layer; `teacher-selection.fk` is where the routing comes home to the four-way body. Named the bridge honestly in the recipe header — Python is the carrier, the Form recipe is the destination. Band unchanged, `11111`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)