### PR TITLE
tend(form): form-eval — source tree-walk on the BMF cursor, flatten becomes optional speed

### DIFF
--- a/form/form-stdlib/form-eval.fk
+++ b/form/form-stdlib/form-eval.fk
@@ -1,0 +1,52 @@
+; form-eval.fk — the source tree-walk, in Form, on the BMF cursor: Form source string -> value, evaluated AS it
+; is read, with NO flatten table. This dissolves the flatten knot for the core grammar: running a recipe no longer
+; REQUIRES flattening — the cursor reads and computes directly; flatten becomes optional SPEED (the JIT path).
+; Mirrors form-parse.fk's recursive-descent over the cursor (no tokenizer, the BMF discipline), but each node
+; returns its VALUE instead of a cell. Grammar (the first stone): expr := integer | '(' op a (b) ')'; op := add|sub|le|if.
+; State threads as (value, end-pos). Completion to full Form (defn/let/user-calls) extends this same shape; this
+; proves the principle four-way on our own kernel. Self-contained over core.
+;
+; Four-way by tests/form-eval-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn fe-fst (pr) (head pr))
+    (defn fe-snd (pr) (head (tail pr)))
+    (defn fe-at (s pos) (ord (char_at s pos)))
+    (defn fe-len (s) (str_len s))
+    (defn fe-isdigit (c) (and (ge c 48) (ge 57 c)))
+    (defn fe-isws (c) (if (eq c 32) 1 (if (eq c 10) 1 (if (eq c 13) 1 (if (eq c 9) 1 0)))))
+    (defn fe-isdelim (c) (if (eq (fe-isws c) 1) 1 (if (eq c 40) 1 (if (eq c 41) 1 0))))
+    (defn fe-skip (s pos)
+        (if (ge pos (fe-len s)) pos
+            (if (eq (fe-isws (fe-at s pos)) 1) (fe-skip s (add pos 1)) pos)))
+    (defn fe-digits (s pos acc)
+        (if (ge pos (fe-len s)) (list acc pos)
+            (if (fe-isdigit (fe-at s pos))
+                (fe-digits s (add pos 1) (add (mul acc 10) (sub (fe-at s pos) 48)))
+                (list acc pos))))
+    (defn fe-sym-end (s pos)
+        (if (ge pos (fe-len s)) pos
+            (if (eq (fe-isdelim (fe-at s pos)) 1) pos (fe-sym-end s (add pos 1)))))
+    (defn fe-expr (s pos) (fe-expr2 s (fe-skip s pos)))
+    (defn fe-expr2 (s pos)
+        (if (eq (fe-at s pos) 40) (fe-list s (add pos 1)) (fe-digits s pos 0)))
+    (defn fe-list (s pos) (fe-op s pos (fe-sym-end s pos)))
+    (defn fe-op (s a b) (fe-byop (substring s a b) s b))
+    (defn fe-byop (op s pos) (if (str_eq op "if") (fe-if s pos) (fe-bin op s pos)))
+    (defn fe-bin (op s pos) (fe-bin-a op s (fe-expr s pos)))
+    (defn fe-bin-a (op s ae) (fe-bin-b op s (fe-fst ae) (fe-expr s (fe-snd ae))))
+    (defn fe-bin-b (op s a be) (list (fe-apply op a (fe-fst be)) (fe-close s (fe-snd be))))
+    (defn fe-apply (op a b)
+        (if (str_eq op "add") (add a b)
+            (if (str_eq op "sub") (sub a b)
+                (if (str_eq op "le") (if (le a b) 1 0) (add a b)))))
+    (defn fe-if (s pos) (fe-if-c s (fe-expr s pos)))
+    (defn fe-if-c (s ce) (fe-if-t s (fe-fst ce) (fe-expr s (fe-snd ce))))
+    (defn fe-if-t (s c te) (fe-if-e s c (fe-fst te) (fe-expr s (fe-snd te))))
+    (defn fe-if-e (s c t ee) (list (if (eq c 0) (fe-fst ee) t) (fe-close s (fe-snd ee))))
+    (defn fe-close (s pos)
+        (if (ge (fe-skip s pos) (fe-len s)) (fe-skip s pos) (add (fe-skip s pos) 1)))
+    (defn fe-eval (s) (fe-fst (fe-expr s 0)))
+)

--- a/form/form-stdlib/tests/form-eval-band.fk
+++ b/form/form-stdlib/tests/form-eval-band.fk
@@ -1,0 +1,7 @@
+; tests/form-eval-band.fk — the source tree-walk: Form source evaluated directly by the cursor, no flatten, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/form-eval.fk
+;
+; One representative source string exercises the whole core grammar — add, sub, le, if, and nesting — evaluated
+; straight off the cursor with no flatten table. (if (le (add 40 2) 50) (sub 50 8) 0): le(42,50)=true -> sub(50,8) -> 42.
+; If this crosses four-way (including fkwu, our c-bootstrap), Form source RUNS without flattening: the knot is cut.
+(do (fe-eval "(if (le (add 40 2) 50) (sub 50 8) 0)"))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1155,3 +1155,4 @@ self-portrait fks 11111
 speak-compose fks 11111
 speak-locale fks 11111
 opencode-loop fks 1111111
+form-eval fks 42


### PR DESCRIPTION
The final gap, crossed for the core grammar. `form-eval` reads Form source off the BMF cursor (no tokenizer) and **evaluates as it reads** — source string → value, with **no flatten of the source**. Witnessed **four-way** (Go=Rust=TS=fkwu) → `42`, 0 divergent: `(if (le (add 40 2) 50) (sub 50 8) 0)` evaluated straight off the cursor by all four kernels including the c-bootstrap. So running a recipe no longer *requires* flattening it — the cursor reads and computes directly; **flatten drops to optional speed**. The only thing still flattened is the evaluator recipe itself (the cursor *is* the core, flattened once as the seed). Honest floor: core grammar (int, add/sub/le/if, nesting); full Form extends the same `fe-` shape. The c-bootstrap stays minimal — the tree-walk lives in Form, on the cursor.
