### PR TITLE
tend(form): BPE tokenization is a grammar over the one cursor (four-way)

### DIFF
--- a/form/form-stdlib/tests/tokenize-grammar-band.fk
+++ b/form/form-stdlib/tests/tokenize-grammar-band.fk
@@ -1,0 +1,50 @@
+; tokenize-grammar-band.fk — proves BPE tokenization runs as a grammar over the
+; one BMF cursor: a grapheme PAIR merges into a single token node, and the merge
+; is preferred over the single-grapheme fallback (BPE's core choice), all as DATA.
+;
+; This is the one-engine lift bpe-tokenizer.fk named: tokenizing the text channel
+; is g-parse over a tokenization grammar, not a second walker. The cursor that
+; parses shell / arith / form.bml parses the token stream too.
+;
+; preludes: form-stdlib/core.fk form-stdlib/json.fk form-stdlib/cache.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/grammar-loader.fk form-stdlib/tokenize-grammar.fk
+
+(do
+    ;; expected stream node: fncall("__toks__", toks...)
+    (defn tgb-stream (toks) (intern_node (bp "fncall") (cons (intern_trivial_string "__toks__") toks)))
+
+    ;; ── A merge table with two 2-grapheme merges and single-char fallbacks.
+    ;;    "ab" → 100, "cd" → 101 ; "a"→1 "b"→2 "c"→3 "d"→4.
+    ;;    2-char rows FIRST so longest-first alt prefers the merge.
+    (let rows (list
+        (list "ab" 100) (list "cd" 101)
+        (list "a" 1) (list "b" 2) (list "c" 3) (list "d" 4)))
+    (let g (tkg-grammar rows))
+
+    ;; 1. the PAIR merges: "ab" → __toks__[ TOK[100] ]  (one token, not two)
+    (let s-merge
+        (if (node_eq (g-parse g "ab")
+                     (tgb-stream (list (tkg-tok 100))))
+            100 0))
+
+    ;; 2. merge PREFERRED over fallback, and a second merge follows:
+    ;;    "abcd" → __toks__[ TOK[100], TOK[101] ]
+    (let s-prefer
+        (if (node_eq (g-parse g "abcd")
+                     (tgb-stream (list (tkg-tok 100) (tkg-tok 101))))
+            100 0))
+
+    ;; 3. fallback to single graphemes where no merge applies, mixed with a merge:
+    ;;    "acd" → __toks__[ TOK[1], TOK[101] ]   (a alone, then cd merged)
+    (let s-mix
+        (if (node_eq (g-parse g "acd")
+                     (tgb-stream (list (tkg-tok 1) (tkg-tok 101))))
+            100 0))
+
+    ;; 4. the token node carries its vocab id as a readable integer leaf:
+    ;;    children of fncall("__tok__", 100) are ["__tok__", 100]; second is the id.
+    (let s-readback
+        (if (node_eq (head (tail (node_children (tkg-tok 100)))) (intern_trivial_int 100))
+            100 0))
+
+    ; Expected total: 400
+    (add s-merge (add s-prefer (add s-mix s-readback))))

--- a/form/form-stdlib/tokenize-grammar.fk
+++ b/form/form-stdlib/tokenize-grammar.fk
@@ -1,0 +1,81 @@
+; tokenize-grammar.fk — BPE tokenization expressed as a GRAMMAR-as-DATA over the
+; one BMF cursor, not as a second walker beside it.
+;
+; The one-engine lift named in bpe-tokenizer.fk's own header: "the merge-ranks
+; expressed as a grammar the one loader carries, not a second walker beside it."
+; This is that grammar. tokenizer.fk (a hardcoded 2-rule merge) and bpe-tokenizer.fk
+; (a hand-written merge loop) are PARALLEL PATHS; this cell composts them into the
+; cursor — surface ─▶ cursor ─▶ match(pattern) ─▶ build(template) ─▶ token node.
+;
+; The BPE insight in grammar terms: a merge "grapheme pair `ab` → token N" IS a
+; rule `(p-lit "ab") → (t-emit "TOK" [(t-const-int N)])`. The merge TABLE is the
+; alt over all such rules, longest-literal-first so a 2-grapheme merge wins over
+; the single-grapheme fallback at the same cursor — exactly BPE's "prefer the
+; merge." A whole text tokenizes as `rep` of one token rule. The merge ranks and
+; ids are DATA in the grammar's rules; the kernel never learns "tokenizer", it
+; runs the same g-parse it runs for shell, arith, and form.bml.
+;
+; A token node reuses the ONE universal op the shell grammar reuses for the same
+; reason — new blueprint names can't be minted without rebuilding every kernel,
+; so a token is fncall("__tok__", int-id). The reserved "__"-tag cannot collide
+; with a real word; node_children reads the id leaf back, and the whole token
+; stream is the rep node-list the cursor already produces.
+;
+; Honest floor: the grammar here carries a tiny demonstration merge table (the
+; shape, four-way-proven). The real version loads whisper's merge rows as rules
+; the SAME way — one rule per merge — so scaling to the 50k table is more DATA,
+; not more code. Ranking (lowest-rank-pair-first) becomes rule ORDER under the
+; cursor's longest-first alt; that ordering pass is the next step, not this cell.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/grammar-loader.fk
+
+(do
+    ;; one merge rule: a grapheme run (1 or 2 chars) → a token node carrying its
+    ;; vocab id. Built as data so a caller assembles a table by listing rules.
+    ;;   tkg-merge "ab" 100  ≡  (p-lit "ab") emits fncall("__tok__", 100)
+    (defn tkg-merge (grapheme id)
+        (rule3 (str_concat "m-" grapheme)
+            (list "lit" grapheme)
+            (t-emit "fncall" (list (t-const "__tok__") (t-const-int id)))))
+
+    ;; the alt over a list of merge-rule NAMES — the cursor tries each in order,
+    ;; longest-literal-first = "prefer the merge" (BPE's core choice).
+    (defn tkg-alt-refs (names)
+        (if (nil? names) (empty)
+            (cons (list "ref" (head names)) (tkg-alt-refs (tail names)))))
+
+    ;; a token node carrying vocab id `n` — for assertions / decode.
+    ;;   fncall("__tok__", n) ; head-child is the "__tok__" tag, second is the id.
+    (defn tkg-tok (n)
+        (intern_node (bp "fncall")
+            (list (intern_trivial_string "__tok__") (intern_trivial_int n))))
+
+    ;; assemble a tokenization grammar from (grapheme id) merge rows.
+    ;; rows : list of (grapheme id). The "tokens" start rule reps one "token";
+    ;; "token" is the alt over every merge rule (longest grapheme first wins
+    ;; because the caller lists 2-char merges before their 1-char fallbacks).
+    ;; Emits fncall("__toks__", tok...) so the stream is one node the cursor built.
+    (defn tkg-grammar (rows)
+        (grammar "tokens"
+            (cons
+                (rule3 "tokens"
+                    (p-cap "ts" (p-rep (p-ref "token")))
+                    (t-emit "fncall" (list (t-const "__toks__") (t-splices "ts"))))
+                (cons
+                    (rule3 "token"
+                        (p-cap "v" (cons "alt" (tkg-alt-refs (tkg-row-names rows))))
+                        (t-splice "v"))
+                    (tkg-row-rules rows)))))
+
+    ;; rows → the per-merge rule names (parallel to tkg-row-rules order).
+    (defn tkg-row-names (rows)
+        (if (nil? rows) (empty)
+            (cons (str_concat "m-" (head (head rows)))
+                  (tkg-row-names (tail rows)))))
+
+    ;; rows → the per-merge rules.
+    (defn tkg-row-rules (rows)
+        (if (nil? rows) (empty)
+            (cons (tkg-merge (head (head rows)) (head (tail (head rows))))
+                  (tkg-row-rules (tail rows)))))
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1148,3 +1148,4 @@ phoneme-timing fks 11111
 prosody-contour fks 11111
 g2p fks 11111
 tokenizer fks 11111
+tokenize-grammar fks 400


### PR DESCRIPTION
Urs caught the redundancy: a standalone tokenizer is a parallel path that duplicates the one engine — the BMF cursor already turns a surface into a recipe tree via grammar-as-DATA, which IS tokenization.

This expresses BPE tokenization as a **tokenization grammar consumed by the cursor**, not its own code. `bpe-tokenizer.fk`'s own header named this exact lift ("the merge-ranks expressed as a grammar the one loader carries, not a second walker beside it").

**The insight in grammar terms:** a merge "grapheme pair `ab` → token N" IS a cursor rule `(p-lit "ab") → fncall("__tok__", N)`. The merge table is the longest-first `alt` over such rules (= BPE's "prefer the merge"); a whole text tokenizes as `rep` of one token rule. The kernel never learns "tokenizer" — it runs the same `g-parse` it runs for shell / arith / form.bml.

Token nodes reuse the **one universal op `fncall`** (reserved `__tok__` tag), the same discipline the shell grammar documents — so no new blueprint name to register across four kernels.

**Proof:** `tokenize-grammar fks 400` crosses FOUR-WAY (Go/Rust/TS/fkwu = 400, `0 divergent`):
1. grapheme pair merges to one token node
2. merge preferred over single-grapheme fallback, second merge follows
3. fallback to single graphemes where no merge applies
4. vocab id readable from the token node

**Compost recommendation:** the hardcoded `tokenizer.fk` (2-rule merge table) and the hand-written `bpe-tokenizer.fk` merge loop should compost into this cursor-grammar (the one-home principle). Both are now superseded parallel paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)