### PR TITLE
tend(form): validate.sh names a missing input file as missing, not a divergence

### DIFF
--- a/form/validate.sh
+++ b/form/validate.sh
@@ -326,6 +326,22 @@ if [[ $# -gt 0 ]]; then
             explicit_args=(form-stdlib/core.fk $preludes "$f")
         fi
     fi
+    # A missing input file is not a kernel divergence. Without this guard the
+    # three walkers each open the absent path and emit a DIFFERENT file-not-found
+    # string while fkwu emits nothing, so the verdict reads "kernels disagree —
+    # investigate which is correct" — a phantom divergence that has cost real
+    # diagnostic effort (e.g. running `gelu-erf-band.fk` when the band is named
+    # `transformer-gelu-erf-band.fk`). Name the absent path plainly instead.
+    missing=()
+    for f in "${explicit_args[@]}"; do
+        [[ -f "$f" ]] || missing+=("$f")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        printf "  ✗  input file(s) not found — this is a missing file, not a kernel divergence.\n" >&2
+        printf "      kernel input paths resolve relative to the form/ directory (e.g. form-stdlib/core.fk):\n" >&2
+        for f in "${missing[@]}"; do printf "        %s\n" "$f" >&2; done
+        exit 2
+    fi
     label=""
     for f in "${explicit_args[@]}"; do
         base="$(basename "$f")"


### PR DESCRIPTION
## What this is

Root-causing a reported `transformer-gelu-erf` fkwu divergence. **There is no divergence.** The real band `form/form-stdlib/tests/transformer-gelu-erf-band.fk` crosses **four-way at 255 (1 ok, 0 divergent)** with a cleared `.cache/fourth` — confirmed by running the fkwu binary directly (exit 0, fn-0 = 255, no crash). CLAUDE.md's "369 four-way, 0 divergent" including exact-erf gelu holds.

The reported "0 ok, 1 divergent" reproduces **only** against the **nonexistent path** `form-stdlib/tests/gelu-erf-band.fk` (the band is named `transformer-gelu-erf-band.fk`). With a missing file, go/rust/ts each emit a *different* file-not-found error string and fkwu emits nothing — and `validate.sh` counted that as a kernel divergence: `0 ok, 1 divergent — kernels disagree. Investigate which is correct.` That false signal is what spun up a full root-cause pass.

## The fix

`validate.sh` explicit mode now checks every resolved input file exists before running the kernels. If any is absent it names the path and exits 2 (distinct from the exit-1 real-divergence path):

```
  ✗  input file(s) not found — this is a missing file, not a kernel divergence.
      kernel input paths resolve relative to the form/ directory (e.g. form-stdlib/core.fk):
        form-stdlib/tests/gelu-erf-band.fk
```

Suite mode (no args) is untouched. The guard composts a recurring false-divergence trap into an honest, evidence-bearing check — *checks read the body; they serve vitality when they show what the body knows now.*

## Evidence
- `transformer-gelu-erf-band.fk` → 255, four-way, cleared cache.
- `fourth_band_srcs transformer-gelu-erf` lists 5 preludes + band file (no prose) — flatten healthy, not a dropped band.
- fkwu binary direct on the table → 255, exit 0, no SIGSEGV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)