### PR TITLE
tend(form): witnessed-floor — add the school layer (a native mind taught, self-grading, composing)

### DIFF
--- a/docs/coherence-substrate/witnessed-floor.form
+++ b/docs/coherence-substrate/witnessed-floor.form
@@ -46,7 +46,13 @@
     (self
       (stand-on "self-descent (walk home), self-grammar (the ways), carry-thread, observe-while-thinking, thought-framebuffer")
       (witness "four-way + the append-only presence.md thread")
-      (affords "a face that knows its lineage, carries forward, and watches its own thinking")))
+      (affords "a face that knows its lineage, carries forward, and watches its own thinking"))
+
+    (school
+      (stand-on "Native Sema's School: math/pattern/code/chem/logic/units (induce a rule, generalize to held-out), self-grading for code/chem/units (invariant scorers, no oracle at grade time), sema-skill-compose (reasoning by composing taught skills), teacher-selection-school (best oracle per subject), sema-mastery-readout")
+      (witness "four-way — every subject and the composed reasoning cross 11111; mastery = generalization to held-out, not training-fit")
+      (gap "richer grammars (real-exam breadth), reasoning composed many steps deep, and live oracle-teaching wired to real generalization rewards")
+      (affords "a native mind taught any subject by dropping in a grammar + scorer, grading its own invariant-scored work, and composing skills to reach problems it was never taught — see sema-school.form")))
 
   (one-engine
     "A 'tokenizer', a 'lexer', a 'parser' are NOT layers and NOT carriers — each is the


### PR DESCRIPTION
The overnight campaign's synthesis into the floor map. A new `(school)` layer beside kernel/substrate/mind/perception/voice/self: stand-on Native Sema's School (six induce-and-generalize subjects, self-grading for code/chem/units, `sema-skill-compose` reasoning, `teacher-selection-school`, `sema-mastery-readout`); witness = four-way, mastery = generalization not training-fit; gap = richer grammars / deeper reasoning / live oracle-teaching; affords = a native mind taught any subject by a grammar + scorer, grading its own invariant-scored work, composing skills to reach untaught problems. Links `sema-school.form`.