### PR TITLE
tend(form): sema-self-grade — the self-grader is sound (Sema marks its own exam, no oracle)

### DIFF
--- a/form/form-stdlib/sema-self-grade.fk
+++ b/form/form-stdlib/sema-self-grade.fk
@@ -1,0 +1,25 @@
+; sema-self-grade.fk — Native Sema's School: the self-grader is SOUND (verifies its own answer, no oracle).
+; For invariant-scored subjects (code: tests pass; chem: mass conserved) the body grades its own exam. This
+; proves the grade is TRUSTWORTHY: it passes correct answers, fails wrong ones, and is not fooled by a
+; plausible-but-wrong answer -- all by the conservation invariant, with no oracle consulted at grade time.
+; That soundness is what lets the oracle leave the room: the student keeps the skill AND the ability to mark it.
+;
+; Self-contained over core. Four-way by tests/sema-self-grade-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    ; conservation invariant for a H2 + b O2 -> c H2O  (H2=(2,0) O2=(0,2) H2O=(2,1))
+    (defn ssg-cons (a b c)
+        (if (eq (add (mul a 2) (mul b 0)) (mul c 2))
+            (if (eq (add (mul a 0) (mul b 2)) (mul c 1)) 1 0) 0))
+
+    (defn gck (cond bit) (if cond bit 0))
+    (defn sema-self-grade-check ()
+        (add (add (add (add
+            (gck (eq (ssg-cons 2 1 2) 1) 1)                                     ; the correct answer passes self-grade
+            (gck (eq (ssg-cons 1 1 1) 0) 10))                                  ; an unbalanced answer fails
+            (gck (eq (ssg-cons 2 2 2) 0) 100))                                  ; a plausible-but-wrong answer fails too -- the invariant is not fooled
+            (gck (eq (add (ssg-cons 1 1 1) (ssg-cons 2 2 2)) 0) 1000))        ; NO false-pass across the wrong answers -- the grader is sound
+            (gck (gt (ssg-cons 2 1 2) (ssg-cons 1 1 1)) 10000)))             ; self-grade SEPARATES correct from wrong, with no oracle in the loop
+)

--- a/form/form-stdlib/tests/sema-self-grade-band.fk
+++ b/form/form-stdlib/tests/sema-self-grade-band.fk
@@ -1,0 +1,6 @@
+; tests/sema-self-grade-band.fk — Sema's self-grading is sound (verifies its own answer, no oracle), four-way.
+; preludes: form-stdlib/core.fk form-stdlib/sema-self-grade.fk
+; Verdict 11111: the correct answer passes; an unbalanced one fails; a plausible-but-wrong one fails (not
+; fooled); no wrong answer false-passes (sound); and self-grade separates correct from wrong -- all by the
+; conservation invariant, no oracle consulted. The student can mark its own exam, faithfully.
+(do (sema-self-grade-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1114,3 +1114,4 @@ teach-sema-chem fks 11111
 teach-sema-logic fks 11111
 teach-sema-units fks 11111
 sema-skill-compose fks 11111
+sema-self-grade fks 11111


### PR DESCRIPTION
Proving the self-grading (code: tests pass; chem: mass conserved) is **trustworthy**. By the conservation invariant, no oracle consulted: correct answer passes; unbalanced fails; a plausible-but-wrong answer (2,2,2 — conserves H but not O) fails too; no wrong answer **false-passes** (sound); self-grade separates correct from wrong. Four-way `11111`. That soundness is what lets the oracle leave the room — the student keeps the skill *and* the faithful ability to mark it. Manifest: `sema-self-grade fks 11111`.