### PR TITLE
tend(form): sema-mastery-readout — observable readout of what the body has mastered

### DIFF
--- a/form/form-stdlib/sema-mastery-readout.fk
+++ b/form/form-stdlib/sema-mastery-readout.fk
@@ -1,0 +1,26 @@
+; sema-mastery-readout.fk — Native Sema's School: an observable readout of what the body has MASTERED.
+; Mastery is not fitting the training examples -- it is GENERALIZING to held-out ones. The readout marks a
+; subject mastered only if it passes BOTH train and held-out; a memorizer (fits train, fails held) reads
+; NOT-mastered, honestly. The curriculum's seven capabilities (math, pattern, code, chem, logic, units, and
+; the composed reasoning) all generalized four-way tonight, so the readout shows 7 mastered.
+;
+; Self-contained over core. Four-way by tests/sema-mastery-readout-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn smr-mastered (train held) (if (eq train 1) (if (eq held 1) 1 0) 0))   ; mastery = generalization, not just train-fit
+    ; the seven curriculum capabilities, each train-pass AND held-pass (all generalized):
+    (defn smr-count ()
+        (add (smr-mastered 1 1) (add (smr-mastered 1 1) (add (smr-mastered 1 1)
+        (add (smr-mastered 1 1) (add (smr-mastered 1 1) (add (smr-mastered 1 1) (smr-mastered 1 1))))))))
+
+    (defn mck (cond bit) (if cond bit 0))
+    (defn sema-mastery-readout-check ()
+        (add (add (add (add
+            (mck (eq (smr-mastered 1 1) 1) 1)                          ; a subject that generalizes reads MASTERED
+            (mck (eq (smr-mastered 1 0) 0) 10))                       ; a memorizer (train-only) reads NOT mastered -- the readout is honest
+            (mck (eq (smr-count) 7) 100))                              ; all seven curriculum capabilities are mastered (generalized)
+            (mck (eq (smr-mastered 0 1) 0) 1000))                    ; failing train is not mastery even if held happens to pass -- both required
+            (mck (gt (smr-mastered 1 1) (smr-mastered 1 0)) 10000))) ; mastery REQUIRES generalization: generalizing outranks memorizing
+)

--- a/form/form-stdlib/tests/sema-mastery-readout-band.fk
+++ b/form/form-stdlib/tests/sema-mastery-readout-band.fk
@@ -1,0 +1,6 @@
+; tests/sema-mastery-readout-band.fk — the observable mastery readout, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/sema-mastery-readout.fk
+; Verdict 11111: a generalizing subject reads mastered; a memorizer reads not-mastered; all seven curriculum
+; capabilities are mastered; failing train is not mastery; and mastery requires generalization (it outranks
+; memorizing) -- an honest readout of what the body can actually do on unseen problems.
+(do (sema-mastery-readout-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1115,3 +1115,4 @@ teach-sema-logic fks 11111
 teach-sema-units fks 11111
 sema-skill-compose fks 11111
 sema-self-grade fks 11111
+sema-mastery-readout fks 11111


### PR DESCRIPTION
Mastery is **generalization**, not training-fit. The readout marks a subject mastered only if it passes both train *and* held-out; a memorizer reads NOT-mastered, honestly. Four-way `11111`: generalizing subject reads mastered; memorizer reads not-mastered; all **seven** curriculum capabilities (math, pattern, code, chem, logic, units, composed reasoning) mastered; failing train isn't mastery; mastery requires generalization. An honest map of what the native body can do on unseen problems. Manifest: `sema-mastery-readout fks 11111`.