### PR TITLE
tend(form): md-grammar — the markdown READER as a BMF cursor grammar, four-way (verdict 7)

### DIFF
--- a/form/form-stdlib/md-grammar.fk
+++ b/form/form-stdlib/md-grammar.fk
@@ -1,0 +1,72 @@
+; md-grammar.fk — the markdown READER as a BMF cursor grammar-as-DATA, the read
+; direction that complements md-emit.fk (the writer). md-emit walks a recipe -> text;
+; this walks text -> recipe, both over Markdown, the lingua franca of human/agent
+; communication. It is NOT a standalone hand-written parser — it is rules (pattern,
+; template) over the ONE cursor, exactly like tokenize-grammar.fk and shell-grammar.fk:
+;
+;   surface ─▶ cursor ─▶ match(pattern) ─▶ build(template) ─▶ markdown node
+;
+; The three core markdown shapes, each one rule:
+;   `# heading`   — a line starting with "# "   → a heading node
+;   `**bold**`    — text between "**" ... "**"   → a bold node
+;   `- item`      — a line starting with "- "    → a list-item node
+;
+; Universal-op discipline (the keystone tokenize-grammar.fk names): a new blueprint
+; name cannot be minted without rebuilding every kernel, so a markdown node reuses the
+; ONE universal op the shell + token grammars reuse — fncall("__md__", kind, text).
+; The reserved "__"-tag cannot collide with a real word; node_children reads the kind
+; and text leaves back. No new blueprint = no fourth-arm divergence (the exact wall the
+; tokenize-grammar agent hit and fixed with the universal op).
+;
+; Honest floor: content is one alnum word here (the witness surfaces — "Hi" / "x" / "z"
+; — and md-emit's own round-trip examples). Richer inline content (spaces, links,
+; nesting) composes as more content rules over the same cursor later, never more code
+; paths — the writer's deeper structure (md-link, levels) earns its reader the same way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/grammar-loader.fk
+
+(do
+    ;; a markdown node carrying its kind ("heading" / "bold" / "item") — for
+    ;; assertions / structural reads. fncall("__md__", kind, text): head-child is
+    ;; the "__md__" tag, second the kind, third the content text. One universal
+    ;; op, three children — the same shape tkg-tok uses for a token.
+    (defn mdg-node (kind text)
+        (intern_node (bp "fncall")
+            (list (intern_trivial_string "__md__")
+                  (intern_trivial_string kind)
+                  (intern_trivial_string text))))
+
+    ;; one block rule: a `lit` prefix, then the captured content word, emitting
+    ;; fncall("__md__", kind, <content>). Built as data so each markdown shape is
+    ;; one row — the prefix and kind are the only things that vary.
+    ;;   mdg-prefix-rule "heading" "# "  ≡  (lit "# ") (cap "t" (run alnum))
+    ;;                                       → fncall("__md__","heading",<t>)
+    (defn mdg-prefix-rule (kind prefix)
+        (rule3 kind
+            (list "seq" (p-lit prefix) (p-cap "t" (p-run "alnum")))
+            (t-emit "fncall"
+                (list (t-const "__md__") (t-const kind) (t-splice "t")))))
+
+    ;; the bold rule: content fenced by "**" ... "**". Same shape, two literals.
+    (defn mdg-bold-rule ()
+        (rule3 "bold"
+            (list "seq" (p-lit "**") (p-cap "t" (p-run "alnum")) (p-lit "**"))
+            (t-emit "fncall"
+                (list (t-const "__md__") (t-const "bold") (t-splice "t")))))
+
+    ;; the markdown grammar: a "block" is the alt over the three shapes. bold is
+    ;; tried first so its "**" fence is recognized before any fallback; heading and
+    ;; item are line-prefix rules. The start rule "block" parses one markdown block.
+    (defn mdg-grammar ()
+        (grammar "block"
+            (list
+                (rule3 "block"
+                    (p-cap "b" (list "alt"
+                        (p-ref "bold")
+                        (p-ref "heading")
+                        (p-ref "item")))
+                    (t-splice "b"))
+                (mdg-bold-rule)
+                (mdg-prefix-rule "heading" "# ")
+                (mdg-prefix-rule "item" "- "))))
+)

--- a/form/form-stdlib/tests/md-grammar-band.fk
+++ b/form/form-stdlib/tests/md-grammar-band.fk
@@ -1,0 +1,32 @@
+; tests/md-grammar-band.fk — the markdown READER (text -> recipe) as a BMF cursor
+; grammar, lifted to the four-kernel floor. The read direction that complements the
+; md-emit band (recipe -> text): md-emit proves "# Hi\n" is what a heading EMITS; this
+; proves "# Hi" is what the cursor READS BACK into a heading node. Together they close
+; the markdown round-trip on one engine.
+;
+; The proof is the three core shapes, each parsed by g-parse over the ONE cursor and
+; asserted by node_eq against the node mdg-node builds from the same universal op —
+; so a node minted by the parse and a node minted directly must be the SAME coordinate
+; (the universal-op discipline: no new blueprint, so all four kernels agree):
+;
+;   bit 1 — "# Hi"  parses to fncall("__md__","heading","Hi")   — the heading shape
+;   bit 2 — "- z"   parses to fncall("__md__","item","z")       — the list-item shape
+;   bit 4 — "**x**" parses to fncall("__md__","bold","x")       — the bold shape
+;
+; Pure cursor + list/string recursion — no host I/O, no floats — the fourth-friendly
+; subset. Verdict 7 when all three markdown shapes read back four-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-ontology-loader.fk form-stdlib/line-grammar.fk form-stdlib/bmf-core.fk form-stdlib/bmf-grammar.fk form-stdlib/grammar-loader.fk form-stdlib/md-grammar.fk
+(do
+    (let g (mdg-grammar))
+
+    ; bit 1 — heading: "# Hi" -> fncall("__md__","heading","Hi")
+    (let c0 (if (node_eq (g-parse g "# Hi") (mdg-node "heading" "Hi")) 1 0))
+
+    ; bit 2 — list item: "- z" -> fncall("__md__","item","z")
+    (let c1 (if (node_eq (g-parse g "- z") (mdg-node "item" "z")) 2 0))
+
+    ; bit 4 — bold: "**x**" -> fncall("__md__","bold","x")
+    (let c2 (if (node_eq (g-parse g "**x**") (mdg-node "bold" "x")) 4 0))
+
+    (add c0 (add c1 c2)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1158,3 +1158,4 @@ opencode-loop fks 1111111
 form-eval fks 42
 voice-phrasing fks 11111
 form-eval-full fks 131
+md-grammar fks 7


### PR DESCRIPTION
The read direction that complements `md-emit` (the writer). `md-emit` walks a recipe → markdown text; `md-grammar` walks markdown text → recipe, both over the **one** BMF cursor as **grammar-as-DATA** (rules of pattern+template), not a standalone hand-written parser — same shape as `tokenize-grammar.fk` / `shell-grammar.fk`.

## Shapes (each one rule)
- `# heading` → `fncall("__md__","heading",<text>)`
- `**bold**` → `fncall("__md__","bold",<text>)`
- `- item` → `fncall("__md__","item",<text>)`

## Universal-op discipline
A markdown node reuses the **one** op the shell + token grammars reuse — `fncall("__md__", kind, text)` — never a new blueprint name (the exact wall the tokenize-grammar agent hit and fixed). No new blueprint ⇒ no fourth-arm divergence; all four kernels agree.

## Witness
`md-grammar-band` runs `g-parse` over `"# Hi"` / `"- z"` / `"**x**"`, asserting each node via `node_eq` against the node `mdg-node` builds from the same universal op. **Verdict 7 — all three shapes read back four-way, 0 divergent on fkwu.**

Honest floor: content is one alnum word here (the witness surfaces + md-emit's own round-trip examples); richer inline content composes as more content rules over the same cursor later, never more code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)