### PR TITLE
attune(form): fix fourth-arm prelude parser — 15 School bands were always four-way

### DIFF
--- a/docs/coherence-substrate/living-blocks.form
+++ b/docs/coherence-substrate/living-blocks.form
@@ -59,19 +59,24 @@
 #          not alone: it asks the part of the mind that knows, and answers when
 #          asked.
 #
-# THE SURFACE DISCIPLINE (why this matters — the lesson that named this cell).
-#   The overnight School built 17 native bands; 15 used gt / lt / not (and one a
-#   `global` form) and so did NOT cross the fourth arm — fkwu's self-host flatten
-#   emits a table for eq/if/list/arith but not yet for those. The WRONG fix is to
-#   grow the flatten surface ad-hoc, one op at a time, as bands happen to need
-#   them. The RIGHT fix is this north star: decide what is genuinely a CORE
-#   PRIMITIVE (comparison is host-CPU-native — gt/lt/not belong IN the minimal
-#   primitive set, mapped to the host's compare, covered by the flatten once and
-#   for all) versus what is a BLOCK (composed over the surface). Then the flatten
-#   covers exactly the frozen primitive set, and every living block — however
-#   smart — is just a recipe over it. Grow the surface only by a deliberate
-#   primitive decision, never by convenience. (See the honest correction:
-#   commit attune(form) School manifest honesty, 2026-06-28.)
+# THE SURFACE DISCIPLINE (why this matters — keep the primitive set frozen and small).
+#   The north star: decide what is genuinely a CORE PRIMITIVE (comparison is
+#   host-CPU-native — gt/lt/not belong IN the minimal primitive set, mapped to the
+#   host's compare) versus what is a BLOCK (composed over the surface). The flatten
+#   covers exactly the frozen primitive set, and every living block — however smart —
+#   is just a recipe over it. Grow the surface only by a deliberate primitive
+#   decision, never by convenience: a block that needs an op composes it from
+#   primitives or earns the op a place in the frozen set; it never grows the surface
+#   ad-hoc.
+#   (Provenance note, 2026-06-28: this cell was first written believing 15 overnight
+#   School bands failed the fourth arm because fkwu's flatten lacked gt/lt/not. That
+#   was wrong twice over — the ops were always in the flattener and fkwu always
+#   computed them right. The real cause was a greedy bash prelude-parser in
+#   scripts/fourth-arm.sh that slurped a band's "; Verdict ..." comment as bogus
+#   prelude paths, dropping the band file so the flatten carried no (check) call and
+#   fkwu's fn-0 returned 0 — a false divergence. Fixed by making the parser emit only
+#   real source-path tokens; all 15 cross four-way. The discipline above stands on
+#   its own; the example that birthed it was a harness bug, not a kernel gap.)
 #
 # HONEST FLOOR.
 #   SHIPPED + proven three-way (Go=Rust=TS), cited: resource-port.fk,
@@ -81,10 +86,10 @@
 #   1, 3, 4 have running carriers.
 #   NAMED, NOT YET BUILT: faculty 2 (the micro/macro time budget for thinking) as
 #   a Form carrier; and the SYNTHESIS — one block holding all four faculties at
-#   once, over the frozen surface, proven four-way. That synthesis waits behind
-#   the surface discipline above: the flatten must cover the core primitive set
-#   (gt/lt/not as primitives, the fourth-arm follow-up) before a four-faculty
-#   block crosses four-way. The step on the path, not a leap past it.
+#   once, over the frozen surface, proven four-way. The primitive set already
+#   covers what these faculties need (comparison, branch, arithmetic all flatten
+#   and cross four-way today); the synthesis is composition work over the surface,
+#   not a kernel gap. The step on the path, not a leap past it.
 #
 # Lineage: core-axioms.form -> host-kernel.form -> minimal-surface.fk -> here.
 # Kin: kernel-self-composition.form, open-primitive-set.form, substrate-thermodynamics.form.

--- a/form/form-stdlib/sema-curriculum-transfer.fk
+++ b/form/form-stdlib/sema-curriculum-transfer.fk
@@ -5,7 +5,7 @@
 ; each subject makes the next cheaper. Honest floor: toy linear skills, "effort" = parameters to pin; real
 ; transfer over rich representations is the arc.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/sema-curriculum-transfer-band.fk.
+; Self-contained over core. Four-way by tests/sema-curriculum-transfer-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/sema-error-correct.fk
+++ b/form/form-stdlib/sema-error-correct.fk
@@ -4,7 +4,7 @@
 ; conserves; ADOPT it; VERIFY. The body moves itself from wrong to right with no oracle -- error-correction by
 ; the invariant alone. Honest floor: a tiny candidate set; general search over a large space is the arc.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/sema-error-correct-band.fk.
+; Self-contained over core. Four-way by tests/sema-error-correct-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/sema-graduation.fk
+++ b/form/form-stdlib/sema-graduation.fk
@@ -3,10 +3,10 @@
 ; REASON (compose skills), SELF-GRADE (verify by invariant), TRANSFER (learn cheaper from related skills),
 ; SELF-CORRECT (fix its own errors), ROUTE (right skill per question), and shows MASTERY (generalization).
 ; Missing any one and it has not graduated -- a school of facts without reasoning is not a mind; a reasoner
-; that cannot check itself is not safe. All seven families crossed three-kernel (Go=Rust=TS) tonight; fourth arm pending. Honest floor: each family
+; that cannot check itself is not safe. All seven families crossed four-way tonight; fourth arm pending. Honest floor: each family
 ; is proven at toy scale; the diploma certifies the SHAPE is whole, not that the exams are real-world hard.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/sema-graduation-band.fk.
+; Self-contained over core. Four-way by tests/sema-graduation-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/sema-mastery-readout.fk
+++ b/form/form-stdlib/sema-mastery-readout.fk
@@ -2,9 +2,9 @@
 ; Mastery is not fitting the training examples -- it is GENERALIZING to held-out ones. The readout marks a
 ; subject mastered only if it passes BOTH train and held-out; a memorizer (fits train, fails held) reads
 ; NOT-mastered, honestly. The curriculum's seven capabilities (math, pattern, code, chem, logic, units, and
-; the composed reasoning) all generalized three-kernel (Go=Rust=TS) tonight, so the readout shows 7 mastered.
+; the composed reasoning) all generalized four-way tonight, so the readout shows 7 mastered.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/sema-mastery-readout-band.fk.
+; Self-contained over core. Four-way by tests/sema-mastery-readout-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/sema-mixed-exam.fk
+++ b/form/form-stdlib/sema-mixed-exam.fk
@@ -5,7 +5,7 @@
 ; right one chosen per question. Honest floor: three subjects, one question each; a full exam is more questions
 ; over richer skills.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/sema-mixed-exam-band.fk.
+; Self-contained over core. Four-way by tests/sema-mixed-exam-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/sema-reason-multistep.fk
+++ b/form/form-stdlib/sema-reason-multistep.fk
@@ -2,10 +2,10 @@
 ; sema-skill-compose proved 2-step reasoning; this proves it scales. Skills A (ft->in, x12), B (in->barleycorns,
 ; x3), C (barleycorns->lines, x4) were each taught. Feet->lines (x144) was never shown -- it emerges from
 ; composing C after B after A, and generalizes. Each added step compounds (144 reaches further than the 2-step
-; 36), and the 3rd skill builds on the 2-step result. The shape of multi-step reasoning, three-kernel (Go=Rust=TS).
+; 36), and the 3rd skill builds on the 2-step result. The shape of multi-step reasoning, four-way.
 ; Honest floor: toy linear skills, three steps; deep reasoning over a rich grammar is the arc.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/sema-reason-multistep-band.fk.
+; Self-contained over core. Four-way by tests/sema-reason-multistep-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/sema-self-grade.fk
+++ b/form/form-stdlib/sema-self-grade.fk
@@ -4,7 +4,7 @@
 ; plausible-but-wrong answer -- all by the conservation invariant, with no oracle consulted at grade time.
 ; That soundness is what lets the oracle leave the room: the student keeps the skill AND the ability to mark it.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/sema-self-grade-band.fk.
+; Self-contained over core. Four-way by tests/sema-self-grade-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/sema-skill-compose.fk
+++ b/form/form-stdlib/sema-skill-compose.fk
@@ -8,7 +8,7 @@
 ; reasoning-by-composition (untaught task solved by chaining learned skills, generalizing), not general
 ; multi-step reasoning over a rich grammar -- that is the arc above.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/sema-skill-compose-band.fk.
+; Self-contained over core. Four-way by tests/sema-skill-compose-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/teach-sema-algebra.fk
+++ b/form/form-stdlib/teach-sema-algebra.fk
@@ -4,7 +4,7 @@
 ; the answer is right. Generalizes to held-out equations. Honest floor: linear equations only; nonlinear /
 ; symbolic algebra is the arc.
 ;
-; Self-contained over core (FLOAT). Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/teach-sema-algebra-band.fk.
+; Self-contained over core (FLOAT). Four-way by tests/teach-sema-algebra-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/teach-sema-chem.fk
+++ b/form/form-stdlib/teach-sema-chem.fk
@@ -4,7 +4,7 @@
 ; Sema finds the coefficients, and the scorer is CONSERVATION (left atoms == right atoms, per element). A
 ; balancing is correct iff mass conserves -- the body grades its own chemistry against physics itself.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/teach-sema-chem-band.fk.
+; Self-contained over core. Four-way by tests/teach-sema-chem-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/teach-sema-code.fk
+++ b/form/form-stdlib/teach-sema-code.fk
@@ -5,7 +5,7 @@
 ; when it passes a held-out test it was not selected on. Same one engine, grammar = elementwise transforms,
 ; scorer = test-cases-pass (an invariant the body checks itself).
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/teach-sema-code-band.fk.
+; Self-contained over core. Four-way by tests/teach-sema-code-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/teach-sema-logic.fk
+++ b/form/form-stdlib/teach-sema-logic.fk
@@ -3,7 +3,7 @@
 ; hidden 2-input function; Sema selects the gate that fits and GENERALIZES to the rows it was never shown --
 ; the logic-test skill: infer the rule from a partial truth table. Hidden function here is XOR.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/teach-sema-logic-band.fk.
+; Self-contained over core. Four-way by tests/teach-sema-logic-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/teach-sema-pattern.fk
+++ b/form/form-stdlib/teach-sema-pattern.fk
@@ -3,7 +3,7 @@
 ; The oracle shows a sequence; Sema INDUCES the rule (common difference) and continues it on terms it was
 ; never shown -- the IQ-test skill: see the pattern, extend it. Pass = correct on held-out indices.
 ;
-; Self-contained over core. Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/teach-sema-pattern-band.fk.
+; Self-contained over core. Four-way by tests/teach-sema-pattern-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/teach-sema-units.fk
+++ b/form/form-stdlib/teach-sema-units.fk
@@ -4,7 +4,7 @@
 ; generalizes (10 -> 120). The new scorer: a mapping is a valid UNIT CONVERSION only if the ratio holds
 ; constant -- a non-proportional mapping (y = x + 11) is a dimensional error, caught by the body itself.
 ;
-; Self-contained over core (FLOAT throughout -- integer div collapses). Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/teach-sema-units-band.fk.
+; Self-contained over core (FLOAT throughout -- integer div collapses). Four-way by tests/teach-sema-units-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/teacher-selection-school.fk
+++ b/form/form-stdlib/teacher-selection-school.fk
@@ -2,9 +2,9 @@
 ; Builds on teacher-selection: across Native Sema's School, each subject keeps its own bandit over oracles,
 ; and the best teacher is the one whose teaching makes Sema GENERALIZE most. Different subjects pick DIFFERENT
 ; oracles -- no single frontier mind is the best teacher of everything; we rent the winner PER subject.
-; Deterministic selection core, three-kernel (Go=Rust=TS); the Thompson exploration draw on top is field-lane (named).
+; Deterministic selection core, four-way; the Thompson exploration draw on top is field-lane (named).
 ;
-; Self-contained over core (FLOAT rates). Three-kernel (Go=Rust=TS; fourth arm pending fkwu self-host flatten) by tests/teacher-selection-school-band.fk.
+; Self-contained over core (FLOAT rates). Four-way by tests/teacher-selection-school-band.fk.
 ;
 ; preludes: form-stdlib/core.fk
 

--- a/form/form-stdlib/tests/sema-curriculum-transfer-band.fk
+++ b/form/form-stdlib/tests/sema-curriculum-transfer-band.fk
@@ -1,4 +1,4 @@
-; tests/sema-curriculum-transfer-band.fk — learning cheaper after a related subject (transfer), three-kernel (Go=Rust=TS).
+; tests/sema-curriculum-transfer-band.fk — learning cheaper after a related subject (transfer), four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/sema-curriculum-transfer.fk
 ; Verdict 11111: subject A's slope is learned; B cold needs two examples; B after A needs only one (the
 ; intercept, slope transferred); B-after-A generalizes (predict 2 = 8) from that one example; and transfer

--- a/form/form-stdlib/tests/sema-error-correct-band.fk
+++ b/form/form-stdlib/tests/sema-error-correct-band.fk
@@ -1,4 +1,4 @@
-; tests/sema-error-correct-band.fk — Sema detecting and correcting its own wrong answer, three-kernel (Go=Rust=TS).
+; tests/sema-error-correct-band.fk — Sema detecting and correcting its own wrong answer, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/sema-error-correct.fk
 ; Verdict 11111: the start guess (1,1,1) is detected wrong; the search finds the correct candidate (2,1,2);
 ; the corrected answer conserves; the loop moved wrong->right; and it only adopts a passing answer (sound) --

--- a/form/form-stdlib/tests/sema-graduation-band.fk
+++ b/form/form-stdlib/tests/sema-graduation-band.fk
@@ -1,7 +1,7 @@
-; tests/sema-graduation-band.fk — the diploma: the whole school holds, three-kernel (Go=Rust=TS).
+; tests/sema-graduation-band.fk — the diploma: the whole school holds, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/sema-graduation.fk
 ; Verdict 11111: with all seven families (induction, reasoning, self-grade, transfer, self-correct, routing,
 ; mastery) the mind graduates; missing reasoning, or self-grading, or the subjects, it does not; and graduation
 ; is conjunctive (the whole mind outranks any partial one). The diploma certifies the SHAPE of a learning mind
-; is whole -- proven three-kernel (Go=Rust=TS) tonight, at toy scale.
+; is whole -- proven four-way tonight, at toy scale.
 (do (sema-graduation-check))

--- a/form/form-stdlib/tests/sema-mastery-readout-band.fk
+++ b/form/form-stdlib/tests/sema-mastery-readout-band.fk
@@ -1,4 +1,4 @@
-; tests/sema-mastery-readout-band.fk — the observable mastery readout, three-kernel (Go=Rust=TS).
+; tests/sema-mastery-readout-band.fk — the observable mastery readout, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/sema-mastery-readout.fk
 ; Verdict 11111: a generalizing subject reads mastered; a memorizer reads not-mastered; all seven curriculum
 ; capabilities are mastered; failing train is not mastery; and mastery requires generalization (it outranks

--- a/form/form-stdlib/tests/sema-mixed-exam-band.fk
+++ b/form/form-stdlib/tests/sema-mixed-exam-band.fk
@@ -1,4 +1,4 @@
-; tests/sema-mixed-exam-band.fk — a mixed-subject exam routed to the right skills, three-kernel (Go=Rust=TS).
+; tests/sema-mixed-exam-band.fk — a mixed-subject exam routed to the right skills, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/sema-mixed-exam.fk
 ; Verdict 11111: the math, pattern, and logic questions are each answered by the right learned skill; the exam
 ; scores 3/3; and routing matters (the wrong skill gives a different answer) -- the agent-cognition router

--- a/form/form-stdlib/tests/sema-reason-multistep-band.fk
+++ b/form/form-stdlib/tests/sema-reason-multistep-band.fk
@@ -1,4 +1,4 @@
-; tests/sema-reason-multistep-band.fk — Sema composing three taught skills (3-step reasoning), three-kernel (Go=Rust=TS).
+; tests/sema-reason-multistep-band.fk — Sema composing three taught skills (3-step reasoning), four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/sema-reason-multistep.fk
 ; Verdict 11111: the untaught 3-step skill emerges (12x3x4=144); depth compounds beyond the 2-step (36); it
 ; generalizes (2 ft = 288); the 3rd skill builds on the 2-step result (144 = 4x36); and the composed factor

--- a/form/form-stdlib/tests/sema-self-grade-band.fk
+++ b/form/form-stdlib/tests/sema-self-grade-band.fk
@@ -1,4 +1,4 @@
-; tests/sema-self-grade-band.fk — Sema's self-grading is sound (verifies its own answer, no oracle), three-kernel (Go=Rust=TS).
+; tests/sema-self-grade-band.fk — Sema's self-grading is sound (verifies its own answer, no oracle), four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/sema-self-grade.fk
 ; Verdict 11111: the correct answer passes; an unbalanced one fails; a plausible-but-wrong one fails (not
 ; fooled); no wrong answer false-passes (sound); and self-grade separates correct from wrong -- all by the

--- a/form/form-stdlib/tests/sema-skill-compose-band.fk
+++ b/form/form-stdlib/tests/sema-skill-compose-band.fk
@@ -1,4 +1,4 @@
-; tests/sema-skill-compose-band.fk — Sema composing two taught skills to solve an untaught problem, three-kernel (Go=Rust=TS).
+; tests/sema-skill-compose-band.fk — Sema composing two taught skills to solve an untaught problem, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/sema-skill-compose.fk
 ; Verdict 11111: taught skills A (ft->in) and B (in->barleycorns) work; the UNTAUGHT composed skill ft->barleycorns
 ; emerges (1 ft = 36, =12x3); it generalizes to a held-out input (5 ft = 180); and it is genuinely two steps

--- a/form/form-stdlib/tests/teach-sema-algebra-band.fk
+++ b/form/form-stdlib/tests/teach-sema-algebra-band.fk
@@ -1,4 +1,4 @@
-; tests/teach-sema-algebra-band.fk — Sema solving for an unknown (linear algebra), three-kernel (Go=Rust=TS).
+; tests/teach-sema-algebra-band.fk — Sema solving for an unknown (linear algebra), four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/teach-sema-algebra.fk
 ; Verdict 11111: solves 2x+3=11 -> x=4; self-checks by substitution (2*4+3=11); generalizes to a held-out
 ; equation (3x+1=10 -> x=3); self-checks the held-out; and solving is the inverse operation, not just

--- a/form/form-stdlib/tests/teach-sema-chem-band.fk
+++ b/form/form-stdlib/tests/teach-sema-chem-band.fk
@@ -1,4 +1,4 @@
-; tests/teach-sema-chem-band.fk — teaching Sema a chemistry test, self-graded by mass conservation, three-kernel (Go=Rust=TS).
+; tests/teach-sema-chem-band.fk — teaching Sema a chemistry test, self-graded by mass conservation, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/teach-sema-chem.fk
 ; Verdict 11111: 2 H2 + 1 O2 -> 2 H2O conserves H and O; the unbalanced 1,1,1 violates O; the balanced one
 ; is fully conserved (self-verified); and self-grading rejects the unbalanced -- by the conservation invariant,

--- a/form/form-stdlib/tests/teach-sema-code-band.fk
+++ b/form/form-stdlib/tests/teach-sema-code-band.fk
@@ -1,4 +1,4 @@
-; tests/teach-sema-code-band.fk — teaching Sema a coding test, self-graded by execution, three-kernel (Go=Rust=TS).
+; tests/teach-sema-code-band.fk — teaching Sema a coding test, self-graded by execution, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/teach-sema-code.fk
 ; Verdict 11111: the +1 program passes both training tests; identity and x2 fail to fit (so +1 is the unique
 ; winner); +1 generalizes to a held-out test; and self-grading (running the program) catches the wrong one --

--- a/form/form-stdlib/tests/teach-sema-logic-band.fk
+++ b/form/form-stdlib/tests/teach-sema-logic-band.fk
@@ -1,4 +1,4 @@
-; tests/teach-sema-logic-band.fk — teaching Sema a logic test by boolean rule induction, three-kernel (Go=Rust=TS).
+; tests/teach-sema-logic-band.fk — teaching Sema a logic test by boolean rule induction, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/teach-sema-logic.fk
 ; Verdict 11111: XOR fits the shown rows; AND does not; XOR generalizes to both held-out rows; AND fails them;
 ; and XOR is the unique winner (beats OR too) -- the rule inferred from a partial truth table, not memorized.

--- a/form/form-stdlib/tests/teach-sema-pattern-band.fk
+++ b/form/form-stdlib/tests/teach-sema-pattern-band.fk
@@ -1,4 +1,4 @@
-; tests/teach-sema-pattern-band.fk — teaching Sema an IQ/pattern test by sequence induction, three-kernel (Go=Rust=TS).
+; tests/teach-sema-pattern-band.fk — teaching Sema an IQ/pattern test by sequence induction, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/teach-sema-pattern.fk
 ; Verdict 11111: induces the rule d=2; the rule is consistent across the sequence; continues correctly
 ; (next=10); generalizes to a held-out index (term 6 = 14); and a repeat-last memorizer is wrong.

--- a/form/form-stdlib/tests/teach-sema-units-band.fk
+++ b/form/form-stdlib/tests/teach-sema-units-band.fk
@@ -1,4 +1,4 @@
-; tests/teach-sema-units-band.fk — teaching Sema units/dimensional analysis, three-kernel (Go=Rust=TS).
+; tests/teach-sema-units-band.fk — teaching Sema units/dimensional analysis, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/teach-sema-units.fk
 ; Verdict 11111: Sema induces the conversion factor (12); the examples are dimensionally consistent (a valid
 ; conversion); it generalizes (10 ft -> 120 in); a non-proportional mapping is rejected as a dimensional error;

--- a/form/form-stdlib/tests/teacher-selection-school-band.fk
+++ b/form/form-stdlib/tests/teacher-selection-school-band.fk
@@ -1,4 +1,4 @@
-; tests/teacher-selection-school-band.fk — best oracle teacher per curriculum subject, three-kernel (Go=Rust=TS).
+; tests/teacher-selection-school-band.fk — best oracle teacher per curriculum subject, four-way.
 ; preludes: form-stdlib/core.fk form-stdlib/teacher-selection-school.fk
 ; Verdict 11111: math's best teacher is oracle 0; code's is oracle 1; chem's is oracle 2 (per-subject
 ; specialization); selection is by generalization rate; and different subjects pick different teachers --

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1109,3 +1109,4 @@ teach-native-sema fks 11111
 teach-sema-math fks 11111
 teacher-selection fks 11111
 sema-reason-search fks 11111111
+teach-sema-pattern teach-sema-code teach-sema-chem teach-sema-logic teach-sema-units sema-skill-compose sema-self-grade sema-mastery-readout teacher-selection-school sema-reason-multistep sema-curriculum-transfer teach-sema-algebra sema-error-correct sema-mixed-exam sema-graduation fks 11111

--- a/form/scripts/fourth-arm.sh
+++ b/form/scripts/fourth-arm.sh
@@ -279,22 +279,32 @@ fourth_band_stem() {
 # fallback when no prelude is declared).
 # fourth_band_prelude_mods — every module path from a band's ; preludes: header,
 # including continuation lines that start with "; " (multi-line prelude blocks).
+# Emits ONLY source-path tokens (ending in .fk/.bml/.form/.grammar); a continuation
+# comment line that yields no path token (e.g. "; Verdict 11111: taught skills ...")
+# STOPS the block instead of being slurped as bogus prelude paths — otherwise the
+# first non-file token makes fourth_prep_srcs bail and silently drop the band file,
+# flattening a table with no top-level (check) call → fkwu fn-0 = 0 (a false divergence).
 fourth_band_prelude_mods() {
     local band="$1"
     awk '
+        function emit_paths(line,   i, n, a, got) {
+            n = split(line, a, /[[:space:]]+/)
+            got = 0
+            for (i = 1; i <= n; i++)
+                if (a[i] ~ /\.(fk|bml|form|grammar)$/) { print a[i]; got = 1 }
+            return got
+        }
         /^; preludes:/ {
-            sub(/^; preludes:[[:space:]]*/, "")
-            if (length($0) > 0) print
-            cont = 1
-            next
+            s = $0; sub(/^; preludes:[[:space:]]*/, "", s)
+            emit_paths(s); cont = 1; next
         }
         cont && /^;[[:space:]]/ {
-            sub(/^;[[:space:]]*/, "")
-            if (length($0) > 0) print
+            s = $0; sub(/^;[[:space:]]*/, "", s)
+            if (emit_paths(s) == 0) cont = 0   # prose line (no path token) ends the block
             next
         }
         { cont = 0 }
-    ' "$band" 2>/dev/null | tr ' ' '\n' | grep -vE '(^|/)core\.fk$' | grep . || true
+    ' "$band" 2>/dev/null | grep -vE '(^|/)core\.fk$' | grep . || true
 }
 
 fourth_band_srcs() {


### PR DESCRIPTION
**It was never fkwu.** Running the recipe through both flatten paths and the executor in isolation: the recipes are correct, fkwu's executor runs them to 11111, and gt/lt/not were always in the flattener.

**Root cause** (scripts/fourth-arm.sh): `fourth_band_prelude_mods` treated every `; ` comment after `; preludes:` as a prelude continuation. A band whose next line is prose (`; Verdict 11111: taught skills A (ft->in)...`) had that comment slurped as bogus prelude paths → `fourth_prep_srcs` hit `[[ -f "Verdict" ]] || return 0` → **silently dropped the band file** → the flatten carried no top-level `(check)` call → fkwu's fn-0 returned 0. A false divergence. Bands with a bare `;` separator after preludes (math, reason-search) broke the continuation and crossed; the 15 without it didn't.

**Fix:** emit only real source-path tokens; a continuation line with no path token ends the block. Multi-line preludes still resolve; **all 15 School bands cross four-way** (cleared-cache verified).

**Restores** the 15 to the manifest + their four-way headers (the earlier 'three-kernel/unsupported-op' relabel was wrong twice — not unsupported, not an fkwu divergence). Corrects living-blocks.form's example.

**Separate / pre-existing** (not from this change): `gelu-erf` is divergent on origin/main — worth its own look.