### PR TITLE
tend(form): fam-horner2 — degree-2 Horner polynomial as Form→asm bytes (first fa-fmadd; the transcendental eval engine)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 391 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 393 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-06-29_form_asm_horner.json
+++ b/docs/system_audit/commit_evidence_2026-06-29_form_asm_horner.json
@@ -1,0 +1,37 @@
+{
+  "title": "fam-horner2 — a degree-2 Horner polynomial ((2x+3)x+4) as Form->asm BYTES, four-way + run on M4 (+ the fa-fmadd fused-multiply-add encoder)",
+  "date": "2026-06-29",
+  "author": "Sema (Opus 4.8), autonomous native-ML walk",
+  "stone": "The NEXT nonlinear rung on the native asm lane after fam-rsqrt. fam-rsqrt opened the first float constant + first fdiv; fam-horner2 opens the first fa-fmadd (fused multiply-add) — and Horner-over-fmadd is the literal eval engine of every transcendental still to come. exp/sin/cos/gelu on the native lane are all polynomial (or rational) approximations, and Horner folds a degree-n poly into n fused multiply-adds (one rounding each). This proves the 2-step fold byte-exact and runs it on the M4, the floor under emitting a real exp/softmax kernel. Advances form-native-models.form 'GAPS — LLM INFERENCE' A note: 'the nonlinear ops as form-asm bytes (exp/sin/cos/rsqrt for softmax/RoPE/RMSNorm/SwiGLU)' — Horner is the shared body those approximations are written in.",
+  "new_encoder": "form/form-stdlib/form-asm.fk :: fa-fmadd (rd rn rm ra) — fmadd d<rd>, d<rn>, d<rm>, d<ra> (rd = rn*rm + ra, ONE rounding): base 0x1F400000 | rm<<16 | ra<<10 | rn<<5 | rd. The fused multiply-add clang fuses every dot/Horner step to. One hardware op = one rounding, so a polynomial folded with it is byte-DISTINCT from fmul-then-fadd; matching clang requires the fused form. The genuinely-reusable win: every later transcendental Horner step (and the composed dot/normalizer the rsqrt note deferred — 'clang fuses that to fmadd') routes through this encoder.",
+  "recipe": "form/form-stdlib/form-asm-matvec.fk :: fam-horner2 — 6 arm64 instructions / 24 bytes, scalar (no loop). ABI: d0 = x, returns d0 = ((2*x + 3)*x + 4). Program: fmov d1,#3.0 (1e611001) ; fmov d2,#2.0 (1e601002) ; fmadd d1,d0,d2,d1 (1f420401) ; fmov d2,#4.0 (1e621002) ; fmadd d0,d1,d0,d2 (1f400820) ; ret (d65f03c0). The coefficients ride fa-fmov-imm (the float-constant primitive fam-rsqrt opened): 2.0=imm8 0, 3.0=imm8 8, 4.0=imm8 16 — all VFP-expressible, so no constant pool yet (real exp coeffs like 1/6 will need one; this is the clean floor on which the constant pool is the next named gap).",
+  "four_way": {
+    "band": "form/form-stdlib/tests/form-asm-horner-band.fk",
+    "manifest_row": "form-asm-horner fks 31",
+    "verdict": 31,
+    "claims": "1 len==24  +2 FULL 24-byte program byte-equals the clang oracle (fa-conviction)  +4 fmadd d1,d0,d2,d1 (the FIRST fused multiply-add, new encoder)  +8 fmadd d0,d1,d0,d2 (the Horner reduction second step)  +16 fmov d2,#4.0 (a polynomial coefficient as a float constant)",
+    "result": "Go = Rust = TS = fkwu = 31, 0 divergent. fourth arm: 1 band four-way (fkwu + pre-flattened tables). No regression: form-asm-rsqrt (31), form-asm-ss-sqrt (127), form-asm-matvec-2d (127) all still cross four-way after the shared-file edits.",
+    "reproduce": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-horner-band.fk"
+  },
+  "oracle": "clang -O2 -c -target arm64-apple-macos + otool -tvVj of `double p(double x){return __builtin_fma(__builtin_fma(2.0,x,3.0),x,4.0);}` — the exact 6-word image the recipe matches byte-for-byte: 1e611001 fmov d1,#3.0 / 1e601002 fmov d2,#2.0 / 1f420401 fmadd d1,d0,d2,d1 / 1e621002 fmov d2,#4.0 / 1f400820 fmadd d0,d1,d0,d2 / d65f03c0 ret. clang is the teacher that confirmed the bytes once (including which register clang picks and that it materializes 2.0/3.0/4.0 via fmov-imm), dropped from the runtime by fa-conviction's byte-identity gate.",
+  "hardware_witness": {
+    "script": "scripts/form_asm_horner_witness.sh",
+    "device": "Apple M4 Max, arm64 Darwin",
+    "path": "Form kernel emits fam-horner2's 24 bytes -> form-macho mo-object-sym wraps a Mach-O .o exporting _recipe -> ld -dylib + ad-hoc sign (no clang in the link) -> C harness dlopen+call as double recipe(double x)",
+    "emitted_bytes": "0110611e 0210601e 0104421f 0210621e 2008401f c0035fd6",
+    "compute_toolchain_free": "no rustc/clang in the COMPUTE; clang only builds the dumb dlopen loader. The reference uses the SAME fma() fold the recipe emits, so parity is bit-for-bit == not epsilon-close.",
+    "results": [
+      {"case": "0.0",   "x": 0.0,   "got": 4.0,                  "expected": 4.0,                  "match": true},
+      {"case": "1.0",   "x": 1.0,   "got": 9.0,                  "expected": 9.0,                  "match": true},
+      {"case": "2.0",   "x": 2.0,   "got": 18.0,                 "expected": 18.0,                 "match": true},
+      {"case": "-1.0",  "x": -1.0,  "got": 3.0,                  "expected": 3.0,                  "match": true},
+      {"case": "0.5",   "x": 0.5,   "got": 6.0,                  "expected": 6.0,                  "match": true},
+      {"case": "1e8",   "x": 1e8,   "got": 20000000300000004,    "expected": 20000000300000004,    "match": true},
+      {"case": "1e-8",  "x": 1e-8,  "got": 4.0000000299999998,   "expected": 4.0000000299999998,   "match": true},
+      {"case": "0.1",   "x": 0.1,   "got": 4.3200000000000003,   "expected": 4.3200000000000003,   "match": true}
+    ],
+    "parity": "8/8 bit-for-bit == vs fma(fma(2.0,x,3.0),x,4.0). The fp-stress 1e8 case (20000000300000004) and the irrational-binary 0.1 case (4.3200000000000003) match to the last bit, confirming the fused-multiply-add rounding is identical."
+  },
+  "reading": "The Horner polynomial fold — the eval engine of every transcendental on the native lane — is now sovereign native arm64 bytes, proven byte-identical across all four kernels AND executed on the M4. The native asm lane now carries the 2-D matvec (dominant linear compute), the L2-norm reduction (fam-ss-sqrt), the reciprocal-sqrt normalizer (fam-rsqrt), the float-constant materialization (fa-fmov-imm), and now the fused multiply-add (fa-fmadd) + the Horner recurrence. Next named rungs in form-native-models.form: a CONSTANT POOL (real exp/sin coefficients like 1/6, 1/120 are not VFP-immediate-expressible — load from a literal pool via ldr-d off a base register), then exp (range reduction over the present fcvtzs/scvtf + a higher-degree Horner using the pool), sin/cos (RoPE), then ll-buffer staging of the dequanted tensor set + the 28-layer fold.",
+  "reproduce": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-horner-band.fk && bash ../scripts/form_asm_horner_witness.sh"
+}

--- a/form/form-stdlib/form-asm-matvec.fk
+++ b/form/form-stdlib/form-asm-matvec.fk
@@ -140,4 +140,22 @@
                 (append (fa-fdiv 0 1 0)
                     (fa-ret)))))
 
+    ; fam-horner2: a degree-2 Horner polynomial p(x) = ((2*x + 3)*x + 4) as Form->asm bytes — the FIRST use of
+    ; fa-fmadd on the witnessed native lane, and the literal eval engine of every transcendental yet to come.
+    ; exp/sin/cos/gelu on the native lane are all polynomial (or rational) approximations; Horner folds a degree-n
+    ; poly into n fused multiply-adds, one rounding each — this proves the 2-step fold byte-exact. The coefficients
+    ; ride fa-fmov-imm (the float-constant primitive fam-rsqrt opened): 2.0=imm8 0, 3.0=imm8 8, 4.0=imm8 16 — all
+    ; VFP-expressible, so no constant pool yet (real exp coeffs like 1/6 will need one; this is the clean floor).
+    ; ABI: d0 = x, returns d0 = p(x). 6 arm64 instructions = 24 bytes, byte-identical to the clang -O2 oracle for
+    ; `__builtin_fma(__builtin_fma(2.0,x,3.0),x,4.0)`:
+    ;   0 fmov d1,#3.0 (1e611001)   1 fmov d2,#2.0 (1e601002)   2 fmadd d1,d0,d2,d1 (1f420401)
+    ;   3 fmov d2,#4.0 (1e621002)   4 fmadd d0,d1,d0,d2 (1f400820)   5 ret (d65f03c0)
+    (defn fam-horner2 ()
+        (append (fa-fmov-imm 1 8)
+            (append (fa-fmov-imm 2 0)
+                (append (fa-fmadd 1 0 2 1)
+                    (append (fa-fmov-imm 2 16)
+                        (append (fa-fmadd 0 1 0 2)
+                            (fa-ret)))))))
+
     0)

--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -171,6 +171,11 @@
     (defn fa-fmul (rd rn rm) (fa-asm 509609984 (list 1 32 65536) (list rd rn rm)))
     ; fdiv d<rd>, d<rn>, d<rm> : base 0x1E601800                         (oracle 1e621820)
     (defn fa-fdiv (rd rn rm) (fa-asm 509614080 (list 1 32 65536) (list rd rn rm)))
+    ; fmadd d<rd>, d<rn>, d<rm>, d<ra> (rd = rn*rm + ra, one rounding) : base 0x1F400000 | rm<<16 | ra<<10 | rn<<5 | rd
+    ; the fused multiply-add — the workhorse clang fuses every dot/Horner step to (oracle 1f420401 = fmadd d1,d0,d2,d1).
+    ; one hardware op = one rounding, so a polynomial folded with it is byte-distinct from fmul-then-fadd. Horner over
+    ; this IS the eval engine of every transcendental (exp/sin/cos): p(x) = ((c_n*x + c_{n-1})*x + ...) is n fmadds.
+    (defn fa-fmadd (rd rn rm ra) (fa-asm 524288000 (list 1 32 65536 1024) (list rd rn rm ra)))
     ; fsqrt d<rd>, d<rn> : base 0x1E61C000 | rn<<5 | rd                  (oracle 1e61c020)
     (defn fa-fsqrt (rd rn) (fa-asm 509722624 (list 1 32) (list rd rn)))
     ; fmov d<rd>, d<rn> : base 0x1E604000                               (oracle 1e604020)

--- a/form/form-stdlib/tests/form-asm-horner-band.fk
+++ b/form/form-stdlib/tests/form-asm-horner-band.fk
@@ -1,0 +1,36 @@
+; form-asm-horner-band — a degree-2 Horner polynomial p(x)=((2x+3)x+4) emits four-way as Form->asm bytes, no rustc.
+; fam-horner2 is the FIRST use of fa-fmadd (fused multiply-add) on the witnessed native lane, and the literal eval
+; engine of every transcendental still to come: exp/sin/cos/gelu on the native lane are all polynomial (or rational)
+; approximations, and Horner folds a degree-n poly into n fused multiply-adds (one rounding each). This proves the
+; 2-step fold byte-exact, the floor under emitting a real exp/softmax kernel next. It is the next nonlinear rung after
+; fam-rsqrt (form-asm-rsqrt 31): where rsqrt opened the first float constant + first fdiv, this opens the first fmadd.
+;
+; The new ground vs fam-rsqrt: (1) fa-fmadd — the fused multiply-add clang emits for every dot/Horner step; one
+; hardware op = one rounding, so a poly folded with it is byte-DISTINCT from fmul-then-fadd. (2) two fmadds chained
+; (the Horner recurrence) over three fmov-imm coefficients. The float ops are proven byte-identical to the clang/LLVM
+; oracle in form-asm-float (2047); the new claim is that the COMPOSITION emits the exact 24-byte arm64 program
+; four-way. ABI: d0 = x, returns d0 = p(x).
+;
+; The 6-instruction program, otool -tvVj of the clang -O2 oracle (`__builtin_fma(__builtin_fma(2.0,x,3.0),x,4.0)`):
+;   1e611001 fmov d1,#3.0   1e601002 fmov d2,#2.0   1f420401 fmadd d1,d0,d2,d1
+;   1e621002 fmov d2,#4.0   1f400820 fmadd d0,d1,d0,d2   d65f03c0 ret
+;
+; Verdict 31 when every claim lands:
+;   1    the program is 6 instructions = 24 bytes                       (len == 24)
+;   2    the FULL program byte-equals the 24-byte clang oracle          (fa-conviction == 1)
+;   4    fmadd d1,d0,d2,d1 — the FIRST fused multiply-add (new encoder) (fa-conviction == 1)
+;   8    fmadd d0,d1,d0,d2 — the Horner reduction second step           (fa-conviction == 1)
+;   16   fmov d2,#4.0 — a polynomial coefficient as a float constant    (fa-conviction == 1)
+;
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+(do
+    (let prog (fam-horner2))
+    (let oracle (list
+        1 16 97 30      2 16 96 30      1 4 66 31
+        2 16 98 30      32 8 64 31      192 3 95 214))
+    (let c0 (if (eq (len prog) 24)                                            1 0))
+    (let c1 (if (eq (fa-conviction prog oracle)                          1)   2 0))
+    (let c2 (if (eq (fa-conviction (fa-fmadd 1 0 2 1) (list 1 4 66 31))  1)   4 0))
+    (let c3 (if (eq (fa-conviction (fa-fmadd 0 1 0 2) (list 32 8 64 31)) 1)   8 0))
+    (let c4 (if (eq (fa-conviction (fa-fmov-imm 2 16) (list 2 16 98 30)) 1)  16 0))
+    (add c0 (add c1 (add c2 (add c3 c4)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1044,6 +1044,7 @@ form-asm-matvec-loop fks 127
 form-asm-matvec-2d fks 127
 form-asm-ss-sqrt fks 127
 form-asm-rsqrt fks 31
+form-asm-horner fks 31
 weight-load fks 4095
 weight-load-q4k fks 4095
 block-join fks 255

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 391
+**Total files**: 393
 
 | File | Purpose |
 |---|---|
@@ -110,8 +110,10 @@
 | [form-cli-run.sh](form-cli-run.sh) | form-cli-run.sh — minimal stdin carrier for form/form-cli (one line, then EOF). |
 | [form-convert.sh](form-convert.sh) | form-convert — the machine-native kernel-cli for the goal Urs named: |
 | [form_asm_conviction_demo.sh](form_asm_conviction_demo.sh) | form_asm_conviction_demo.sh — the byte-conviction gate that licenses dropping |
+| [form_asm_horner_witness.sh](form_asm_horner_witness.sh) | form_asm_horner_witness.sh — the EXECUTION WITNESS for fam-horner2: the Form-emitted degree-2 Horner |
 | [form_asm_matvec_2d_witness.sh](form_asm_matvec_2d_witness.sh) | form_asm_matvec_2d_witness.sh — the EXECUTION WITNESS for fam-matvec: the Form-emitted |
 | [form_asm_matvec_witness.sh](form_asm_matvec_witness.sh) | form_asm_matvec_witness.sh — the EXECUTION WITNESS for fam-dot2: the Form-emitted |
+| [form_asm_rsqrt_witness.sh](form_asm_rsqrt_witness.sh) | form_asm_rsqrt_witness.sh — the EXECUTION WITNESS for fam-rsqrt: the Form-emitted reciprocal-sqrt |
 | [form_asm_ss_sqrt_witness.sh](form_asm_ss_sqrt_witness.sh) | form_asm_ss_sqrt_witness.sh — the EXECUTION WITNESS for fam-ss-sqrt: the Form-emitted RMSNorm/LayerNorm |
 | [form_branch_demo.sh](form_branch_demo.sh) | form_branch_demo.sh — the FULL asm-pl-human program, compiled by Form and run on |
 | [form_cat_demo.sh](form_cat_demo.sh) | form_cat_demo.sh — `cat`, a real unix command, built with ZERO clang and direct |

--- a/scripts/form_asm_horner_witness.sh
+++ b/scripts/form_asm_horner_witness.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# form_asm_horner_witness.sh — the EXECUTION WITNESS for fam-horner2: the Form-emitted degree-2 Horner
+# polynomial p(x)=((2x+3)x+4) (form-asm-horner-band proves it four-way) doesn't just BYTE-MATCH the arm64
+# oracle — it actually RUNS on this arm64 host, no rustc/clang in the COMPUTE (clang is only the dumb
+# dlopen harness).
+#
+# Sibling of form_asm_rsqrt_witness.sh. fam-horner2 is the NEXT nonlinear rung on the native lane after
+# fam-rsqrt: where rsqrt opened the first float constant + first fdiv, this opens the first fa-fmadd (fused
+# multiply-add) — and Horner over fmadd IS the eval engine of every transcendental still to come
+# (exp/sin/cos/gelu are polynomial/rational approximations; a degree-n poly folds into n fmadds). This
+# proves the 2-step fold runs bit-exact on hardware, the floor under emitting a real exp/softmax kernel.
+#
+# Path:
+#   1. Form kernel emits fam-horner2's 6-instruction (24-byte) arm64 program, then wraps it via
+#      form-macho's mo-object-sym into a Mach-O .o exporting `_recipe`.
+#   2. `ld -dylib` links + ad-hoc signs the .o into a dlopen-able dylib (the recipe-dylib path, no clang).
+#   3. A tiny C harness dlopens it, casts `_recipe` to the ABI  double recipe(double x)  (arm64 arg lands
+#      in d0, result in d0 — exactly the recipe's register plan), and calls it with real scalars.
+#   4. Assert recipe(x) == fma(fma(2.0,x,3.0),x,4.0), bit-for-bit — the harness uses the SAME fused
+#      multiply-adds the recipe folds (one rounding each), so it is == not epsilon-close.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS witness; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+command -v clang >/dev/null || { echo "need clang for the loader harness; skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/fhorner.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+MATVEC="$FORM/form-stdlib/form-asm-matvec.fk"
+[[ -f "$MATVEC" ]] || { echo "FAIL: form-asm-matvec.fk not found"; exit 1; }
+
+# Form: emit fam-horner2 bytes, wrap as a Mach-O .o exporting _recipe (mo-object-sym), hex.
+{ echo "(do"
+  echo '    (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))'
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$MATVEC"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<'DRV'
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code (fam-horner2))
+    (print (str_concat "HBYTES " (hxb code)))
+    ; _recipe = 95 114 101 99 105 112 101 (the recipe-dylib export name)
+    (print (str_concat "MACHO " (hxb (mo-object-sym code (list 95 114 101 99 105 112 101)))))
+    0)
+DRV
+} > "$work/emit.fk"
+
+out="$(cd "$FORM" && "$GO" "$work/emit.fk" 2>/dev/null)"
+hbytes="$(echo "$out" | grep '^HBYTES ' | sed 's/^HBYTES //')"
+hex="$(echo "$out" | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; cd "$FORM" && "$GO" "$work/emit.fk" 2>&1 | head; exit 1; }
+echo "fam-horner2 program: $(( ${#hbytes} / 2 )) bytes (no rustc/clang in this compute)"
+echo "  arm64 bytes: $hbytes"
+
+echo "$hex" | xxd -r -p > "$work/recipe.o"
+echo "Form-emitted Mach-O object: $(wc -c < "$work/recipe.o" | tr -d ' ') bytes, $(file "$work/recipe.o" | sed 's/^[^:]*: //')"
+echo "  exported symbol: $(nm "$work/recipe.o" 2>/dev/null | tr -s ' ')"
+
+# ld -dylib links + ad-hoc signs (no clang) — the recipe-dylib path.
+SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$work/recipe.dylib" "$work/recipe.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null \
+   || { echo "FAIL: ld -dylib"; exit 1; }
+echo "ld -dylib + ad-hoc sign: $(codesign -dv "$work/recipe.dylib" 2>&1 | grep -E '^CodeDirectory' | sed 's/ hashes.*//')"
+echo
+
+# The dumb loader: dlopen, cast _recipe to the horner ABI, call with real scalars.
+cat > "$work/harness.c" <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+typedef double (*h_fn)(double x);
+static int check(h_fn h, const char *name, double x) {
+    /* reference: the SAME fused multiply-adds the recipe folds — so == not epsilon-close */
+    double expect = fma(fma(2.0, x, 3.0), x, 4.0);
+    double got = h(x);
+    int ok = (got == expect);
+    printf("EXEC %-8s x=%-12g got=%.17g expected=%.17g %s\n", name, x, got, expect, ok ? "MATCH" : "FAIL");
+    return ok;
+}
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen fail: %s\n", dlerror()); return 2; }
+    h_fn p = (h_fn)dlsym(h, "recipe");      /* leading _ stripped by dlsym */
+    if (!p) { fprintf(stderr, "dlsym fail: %s\n", dlerror()); return 3; }
+    int all = 1;
+    all &= check(p, "0.0",   0.0);        /* p(0) = 4 */
+    all &= check(p, "1.0",   1.0);        /* p(1) = 2+3+4 = 9 */
+    all &= check(p, "2.0",   2.0);        /* p(2) = 8+6+4 = 18 */
+    all &= check(p, "-1.0", -1.0);        /* p(-1) = 2-3+4 = 3 */
+    all &= check(p, "0.5",   0.5);        /* p(0.5) = 0.5+1.5+4 = 6 */
+    all &= check(p, "1e8",   1e8);        /* fp stress: large -> 2e16-ish */
+    all &= check(p, "1e-8",  1e-8);       /* fp stress: small -> ~4 with tiny tail */
+    all &= check(p, "0.1",   0.1);        /* irrational binary -> full mantissa fold */
+    dlclose(h);
+    return all ? 0 : 1;
+}
+EOF
+clang -o "$work/harness" "$work/harness.c" -lm || { echo "FAIL: harness build"; exit 1; }
+
+"$work/harness" "$work/recipe.dylib"; rc=$?
+echo
+if [[ "$rc" == "0" ]]; then
+    echo "WITNESS: the Form-emitted Horner polynomial ((2x+3)x+4) RUNS and MATCHES on $(uname -m)."
+    echo "  fam-horner2's 24 bytes (form-asm, four-way) -> form-macho .o -> ld -dylib -> dlopen+call."
+    echo "  The first fa-fmadd on the witnessed lane; Horner-over-fmadd is the eval engine of every transcendental."
+else
+    echo "WITNESS FAIL (rc=$rc): the emitted program did not match the reference."
+fi
+exit $rc


### PR DESCRIPTION
## The brick

The next nonlinear rung on the LLM-inference **native asm lane** after fam-rsqrt ([#3835](https://github.com/seeker71/Coherence-Network/pull/3835)). Where rsqrt opened the first float constant + first `fdiv`, this opens the first **`fa-fmadd`** (fused multiply-add) — and **Horner-over-fmadd is the literal eval engine of every transcendental still to come**: `exp`/`sin`/`cos`/`gelu` on the native lane are all polynomial (or rational) approximations, and Horner folds a degree-n poly into n fused multiply-adds (one rounding each).

## What landed

- **`fa-fmadd` encoder** (`form-asm.fk`): `fmadd d<rd>,d<rn>,d<rm>,d<ra>`, base `0x1F400000 | rm<<16 | ra<<10 | rn<<5 | rd`. One hardware op = one rounding, byte-distinct from `fmul`-then-`fadd` — the form clang fuses every dot/Horner step to (the deferred *"clang fuses that to fmadd"* from the rsqrt note).
- **`fam-horner2` recipe** (`form-asm-matvec.fk`): `p(x)=((2x+3)x+4)`, 6 instrs / 24 bytes, coefficients via the proven `fa-fmov-imm` (2.0=imm8 0, 3.0=8, 4.0=16). ABI `d0 → d0`.
- **Band `form-asm-horner` → verdict 31**, Go=Rust=TS=fkwu, **0 divergent**, byte-exact vs the clang -O2 oracle for `__builtin_fma(__builtin_fma(2,x,3),x,4)`.
- **Hardware witness on M4 Max: 8/8 bit-exact**, no rustc/clang in the compute (form-macho `.o` → `ld -dylib` → `dlopen`+call).
- **No regression**: form-asm-rsqrt (31) / ss-sqrt (127) / matvec-2d (127) all still cross four-way after the shared-file edits.

## Proof

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk \
  form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-horner-band.fk
#  → 31   1 ok, 0 divergent — kernels agree on every sample.
bash scripts/form_asm_horner_witness.sh
#  EXEC ... MATCH ×8  →  WITNESS: the Form-emitted Horner polynomial RUNS and MATCHES on arm64.
```

Manifest row (`form-asm-horner fks 31`) + scripts INDEX + commit evidence land in the same commit.
Receipt: `docs/system_audit/commit_evidence_2026-06-29_form_asm_horner.json`

Next named rung (`form-native-models.form`): a **constant pool** — real exp/sin coefficients (1/6, 1/120) are not VFP-immediate-expressible, so they load from a literal pool via `ldr-d` off a base register — then `exp` (range reduction + higher-degree Horner over the pool), `sin`/`cos` (RoPE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)