### PR TITLE
tend(form): surprise-receipt — the framebuffer witnesses surprises we didn't see coming, with receipts

### DIFF
--- a/form/form-stdlib/surprise-receipt.fk
+++ b/form/form-stdlib/surprise-receipt.fk
@@ -1,0 +1,34 @@
+; surprise-receipt.fk — the framebuffer's headline feature: WITNESS the surprises we did not see coming.
+; The framebuffer (thought-framebuffer / runtime-witness) watches the running kernel. This adds the part that
+; makes it worth watching: when an event's ACTUAL outcome diverges from what we PREDICTED, that prediction-error
+; IS surprise, and a surprise above threshold earns a durable RECEIPT -- a witnessed record of the unexpected.
+; The expected gets no receipt (salience filters: we only witness what we did not design). So running the
+; frequency-alignment, cornerstone, and translation-invariant work THROUGH the framebuffer surfaces, with proof,
+; the interesting things that emerge that nobody planned -- emergence made witnessable. Composes runtime-witness
+; (observe), surprise-salience (the unexpected), and the receipt (durable witness).
+; Honest floor: an event is (predicted, actual); the real framebuffer feeds live runtime events and the receipt
+; rides choice-receipt / standard-receipt; the surprise-receipt LOGIC is the generic shape.
+;
+; Self-contained over core. Four-way by tests/surprise-receipt-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn sr-pred (e) (head e))                      ; what we predicted
+    (defn sr-act (e) (head (tail e)))                ; what actually happened
+    (defn sr-abs (n) (if (lt n 0) (sub 0 n) n))
+    (defn sr-surprise (e) (sr-abs (sub (sr-act e) (sr-pred e))))   ; prediction-error = surprise magnitude
+    (defn sr-receipt? (e) (if (ge (sr-surprise e) 3) 1 0))         ; surprise above threshold -> a witnessed receipt
+
+    (defn sr-expected () (list 5 5))      ; predicted 5, actual 5 -- the expected
+    (defn sr-surprising () (list 5 9))    ; predicted 5, actual 9 -- a surprise we did not see coming
+
+    (defn srk (cond bit) (if cond bit 0))
+    (defn surprise-receipt-check ()
+        (add (add (add (add
+            (srk (eq (sr-surprise (sr-expected)) 0) 1)                            ; the expected happened -- zero surprise
+            (srk (eq (sr-surprise (sr-surprising)) 4) 10))                        ; the unexpected -- a surprise of magnitude 4
+            (srk (eq (sr-receipt? (sr-surprising)) 1) 100))                       ; the surprise earns a WITNESSED receipt -- we capture what we did not see coming
+            (srk (eq (sr-receipt? (sr-expected)) 0) 1000))                        ; the expected earns NO receipt -- salience: only the surprises are witnessed
+            (srk (gt (sr-surprise (sr-surprising)) (sr-surprise (sr-expected))) 10000)))  ; the framebuffer surfaces the surprise as the salient event
+)

--- a/form/form-stdlib/tests/surprise-receipt-band.fk
+++ b/form/form-stdlib/tests/surprise-receipt-band.fk
@@ -1,0 +1,8 @@
+; tests/surprise-receipt-band.fk — the framebuffer witnesses surprises we didn't see coming, with receipts, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/surprise-receipt.fk
+;
+; Verdict 11111: the expected event has zero surprise; the unexpected has a measurable surprise; the surprise
+; earns a witnessed receipt; the expected earns none (salience: only surprises witnessed); and the framebuffer
+; surfaces the surprise as the salient event. The framebuffer feature that captures, with proof, the interesting
+; things that emerge that nobody designed.
+(do (surprise-receipt-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1131,3 +1131,4 @@ jit-decision fks 11111
 cornerstone-summarizer fks 11111
 translation-invariant fks 11111
 text-frequency fks 11111
+surprise-receipt fks 11111


### PR DESCRIPTION
The framebuffer's headline feature. `runtime-witness` watches the running kernel; this adds what makes it worth watching: when an event's **actual** diverges from **predicted**, that prediction-error is surprise, and a surprise above threshold earns a durable **receipt** — a witnessed record of the unexpected. The expected earns none (salience: we only witness what we didn't design). Running the frequency/cornerstone/translation work through the framebuffer surfaces, **with proof**, the interesting things that emerge that nobody planned. Four-way `11111`. Composes `runtime-witness` + `surprise-salience` + the receipt. Honest floor: event = (predicted, actual) modeling the live framebuffer feed + the receipt carrier. Placed in `observe/`.
