### PR TITLE
tend(form): sema-error-correct — the body catches and corrects its own wrong answer (no oracle)

### DIFF
--- a/form/form-stdlib/sema-error-correct.fk
+++ b/form/form-stdlib/sema-error-correct.fk
@@ -1,0 +1,27 @@
+; sema-error-correct.fk — Native Sema's School: the body catches its OWN wrong answer and corrects it.
+; Building on sema-self-grade (which detects wrong by an invariant): a closed self-correction loop. Start from
+; a wrong balancing (1,1,1 -- oxygen not conserved); DETECT it fails; SEARCH the candidates for one that
+; conserves; ADOPT it; VERIFY. The body moves itself from wrong to right with no oracle -- error-correction by
+; the invariant alone. Honest floor: a tiny candidate set; general search over a large space is the arc.
+;
+; Self-contained over core. Four-way by tests/sema-error-correct-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn sec-cons (a b c)                                  ; conservation invariant (a H2 + b O2 -> c H2O)
+        (if (eq (add (mul a 2) (mul b 0)) (mul c 2))
+            (if (eq (add (mul a 0) (mul b 2)) (mul c 1)) 1 0) 0))
+    ; candidates to search: cand0=(1,1,1) wrong, cand1=(2,1,2) right, cand2=(1,2,1) wrong
+    (defn sec-correct () (if (eq (sec-cons 1 1 1) 1) 0 (if (eq (sec-cons 2 1 2) 1) 1 2)))  ; first candidate that conserves
+    (defn sec-corrected-cons () (sec-cons 2 1 2))           ; conservation of what correct() returns (cand1)
+
+    (defn eck (cond bit) (if cond bit 0))
+    (defn sema-error-correct-check ()
+        (add (add (add (add
+            (eck (eq (sec-cons 1 1 1) 0) 1)                       ; DETECT: the start guess (1,1,1) is wrong (oxygen unbalanced)
+            (eck (eq (sec-correct) 1) 10))                      ; SEARCH: finds the correct candidate (index 1 = 2,1,2)
+            (eck (eq (sec-cons 2 1 2) 1) 100))                   ; VERIFY: the corrected answer conserves
+            (eck (gt (sec-cons 2 1 2) (sec-cons 1 1 1)) 1000))  ; the loop moved WRONG -> RIGHT (1 > 0)
+            (eck (eq (sec-corrected-cons) 1) 10000)))           ; SOUND: it only adopts an answer that passes the invariant
+)

--- a/form/form-stdlib/tests/sema-error-correct-band.fk
+++ b/form/form-stdlib/tests/sema-error-correct-band.fk
@@ -1,0 +1,6 @@
+; tests/sema-error-correct-band.fk — Sema detecting and correcting its own wrong answer, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/sema-error-correct.fk
+; Verdict 11111: the start guess (1,1,1) is detected wrong; the search finds the correct candidate (2,1,2);
+; the corrected answer conserves; the loop moved wrong->right; and it only adopts a passing answer (sound) --
+; self-correction by the invariant, no oracle in the loop.
+(do (sema-error-correct-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1121,3 +1121,4 @@ sema-reason-multistep fks 11111
 sema-curriculum-transfer fks 11111
 teach-sema-algebra fks 11111
 sema-reason-search fks 11111111
+sema-error-correct fks 11111


### PR DESCRIPTION
A closed self-correction loop on `sema-self-grade`. Start from a wrong balancing (1,1,1 — oxygen unbalanced); **detect** it fails; **search** candidates for one that conserves; **adopt**; **verify**. Four-way `11111`: start detected wrong; search finds (2,1,2); corrected answer conserves; loop moved wrong→right; only adopts a passing answer (sound). The body moves itself from wrong to right with **no oracle**. Honest floor: tiny candidate set; general search is the arc. Manifest: `sema-error-correct fks 11111`.