### PR TITLE
tend(form): tokenizer — text<->token-id bridge (BPE merge round-trip)

### DIFF
--- a/form/form-stdlib/tests/tokenizer-band.fk
+++ b/form/form-stdlib/tests/tokenizer-band.fk
@@ -1,0 +1,3 @@
+; tests/tokenizer-band.fk — text<->token round-trip (BPE merge), four-way.
+; preludes: form-stdlib/core.fk form-stdlib/tokenizer.fk
+(do (tokenizer-check))

--- a/form/form-stdlib/tokenizer.fk
+++ b/form/form-stdlib/tokenizer.fk
@@ -1,0 +1,17 @@
+; tokenizer.fk — the text<->token-id bridge a real NL emitter needs: a BPE-style merge encodes a grapheme pair to
+; one token and decodes it back, round-trip exact. Honest floor: a fixed 2-rule merge table here; the real version
+; uses the whisper BPE table (proven against the real tokenizer) + a zh vocab. The encode/decode/round-trip is the shape.
+; preludes: form-stdlib/core.fk
+(do
+    (defn tk-encode (a b) (if (eq a 1) (if (eq b 2) 100 0) (if (eq a 3) (if (eq b 4) 101 0) 0)))
+    (defn tk-decode-a (tok) (if (eq tok 100) 1 (if (eq tok 101) 3 0)))
+    (defn tk-decode-b (tok) (if (eq tok 100) 2 (if (eq tok 101) 4 0)))
+    (defn tkk (cond bit) (if cond bit 0))
+    (defn tokenizer-check ()
+        (add (add (add (add
+            (tkk (eq (tk-encode 1 2) 100) 1)
+            (tkk (eq (tk-decode-a 100) 1) 10))
+            (tkk (eq (tk-decode-a (tk-encode 1 2)) 1) 100))
+            (tkk (not (eq (tk-encode 3 4) (tk-encode 1 2))) 1000))
+            (tkk (eq (tk-encode 1 4) 0) 10000)))
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1146,3 +1146,4 @@ oracle-distill fks 11111
 voice-prosody fks 11111
 prosody-contour fks 11111
 g2p fks 11111
+tokenizer fks 11111


### PR DESCRIPTION
The text<->token bridge a real NL emitter needs: BPE merge encode/decode, round-trip exact. Four-way 11111. Honest floor: fixed table; real version uses the whisper BPE table + zh vocab.