### PR TITLE
tend(form): fam-rsqrt — 1/sqrt(x) as Form→asm bytes (RMSNorm/RoPE normalizer; first fdiv + float-constant on the native lane)

### DIFF
--- a/docs/coherence-substrate/form-native-models.form
+++ b/docs/coherence-substrate/form-native-models.form
@@ -142,9 +142,19 @@
 ;        bytes four-way (Go=Rust=TS=fkwu byte-identical to the clang oracle): a counted square-accumulate
 ;        loop closed by fsqrt OUTSIDE the loop. Execution witness scripts/form_asm_ss_sqrt_witness.sh runs
 ;        those bytes on the M4 (form-macho .o -> ld -dylib -> dlopen+call) bit-exact vs sqrt(sum x^2),
-;        fp-stress included, no rustc/clang in the compute. Remaining nonlinear rungs: exp (softmax),
-;        sin/cos (RoPE), the 1/RMS reciprocal (fdiv is already an encoder). Receipt:
+;        fp-stress included, no rustc/clang in the compute. Receipt:
 ;        commit_evidence_2026-06-28_form_asm_ss_sqrt.json.
+;     A‴. ✓ DONE — form-asm-rsqrt (31): the reciprocal-sqrt 1/sqrt(x) — the RMSNorm/RoPE/SwiGLU normalizer
+;        core (RMSNorm scale = g/sqrt(mean(x^2)+eps); RoPE inv-freq = 1/base^(2i/d)) — emits as 16 arm64
+;        bytes four-way (Go=Rust=TS=fkwu byte-identical to the clang -O2 oracle): fsqrt;fmov d1,#1.0;fdiv;ret.
+;        Lands TWO firsts on the witnessed lane: the first fa-fdiv (a reciprocal division) AND the first
+;        fa-fmov-imm — a FLOAT CONSTANT materialized into a register (the missing primitive every later
+;        nonlinear op needs for its coefficients: ln2, RoPE base, poly terms). Execution witness
+;        scripts/form_asm_rsqrt_witness.sh runs the bytes on the M4 bit-exact vs 1/sqrt(x) (irrational
+;        1/sqrt(2) full-mantissa + fp-stress 1e8/1e-8), no rustc/clang in the compute. Receipt:
+;        commit_evidence_2026-06-29_form_asm_rsqrt.json. Remaining nonlinear rungs: exp (softmax — range
+;        reduction over the present fcvtzs/scvtf + a Horner polynomial with fa-fmov-imm coefficients),
+;        sin/cos (RoPE), then ll-buffer staging + the 28-layer fold.
 ;     B. ✓ DONE — scripts/form_asm_matvec_witness.sh: fam-dot2's form-asm bytes → form-macho .o → ld -dylib →
 ;        dlopen+call → d0 MATCHES bit-exact ([2,3,5,7]→31, edge cases). The bytes proven four-way are the bytes
 ;        that ran. form-macho's wrap is ABI-agnostic; in-kernel float-call later wants a small dylib_call_f64ptr.

--- a/docs/system_audit/commit_evidence_2026-06-29_form_asm_rsqrt.json
+++ b/docs/system_audit/commit_evidence_2026-06-29_form_asm_rsqrt.json
@@ -1,0 +1,36 @@
+{
+  "title": "fam-rsqrt — the reciprocal-sqrt 1/sqrt(x) as Form->asm BYTES, four-way + run on M4 (+ the fa-fmov-imm float-constant encoder)",
+  "date": "2026-06-29",
+  "author": "Sema (Opus 4.8), autonomous native-ML walk",
+  "stone": "The NEXT nonlinear rung on the native asm lane after fam-ss-sqrt: where ss-sqrt ENDED in fsqrt, fam-rsqrt closes the transcendental in a RECIPROCAL. 1/sqrt(x) is the shared core of the RMSNorm scale (g/sqrt(mean(x^2)+eps)), the RoPE inverse frequency (1/base^(2i/d)), and SwiGLU normalization. Advances form-native-models.form 'GAPS — LLM INFERENCE' A'/D11 note: 'the nonlinear ops as form-asm bytes (exp/sin/cos/rsqrt for softmax/RoPE/RMSNorm/SwiGLU)'. It lands the explicitly-named rsqrt rung AND the missing primitive every later nonlinear op needs: a FLOAT CONSTANT materialized into a register.",
+  "new_encoder": "form/form-stdlib/form-asm.fk :: fa-fmov-imm (rd imm) — fmov d<rd>, #imm8 (the VFP modified-immediate form): base 0x1E601000 | imm8<<13 | rd. The genuinely-missing primitive: form-asm had only register-to-register fmov; every constant-bearing nonlinear op (1.0 for the reciprocal, later ln2/RoPE-base/poly coeffs) needs the immediate form. clang emits exactly this (fmov d1,#1.00000000 = 1e6e1001, imm8=0x70) rather than an int->float scvtf, so the byte-exact path requires it.",
+  "recipe": "form/form-stdlib/form-asm-matvec.fk :: fam-rsqrt — 4 arm64 instructions / 16 bytes, scalar (no loop). ABI: d0 = x, returns d0 = 1/sqrt(x). Program: fsqrt d0,d0 (1e61c000) ; fmov d1,#1.0 (1e6e1001) ; fdiv d0,d1,d0 (1e601820) ; ret (d65f03c0). New ground vs fam-ss-sqrt: the FIRST fa-fmov-imm (a float constant) and the FIRST fa-fdiv (a reciprocal division) on the witnessed native lane.",
+  "four_way": {
+    "band": "form/form-stdlib/tests/form-asm-rsqrt-band.fk",
+    "manifest_row": "form-asm-rsqrt fks 31",
+    "verdict": 31,
+    "claims": "1 len==16  +2 FULL 16-byte program byte-equals the clang oracle (fa-conviction)  +4 fmov d1,#1.0 (the FIRST float constant, new encoder)  +8 fdiv d0,d1,d0 (the FIRST reciprocal on the lane)  +16 fsqrt d0,d0",
+    "result": "Go = Rust = TS = fkwu = 31, 0 divergent. fourth arm: 1 band four-way (fkwu + pre-flattened tables).",
+    "reproduce": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-rsqrt-band.fk"
+  },
+  "oracle": "clang -O2 -c -target arm64-apple-macos + otool -tvVj of `double r(double x){return 1.0/__builtin_sqrt(x);}` — the exact 4-word image the recipe matches byte-for-byte: 1e61c000 fsqrt d0,d0 / 1e6e1001 fmov d1,#1.00000000 / 1e601820 fdiv d0,d1,d0 / d65f03c0 ret. clang is the teacher that confirmed the bytes once, dropped from the runtime by fa-conviction's byte-identity gate.",
+  "hardware_witness": {
+    "script": "scripts/form_asm_rsqrt_witness.sh",
+    "device": "Apple M4 Max, arm64 Darwin",
+    "path": "Form kernel emits fam-rsqrt's 16 bytes -> form-macho mo-object-sym wraps a Mach-O .o exporting _recipe -> ld -dylib + ad-hoc sign (no clang in the link) -> C harness dlopen+call as double recipe(double x)",
+    "emitted_bytes": "00c0611e 01106e1e 2018601e c0035fd6",
+    "compute_toolchain_free": "no rustc/clang in the COMPUTE; clang only builds the dumb dlopen loader",
+    "results": [
+      {"case": "4.0",   "x": 4.0,   "got": 0.5,                  "expected": 0.5,                  "match": true},
+      {"case": "1.0",   "x": 1.0,   "got": 1.0,                  "expected": 1.0,                  "match": true},
+      {"case": "0.25",  "x": 0.25,  "got": 2.0,                  "expected": 2.0,                  "match": true},
+      {"case": "100.0", "x": 100.0, "got": 0.10000000000000001,  "expected": 0.10000000000000001,  "match": true},
+      {"case": "2.0",   "x": 2.0,   "got": 0.70710678118654746,  "expected": 0.70710678118654746,  "match": true},
+      {"case": "1e8",   "x": 1e8,   "got": 0.0001,               "expected": 0.0001,               "match": true},
+      {"case": "1e-8",  "x": 1e-8,  "got": 10000.0,              "expected": 10000.0,              "match": true}
+    ],
+    "parity": "bit-for-bit == vs 1.0/sqrt(x); the irrational case 1/sqrt(2)=0.70710678118654746 matches to the full mantissa, and the fp-stress 1e8/1e-8 cases match to the last bit."
+  },
+  "reading": "The reciprocal-of-a-root — the literal RMSNorm/RoPE normalizer core — is now sovereign native arm64 bytes, proven byte-identical across all four kernels AND executed on the M4. The native lane now carries the 2-D matvec (dominant linear compute), the L2-norm reduction (fam-ss-sqrt), and the reciprocal-sqrt normalizer, plus the float-constant materialization (fa-fmov-imm) that unblocks the remaining nonlinear rungs. Next named rungs in form-native-models.form: exp (softmax — needs range reduction over the now-present fcvtzs/scvtf + a Horner polynomial using fa-fmov-imm coefficients), sin/cos (RoPE), then ll-buffer staging of the dequanted tensor set + the 28-layer fold.",
+  "reproduce": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-rsqrt-band.fk && bash ../scripts/form_asm_rsqrt_witness.sh"
+}

--- a/form/form-stdlib/form-asm-matvec.fk
+++ b/form/form-stdlib/form-asm-matvec.fk
@@ -127,4 +127,17 @@
                                                     (append (fa-fsqrt 0 0)
                                                         (fa-ret))))))))))))))
 
+    ; fam-rsqrt: the reciprocal-sqrt 1/sqrt(x) as Form->asm bytes — the RMSNorm/RoPE/SwiGLU normalizer
+    ; (RMSNorm scale = g / sqrt(mean(x^2)+eps); RoPE inv-freq = 1/base^(2i/d); rsqrt is the shared core).
+    ; The next nonlinear rung after fam-ss-sqrt: it closes a transcendental in a RECIPROCAL — the first
+    ; fa-fdiv on the witnessed native lane, and the first FLOAT CONSTANT materialized via fa-fmov-imm
+    ; (#1.0 = imm8 0x70). Scalar, no loop. ABI: d0 = x, returns d0 = 1/sqrt(x). 4 arm64 instructions = 16
+    ; bytes, byte-identical to the clang -O2 oracle for `1.0/__builtin_sqrt(x)`:
+    ;   0 fsqrt d0,d0 (1e61c000)   1 fmov d1,#1.0 (1e6e1001)   2 fdiv d0,d1,d0 (1e601820)   3 ret (d65f03c0)
+    (defn fam-rsqrt ()
+        (append (fa-fsqrt 0 0)
+            (append (fa-fmov-imm 1 112)
+                (append (fa-fdiv 0 1 0)
+                    (fa-ret)))))
+
     0)

--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -175,6 +175,10 @@
     (defn fa-fsqrt (rd rn) (fa-asm 509722624 (list 1 32) (list rd rn)))
     ; fmov d<rd>, d<rn> : base 0x1E604000                               (oracle 1e604020)
     (defn fa-fmov (rd rn) (fa-asm 509624320 (list 1 32) (list rd rn)))
+    ; fmov d<rd>, #imm8 : base 0x1E601000 | imm8<<13 | rd               (oracle 1e6e1001 = fmov d1,#1.0)
+    ; the VFP modified-immediate form — the float CONSTANT every nonlinear op needs (1.0 for the reciprocal,
+    ; later ln2/RoPE-base/poly coeffs). imm8 is the 8-bit fp code: #1.0 -> 0x70 (112), #2.0 -> 0x00, #0.5 -> 0x60.
+    (defn fa-fmov-imm (rd imm) (fa-asm 509612032 (list 1 8192) (list rd imm)))
     ; fcmp d<rn>, d<rm> (sets NZCV; read by fa-bcond) : base 0x1E602000 | rm<<16 | rn<<5  (oracle 1e622020)
     (defn fa-fcmp (rn rm) (fa-asm 509616128 (list 32 65536) (list rn rm)))
     ; scvtf d<rd>, x<rn> (signed i64 -> f64) : base 0x9E620000 | rn<<5 | rd               (oracle 9e620020)

--- a/form/form-stdlib/tests/form-asm-rsqrt-band.fk
+++ b/form/form-stdlib/tests/form-asm-rsqrt-band.fk
@@ -1,0 +1,34 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+;
+; form-asm-rsqrt-band — the reciprocal-sqrt 1/sqrt(x) emits four-way as Form->asm bytes, no rustc.
+; fam-rsqrt is the RMSNorm/RoPE/SwiGLU normalizer core (RMSNorm scale = g/sqrt(mean(x^2)+eps); RoPE
+; inv-freq = 1/base^(2i/d) — rsqrt is the shared reciprocal-of-a-root). It is the next nonlinear rung on
+; the native lane after fam-ss-sqrt (sqrt(sum x^2), form-asm-ss-sqrt 127): where ss-sqrt ENDED in fsqrt,
+; this one closes the transcendental in a RECIPROCAL.
+;
+; The new ground vs fam-ss-sqrt: (1) the FIRST fa-fmov-imm — a FLOAT CONSTANT (#1.0) materialized into a
+; register, the missing primitive every later nonlinear op needs (ln2/RoPE-base/poly coeffs); clang emits
+; exactly this (fmov d1,#1.00000000 = 1e6e1001) rather than an int->float scvtf. (2) the FIRST fa-fdiv on
+; the witnessed native lane — a reciprocal division, not just fmul/fadd. The float ops are proven
+; byte-identical to the clang/LLVM oracle in form-asm-float (2047); the new claim is that the COMPOSITION
+; emits the exact 16-byte arm64 program four-way. ABI: d0 = x, returns d0 = 1/sqrt(x).
+;
+; The 4-instruction program, otool -tvVj of the clang -O2 oracle (`double r(double x){return 1.0/sqrt(x);}`):
+;   1e61c000 fsqrt d0,d0     1e6e1001 fmov d1,#1.0     1e601820 fdiv d0,d1,d0     d65f03c0 ret
+;
+; Verdict 31 when every claim lands:
+;   1    the program is 4 instructions = 16 bytes                 (len == 16)
+;   2    the FULL program byte-equals the 16-byte clang oracle    (fa-conviction == 1)
+;   4    fmov d1,#1.0 — the FIRST float constant (new encoder)    (fa-conviction == 1)
+;   8    fdiv d0,d1,d0 — the FIRST reciprocal on the lane         (fa-conviction == 1)
+;   16   fsqrt d0,d0 — the root being reciprocated                (fa-conviction == 1)
+(do
+    (let prog (fam-rsqrt))
+    (let oracle (list
+        0 192 97 30     1 16 110 30     32 24 96 30     192 3 95 214))
+    (let c0 (if (eq (len prog) 16)                                           1 0))
+    (let c1 (if (eq (fa-conviction prog oracle)                         1)   2 0))
+    (let c2 (if (eq (fa-conviction (fa-fmov-imm 1 112) (list 1 16 110 30)) 1) 4 0))
+    (let c3 (if (eq (fa-conviction (fa-fdiv 0 1 0)  (list 32 24 96 30))  1)   8 0))
+    (let c4 (if (eq (fa-conviction (fa-fsqrt 0 0)   (list 0 192 97 30))  1)  16 0))
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1043,6 +1043,7 @@ form-asm-matvec fks 127
 form-asm-matvec-loop fks 127
 form-asm-matvec-2d fks 127
 form-asm-ss-sqrt fks 127
+form-asm-rsqrt fks 31
 weight-load fks 4095
 weight-load-q4k fks 4095
 block-join fks 255

--- a/scripts/form_asm_rsqrt_witness.sh
+++ b/scripts/form_asm_rsqrt_witness.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# form_asm_rsqrt_witness.sh — the EXECUTION WITNESS for fam-rsqrt: the Form-emitted reciprocal-sqrt
+# 1/sqrt(x) (form-asm-rsqrt-band proves it four-way) doesn't just BYTE-MATCH the arm64 oracle — it
+# actually RUNS 1/sqrt(x) on this arm64 host, no rustc/clang in the COMPUTE (clang is only the dumb
+# dlopen harness).
+#
+# Sibling of form_asm_ss_sqrt_witness.sh. fam-rsqrt is the NEXT nonlinear rung on the native lane after
+# fam-ss-sqrt: where ss-sqrt ENDED in fsqrt, this one closes the transcendental in a RECIPROCAL — the
+# RMSNorm/RoPE/SwiGLU normalizer core (RMSNorm scale = g/sqrt(mean(x^2)+eps); RoPE inv-freq =
+# 1/base^(2i/d)). It introduces the FIRST float constant on the lane (fa-fmov-imm #1.0) and the FIRST
+# fa-fdiv (a reciprocal division), the primitives every later nonlinear op needs.
+#
+# Path:
+#   1. Form kernel emits fam-rsqrt's 4-instruction (16-byte) arm64 program, then wraps it via
+#      form-macho's mo-object-sym into a Mach-O .o exporting `_recipe`.
+#   2. `ld -dylib` links + ad-hoc signs the .o into a dlopen-able dylib (the recipe-dylib path, no clang).
+#   3. A tiny C harness dlopens it, casts `_recipe` to the ABI  double recipe(double x)  (arm64 arg lands
+#      in d0, result in d0 — exactly the recipe's register plan), and calls it with real scalars.
+#   4. Assert recipe(x) == 1.0/sqrt(x), bit-for-bit — the harness uses the SAME fsqrt then 1.0/y the
+#      recipe folds (fsqrt d0,d0 ; fdiv d0,d1,d0 with d1=1.0), so it is == not epsilon-close.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS witness; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+command -v clang >/dev/null || { echo "need clang for the loader harness; skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/frsqrt.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+MATVEC="$FORM/form-stdlib/form-asm-matvec.fk"
+[[ -f "$MATVEC" ]] || { echo "FAIL: form-asm-matvec.fk not found"; exit 1; }
+
+# Form: emit fam-rsqrt bytes, wrap as a Mach-O .o exporting _recipe (mo-object-sym), hex.
+{ echo "(do"
+  echo '    (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))'
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$MATVEC"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<'DRV'
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code (fam-rsqrt))
+    (print (str_concat "RSBYTES " (hxb code)))
+    ; _recipe = 95 114 101 99 105 112 101 (the recipe-dylib export name)
+    (print (str_concat "MACHO " (hxb (mo-object-sym code (list 95 114 101 99 105 112 101)))))
+    0)
+DRV
+} > "$work/emit.fk"
+
+out="$(cd "$FORM" && "$GO" "$work/emit.fk" 2>/dev/null)"
+rsbytes="$(echo "$out" | grep '^RSBYTES ' | sed 's/^RSBYTES //')"
+hex="$(echo "$out" | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; cd "$FORM" && "$GO" "$work/emit.fk" 2>&1 | head; exit 1; }
+echo "fam-rsqrt program: $(( ${#rsbytes} / 2 )) bytes (no rustc/clang in this compute)"
+echo "  arm64 bytes: $rsbytes"
+
+echo "$hex" | xxd -r -p > "$work/recipe.o"
+echo "Form-emitted Mach-O object: $(wc -c < "$work/recipe.o" | tr -d ' ') bytes, $(file "$work/recipe.o" | sed 's/^[^:]*: //')"
+echo "  exported symbol: $(nm "$work/recipe.o" 2>/dev/null | tr -s ' ')"
+
+# ld -dylib links + ad-hoc signs (no clang) — the recipe-dylib path.
+SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$work/recipe.dylib" "$work/recipe.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null \
+   || { echo "FAIL: ld -dylib"; exit 1; }
+echo "ld -dylib + ad-hoc sign: $(codesign -dv "$work/recipe.dylib" 2>&1 | grep -E '^CodeDirectory' | sed 's/ hashes.*//')"
+echo
+
+# The dumb loader: dlopen, cast _recipe to the rsqrt ABI, call with real scalars.
+cat > "$work/harness.c" <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+typedef double (*rs_fn)(double x);
+static int check(rs_fn rs, const char *name, double x) {
+    /* reference: the SAME fsqrt then 1.0/y the recipe computes — so == not epsilon-close */
+    double expect = 1.0 / sqrt(x);
+    double got = rs(x);
+    int ok = (got == expect);
+    printf("EXEC %-8s x=%-12g got=%.17g expected=%.17g %s\n", name, x, got, expect, ok ? "MATCH" : "FAIL");
+    return ok;
+}
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen fail: %s\n", dlerror()); return 2; }
+    rs_fn rs = (rs_fn)dlsym(h, "recipe");      /* leading _ stripped by dlsym */
+    if (!rs) { fprintf(stderr, "dlsym fail: %s\n", dlerror()); return 3; }
+    int all = 1;
+    all &= check(rs, "4.0",   4.0);       /* 0.5, the classic */
+    all &= check(rs, "1.0",   1.0);       /* 1.0 */
+    all &= check(rs, "0.25",  0.25);      /* 2.0 */
+    all &= check(rs, "100.0", 100.0);     /* 0.1 */
+    all &= check(rs, "2.0",   2.0);       /* irrational 1/sqrt(2) — full mantissa */
+    all &= check(rs, "1e8",   1e8);       /* fp stress: large */
+    all &= check(rs, "1e-8",  1e-8);      /* fp stress: small -> 10000 */
+    dlclose(h);
+    return all ? 0 : 1;
+}
+EOF
+clang -o "$work/harness" "$work/harness.c" -lm || { echo "FAIL: harness build"; exit 1; }
+
+"$work/harness" "$work/recipe.dylib"; rc=$?
+echo
+if [[ "$rc" == "0" ]]; then
+    echo "WITNESS: the Form-emitted rsqrt (1/sqrt(x)) RUNS and MATCHES on $(uname -m)."
+    echo "  fam-rsqrt's 16 bytes (form-asm, four-way) -> form-macho .o -> ld -dylib -> dlopen+call."
+    echo "  The RMSNorm/RoPE/SwiGLU normalizer core is sovereign native bytes; first fmov-imm + fdiv on the lane."
+else
+    echo "WITNESS FAIL (rc=$rc): the emitted program did not match the reference."
+fi
+exit $rc


### PR DESCRIPTION
## The stone

The next nonlinear rung after `fam-ss-sqrt` (#3834) on the LLM-inference native lane (`form-native-models.form` GAPS A‴). Where ss-sqrt **ended** in `fsqrt`, `fam-rsqrt` closes the transcendental in a **reciprocal**: `1/sqrt(x)` — the shared core of the RMSNorm scale (`g/sqrt(mean(x²)+eps)`), the RoPE inverse frequency (`1/base^(2i/d)`), and SwiGLU normalization.

## Two firsts on the witnessed native lane

- **`fa-fmov-imm`** — the FLOAT CONSTANT encoder (`fmov d<rd>,#imm8`, VFP modified immediate). form-asm had only register-to-register `fmov`; every later nonlinear op needs the immediate form for its coefficients (`1.0`, `ln2`, RoPE base, polynomial terms). clang emits exactly this: `1e6e1001 = fmov d1,#1.0` (imm8 `0x70`).
- **`fa-fdiv` composed into a real op** — the first reciprocal division on the lane (matvec/ss-sqrt used only fmul/fadd).

## Proof — HARD GATE met

`fam-rsqrt` = `fsqrt d0,d0 ; fmov d1,#1.0 ; fdiv d0,d1,d0 ; ret` = 4 instr / 16 bytes, **byte-identical to the clang -O2 oracle** for `1.0/sqrt(x)`.

- **Four-way:** `form-asm-rsqrt fks 31` — Go = Rust = TS = fkwu, 0 divergent (fourth arm crossed).
- **Hardware witness** (`scripts/form_asm_rsqrt_witness.sh`): the 16 bytes (`00c0611e 01106e1e 2018601e c0035fd6`) → form-macho .o → `ld -dylib` → dlopen+call run on the **M4**, **7/7 MATCH** bit-exact vs `1/sqrt(x)` — incl. irrational `1/√2 = 0.70710678118654746` (full mantissa) and fp-stress `1e8`/`1e-8`. No rustc/clang in the compute.

Receipt: `docs/system_audit/commit_evidence_2026-06-29_form_asm_rsqrt.json`

Reproduce:
```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-rsqrt-band.fk && bash ../scripts/form_asm_rsqrt_witness.sh
```

Remaining nonlinear rungs (named in the receipt): exp (softmax — range reduction over the present fcvtzs/scvtf + a Horner polynomial using `fa-fmov-imm` coefficients), sin/cos (RoPE), then ll-buffer staging + the 28-layer fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)