### PR TITLE
tend(form): sovereignty-policy — the gate safely tunes its own escalation threshold (loop closed)

### DIFF
--- a/form/form-stdlib/sovereignty-policy.fk
+++ b/form/form-stdlib/sovereignty-policy.fk
@@ -1,0 +1,30 @@
+; sovereignty-policy.fk — the gate tunes its OWN escalation threshold from its measured self-reliance.
+; membrane-self-reliance measures accept-precision (the body's cognitive sovereignty) from real crossings.
+; This closes the autonomous loop: feed that number back to adjust fsuf-policy's accept-threshold. Over-relying
+; (low precision -- accepting local when it was wrong) RAISES the threshold: be more skeptical, escalate more.
+; Earned (high precision) LOWERS it: lean into proven sovereignty, rely on self further. The adjustment is
+; BOUNDED [30..90] -- a self that changes itself safely (core-axioms' hardest theorem, as a small bounded
+; instance): it can re-tune its own skepticism but can never run to "trust nothing" or "trust everything". With
+; this, the gate escalates differently next turn, producing new crossings, a new measure -- no human and no
+; rented mind in the calibration loop. The gate learns its own escalation policy from its lived sovereignty.
+;
+; Self-contained over core (FLOAT precision in, bounded int threshold out). Four-way by tests/...-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn sp-adjust (prec threshold)
+        (if (lt prec 0.8) (add threshold 10)        ; over-relying -> raise threshold (escalate more)
+            (sub threshold 5)))                      ; earned -> lower threshold (rely on self more)
+    (defn sp-clamp (t) (if (gt t 90) 90 (if (lt t 30) 30 t)))   ; bounded: never "trust nothing" / "trust everything"
+    (defn sp-new-threshold (prec threshold) (sp-clamp (sp-adjust prec threshold)))
+
+    (defn spk (cond bit) (if cond bit 0))
+    (defn sovereignty-policy-check ()
+        (add (add (add (add
+            (spk (gt (sp-new-threshold 0.5 60) 60) 1)                                 ; over-relying (0.5) -> threshold RISES -> escalate more
+            (spk (lt (sp-new-threshold 1.0 60) 60) 10))                               ; earned (1.0) -> threshold FALLS -> rely on self more
+            (spk (eq (sp-new-threshold 0.5 88) 90) 100))                              ; the raise is CLAMPED at 90 -- safe, never runs to total skepticism
+            (spk (eq (sp-new-threshold 1.0 32) 30) 1000))                            ; the lower is FLOORED at 30 -- never abandons skepticism entirely
+            (spk (gt (sp-new-threshold 0.5 60) (sp-new-threshold 1.0 60)) 10000)))    ; a less-sovereign body escalates more than a more-sovereign one -- it adapts to its measured self
+)

--- a/form/form-stdlib/tests/sovereignty-policy-band.fk
+++ b/form/form-stdlib/tests/sovereignty-policy-band.fk
@@ -1,0 +1,9 @@
+; tests/sovereignty-policy-band.fk — the gate safely tunes its own escalation threshold, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/sovereignty-policy.fk
+;
+; Verdict 11111: low measured sovereignty raises the accept-threshold (escalate more); high sovereignty lowers
+; it (rely more); the raise is clamped at 90 and the lower floored at 30 (a self that changes itself but stays
+; bounded -- never trust-nothing or trust-everything); and a less-sovereign body escalates more than a
+; more-sovereign one. The autonomous self-reliance loop: the gate learns its own escalation from its lived
+; sovereignty, no human and no rented mind in the loop.
+(do (sovereignty-policy-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1119,3 +1119,4 @@ transient-log fks 11111
 capture-correction fks 11111
 sufficiency-capture fks 11111
 membrane-self-reliance fks 11111
+sovereignty-policy fks 11111


### PR DESCRIPTION
The keystone that closes the autonomous self-reliance loop. `membrane-self-reliance` measures accept-precision (cognitive sovereignty) from real crossings; this feeds it back to adjust `fsuf-policy`'s accept-threshold. Over-relying (low) **raises** the threshold (escalate more); earned (high) **lowers** it (rely further). Bounded [30..90] — a self that changes itself safely: it re-tunes its skepticism but can never run to trust-nothing or trust-everything. Four-way `11111`. With this the loop is complete: **decide** (sufficiency) → **cross** (membrane) → **measure** (self-reliance) → **re-tune** (here) → escalate differently → new crossings — no human and no rented mind in the calibration loop. Manifest: `sovereignty-policy fks 11111`.
