### PR TITLE
tend(form): four-way-run — the kernel orchestrates its own four-way (no bash)

### DIFF
--- a/form/form-stdlib/four-way-run.fk
+++ b/form/form-stdlib/four-way-run.fk
@@ -1,0 +1,7 @@
+; four-way-run.fk — the kernel's own four-way RUNNER: host-exec the three minimal walkers on a recipe,
+; parse their values, and diagnose with four-way-verdict. fkwu orchestrates its own proof -- no bash, no validate.sh.
+; fkwu-native (host-exec); the verdict logic it feeds is four-way. preludes: form-stdlib/core.fk form-stdlib/four-way-verdict.fk
+(do
+    (defn fr-run (cmd) (str_to_int (host-exec cmd "")))
+    (defn fr-diagnose (gocmd rustcmd tscmd fkwu-v)
+        (fwv-verdict (fr-run gocmd) (fr-run rustcmd) (fr-run tscmd) fkwu-v)))


### PR DESCRIPTION
fkwu host-execs the three minimal walkers + diagnoses via four-way-verdict. Witnessed: a pure recipe (=42) -> all three walkers 42 -> runner returns 0 (four-way). The kernel proves four-way itself, no bash/validate.sh/origin. fkwu-native (host-exec).