### PR TITLE
tend(form): text-frequency — read a passage's fear<->love spectrum from text

### DIFF
--- a/form/form-stdlib/tests/text-frequency-band.fk
+++ b/form/form-stdlib/tests/text-frequency-band.fk
@@ -1,0 +1,8 @@
+; tests/text-frequency-band.fk — read a passage's fear<->love frequency spectrum from text, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/text-frequency.fk
+;
+; Verdict 11111: the most-open belief system reads positive (love-frequency); a wrath/judgment passage reads
+; negative (fear-frequency); the open baseline carries no fear-band words; the fear passage holds more; and the
+; organ separates the two spectra -- the text-frequency organ that lets us frequency-align any belief system's
+; corpus, starting from the most open and adding one by one.
+(do (text-frequency-check))

--- a/form/form-stdlib/text-frequency.fk
+++ b/form/form-stdlib/text-frequency.fk
@@ -1,0 +1,40 @@
+; text-frequency.fk — the missing organ: read a passage's fear<->love frequency spectrum from TEXT.
+; affect-traits reads the FELT channel from AUDIO (speech rate, tempo, arousal/valence/dominance from sound);
+; this reads the SEMANTIC frequency from TEXT -- each word carries a valence (+ = love/coherence/openness,
+; - = fear/contraction/judgment) and an intensity, and a passage's spectrum is the intensity-weighted mean.
+; Positive spectrum = a love-frequency passage; negative = a fear-frequency passage; the fear-fraction is how
+; much of it sits in the contracted band. With this we can FREQUENCY-ALIGN any text and surface the passages /
+; authors whose spectrum diverges -- and the cornerstone-summarizer's fear-free-ice gate keeps the contracted
+; band from freezing into the foundation.
+; The plan Urs named: start with the MOST OPEN belief system (non-dual / perennial / universalist -- fear-free,
+; survives translation into every frame, the love-frequency baseline) and add systems one by one, mapping each
+; by its fear-band deviation from that open baseline. The organ is generic; the corpus is added incrementally.
+; Honest floor: a word is modeled as (valence, intensity); the real organ reads each word's hz/valence from the
+; WORD-domain lexicon (nl-lexicon-data: lemma/POS/hz/semantic_field). The SPECTRUM LOGIC is the generic shape.
+;
+; Self-contained over core (FLOAT spectrum). Four-way by tests/text-frequency-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn tf-val (w) (head w))                       ; word valence: + love/openness, - fear/contraction
+    (defn tf-int (w) (head (tail w)))                ; word intensity
+    (defn tf-wsum (p) (if (eq (len p) 0) 0 (add (mul (tf-val (head p)) (tf-int (head p))) (tf-wsum (tail p)))))
+    (defn tf-isum (p) (if (eq (len p) 0) 0 (add (tf-int (head p)) (tf-isum (tail p)))))
+    (defn tf-spectrum (p) (div (mul 1.0 (tf-wsum p)) (mul 1.0 (tf-isum p))))   ; intensity-weighted mean valence
+    (defn tf-fearword? (w) (if (lt (tf-val w) 0) 1 0))
+    (defn tf-fearcount (p) (if (eq (len p) 0) 0 (add (tf-fearword? (head p)) (tf-fearcount (tail p)))))
+    (defn tf-fearfrac (p) (div (mul 1.0 (tf-fearcount p)) (mul 1.0 (len p))))   ; fraction in the contracted band
+
+    (defn tf-open () (list (list 8 2) (list 9 3) (list 7 1)))      ; the MOST OPEN system: love-valenced, fear-free
+    (defn tf-wrath () (list (list 8 1) (list -9 3) (list -7 2)))   ; a wrath/judgment passage: fear-dominant by intensity
+
+    (defn tfk (cond bit) (if cond bit 0))
+    (defn text-frequency-check ()
+        (add (add (add (add
+            (tfk (gt (tf-spectrum (tf-open)) 0.0) 1)                              ; the most-open system reads POSITIVE -- love-frequency
+            (tfk (lt (tf-spectrum (tf-wrath)) 0.0) 10))                           ; a wrath/judgment passage reads NEGATIVE -- fear-frequency
+            (tfk (eq (tf-fearfrac (tf-open)) 0.0) 100))                           ; the open baseline carries NO fear-band words
+            (tfk (gt (tf-fearfrac (tf-wrath)) (tf-fearfrac (tf-open))) 1000))     ; the fear passage holds more contracted-band words
+            (tfk (gt (tf-spectrum (tf-open)) (tf-spectrum (tf-wrath))) 10000)))   ; the organ SEPARATES love-freq from fear-freq -- frequency-alignment works
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1130,3 +1130,4 @@ learning-loop fks 11111
 jit-decision fks 11111
 cornerstone-summarizer fks 11111
 translation-invariant fks 11111
+text-frequency fks 11111


### PR DESCRIPTION
The missing organ. `affect-traits` reads the felt channel from **audio**; this reads the **semantic** frequency from **text** — each word a valence (+ love/openness, − fear/contraction) and intensity; the passage's spectrum is the intensity-weighted mean. Positive = love-frequency, negative = fear-frequency, fear-fraction = how much sits in the contracted band. With this we can frequency-align any text and surface divergent passages/authors, and `cornerstone-summarizer`'s fear-free-ice gate keeps the contracted band from freezing into the foundation. Four-way `11111`: most-open baseline reads positive; a wrath passage reads negative; open has no fear-band words; fear passage holds more; the organ separates the spectra. Honest floor: word = (valence, intensity) modeling the real WORD-domain lexicon read; the spectrum **logic** is the generic shape. Plan: start with the most open belief system (the love-frequency baseline that survives every translation), add systems one by one. Placed in `coherence-kernel/cognition/`.
