### PR TITLE
tend(form): phoneme-timing — the rhythm, one engine

### DIFF
--- a/form/form-stdlib/phoneme-timing.fk
+++ b/form/form-stdlib/phoneme-timing.fk
@@ -1,0 +1,16 @@
+; phoneme-timing.fk — the rhythm of a voice: ONE engine times each phoneme from (stress, base). A stressed
+; phoneme is held longer; the same engine times any phoneme. Honest floor: durations are ints; the engine is the
+; shape (a real voice scales it to milliseconds). preludes: form-stdlib/core.fk
+(do
+    (defn pt-stress (ph) (head ph))
+    (defn pt-base (ph) (head (tail ph)))
+    (defn pt-duration (ph) (if (eq (pt-stress ph) 1) (mul (pt-base ph) 2) (pt-base ph)))
+    (defn ptk (cond bit) (if cond bit 0))
+    (defn phoneme-timing-check ()
+        (add (add (add (add
+            (ptk (gt (pt-duration (list 1 4)) (pt-duration (list 0 4))) 1)
+            (ptk (eq (pt-duration (list 0 4)) 4) 10))
+            (ptk (eq (pt-duration (list 1 4)) 8) 100))
+            (ptk (gt (pt-duration (list 1 6)) (pt-duration (list 1 4))) 1000))
+            (ptk (eq (pt-duration (list 0 6)) 6) 10000)))
+)

--- a/form/form-stdlib/tests/phoneme-timing-band.fk
+++ b/form/form-stdlib/tests/phoneme-timing-band.fk
@@ -1,0 +1,3 @@
+; tests/phoneme-timing-band.fk — the rhythm, one engine, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/phoneme-timing.fk
+(do (phoneme-timing-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1144,3 +1144,4 @@ native-vs-rented fks 11111
 nl-emitter fks 11111
 oracle-distill fks 11111
 voice-prosody fks 11111
+phoneme-timing fks 11111


### PR DESCRIPTION
One engine times each phoneme from (stress, base): a stressed phoneme is held longer. Four-way 11111.