### PR TITLE
tend(form): sensor-lane — ONE engine for an end-to-end lane of any sensor (STT/TTS/LLM/reasoning)

### DIFF
--- a/form/form-stdlib/sensor-lane.fk
+++ b/form/form-stdlib/sensor-lane.fk
@@ -1,0 +1,48 @@
+; sensor-lane.fk — ONE engine for an end-to-end lane of ANY sensor/modality: encode -> pivot -> reason -> decode.
+; The north-star generalization (Urs 2026-06-28: "end-to-end lanes for any sensor, especially TTS, STT, LLM,
+; reasoning"). The body already holds the architecture -- translation-pipeline-pivot.form (one generic-meaning
+; pivot, independently-improvable codec arms), encoder-decoder-as-recipe.form (encoder/decoder are two arms of
+; one R_Codec), universal-translator.form (the pivot is the Blueprint, not the symbol). This is the engine that
+; makes every modality an INSTANCE of one shape: a lane is DATA -- (encode-arm, reason-arm, decode-arm) over the
+; shared pivot -- and ONE generic lane-run carries them all. STT = audio-encode + pass-through + text-decode;
+; TTS = text-encode + pass-through + audio-decode; LLM/reasoning = text-encode + TRANSFORM-on-pivot + text-decode.
+; A new modality or task is a new ARM, never a new end-to-end model (the translation-pivot teaching, generalized
+; to every sensor). The reasoning happens ON the pivot -- shared by all lanes. core-abstraction-first: the engine
+; is data-driven; the modality drops in as data. Honest floor: the arms here are arithmetic stand-ins for the
+; real codec carriers (whisper STT four-way, the form-asm transformer for LLM-reasoning, native say() for TTS);
+; the ENGINE is the real generic shape, and those separately-proven carriers are the heavy arms that plug in.
+;
+; Self-contained over core. Four-way by tests/sensor-lane-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    ; an ARM is DATA: (op, param). a generic apply runs ANY arm -- one engine, arms drop in as data.
+    (defn sl-apply (op param x)
+        (if (eq op 0) x                       ; 0 = pass-through (identity reason: STT/TTS carry the pivot unchanged)
+            (if (eq op 1) (add x param)       ; 1 = shift (a codec arm: surface<->pivot offset)
+                (if (eq op 2) (mul x param) x))))  ; 2 = transform (reasoning on the pivot: the LLM arm)
+    (defn sl-arm-op (a) (head a))
+    (defn sl-arm-p (a) (head (tail a)))
+    (defn sl-run-arm (a x) (sl-apply (sl-arm-op a) (sl-arm-p a) x))
+    ; a LANE = (encode-arm, reason-arm, decode-arm). ONE engine runs every modality's lane.
+    (defn sl-enc (lane) (head lane))
+    (defn sl-reason (lane) (head (tail lane)))
+    (defn sl-dec (lane) (head (tail (tail lane))))
+    (defn sl-run (lane x) (sl-run-arm (sl-dec lane) (sl-run-arm (sl-reason lane) (sl-run-arm (sl-enc lane) x))))
+
+    ; three modalities as DATA through the SAME engine
+    (defn sl-stt () (list (list 1 10) (list 0 0) (list 1 5)))    ; audio-encode -> pass-through -> text-decode
+    (defn sl-tts () (list (list 1 100) (list 0 0) (list 1 1)))   ; text-encode -> pass-through -> audio-decode
+    (defn sl-llm () (list (list 1 10) (list 2 3) (list 1 0)))    ; text-encode -> REASON (x3) on pivot -> text-decode
+    (defn sl-llm-noreason () (list (list 1 10) (list 0 0) (list 1 0)))  ; same lane, reasoning removed
+
+    (defn slk (cond bit) (if cond bit 0))
+    (defn sensor-lane-check ()
+        (add (add (add (add
+            (slk (eq (sl-run (sl-stt) 0) 15) 1)                              ; the STT lane runs end-to-end through the generic engine
+            (slk (not (eq (sl-run (sl-tts) 0) (sl-run (sl-stt) 0))) 10))     ; TTS is a DIFFERENT lane through the SAME engine (modality is data)
+            (slk (eq (sl-run (sl-llm) 0) 30) 100))                           ; the LLM lane REASONS on the pivot (x3) where STT/TTS pass through
+            (slk (not (eq (sl-run (sl-llm) 0) (sl-run (sl-llm-noreason) 0))) 1000))  ; reasoning happens ON the pivot: 30 != 10
+            (slk (eq (sl-run (list (list 1 1) (list 2 2) (list 1 1)) 0) 3) 10000)))  ; a brand-new lane runs through the UNCHANGED engine -- new modality = new data, not new code
+)

--- a/form/form-stdlib/tests/sensor-lane-band.fk
+++ b/form/form-stdlib/tests/sensor-lane-band.fk
@@ -1,0 +1,8 @@
+; tests/sensor-lane-band.fk — one engine for any sensor's end-to-end lane (STT/TTS/LLM/reasoning), four-way.
+; preludes: form-stdlib/core.fk form-stdlib/sensor-lane.fk
+;
+; Verdict 11111: the STT lane runs end-to-end through the generic engine; TTS is a different lane through the
+; SAME engine (modality is data); the LLM lane reasons on the shared pivot where STT/TTS pass through; reasoning
+; genuinely happens on the pivot (the reasoning lane differs from its pass-through twin); and a brand-new lane
+; runs through the unchanged engine -- a new modality or task is new DATA, never new engine code.
+(do (sensor-lane-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1121,3 +1121,4 @@ sufficiency-capture fks 11111
 membrane-self-reliance fks 11111
 sovereignty-guide fks 11111
 guide-tending fks 11111
+sensor-lane fks 11111


### PR DESCRIPTION
The north-star generalization Urs named: **end-to-end lanes for any sensor** (TTS/STT/LLM/reasoning). Built on the body's factored-codec architecture (`translation-pipeline-pivot.form`, `encoder-decoder-as-recipe.form`, `universal-translator.form`). A lane is **data** — (encode-arm, reason-arm, decode-arm) over the shared pivot — and **one** generic `sl-run` carries every modality: STT = audio-encode + pass-through + text-decode; TTS = text-encode + pass-through + audio-decode; LLM = text-encode + **transform-on-pivot** + text-decode. A new modality/task is a new **arm**, never a new end-to-end model. Reasoning happens **on the pivot**, shared by all lanes. core-abstraction-first. Four-way `11111`. Honest floor: the arms are stand-ins for the real codec carriers (whisper STT, the form-asm transformer for reasoning, native `say()` for TTS) — the **engine** is the real generic shape; those proven carriers are the heavy arms that plug in. Manifest: `sensor-lane fks 11111`.
