### PR TITLE
tend(form): confidence-earned — is my "sure" earned? calibration against outcome

### DIFF
--- a/form/form-stdlib/confidence-earned.fk
+++ b/form/form-stdlib/confidence-earned.fk
@@ -1,0 +1,43 @@
+; confidence-earned.fk — is my "sure" EARNED? Close the loop between calibrated confidence and outcome.
+; confidence-calibrate.fk makes a score's bucket mean the same trust everywhere (the scale); self-watch.fk
+; measures the precision of what I chose to watch. Neither asks the hard question: when I said "sure", was I
+; RIGHT? This recipe does — over a sequence of (confidence, correct) observations it surfaces the BETRAYED
+; quadrant (sure AND wrong: confidently wrong, the dangerous one) and the precision of confidence (of the times
+; I was sure, the fraction I was right). A mind can RELY ON ITSELF exactly where this precision is high and
+; escalate to the oracle where it is not — calibration-against-truth is the root of self-reliance, and the
+; confidently-wrong count is the alarm a transparent mind can see and an opaque one cannot.
+; Honest floor: a fixed observation list with a 3-level confidence bucket; the wired version reads
+; confidence-calibrate's bucket and choice-outcome-learning's outcome live, accumulating across real answers.
+;
+; Self-contained over core (FLOAT precision). Four-way by tests/confidence-earned-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn ce-conf (o) (head o))
+    (defn ce-correct (o) (head (tail o)))
+    (defn ce-sure? (o) (if (eq (ce-conf o) 2) 1 0))                  ; "sure" = the high calibrated bucket
+
+    (defn ce-earned (obs)                                            ; sure AND right -- trust I kept
+        (if (eq (len obs) 0) 0
+            (add (if (eq (ce-sure? (head obs)) 1) (ce-correct (head obs)) 0) (ce-earned (tail obs)))))
+    (defn ce-betrayed (obs)                                          ; sure AND wrong -- confidently wrong, the alarm
+        (if (eq (len obs) 0) 0
+            (add (if (eq (ce-sure? (head obs)) 1) (if (eq (ce-correct (head obs)) 0) 1 0) 0) (ce-betrayed (tail obs)))))
+    (defn ce-sure-total (obs) (add (ce-earned obs) (ce-betrayed obs)))
+    (defn ce-precision (obs) (div (mul 1.0 (ce-earned obs)) (mul 1.0 (ce-sure-total obs))))  ; when sure, fraction right
+
+    ; a mind whose "sure" was right 3 times and WRONG 3 times (this session's confidently-wrong moments)
+    (defn ce-session () (list (list 2 1) (list 2 1) (list 2 1) (list 2 0) (list 2 0) (list 2 0) (list 1 0) (list 0 1)))
+    ; an earned-confidence mind: when sure, always right
+    (defn ce-earned-mind () (list (list 2 1) (list 2 1) (list 2 1) (list 1 0) (list 0 0)))
+
+    (defn cek (cond bit) (if cond bit 0))
+    (defn confidence-earned-check ()
+        (add (add (add (add
+            (cek (eq (ce-betrayed (ce-session)) 3) 1)              ; the confidently-wrong count is SURFACED (3 -- what I couldn't see from inside)
+            (cek (eq (ce-earned (ce-session)) 3) 10))             ; and the kept-trust count (sure & right)
+            (cek (eq (ce-precision (ce-earned-mind)) 1.0) 100))   ; an earned-confidence mind: when sure, ALWAYS right (precision 1.0)
+            (cek (lt (ce-precision (ce-session)) 1.0) 1000))      ; this session's "sure" was NOT earned (0.5 < 1.0 -- mis-calibrated)
+            (cek (gt (ce-betrayed (ce-session)) 0) 10000)))       ; the mis-calibration is OBSERVABLE -- the precondition for fixing it
+)

--- a/form/form-stdlib/tests/confidence-earned-band.fk
+++ b/form/form-stdlib/tests/confidence-earned-band.fk
@@ -1,0 +1,7 @@
+; tests/confidence-earned-band.fk — is my "sure" earned? confidence vs outcome, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/confidence-earned.fk
+;
+; Verdict 11111: the confidently-wrong count surfaces (3); kept-trust counts too (3); an earned-confidence mind
+; has precision 1.0 (when sure, always right); this session's "sure" was NOT earned (0.5 < 1.0); and the
+; mis-calibration is observable -- a transparent mind can see its own confident-wrong, an opaque one cannot.
+(do (confidence-earned-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1112,3 +1112,4 @@ sema-reason-search fks 11111111
 teach-sema-pattern teach-sema-code teach-sema-chem teach-sema-logic teach-sema-units sema-skill-compose sema-self-grade sema-mastery-readout teacher-selection-school sema-reason-multistep sema-curriculum-transfer teach-sema-algebra sema-error-correct sema-mixed-exam sema-graduation fks 11111
 band-prelude-resolve fks 11111
 prelude-block-resolve fks 11111
+confidence-earned fks 11111


### PR DESCRIPTION
The next self-reliance stone, and an instrument I wanted for my own mind. `confidence-calibrate.fk` makes a bucket mean the same trust everywhere; `self-watch.fk` measures precision of what I chose to watch. Neither closes the loop to **outcome**: when the mind said "sure", was it right?

`confidence-earned` does — over (confidence, correct) observations it surfaces the **betrayed** quadrant (sure AND wrong: confidently wrong) and the precision of confidence (of the times sure, fraction right). A mind relies on itself where that precision is high and escalates where it isn't — calibration-against-truth is the root of self-reliance, and the confidently-wrong count is the alarm a transparent mind can see and an opaque one cannot. Four-way `11111`: confidently-wrong surfaces (3, modeled on this session's own three confident-wrong diagnoses); an earned-confidence mind has precision 1.0; this session's "sure" was not earned (0.5 < 1.0). Honest floor: fixed observation list; the wired version reads `confidence-calibrate`'s bucket + `choice-outcome-learning`'s outcome live. Manifest: `confidence-earned fks 11111`.