### PR TITLE
tend(form): form-eval-cli-loop — the standing read-eval-print loop on fkwu

### DIFF
--- a/form/form-stdlib/form-eval-cli-loop.fk
+++ b/form/form-stdlib/form-eval-cli-loop.fk
@@ -1,0 +1,42 @@
+; form-eval-cli-loop.fk — the STANDING read-eval-print loop on the emitted walker (fkwu).
+;
+; The single-file runner (form-eval-cli.fk's fec-read) reads ONE expression from staged input and
+; evaluates it once. This is the interactive loop: read a line, eval it, print the value, recurse to
+; the next line, until EOF. It is the live shape of a REPL over staged input — pipe N expression lines
+; into fkwu's input_byte channel (argv[3] / fk_src) and get N values back, one per line, in order.
+;
+;   line i      = is-line i            — the bytes of the line at byte i, up to '\n' or NUL (input-stream.fk)
+;   next i      = is-next i            — the byte index just past that line's '\n' (or at NUL)
+;   eval line   = fef-eval line        — the FULL grammar tree-walk (do/let/defn/user-calls/if/binops),
+;                                        evaluated AS read with no flatten table (form-eval-full.fk)
+;   print value = print_str (...)      — write the rendered value + newline to fd 1 (walker tag 115)
+;
+; The read+next pair rides input-stream.fk's bounded-depth line readers (recursion bounded by LINE
+; length, never the whole input — the O(n^2) char-accumulate reader stack-overflows on large input).
+; The eval it rides (fef-eval) is four-way proven (tests/form-eval-full-band.fk). Blank lines (e.g. the
+; empty final line after a trailing newline) are skipped so a clean transcript stays clean.
+;
+; fkwu-NATIVE: input_byte (tag 17) and print_str (tag 115) are the staged-input + output ops only the
+; emitted universal walker carries — they are not in the three host walkers. The proof is the native run
+; (fkwu <table> 0 <input-file>), not a four-way band: the loop is the host-io shell, the eval underneath
+; it is the four-way recipe.
+;
+; preludes: form-stdlib/core.fk form-stdlib/input-stream.fk form-stdlib/form-eval-full.fk
+(do
+    ; render one line's value: evaluate the line's source through the full grammar, render to text,
+    ; append a newline, and print it. Returns the printed string (value of this step).
+    (defn fecl-emit (line)
+        (print_str (str_concat (int_to_str (fef-eval line)) "\n")))
+
+    ; the loop: read the line starting at byte i. At EOF (input_byte i = 0) stop. Skip an empty line
+    ; (str_len 0 — a blank or the trailing-newline tail) without evaluating; otherwise eval+print it.
+    ; Either way recurse to the next line (is-next i). Recursion is bounded by LINE COUNT, tail-position.
+    (defn fecl-loop (i)
+        (if (eq (input_byte i) 0) 0
+            (do (let line (is-line i))
+                (if (eq (str_len line) 0) 0 (fecl-emit line))
+                (fecl-loop (is-next i)))))
+
+    ; entry: read-eval-print from the first staged byte to EOF.
+    (defn fecl-repl () (fecl-loop 0))
+    (fecl-repl))


### PR DESCRIPTION
Grows `form-eval-cli` from a single-file source-runner into a STANDING interactive read-eval-print loop on the c-bootstrapped `fkwu` kernel.

## The recipe (`form/form-stdlib/form-eval-cli-loop.fk`)

A recursive loop that reads one line, evaluates it through the full grammar, prints the value, and recurses to the next line until EOF:

- **read** — `is-line i` / `is-next i` (`input-stream.fk`): bounded-depth line readers (recursion bounded by LINE length, never the whole input — the naive char-accumulate reader stack-overflows on large input).
- **eval** — `fef-eval` (`form-eval-full.fk`): the full grammar tree-walk — `do`/`let`/`defn`/user-calls/`if`/binops — four-way proven by `tests/form-eval-full-band.fk`.
- **print** — `print_str` (walker tag 115): the REPL print step.
- EOF on `input_byte i = 0`; blank lines (the trailing-newline tail) skipped.

fkwu-native: `input_byte` (tag 17) and `print_str` (tag 115) are the staged-input + output ops only the emitted universal walker carries. **The proof is the native run, not a four-way band** — the loop is the host-io shell; the eval underneath it is the four-way recipe.

## Native witness — `fkwu <table> 0 <input-file>`

Three expression lines staged into the input_byte channel:

```
(add 40 2)                 -> 42
(do (let x 10) (mul x x))  -> 100
(if (le 3 5) 99 0)         -> 99
```

Each line evaluates to the right value, **in order**. An 8-line transcript (`2 4 6 16 9 6 56 123`) and a user-defn call (`(defn sq (n) (mul n n)) (sq 7) -> 49`) also pass.

## Honest gap

Deep user recursion inside one line (e.g. `fib 10`) hits fkwu's default stack (SIGSEGV) — a stage/stack limit of the raw invocation, not the loop. The loop's own per-line recursion is bounded by line count and stays healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)