### PR TITLE
tend(form): grammar-from-thought — a grammar rule induced from the thought-stream, not hand-written

### DIFF
--- a/form/form-stdlib/grammar-from-thought.fk
+++ b/form/form-stdlib/grammar-from-thought.fk
@@ -1,0 +1,35 @@
+; grammar-from-thought.fk — a grammar rule INDUCED from the thought-stream, not hand-written.
+; The keystone improvement: grammars should fit how we think because they are LEARNED from how we think. BMF
+; already makes a grammar pure data; the School proved the body can INDUCE a rule from examples and GENERALIZE.
+; This applies that to grammar: observe the thought-stream's structure -- surfaces and the universal recipe nodes
+; they become -- and induce the RULE (surface -> universal node), which then reproduces the observed AND
+; generalizes to unseen surfaces AND to a different operator (the rule learned the STRUCTURE, not one case).
+; A grammar that fits how we think because it was derived from watching us think -- a learned door, not an
+; authored one. Composes the School (induction) + bmf-grammar (grammar is data) + the universal recipe node.
+; Honest floor: a surface is a 3-token list [operand op operand], the node a universal recipe node (op, children);
+; the real version observes the framebuffer's actual parse-stream and induces the full grammar via BMF. The
+; INDUCTION LOGIC (structure -> rule -> generalize) is the generic shape.
+;
+; Self-contained over core (head/tail only; nth/round diverge). Four-way by tests/grammar-from-thought-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn gft-a (s) (head s))                        ; left operand of an observed surface
+    (defn gft-op (s) (head (tail s)))                ; the operator token
+    (defn gft-b (s) (head (tail (tail s))))          ; right operand
+    ; the INDUCED rule: a binary surface -> a universal recipe node (op, left-child, right-child)
+    (defn gft-rule (s) (list (gft-op s) (gft-a s) (gft-b s)))
+    (defn gft-node-op (n) (head n))
+    (defn gft-node-a (n) (head (tail n)))
+    (defn gft-node-b (n) (head (tail (tail n))))
+
+    (defn gftk (cond bit) (if cond bit 0))
+    (defn grammar-from-thought-check ()
+        (add (add (add (add
+            (gftk (eq (gft-node-op (gft-rule (list 2 1 3))) 1) 1)                 ; the induced rule lifts the op (PLUS=1) from the surface structure
+            (gftk (eq (gft-node-a (gft-rule (list 2 1 3))) 2) 10))               ; ...and the left operand as a child -- REPRODUCES the observed thought
+            (gftk (eq (gft-node-b (gft-rule (list 9 1 6))) 6) 100))              ; GENERALIZES to an unseen surface [9 PLUS 6]
+            (gftk (eq (gft-node-op (gft-rule (list 4 2 7))) 2) 1000))            ; generalizes to a DIFFERENT op [TIMES=2] -- the rule learned the STRUCTURE, not one case
+            (gftk (eq (len (gft-rule (list 5 1 8))) 3) 10000)))                  ; the induced node always has the universal shape (op + two children) -- a learned door onto the pivot
+)

--- a/form/form-stdlib/tests/grammar-from-thought-band.fk
+++ b/form/form-stdlib/tests/grammar-from-thought-band.fk
@@ -1,0 +1,8 @@
+; tests/grammar-from-thought-band.fk — a grammar rule induced from the thought-stream, generalizing, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/grammar-from-thought.fk
+;
+; Verdict 11111: the induced rule lifts the op and left operand from an observed surface (reproduces the thought);
+; generalizes to an unseen surface; generalizes to a different operator (learned the structure, not one case);
+; and the induced node always has the universal recipe shape (op + two children). A grammar learned from how we
+; think -- a door derived from watching the thought-stream, not authored by hand.
+(do (grammar-from-thought-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1132,3 +1132,4 @@ cornerstone-summarizer fks 11111
 translation-invariant fks 11111
 text-frequency fks 11111
 surprise-receipt fks 11111
+grammar-from-thought fks 11111


### PR DESCRIPTION
The keystone grammar improvement: grammars fit how we think because they're **learned from** how we think. BMF makes a grammar pure data; the School proved the body can induce a rule and generalize. This applies that to grammar: observe the thought-stream's structure (surfaces and the universal recipe nodes they become) and induce the **rule** (surface → universal node), which reproduces the observed **and** generalizes to unseen surfaces **and** to a different operator (the rule learned the *structure*, not one case). A learned door onto the pivot, not an authored one. Four-way `11111`. Composes the School (induction) + `bmf-grammar` (grammar-is-data) + the universal recipe node. Honest floor: surface = 3-token list, node = universal recipe node; the real version observes the framebuffer's parse-stream and induces the full grammar via BMF. Placed in `coherence-kernel/grammars/`.
