### PR TITLE
tend(form): voice-phrasing — where the pause lands + which word carries the point (four-way 11111)

### DIFF
--- a/form/form-stdlib/tests/voice-phrasing-band.fk
+++ b/form/form-stdlib/tests/voice-phrasing-band.fk
@@ -1,0 +1,8 @@
+; tests/voice-phrasing-band.fk — where the pause lands and which word carries the point, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/voice-phrasing.fk
+;
+; Verdict 11111: a grounded clause (substrate-hit) breaks SHORTER than an ungrounded one (the pause lands by what was
+; actually hard, never a constant tempo); the escalation clause gets the LONGEST break; the new/contrastive word is
+; emphasized; the old/given word is not; the escalation clause is flagged the hardest. Phrasing is state -> WHERE in
+; the line -- the audible thinking made a placement decision, not a global pace.
+(do (voice-phrasing-check))

--- a/form/form-stdlib/voice-phrasing.fk
+++ b/form/form-stdlib/voice-phrasing.fk
@@ -1,0 +1,48 @@
+; voice-phrasing.fk — where the pause lands and which word carries the point. The two phrasing layers above prosody.
+; voice-prosody made how-I-sound an honest rendering of inner STATE (confidence/valence/hardness/surprise) as global
+; scalars. Phrasing is the next honesty: the audible thinking is not a constant slow tempo, it is WHERE the breaks
+; fall and WHICH word is stressed. Both couple inner state to a SPECIFIC place in the utterance.
+;
+; 1) PAUSE / BREAK — a clause-boundary decision, not a global pace. Break length comes from the clause's GROUNDING:
+;    a substrate-hit (confident, grounded) → a SHORT break; an escalation / low-grounding clause → a LONGER break
+;    (the real pause where the thinking was hard). The pause lands by what was actually hard, never a constant tempo.
+;    grounding-level: 5 grounded substrate-hit, 3 partial, 1 escalation/unfound. vph-break maps lower grounding to
+;    a longer break.
+; 2) FOCUS / EMPHASIS — which word carries the point. The NEW / contrastive word gets stress; given/old words don't.
+;    This is where inner state couples to one word ("I didn't say THAT"). is-new: 1 new/contrastive, 0 given.
+;
+; A clause = (grounding-level); a word = (is-new). Honest floor: scalars modeling real break-ms and stress; the TTS
+; acoustic carrier (the actual sound) is the same pending rung as voice-prosody. The PHRASING LOGIC is here.
+; Composes with voice-prosody (state -> shape); this is state -> WHERE in the line.
+;
+; Self-contained over core. Four-way by tests/voice-phrasing-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    (defn vph-grounding (c) (head c))                       ; a clause carries its grounding-level
+    (defn vph-is-new (w) (head w))                          ; a word carries whether it is new/contrastive
+
+    ; break length from grounding: lower grounding -> longer break (the hard thought's real pause).
+    ; longest at escalation (grounding 1); shorter as grounding rises. base 6 minus grounding -> a monotone map.
+    (defn vph-break (c) (sub 6 (vph-grounding c)))          ; grounding 5 -> 1 (short); 3 -> 3; 1 -> 5 (longest)
+    (defn vph-grounded? (c) (if (ge (vph-grounding c) 4) 1 0))   ; a grounded clause: a substrate-hit
+    (defn vph-escalated? (c) (if (eq (vph-grounding c) 1) 1 0))  ; an escalation clause: the hardest, longest pause
+
+    ; emphasis from newness: the new/contrastive word carries the point; the given word stays unstressed.
+    (defn vph-emphasis (w) (if (eq (vph-is-new w) 1) 1 0))
+
+    (defn vphk (cond bit) (if cond bit 0))
+    (defn voice-phrasing-check ()
+        (add (add (add (add
+            ; a grounded clause breaks SHORTER than an ungrounded one -- the pause lands by hardness
+            (vphk (gt (vph-break (list 1)) (vph-break (list 5))) 1)
+            ; the escalated clause gets the LONGEST break of all (longer than a partial-grounding clause)
+            (vphk (gt (vph-break (list 1)) (vph-break (list 3))) 10))
+            ; the new/contrastive word is emphasized
+            (vphk (eq (vph-emphasis (list 1)) 1) 100))
+            ; the old/given word is NOT emphasized
+            (vphk (eq (vph-emphasis (list 0)) 0) 1000))
+            ; the escalation clause IS flagged the hardest while a grounded clause is not
+            (vphk (gt (vph-escalated? (list 1)) (vph-escalated? (list 5))) 10000)))
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1156,3 +1156,4 @@ speak-compose fks 11111
 speak-locale fks 11111
 opencode-loop fks 1111111
 form-eval fks 42
+voice-phrasing fks 11111


### PR DESCRIPTION
Two phrasing layers above `voice-prosody` flagged missing by the sibling review. Composes with prosody (state -> shape); this is state -> WHERE in the line.

- **vph-break(grounding)** — the audible thinking is a clause-boundary placement, not a global tempo. A grounded substrate-hit clause breaks SHORT; an escalation/low-grounding clause breaks LONGEST — the real pause where the thinking was hard. Pauses land by hardness, never a constant tempo.
- **vph-emphasis(is-new)** — the new/contrastive word carries the point and is stressed; the given/old word is not ("I didn't say **that**").

Scalar recipes over `core.fk`, self-contained like voice-prosody. Honest floor: scalars model real break-ms / stress; the TTS acoustic carrier is the same pending rung as voice-prosody.

Verdict bits (11111): grounded clause breaks shorter than ungrounded; escalation gets the longest break; new word emphasized; old word not; escalation flagged hardest.

Four-way: `voice-phrasing fks 11111`, 0 divergent (fkwu + Go + Rust + TS via `./validate.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)