### PR TITLE
tend(form): text-normalize — integer→words BEFORE g2p, locale-as-data

### DIFF
--- a/form/form-stdlib/tests/text-normalize-band.fk
+++ b/form/form-stdlib/tests/text-normalize-band.fk
@@ -1,0 +1,37 @@
+; text-normalize-band.fk — four-way proof that integer -> words normalizes
+; identically on Go, Rust, TS, and fkwu, driven by the en locale-as-DATA
+; vocabulary in text-normalize.fk (the layer before g2p on the voice path).
+;
+; Each case asserts the engine's word string against the expected en surface via
+; str_eq (the string-membership/nl-emit verdict pattern — string results verify by
+; equality and fold to one stable integer). A weighted sum makes kernel agreement a
+; single number; any digit→word divergence (div/mod/nth/str_concat across kernels)
+; shifts the total, so the bit-for-byte four-way is the proof the layer is sound.
+;
+; Cases span every magnitude boundary the engine recurses across:
+;   0      -> "zero"                                  (the standalone zero word)
+;   7      -> "seven"                                 (ones)
+;   19     -> "nineteen"                              (teens, the 10..19 table)
+;   42     -> "forty-two"                             (tens + join + ones)
+;   100    -> "one hundred"                           (exact hundred, no remainder)
+;   105    -> "one hundred five"                      (hundred + space + ones)
+;   999    -> "nine hundred ninety-nine"              (hundred + tens + join + ones)
+;   1000   -> "one thousand"                          (exact thousand, no remainder)
+;   12345  -> "twelve thousand three hundred forty-five"  (thousands group + 3-digit)
+;
+; preludes: form-stdlib/text-normalize.fk
+
+(do
+    (defn case (n expected weight)
+        (if (str_eq (tn-en n) expected) weight 0))
+
+    ;; Expected total = 1+2+4+8+16+32+64+128+256 = 511
+    (add (case 0 "zero" 1)
+    (add (case 7 "seven" 2)
+    (add (case 19 "nineteen" 4)
+    (add (case 42 "forty-two" 8)
+    (add (case 100 "one hundred" 16)
+    (add (case 105 "one hundred five" 32)
+    (add (case 999 "nine hundred ninety-nine" 64)
+    (add (case 1000 "one thousand" 128)
+         (case 12345 "twelve thousand three hundred forty-five" 256))))))))))

--- a/form/form-stdlib/text-normalize.fk
+++ b/form/form-stdlib/text-normalize.fk
@@ -1,0 +1,97 @@
+; text-normalize.fk — the named missing first-class layer BEFORE g2p on the voice
+; path. g2p assumes clean graphemes; numbers, acronyms, punctuation, heteronyms,
+; and loanwords need explicit data first. This is the smallest honest step on that
+; path: integer -> words (42 -> "forty-two", 105 -> "one hundred five",
+; 1000 -> "one thousand"), with LOCALE-AS-DATA — the one-engine pattern the rest of
+; the voice/i18n body already holds (i18n.fk locale-pairs, nl-emit-all over
+; (list (list "en" en-recipe) ...)). The number-word vocabulary IS data; the
+; normalization engine is ONE recipe that walks any locale. en is the first locale
+; instance; de/es/fr/id/pt-br drop in as more data rows, never parallel code.
+;
+; The locale recipe is an association list of named vocabulary sections:
+;   ("zero" <word>)            — the word for 0
+;   ("ones" <list of 0..9>)    — index 0 unused ("") , 1..9 the digit words
+;   ("teens" <list of 10..19>) — index 0 = ten, 1 = eleven, ... 9 = nineteen
+;   ("tens"  <list of 0..9>)   — index 2 = twenty ... 9 = ninety (0,1 unused)
+;   ("hundred" <word>)         — the scale word for 100
+;   ("thousand" <word>)        — the scale word for 1000
+;   ("join" <sep>)             — separator between tens-word and ones-word (en: "-")
+;   ("space" <sep>)            — separator between groups (en: " ")
+;
+; Engine recipe family (locale passed as first arg everywhere — locale is data):
+;   tn-vocab        — assoc lookup of a named section in the locale
+;   tn-2digit       — 0..99  -> words   (ones / teens / tens[+join+ones])
+;   tn-3digit       — 0..999 -> words   (hundreds [+space+ tn-2digit])
+;   int->words      — 0..999999 -> words (thousands group [+space+ tn-3digit])
+;
+; Self-contained over core (div, mod, nth, str_concat, str_eq — all four-way on
+; fkwu per fourth-shim.fk). Four-way proven by tests/text-normalize-band.fk.
+;
+; preludes: form-stdlib/core.fk
+
+(do
+    ;; ── locale-as-data: the en number-word vocabulary ──────────────
+    ;; One row per section; index discipline matches the engine's lookups.
+    (defn tn-locale-en ()
+        (list
+            (list "zero" "zero")
+            (list "ones" (list "" "one" "two" "three" "four" "five" "six" "seven" "eight" "nine"))
+            (list "teens" (list "ten" "eleven" "twelve" "thirteen" "fourteen" "fifteen" "sixteen" "seventeen" "eighteen" "nineteen"))
+            (list "tens" (list "" "" "twenty" "thirty" "forty" "fifty" "sixty" "seventy" "eighty" "ninety"))
+            (list "hundred" "hundred")
+            (list "thousand" "thousand")
+            (list "join" "-")
+            (list "space" " ")))
+
+    ;; ── the engine: locale is the first argument everywhere ────────
+    ;; tn-vocab — assoc lookup of a named section in the locale recipe.
+    (defn tn-vocab (loc name)
+        (if (eq (len loc) 0) ""
+            (if (str_eq (head (head loc)) name)
+                (head (tail (head loc)))
+                (tn-vocab (tail loc) name))))
+
+    ;; tn-2digit — 0..99 -> words.
+    (defn tn-2digit (loc n)
+        (if (lt n 10)
+            (nth (tn-vocab loc "ones") n)
+            (if (lt n 20)
+                (nth (tn-vocab loc "teens") (sub n 10))
+                (do
+                    (let t (nth (tn-vocab loc "tens") (div n 10)))
+                    (let o (mod n 10))
+                    (if (eq o 0) t
+                        (str_concat t (str_concat (tn-vocab loc "join") (nth (tn-vocab loc "ones") o))))))))
+
+    ;; tn-3digit — 0..999 -> words. Hundreds prefix + space + remainder.
+    (defn tn-3digit (loc n)
+        (if (lt n 100)
+            (tn-2digit loc n)
+            (do
+                (let h (div n 100))
+                (let r (mod n 100))
+                (let head-words
+                    (str_concat (nth (tn-vocab loc "ones") h)
+                        (str_concat (tn-vocab loc "space") (tn-vocab loc "hundred"))))
+                (if (eq r 0) head-words
+                    (str_concat head-words
+                        (str_concat (tn-vocab loc "space") (tn-3digit loc r)))))))
+
+    ;; int->words — 0..999999 -> words. Thousands group + space + 3-digit remainder.
+    ;; Zero is its own word; the recursive arms never emit "zero" mid-number.
+    (defn int->words (loc n)
+        (if (eq n 0) (tn-vocab loc "zero")
+            (if (lt n 1000) (tn-3digit loc n)
+                (do
+                    (let th (div n 1000))
+                    (let r (mod n 1000))
+                    (let head-words
+                        (str_concat (tn-3digit loc th)
+                            (str_concat (tn-vocab loc "space") (tn-vocab loc "thousand"))))
+                    (if (eq r 0) head-words
+                        (str_concat head-words
+                            (str_concat (tn-vocab loc "space") (tn-3digit loc r))))))))
+
+    ;; Convenience: normalize an integer in the en locale.
+    (defn tn-en (n) (int->words (tn-locale-en) n))
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1161,3 +1161,4 @@ voice-phrasing fks 11111
 form-eval-full fks 131
 md-grammar fks 7
 four-way-verdict fks 11111
+text-normalize fks 511


### PR DESCRIPTION
## text-normalize — the named missing layer before g2p

Per the voice roadmap: text-normalize must run BEFORE g2p, because g2p assumes clean graphemes. This is the smallest honest step on that path — **integer → words** for en — built as **one engine over locale-as-DATA**, the same pattern the i18n/voice body already holds (`nl-emit-all` over `(list (list "en" recipe) ...)`).

### Shape (locale-as-data, one engine)
`text-normalize.fk`:
- **Locale = data**: an association list of named vocabulary sections — `zero`, `ones`, `teens`, `tens`, `hundred`, `thousand`, `join`, `space`. `tn-locale-en` is the first locale instance; de/es/fr/id/pt-br drop in as more data rows, never parallel code paths.
- **Engine = one recipe family**: `tn-vocab` (assoc lookup) → `tn-2digit` (0–99) → `tn-3digit` (0–999) → `int->words` (0–999999). Locale is the first argument everywhere.

Examples: `42 → "forty-two"`, `105 → "one hundred five"`, `1000 → "one thousand"`, `12345 → "twelve thousand three hundred forty-five"`.

### Four-way proof
`tests/text-normalize-band.fk` asserts nine cases across every magnitude boundary via `str_eq`, folded to a weighted sum.

```
✓  core.fk+text-normalize.fk+text-normalize-band.fk  → 511
fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
1 ok, 0 divergent — kernels agree on every sample.
```

Go = Rust = TS = fkwu = **511**. Self-contained over core (`div`/`mod`/`nth`/`str_concat`/`str_eq` — all four-way on fkwu per `fourth-shim.fk`). Manifest row: `text-normalize fks 511`.

Note: an initial run showed the TS walker rejecting a surplus-paren in the band (strict reader; Go/Rust/fkwu tolerated it). Root-caused to a paren imbalance in the test, fixed — not a kernel-logic divergence. All four now agree byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)