### PR TITLE
tend(form): translate-lane — the first REAL carrier plugged into the sensor-lane engine

### DIFF
--- a/form/form-stdlib/tests/translate-lane-band.fk
+++ b/form/form-stdlib/tests/translate-lane-band.fk
@@ -1,0 +1,8 @@
+; tests/translate-lane-band.fk — translate as a sensor-lane with REAL nl-translate arms, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/string-case.fk form-stdlib/nl-lexicon-data.fk form-stdlib/nl-translate.fk form-stdlib/translate-lane.fk
+;
+; Verdict 11111: the EN->ID lane runs end-to-end with real arms ("the source is native" -> "sumber adalah asli");
+; the reverse lane is the same engine with swapped arms; the lane generalizes to a new sentence; en and id meet
+; at one shared pivot symbol (where reasoning would act); and a round-trip through both lanes preserves meaning.
+; The first real carrier plugged into the sensor-lane engine -- translate is not a special model, it is the lane.
+(do (translate-lane-check))

--- a/form/form-stdlib/translate-lane.fk
+++ b/form/form-stdlib/translate-lane.fk
@@ -1,0 +1,26 @@
+; translate-lane.fk — the FIRST real-carrier sensor-lane: NL translate plugged into the one lane engine.
+; sensor-lane proved ONE engine (encode -> reason -> decode over a shared pivot) for any modality, with
+; arithmetic STAND-IN arms. This plugs in REAL arms. nl-translate's tr-en-id IS that lane:
+; dec-id . norm-en . g-parse(nl-en) -- encode (en surface -> pivot), reason = identity (translation preserves
+; meaning on the pivot), decode (pivot -> id surface). tr-id-en is the SAME compose with SWAPPED codec arms
+; (id<->en). Both meet at ONE shared pivot symbol (nlt-en->c "source" == nlt-id->c "sumber" == the neutral
+; cell) -- exactly where an LLM reason-arm would act, shared by every lane. So translate is not a special model;
+; it is sensor-lane with real arms, already live native EN<->ID (experiments/coherence-sense-android/
+; native-translate-speak.sh). The next arms drop into the same shape: whisper's encoder (STT), native say()
+; (TTS), the form-asm transformer (the reason arm).
+;
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/string-case.fk form-stdlib/nl-lexicon-data.fk form-stdlib/nl-translate.fk
+
+(do
+    (defn tle-en-id (x) (tr-en-id x))   ; the EN->ID lane: encode(norm-en . g-parse nl-en) -> identity -> decode(dec-id)
+    (defn tle-id-en (x) (tr-id-en x))   ; the ID->EN lane: the SAME engine compose, SWAPPED codec arms
+
+    (defn tlek (cond bit) (if cond bit 0))
+    (defn translate-lane-check ()
+        (add (add (add (add
+            (tlek (str_eq (tle-en-id "the source is native") "sumber adalah asli") 1)            ; the EN->ID lane runs end-to-end with REAL arms
+            (tlek (str_eq (tle-id-en "sumber adalah asli") "the source is native") 10))          ; the reverse lane: SAME engine, swapped arms
+            (tlek (str_eq (tle-en-id "the kernel is native") "inti adalah asli") 100))            ; the lane GENERALIZES to a new sentence
+            (tlek (str_eq (nlt-en->c "source") (nlt-id->c "sumber")) 1000))                      ; en and id meet at ONE shared pivot symbol (where the reason-arm acts)
+            (tlek (str_eq (tle-en-id (tle-id-en "inti adalah asli")) "inti adalah asli") 10000)))  ; round-trip through both lanes preserves meaning -- the pivot is faithful
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1122,3 +1122,4 @@ membrane-self-reliance fks 11111
 sovereignty-guide fks 11111
 guide-tending fks 11111
 sensor-lane fks 11111
+translate-lane fks 11111


### PR DESCRIPTION
`sensor-lane` proved one engine with arithmetic stand-in arms; this plugs in **real** arms. `nl-translate`'s `tr-en-id` **is** that lane — `dec-id ∘ norm-en ∘ g-parse(nl-en)`: encode (en→pivot), reason = identity, decode (pivot→id). `tr-id-en` is the same compose with swapped codec arms. Four-way `11111` with real carriers: EN→ID runs end-to-end ("the source is native" → "sumber adalah asli"); the reverse is the same engine, swapped arms; it generalizes to a new sentence; en and id meet at **one shared pivot symbol** (`nlt-en->c "source"` == `nlt-id->c "sumber"`, where a reason-arm would act); round-trip preserves meaning. Translate is not a special model — it **is** sensor-lane with real arms, already live native EN↔ID. Next arms: whisper's encoder (STT), native `say()` (TTS), the form-asm transformer (reason). Manifest: `translate-lane fks 11111`.
