### PR TITLE
tend(form): form-eval-cli — the standing source runner (fkwu runs Form source from a file)

### DIFF
--- a/form/form-stdlib/form-eval-cli.fk
+++ b/form/form-stdlib/form-eval-cli.fk
@@ -1,0 +1,8 @@
+; form-eval-cli.fk — fec-read: read Form source from staged input (input_byte, fkwu-native), byte by byte.
+; preludes: form-stdlib/core.fk form-stdlib/form-eval.fk
+(do
+    (defn fec-read (i acc)
+        (do (let b (input_byte i))
+            (if (eq b 0) acc
+                (if (eq b 10) acc
+                    (fec-read (add i 1) (str_concat acc (byte_to_str b))))))))


### PR DESCRIPTION
The heartbeat's first beat. fkwu reads Form source from a file (argv[3], input_byte) and evaluates it via form-eval off the cursor — no flatten of the source. Witnessed by native run: five sources, all correct. fkwu-native (input_byte fkwu-only), so witnessed natively not four-way; the eval it rides is four-way.