### PR TITLE
tend(form): capture-correction — the correction reflex as a combinator (the auto-capture hook)

### DIFF
--- a/form/form-stdlib/capture-correction.fk
+++ b/form/form-stdlib/capture-correction.fk
@@ -1,0 +1,33 @@
+; capture-correction.fk — the correction reflex made a COMBINATOR: the auto-capture hook for the transient log.
+; correction-reflex proved why the reflex makes a mind trustworthy; transient-log gave the durable format. This
+; closes the loop: a decision point wraps its claim here, and capture AUTO-detects whether the claim matched the
+; verified truth, AUTO-corrects (always commits the verified truth, never the claim), and produces the
+; transient-log event (sure, transiently-correct, caught) -- no hand-labeling. Wrap a real decision (the
+; sufficiency gate's grounded-vs-escalate, champion-challenger's authority flip, the validate predict->verify)
+; in this combinator and the transient log fills itself from the body's own reasoning, so conviction-curve /
+; correction-reflex run over a LIVING stream. The combinator's logic is four-way; the log append is the runtime
+; act that composes on top.
+;
+; Self-contained over core. Four-way by tests/capture-correction-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn cc-tcorrect (claim truth) (if (eq claim truth) 1 0))   ; was the in-the-moment claim right? (AUTO, not labeled)
+    (defn cc-event (claim truth sure)                            ; the transient-log event the wrapper emits
+        (list sure (cc-tcorrect claim truth) 1))                ;   caught = 1: the wrapper IS the reflex (it verified)
+    (defn cc-commit (claim truth) truth)                         ; always commit the verified truth -- the auto-correction
+
+    (defn cc-ev-sure (e) (head e))
+    (defn cc-ev-tcorrect (e) (head (tail e)))
+    (defn cc-ev-caught (e) (head (tail (tail e))))
+
+    (defn cck (cond bit) (if cond bit 0))
+    (defn capture-correction-check ()
+        (add (add (add (add
+            (cck (eq (cc-ev-tcorrect (cc-event 5 5 1)) 1) 1)             ; a right claim auto-logs transiently-correct
+            (cck (eq (cc-ev-tcorrect (cc-event 4 5 1)) 0) 10))           ; a wrong claim auto-logs transiently-WRONG (detected, not labeled)
+            (cck (eq (cc-commit 4 5) 5) 100))                            ; the wrapper COMMITS the verified truth (5), not the wrong claim (4) -- auto-corrected
+            (cck (eq (cc-ev-caught (cc-event 4 5 1)) 1) 1000))           ; the wrong claim was caught -- the wrapper is the reflex
+            (cck (eq (cc-commit 4 5) (cc-commit 5 5)) 10000)))           ; committed = truth regardless of the claim -- wrap anything, commit truth
+)

--- a/form/form-stdlib/tests/capture-correction-band.fk
+++ b/form/form-stdlib/tests/capture-correction-band.fk
@@ -1,0 +1,8 @@
+; tests/capture-correction-band.fk — the reflex-as-combinator auto-captures and auto-corrects, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/capture-correction.fk
+;
+; Verdict 11111: a right claim auto-logs transiently-correct; a wrong claim auto-logs transiently-wrong
+; (detected, not hand-labeled); the wrapper commits the verified truth not the wrong claim (auto-correction);
+; the wrong claim is caught (the wrapper is the reflex); and committed equals truth regardless of the claim --
+; wrap any decision and the transient log fills itself with real correction events.
+(do (capture-correction-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1116,3 +1116,4 @@ confidence-earned fks 11111
 conviction-curve fks 11111
 correction-reflex fks 11111
 transient-log fks 11111
+capture-correction fks 11111


### PR DESCRIPTION
`correction-reflex` proved why the reflex makes a mind trustworthy; `transient-log` gave the durable format. This closes the loop: a decision point wraps its claim here, and capture **auto-detects** whether the claim matched the verified truth, **auto-corrects** (commits the verified truth, never the claim), and emits the transient-log event — no hand-labeling. Wrap a real decision (the sufficiency gate, champion-challenger's flip, the validate predict→verify) and the transient log fills itself from the body's own reasoning, so `conviction-curve` / `correction-reflex` run over a **living** stream. Four-way `11111`. Manifest: `capture-correction fks 11111`.
