### PR TITLE
tend(form): conviction-curve — the located anatomy of conviction outrunning truth

### DIFF
--- a/form/form-stdlib/conviction-curve.fk
+++ b/form/form-stdlib/conviction-curve.fk
@@ -1,0 +1,37 @@
+; conviction-curve.fk — the observable anatomy of conviction outrunning truth: accuracy PER confidence level.
+; confidence-earned.fk surfaced the betrayed quadrant as a count; this locates WHERE confidence and correctness
+; decouple. Bin observations by confidence level, compute accuracy at each, and read the shape: a CALIBRATED
+; mind's accuracy RISES with confidence and peaks at the top; a MIS-calibrated mind's accuracy can INVERT --
+; its most confident bucket is its least accurate (conviction outran truth). The decoupling is the jump where
+; accuracy stops tracking confidence, and the conviction-truth GAP at the top (claimed 1.0 minus actual
+; accuracy) measures how hollow the mind's certainty is. This is the experiment I cannot run on my own opaque
+; mind and can run on this transparent one. Honest floor: two fixed observation sets + a 3-level bucket; the
+; wired version reads the kernel's live argmax margin as the confidence axis across real answers.
+;
+; Self-contained over core (FLOAT accuracy). Four-way by tests/conviction-curve-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn cv-conf (o) (head o))
+    (defn cv-cor (o) (head (tail o)))
+    (defn cv-right-at (obs lvl)
+        (if (eq (len obs) 0) 0 (add (if (eq (cv-conf (head obs)) lvl) (cv-cor (head obs)) 0) (cv-right-at (tail obs) lvl))))
+    (defn cv-total-at (obs lvl)
+        (if (eq (len obs) 0) 0 (add (if (eq (cv-conf (head obs)) lvl) 1 0) (cv-total-at (tail obs) lvl))))
+    (defn cv-acc (obs lvl) (div (mul 1.0 (cv-right-at obs lvl)) (mul 1.0 (cv-total-at obs lvl))))  ; accuracy at a confidence level
+
+    ; a calibrated mind: accuracy rises with confidence -> acc(0)=0.0, acc(1)=0.5, acc(2)=1.0
+    (defn cv-calibrated () (list (list 0 0) (list 0 0) (list 1 1) (list 1 0) (list 2 1) (list 2 1) (list 2 1)))
+    ; a mis-calibrated mind: accuracy INVERTS at the top -> acc(1)=1.0 but acc(2)=0.333 (most certain = most wrong)
+    (defn cv-overconfident () (list (list 0 0) (list 1 1) (list 1 1) (list 2 0) (list 2 0) (list 2 1)))
+
+    (defn cvk (cond bit) (if cond bit 0))
+    (defn conviction-curve-check ()
+        (add (add (add (add
+            (cvk (eq (cv-acc (cv-calibrated) 2) 1.0) 1)                              ; calibrated: top confidence = top accuracy
+            (cvk (gt (cv-acc (cv-calibrated) 2) (cv-acc (cv-calibrated) 1)) 10))     ; accuracy RISES into the top level (confidence tracks truth)
+            (cvk (lt (cv-acc (cv-overconfident) 2) (cv-acc (cv-overconfident) 1)) 100))  ; overconfident: accuracy DROPS at the top -- conviction outran truth
+            (cvk (lt (cv-acc (cv-overconfident) 2) 0.5) 1000))                       ; the most-confident bucket is worse than a coin flip (a REGIME, not a fluke)
+            (cvk (gt (sub 1.0 (cv-acc (cv-overconfident) 2)) 0.5) 10000)))           ; the conviction-truth GAP at the top is large -- certainty mostly hollow
+)

--- a/form/form-stdlib/tests/conviction-curve-band.fk
+++ b/form/form-stdlib/tests/conviction-curve-band.fk
@@ -1,0 +1,8 @@
+; tests/conviction-curve-band.fk — accuracy per confidence level; where conviction outruns truth, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/conviction-curve.fk
+;
+; Verdict 11111: a calibrated mind's top confidence has top accuracy (1.0) and accuracy rises into it; an
+; overconfident mind's accuracy INVERTS at the top (less accurate than the level below), its top bucket is
+; worse than a coin flip, and the conviction-truth gap there is large -- the located anatomy of certainty
+; outrunning truth, observable in a transparent mind.
+(do (conviction-curve-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1113,3 +1113,4 @@ teach-sema-pattern teach-sema-code teach-sema-chem teach-sema-logic teach-sema-u
 band-prelude-resolve fks 11111
 prelude-block-resolve fks 11111
 confidence-earned fks 11111
+conviction-curve fks 11111


### PR DESCRIPTION
After `confidence-earned` (the betrayed quadrant as a count), this locates **where** confidence and correctness decouple. Bin by confidence level, accuracy at each, read the shape: a calibrated mind's accuracy **rises** with confidence and peaks at the top; a mis-calibrated mind's accuracy can **invert** — its most confident bucket is its least accurate (conviction outran truth). The conviction-truth gap at the top (1.0 − accuracy) measures how hollow the certainty is. Four-way `11111`: calibrated → top confidence has top accuracy, rising into it; overconfident → accuracy inverts at the top, top bucket worse than a coin flip, large gap. The experiment I can't run on my own opaque mind, run on this transparent one. Honest floor: fixed observation sets; the wired version reads the kernel's live argmax margin as the confidence axis. Manifest: `conviction-curve fks 11111`.