### PR TITLE
tend(form): md-emit — form-native markdown emitter (recipe -> markdown)

### DIFF
--- a/form/form-stdlib/md-emit.fk
+++ b/form/form-stdlib/md-emit.fk
@@ -1,0 +1,20 @@
+; md-emit.fk — a form-native Markdown emitter (recipe -> markdown text), the str_concat text-emitter pattern
+; (like form-glsl / svg-emit) applied to Markdown — the lingua franca of human/agent communication. The reading
+; direction (markdown surface -> recipe) is a BMF cursor grammar, separate. Honest floor: heading level is a small
+; if-ladder (1-3) here; deeper structure (nested lists, code fences, tables) composes as more emitters later.
+; preludes: form-stdlib/core.fk
+(do
+    (defn md-heading (level text)
+        (str_concat (if (eq level 1) "# " (if (eq level 2) "## " "### ")) (str_concat text "\n")))
+    (defn md-bold (text) (str_concat "**" (str_concat text "**")))
+    (defn md-link (text url) (str_concat "[" (str_concat text (str_concat "](" (str_concat url ")")))))
+    (defn md-item (text) (str_concat "- " (str_concat text "\n")))
+    (defn mek (cond bit) (if cond bit 0))
+    (defn md-emit-check ()
+        (add (add (add (add
+            (mek (str_eq (md-heading 1 "Hi") "# Hi\n") 1)
+            (mek (str_eq (md-heading 2 "Yo") "## Yo\n") 10))
+            (mek (str_eq (md-bold "x") "**x**") 100))
+            (mek (str_eq (md-link "a" "u") "[a](u)") 1000))
+            (mek (str_eq (md-item "z") "- z\n") 10000)))
+)

--- a/form/form-stdlib/tests/md-emit-band.fk
+++ b/form/form-stdlib/tests/md-emit-band.fk
@@ -1,0 +1,3 @@
+; tests/md-emit-band.fk — form-native markdown emitter (recipe -> markdown text), four-way.
+; preludes: form-stdlib/core.fk form-stdlib/md-emit.fk
+(do (md-emit-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1150,3 +1150,4 @@ g2p fks 11111
 tokenizer fks 11111
 tokenize-grammar fks 400
 svg-emit fks 11111
+md-emit fks 11111


### PR DESCRIPTION
Markdown is the lingua franca of communication; writing it is the str_concat text-emitter pattern (like svg-emit), now native. heading/bold/link/item. Four-way 11111. The reading direction (md->recipe) is a separate cursor grammar.