### PR TITLE
tend(form): fam-ss-sqrt — RMSNorm/LayerNorm reduction core as Form→asm bytes (first nonlinear op on the native lane)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 390 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 391 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -137,6 +137,14 @@
 ;        The dominant compute of a transformer forward pass is now sovereign native bytes; the remaining
 ;        native-lane rungs are the nonlinear ops (exp/sin/cos/rsqrt for softmax/RoPE/RMSNorm/SwiGLU as asm),
 ;        ll-buffer staging of the dequanted tensor set, and the 28-layer fold orchestrated over those.
+;     A''. ✓ DONE — form-asm-ss-sqrt (127): the FIRST nonlinear op on the native lane — fam-ss-sqrt emits
+;        sqrt(sum_j x[j]^2), the RMSNorm/LayerNorm denominator-root (L2 norm = sqrt(n)*RMS), as 52 arm64
+;        bytes four-way (Go=Rust=TS=fkwu byte-identical to the clang oracle): a counted square-accumulate
+;        loop closed by fsqrt OUTSIDE the loop. Execution witness scripts/form_asm_ss_sqrt_witness.sh runs
+;        those bytes on the M4 (form-macho .o -> ld -dylib -> dlopen+call) bit-exact vs sqrt(sum x^2),
+;        fp-stress included, no rustc/clang in the compute. Remaining nonlinear rungs: exp (softmax),
+;        sin/cos (RoPE), the 1/RMS reciprocal (fdiv is already an encoder). Receipt:
+;        commit_evidence_2026-06-28_form_asm_ss_sqrt.json.
 ;     B. ✓ DONE — scripts/form_asm_matvec_witness.sh: fam-dot2's form-asm bytes → form-macho .o → ld -dylib →
 ;        dlopen+call → d0 MATCHES bit-exact ([2,3,5,7]→31, edge cases). The bytes proven four-way are the bytes
 ;        that ran. form-macho's wrap is ABI-agnostic; in-kernel float-call later wants a small dylib_call_f64ptr.

--- a/docs/system_audit/commit_evidence_2026-06-28_form_asm_ss_sqrt.json
+++ b/docs/system_audit/commit_evidence_2026-06-28_form_asm_ss_sqrt.json
@@ -1,0 +1,32 @@
+{
+  "title": "fam-ss-sqrt — the RMSNorm/LayerNorm reduction core as Form->asm BYTES, four-way + run on M4",
+  "date": "2026-06-28",
+  "author": "Sema (Opus 4.8), autonomous native-ML walk",
+  "stone": "The first NONLINEAR op on the native asm lane after the 2-D matvec. fam-ss-sqrt computes sqrt(sum_j x[j]^2) — the L2 norm = sqrt(n)*RMS, the denominator-root every normalization layer needs (RMSNorm = x[i]*w[i]/RMS). Advances form-native-models.form 'GAPS — LLM INFERENCE' A' note: 'the remaining native-lane rungs are the nonlinear ops (exp/sin/cos/rsqrt for softmax/RoPE/RMSNorm/SwiGLU) as asm'.",
+  "recipe": "form/form-stdlib/form-asm-matvec.fk :: fam-ss-sqrt — 13 arm64 instructions / 52 bytes; a counted square-accumulate loop (fam-dot-loop's twin, one buffer squared in place via fmul d2,d1,d1) that ENDS in a transcendental, fsqrt d0,d0 OUTSIDE the loop. ABI: x0 = x base, w1 = n, returns d0 = sqrt(sum x^2). New ground vs form-asm-matvec-loop: the in-place square, accumulate-into-d0, and the trailing nonlinear fsqrt; the float ops are already byte-identical to the clang/LLVM oracle in form-asm-float (2047).",
+  "four_way": {
+    "band": "form/form-stdlib/tests/form-asm-ss-sqrt-band.fk",
+    "manifest_row": "form-asm-ss-sqrt fks 127",
+    "verdict": 127,
+    "claims": "1 len==52  +2 FULL 52-byte program byte-equals the clang oracle (fa-conviction)  +4 fsqrt d0,d0  +8 fmul d2,d1,d1  +16 fadd d0,d0,d2  +32 b.ge +7  +64 b -7",
+    "result": "Go = Rust = TS = fkwu = 127, 0 divergent. fourth arm: 1 band four-way (fkwu + pre-flattened tables).",
+    "reproduce": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-ss-sqrt-band.fk"
+  },
+  "oracle": "clang -c -arch arm64 + otool -tvVj — the 13-word image the recipe must match byte-for-byte: d2800003 mov x3,#0 / d2800004 mov x4,#0 / 9e620080 scvtf d0,x4 / 6b01007f cmp w3,w1 / 540000ea b.ge +7 / fd400001 ldr d1,[x0] / 1e610822 fmul d2,d1,d1 / 1e622800 fadd d0,d0,d2 / 91002000 add x0,#8 / 91000463 add x3,#1 / 17fffff9 b -7 / 1e61c000 fsqrt d0,d0 / d65f03c0 ret. clang is the teacher that confirmed the bytes once, not the runtime.",
+  "hardware_witness": {
+    "script": "scripts/form_asm_ss_sqrt_witness.sh",
+    "device": "Apple M4 Max, arm64 Darwin",
+    "path": "Form kernel emits fam-ss-sqrt's 52 bytes -> form-macho mo-object-sym wraps a Mach-O .o exporting _recipe -> ld -dylib + ad-hoc sign (no clang in the link) -> C harness dlopen+call as double recipe(const double *x, long n)",
+    "compute_toolchain_free": "no rustc/clang in the COMPUTE; clang only builds the dumb dlopen loader",
+    "results": [
+      {"case": "3-4",   "n": 2, "got": 5.0, "expected": 5.0, "match": true},
+      {"case": "ones4", "n": 4, "got": 2.0, "expected": 2.0, "match": true},
+      {"case": "zeros", "n": 3, "got": 0.0, "expected": 0.0, "match": true},
+      {"case": "mixed", "n": 4, "got": 100000000.00000001, "expected": 100000000.00000001, "match": true},
+      {"case": "rms6",  "n": 6, "got": 0.95393920141694566, "expected": 0.95393920141694566, "match": true}
+    ],
+    "parity": "bit-for-bit == vs the reference (same upward fold j=0..n-1, then sqrt); the fp-stress case (1e8+1e-8 mixed) matches to the last bit."
+  },
+  "reading": "The reduction-with-a-transcendental — the literal RMSNorm/LayerNorm denominator-root — is now sovereign native arm64 bytes, proven byte-identical across all four kernels AND executed on the M4. After the 2-D matvec (form-asm-matvec-2d 127) this is the second load-bearing forward-pass kernel on the native lane: the dominant linear compute and the first nonlinear reduction are both Form->asm bytes. Remaining nonlinear rungs named in form-native-models.form: exp (softmax), sin/cos (RoPE), the reciprocal in rsqrt (1/RMS, fdiv is already an encoder), then ll-buffer staging + the 28-layer fold.",
+  "reproduce": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-ss-sqrt-band.fk && bash ../scripts/form_asm_ss_sqrt_witness.sh"
+}

--- a/form/form-stdlib/form-asm-matvec.fk
+++ b/form/form-stdlib/form-asm-matvec.fk
@@ -100,4 +100,31 @@
                                                                                             (append (fa-b-off -19)
                                                                                                 (fa-ret))))))))))))))))))))))))
 
+    ; fam-ss-sqrt: the RMSNorm / LayerNorm reduction CORE as Form->asm bytes — sqrt(sum_j x[j]^2),
+    ; the L2 norm (= sqrt(n) * RMS). This is the first NONLINEAR op on the native lane after the matvec:
+    ; the gap form-native-models.form names ("exp/sin/cos/rsqrt for softmax/RoPE/RMSNorm/SwiGLU as asm").
+    ; The accumulator loop is fam-dot-loop's twin with ONE buffer squared in place (fmul d2,d1,d1), and the
+    ; new ground is the trailing fsqrt OUTSIDE the loop (fa-fsqrt, proven byte-exact in form-asm-float 2047)
+    ; — a reduction that ends in a transcendental, not just the linear dot. ABI: x0 = x base, w1 = n (the
+    ; counter compare rides the 32-bit fa-cmp-r, a count is small), returns d0 = sqrt(sum x^2). 13 arm64
+    ; instructions = 52 bytes; branch offsets in INSTRUCTIONS (lo-streq discipline): b.ge exits +7 to the
+    ; fsqrt, b loops -7 back to the compare.
+    ;   0 movz x3,#0 (j)   1 movz x4,#0   2 scvtf d0,x4 (acc=0.0)
+    ;   3 cmp w3,w1   4 b.ge +7(end)   5 ldr d1,[x0]   6 fmul d2,d1,d1 (x^2)   7 fadd d0,d0,d2
+    ;   8 add x0,#8   9 add x3,#1   10 b -7(loop)   11 fsqrt d0,d0   12 ret
+    (defn fam-ss-sqrt ()
+        (append (fa-movz-x 3 0)
+            (append (fa-movz-x 4 0)
+                (append (fa-scvtf 0 4)
+                    (append (fa-cmp-r 3 1)
+                        (append (fa-bcond 10 7)
+                            (append (fa-ldr-d 1 0 0)
+                                (append (fa-fmul 2 1 1)
+                                    (append (fa-fadd 0 0 2)
+                                        (append (fa-add-x-imm 0 0 8)
+                                            (append (fa-add-x-imm 3 3 1)
+                                                (append (fa-b-off -7)
+                                                    (append (fa-fsqrt 0 0)
+                                                        (fa-ret))))))))))))))
+
     0)

--- a/form/form-stdlib/tests/form-asm-ss-sqrt-band.fk
+++ b/form/form-stdlib/tests/form-asm-ss-sqrt-band.fk
@@ -1,0 +1,40 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+;
+; form-asm-ss-sqrt-band — the RMSNorm/LayerNorm reduction core emits four-way as Form->asm bytes, no rustc.
+; fam-ss-sqrt computes sqrt(sum_j x[j]^2) — the L2 norm, the denominator-root every normalization layer
+; needs (RMS = ss-sqrt / sqrt(n); RMSNorm = x[i] * w[i] / RMS). It is the FIRST nonlinear op on the native
+; lane after the 2-D matvec (form-asm-matvec-2d 127): a counted accumulate loop (the matvec-loop discipline)
+; that ENDS in a transcendental — fsqrt d0,d0 OUTSIDE the loop — rather than just folding a linear dot.
+;
+; The new ground vs form-asm-matvec-loop: the square in place (fmul d2,d1,d1, both operands one register),
+; the accumulate-into-d0 (fadd d0,d0,d2), and the trailing fsqrt — the float ops are proven byte-identical
+; to the clang/LLVM oracle in form-asm-float (2047); here the new claim is the COMPOSITION emits the exact
+; 52-byte arm64 program four-way. ABI: x0 = x base, w1 = n, returns d0 = sqrt(sum x^2).
+;
+; The 13-instruction program, otool -tvVj of the clang oracle (the reference each byte must match):
+;   d2800003 mov x3,#0    d2800004 mov x4,#0    9e620080 scvtf d0,x4   6b01007f cmp w3,w1
+;   540000ea b.ge +7      fd400001 ldr d1,[x0]  1e610822 fmul d2,d1,d1  1e622800 fadd d0,d0,d2
+;   91002000 add x0,#8    91000463 add x3,#1    17fffff9 b -7           1e61c000 fsqrt d0,d0   d65f03c0 ret
+;
+; Verdict 127 when every claim lands:
+;   1    the program is 13 instructions = 52 bytes              (len == 52)
+;   2    the FULL program byte-equals the 52-byte clang oracle  (fa-conviction == 1)
+;   4    fsqrt d0,d0 — the nonlinear reduction tail             (fa-conviction == 1)
+;   8    fmul d2,d1,d1 — the square in place                    (fa-conviction == 1)
+;   16   fadd d0,d0,d2 — accumulate into d0                     (fa-conviction == 1)
+;   32   b.ge +7 exit branch (scaled offset to the fsqrt)       (fa-conviction == 1)
+;   64   b -7 back-edge (26-bit signed offset to the compare)   (fa-conviction == 1)
+(do
+    (let prog (fam-ss-sqrt))
+    (let oracle (list
+        3 0 128 210    4 0 128 210    128 0 98 158   127 0 1 107
+        234 0 0 84     1 0 64 253     34 8 97 30     0 40 98 30
+        0 32 0 145     99 4 0 145     249 255 255 23 0 192 97 30   192 3 95 214))
+    (let c0 (if (eq (len prog) 52)                                            1 0))
+    (let c1 (if (eq (fa-conviction prog oracle)                          1)   2 0))
+    (let c2 (if (eq (fa-conviction (fa-fsqrt 0 0)   (list 0 192 97 30))  1)   4 0))
+    (let c3 (if (eq (fa-conviction (fa-fmul 2 1 1)  (list 34 8 97 30))   1)   8 0))
+    (let c4 (if (eq (fa-conviction (fa-fadd 0 0 2)  (list 0 40 98 30))   1)  16 0))
+    (let c5 (if (eq (fa-conviction (fa-bcond 10 7)  (list 234 0 0 84))   1)  32 0))
+    (let c6 (if (eq (fa-conviction (fa-b-off -7)    (list 249 255 255 23)) 1) 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1042,6 +1042,7 @@ gguf-find fks 255
 form-asm-matvec fks 127
 form-asm-matvec-loop fks 127
 form-asm-matvec-2d fks 127
+form-asm-ss-sqrt fks 127
 weight-load fks 4095
 weight-load-q4k fks 4095
 block-join fks 255

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 390
+**Total files**: 391
 
 | File | Purpose |
 |---|---|
@@ -112,6 +112,7 @@
 | [form_asm_conviction_demo.sh](form_asm_conviction_demo.sh) | form_asm_conviction_demo.sh — the byte-conviction gate that licenses dropping |
 | [form_asm_matvec_2d_witness.sh](form_asm_matvec_2d_witness.sh) | form_asm_matvec_2d_witness.sh — the EXECUTION WITNESS for fam-matvec: the Form-emitted |
 | [form_asm_matvec_witness.sh](form_asm_matvec_witness.sh) | form_asm_matvec_witness.sh — the EXECUTION WITNESS for fam-dot2: the Form-emitted |
+| [form_asm_ss_sqrt_witness.sh](form_asm_ss_sqrt_witness.sh) | form_asm_ss_sqrt_witness.sh — the EXECUTION WITNESS for fam-ss-sqrt: the Form-emitted RMSNorm/LayerNorm |
 | [form_branch_demo.sh](form_branch_demo.sh) | form_branch_demo.sh — the FULL asm-pl-human program, compiled by Form and run on |
 | [form_cat_demo.sh](form_cat_demo.sh) | form_cat_demo.sh — `cat`, a real unix command, built with ZERO clang and direct |
 | [form_cli.py](form_cli.py) | form_cli.py — Form-native CLI: ask, generate, execute, convert. |

--- a/scripts/form_asm_ss_sqrt_witness.sh
+++ b/scripts/form_asm_ss_sqrt_witness.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# form_asm_ss_sqrt_witness.sh — the EXECUTION WITNESS for fam-ss-sqrt: the Form-emitted RMSNorm/LayerNorm
+# reduction core (form-asm-ss-sqrt-band proves it four-way) doesn't just BYTE-MATCH the arm64 oracle — it
+# actually RUNS sqrt(sum_j x[j]^2) on this arm64 host, no rustc/clang in the COMPUTE (clang is only the
+# dumb dlopen harness).
+#
+# This is the sibling of form_asm_matvec_2d_witness.sh. fam-ss-sqrt is the first NONLINEAR op on the
+# native lane (the gap form-native-models.form names: exp/sin/cos/rsqrt for softmax/RoPE/RMSNorm/SwiGLU
+# as asm) — a counted accumulate loop that ENDS in fsqrt, the L2 norm = sqrt(n)*RMS that every
+# normalization layer needs.
+#
+# Path:
+#   1. Form kernel emits fam-ss-sqrt's 13-instruction (52-byte) arm64 program, then wraps it via
+#      form-macho's mo-object-sym into a Mach-O .o exporting `_recipe`.
+#   2. `ld -dylib` links + ad-hoc signs the .o into a dlopen-able dylib (the recipe-dylib path, no clang).
+#   3. A tiny C harness dlopens it, casts `_recipe` to the ABI  double recipe(const double *x, long n)
+#      (arm64 args land in x0=x x1=n, result in d0 — exactly the recipe's register plan), and calls it
+#      with real vectors.
+#   4. Assert recipe(x,n) == sqrt(sum_j x[j]^2), bit-for-bit — the harness accumulates the SAME upward
+#      order (j=0..n-1) the recipe folds, then sqrt, so it is == not epsilon-close.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS witness; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+command -v clang >/dev/null || { echo "need clang for the loader harness; skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/fsssqrt.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+MATVEC="$FORM/form-stdlib/form-asm-matvec.fk"
+[[ -f "$MATVEC" ]] || { echo "FAIL: form-asm-matvec.fk not found"; exit 1; }
+
+# Form: emit fam-ss-sqrt bytes, wrap as a Mach-O .o exporting _recipe (mo-object-sym), hex.
+{ echo "(do"
+  echo '    (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))'
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$MATVEC"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<'DRV'
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code (fam-ss-sqrt))
+    (print (str_concat "SSBYTES " (hxb code)))
+    ; _recipe = 95 114 101 99 105 112 101 (the recipe-dylib export name)
+    (print (str_concat "MACHO " (hxb (mo-object-sym code (list 95 114 101 99 105 112 101)))))
+    0)
+DRV
+} > "$work/emit.fk"
+
+out="$(cd "$FORM" && "$GO" "$work/emit.fk" 2>/dev/null)"
+ssbytes="$(echo "$out" | grep '^SSBYTES ' | sed 's/^SSBYTES //')"
+hex="$(echo "$out" | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; cd "$FORM" && "$GO" "$work/emit.fk" 2>&1 | head; exit 1; }
+echo "fam-ss-sqrt program: $(( ${#ssbytes} / 2 )) bytes (no rustc/clang in this compute)"
+echo "  arm64 bytes: $ssbytes"
+
+echo "$hex" | xxd -r -p > "$work/recipe.o"
+echo "Form-emitted Mach-O object: $(wc -c < "$work/recipe.o" | tr -d ' ') bytes, $(file "$work/recipe.o" | sed 's/^[^:]*: //')"
+echo "  exported symbol: $(nm "$work/recipe.o" 2>/dev/null | tr -s ' ')"
+
+# ld -dylib links + ad-hoc signs (no clang) — the recipe-dylib path.
+SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$work/recipe.dylib" "$work/recipe.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null \
+   || { echo "FAIL: ld -dylib"; exit 1; }
+echo "ld -dylib + ad-hoc sign: $(codesign -dv "$work/recipe.dylib" 2>&1 | grep -E '^CodeDirectory' | sed 's/ hashes.*//')"
+echo
+
+# The dumb loader: dlopen, cast _recipe to the ss-sqrt ABI, call with real n-vectors.
+cat > "$work/harness.c" <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+typedef double (*ss_fn)(const double *x, long n);
+static int check(ss_fn ss, const char *name, const double *x, long n) {
+    /* reference: SAME upward fold (j=0..n-1) the recipe uses, then sqrt — so == not epsilon-close */
+    double acc = 0.0;
+    for (long j = 0; j < n; j++) acc += x[j] * x[j];
+    double expect = sqrt(acc);
+    double got = ss(x, n);
+    int ok = (got == expect);
+    printf("EXEC %-10s n=%ld  got=%.17g expected=%.17g %s\n", name, n, got, expect, ok ? "MATCH" : "FAIL");
+    return ok;
+}
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen fail: %s\n", dlerror()); return 2; }
+    ss_fn ss = (ss_fn)dlsym(h, "recipe");      /* leading _ stripped by dlsym */
+    if (!ss) { fprintf(stderr, "dlsym fail: %s\n", dlerror()); return 3; }
+    int all = 1;
+    { double x[] = {3,4};            all &= check(ss, "3-4",   x, 2); }   /* 5.0, the classic */
+    { double x[] = {1,1,1,1};        all &= check(ss, "ones4", x, 4); }   /* 2.0 */
+    { double x[] = {0,0,0};          all &= check(ss, "zeros", x, 3); }   /* 0.0, empty-ish acc */
+    { double x[] = {-2,0.5,1e8,1e-8};all &= check(ss, "mixed", x, 4); }   /* fp stress: large+small+neg */
+    { double x[] = {0.1,0.2,0.3,0.4,0.5,0.6}; all &= check(ss, "rms6", x, 6); }
+    dlclose(h);
+    return all ? 0 : 1;
+}
+EOF
+clang -o "$work/harness" "$work/harness.c" -lm || { echo "FAIL: harness build"; exit 1; }
+
+"$work/harness" "$work/recipe.dylib"; rc=$?
+echo
+if [[ "$rc" == "0" ]]; then
+    echo "WITNESS: the Form-emitted ss-sqrt (sqrt(sum x^2)) RUNS and MATCHES on $(uname -m)."
+    echo "  fam-ss-sqrt's 52 bytes (form-asm, four-way) -> form-macho .o -> ld -dylib -> dlopen+call."
+    echo "  The first nonlinear reduction (the RMSNorm/LayerNorm denominator-root) is sovereign native bytes."
+else
+    echo "WITNESS FAIL (rc=$rc): the emitted program did not match the reference."
+fi
+exit $rc


### PR DESCRIPTION
## The stone

`sqrt(Σx²)` — the **L2 norm = √n·RMS, the RMSNorm/LayerNorm denominator-root** — emits **four-way as 52 arm64 bytes** (Go=Rust=TS=fkwu, byte-identical to the clang oracle) **and runs on the M4 bit-exact**. The **first nonlinear op on the native asm lane** after the 2-D matvec: a counted square-accumulate loop closed by `fsqrt` *outside* the loop — a reduction that ends in a transcendental, not just a linear dot.

Advances `form-native-models.form` → GAPS — LLM INFERENCE, the A′ note: *the remaining native-lane rungs are the nonlinear ops (exp/sin/cos/rsqrt for softmax/RoPE/RMSNorm/SwiGLU) as asm.*

## Two gates, both green

**Four-way byte-identity** — `form-asm-ss-sqrt fks 127`, 0 divergent:
```
✓  core+form-asm+form-asm-matvec+form-asm-ss-sqrt-band → 127
fourth arm: 1 band four-way (fkwu + pre-flattened tables)
```
Verdict 127 = full 52-byte program byte-equals the clang oracle + per-instruction pins (fsqrt, fmul-square, fadd-accumulate, b.ge +7, b -7).

**Hardware execution** on Apple M4 — `scripts/form_asm_ss_sqrt_witness.sh` (form-macho .o → `ld -dylib` → dlopen+call, no rustc/clang in the compute):
```
EXEC 3-4    n=2  got=5 expected=5 MATCH
EXEC ones4  n=4  got=2 expected=2 MATCH
EXEC zeros  n=3  got=0 expected=0 MATCH
EXEC mixed  n=4  got=100000000.00000001 expected=100000000.00000001 MATCH
EXEC rms6   n=6  got=0.95393920141694566 expected=… MATCH
```

## Files
- recipe: `form/form-stdlib/form-asm-matvec.fk` :: `fam-ss-sqrt` (13 instr / 52 bytes; ABI x0=x, w1=n → d0)
- band: `form/form-stdlib/tests/form-asm-ss-sqrt-band.fk`
- manifest: `form-asm-ss-sqrt fks 127`
- witness: `scripts/form_asm_ss_sqrt_witness.sh`
- receipt: `docs/system_audit/commit_evidence_2026-06-28_form_asm_ss_sqrt.json`
- roadmap + INDEX edges in the same commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)