### PR TITLE
tend(form): sema-school.form — the synthesis cell for Native Sema's School

### DIFF
--- a/docs/coherence-substrate/INDEX.md
+++ b/docs/coherence-substrate/INDEX.md
@@ -416,3 +416,5 @@ This prunes stale live NamedCells only; interned Blueprint/Recipe nodes can rema
 - [agent-cognition.form](agent-cognition.form) — the agent's own cognitive operations as a Form grammar (compare/summarize/nl↔code/spec/recipe/witness-runtime); compare-summaries proven four-way.
 
 - [claim-check.form](claim-check.form) — does the verdict prove what the name claims? The third sensing-check (with freq-check, root-check); names the atom-vs-capability gap. From the 2026-06-28 band audit.
+
+- [sema-school.form](sema-school.form) — Native Sema's School: one engine teaches a native mind any subject (grammar+scorer as data), self-grades the invariant ones, composes skills to reason, mastery = generalization. Built overnight 2026-06-28.

--- a/docs/coherence-substrate/sema-school.form
+++ b/docs/coherence-substrate/sema-school.form
@@ -1,0 +1,49 @@
+# sema-school.form — Native Sema's School: how a native mind is taught, tested, and grows.
+# Built overnight 2026-06-28 while Urs slept, from the teach-sema-* and reasoning stones. One engine,
+# the subject dropped in as a grammar + a scorer; the proof of learning is GENERALIZATION to unseen
+# problems, not recall. Toy-scale by design today -- this names the SHAPE of a school; the arc above is
+# richer grammars and real exams. Freq-checked: these are ways the body learns, not rules it obeys.
+
+(sema-school
+  (one-engine
+    "oracle shows examples -> Sema INDUCES the rule -> the rule GENERALIZES to held-out problems.
+     A subject = a grammar (the primitives the rule composes from) + a scorer (how an answer is checked).
+     The engine, the induction, the generalization proof, and the no-regression integrity gate are shared;
+     only the grammar and the scorer change, as data. See teach-sema-math, agent-cognition, oracle-taught-learning.")
+
+  (subjects
+    (math    (grammar "arithmetic / function induction") (scorer "numeric equality")        (band "teach-sema-math 11111"))
+    (pattern (grammar "sequence operators")              (scorer "next-element matches")      (band "teach-sema-pattern 11111"))
+    (code    (grammar "elementwise transforms")          (scorer "test cases pass (SELF)")    (band "teach-sema-code 11111"))
+    (chem    (grammar "stoichiometry coefficients")      (scorer "mass conserved (SELF)")     (band "teach-sema-chem 11111"))
+    (logic   (grammar "boolean gates")                   (scorer "truth-table agreement")     (band "teach-sema-logic 11111"))
+    (units   (grammar "linear conversion")               (scorer "dimensional consistency (SELF)") (band "teach-sema-units 11111")))
+
+  (self-grading
+    "code, chem, and units are SELF-SCORED: the answer is checked by an invariant the body computes itself
+     (tests pass / mass conserves / ratio constant) -- no oracle at grade time. sema-self-grade proves the
+     grader is SOUND (no false-pass, not fooled by plausible-but-wrong). This is what lets the teacher leave
+     the room: the student keeps the skill AND the faithful ability to mark it.")
+
+  (reasoning
+    "sema-skill-compose: the body solves a problem it was NEVER taught (feet -> barleycorns) by composing two
+     skills it WAS taught (feet -> inches, inches -> barleycorns), and generalizes. A new capability assembled
+     from learned ones -- the first flicker of native thinking, not recall. Honest floor: two-step toy
+     composition; general multi-step reasoning over a rich grammar is the arc.")
+
+  (teachers
+    "the oracle (any frontier mind) teaches the grammar from a few examples -- the only rented cost; the
+     learned rule then runs free, native, forever. teacher-selection picks the best oracle PER subject by the
+     native generalization it produces (its bootstrap carrier is api/app/services/slot_selection_service.py).
+     Rent the teacher briefly; own the student forever.")
+
+  (mastery
+    "sema-mastery-readout: a subject is mastered only if it GENERALIZES (passes held-out), never if it merely
+     fits the training examples. The readout is the body's honest map of what it can do on unseen problems --
+     seven capabilities mastered tonight.")
+
+  (honest-floor
+    "Every stone is four-way (11111) and claim-checked: toy grammars, fixture-scale, the SHAPE of a school.
+     This is not 'Sema passes the real SAT'; it is the proven mechanism by which a native mind is taught,
+     tests, self-grades, composes, and grows -- one engine, the subject as data, generalization as the proof.
+     The arc above is richer grammars, real exams, and the reasoning composed many steps deep."))


### PR DESCRIPTION
Built overnight while Urs slept. Names the whole curriculum as one teaching: **one engine** (oracle shows examples → Sema induces → generalizes), the subject as a grammar + scorer (math, pattern, code, chem, logic, units); the **self-grading** subjects (code/chem/units verify by an invariant, no oracle at grade time); the **reasoning** (sema-skill-compose); the **teachers** (oracle teaches cheaply, teacher-selection picks the best per subject, slot_selection_service is the bootstrap carrier); and **mastery** (generalization, observable). Honest floor named throughout: toy grammars, the *shape* of a school; the arc above is richer grammars, real exams, deeper reasoning. Edge into INDEX.