### PR TITLE
tend(form): cell-card — any cell → recursive card{identity,facets,open-channels}

### DIFF
--- a/form/form-stdlib/cell-card.fk
+++ b/form/form-stdlib/cell-card.fk
@@ -1,0 +1,84 @@
+; cell-card.fk — the render engine the whole living-mesh GUI rests on (living-mesh.form step 1).
+;
+; ONE recipe: any cell -> a CARD = { identity, facets, open-channels }, where the card is RECURSIVE
+; — each open-channel names another cell you can open into its own card. The card-TYPES
+; (where / what / when / concepts / siblings / attribution / self-image / …) are FACET DATA on the
+; cell, NEVER parallel card recipes. One engine; a new card-type is a facet ROW, not code.
+;
+; A cell, as this engine reads it, is uniform data:
+;   cell = (id, name, facets, channels)
+;     id       — the cell's address (a string slug here; a NodeID at the host carrier)
+;     name     — its display name
+;     facets   — a list of facet rows (key, card-type, value). card-type is DATA: "where"/"what"/…
+;     channels — a list of OPEN cross-cell-interface rows toward other cells. Each carries the
+;                target cell-ref, so the card is openable -> recursion: open a channel -> render that
+;                cell's card. The five ways a cell reaches another (sense/ask/share/learn/build) are
+;                cross-cell-interface ROWS read by ONE engine (cross-cell-interface.fk); the open-
+;                channels of a card ARE those rows, each bound to a target.
+;
+; The card the engine produces is itself uniform structured data — (identity, facets, channels) —
+; so a carrier (GUI) renders ANY card with one renderer, and recursion is just: take a channel's
+; target cell and run cc-card on it again. No card is special-cased; a new face is a facet row.
+;
+; Self-contained over core (list traversal) + the channel tissue (channel-interface modes via
+; cross-cell-interface rows). Four-way by tests/cell-card-band.fk.
+;
+; preludes: form-stdlib/core.fk form-stdlib/channel-interface.fk form-stdlib/cross-cell-interface.fk
+
+(do
+    ; ── the cell shape (uniform data; constructors + readers) ───────────────
+    (defn cell-make (id name facets channels) (list id name facets channels))
+    (defn cell-id       (c) (nth c 0))
+    (defn cell-name     (c) (nth c 1))
+    (defn cell-facets   (c) (nth c 2))
+    (defn cell-channels (c) (nth c 3))
+
+    ; ── a FACET row = (key, card-type, value). card-type is DATA, never code. ─
+    ; A new card-type (where/what/when/concepts/siblings/attribution/self-image/…) is just another
+    ; value in the type slot of a facet row — the engine never branches on it.
+    (defn facet-make (key card-type value) (list key card-type value))
+    (defn facet-key   (f) (nth f 0))
+    (defn facet-type  (f) (nth f 1))
+    (defn facet-value (f) (nth f 2))
+
+    ; ── an OPEN CHANNEL = a cross-cell-interface row bound to a TARGET cell-ref.
+    ; (verb mode payload merges target) — the first four are exactly a cci-row (the five ways a cell
+    ; reaches another); the fifth is the target cell-ref that makes the card openable -> recursion.
+    (defn open-channel (verb target)
+        (do
+            (let row (cci-find (cci-registry) verb))
+            (list (cci-row-verb row) (cci-row-mode row) (cci-row-payload row) (cci-row-merges row) target)))
+    (defn channel-verb   (ch) (nth ch 0))
+    (defn channel-mode   (ch) (nth ch 1))
+    (defn channel-target (ch) (nth ch 4))   ; the cell-ref you OPEN into -> recursion
+
+    ; ── THE ONE ENGINE: cell -> card. card = (identity, facets, channels). ──
+    ; identity = (id, name); facets = the cell's facet rows verbatim (each carrying its card-type as
+    ; data); channels = the cell's open cross-cell-interface rows verbatim (each carrying a target).
+    (defn cc-identity (cell) (list (cell-id cell) (cell-name cell)))
+    (defn cc-facets   (cell) (cell-facets cell))
+    (defn cc-channels (cell) (cell-channels cell))
+
+    (defn cc-card (cell)
+        (list (cc-identity cell) (cc-facets cell) (cc-channels cell)))
+
+    ; ── card readers (a carrier renders ANY card through these) ─────────────
+    (defn card-identity (card) (nth card 0))
+    (defn card-facets   (card) (nth card 1))
+    (defn card-channels (card) (nth card 2))
+    (defn card-id   (card) (nth (card-identity card) 0))
+    (defn card-name (card) (nth (card-identity card) 1))
+    (defn card-facet-count   (card) (len (card-facets card)))
+    (defn card-channel-count (card) (len (card-channels card)))
+
+    ; the count of facets of a given card-type — proves card-types are queryable DATA, not branches
+    (defn cc-facets-of-type (facets card-type)
+        (if (eq (len facets) 0) 0
+            (add (if (str_eq (facet-type (head facets)) card-type) 1 0)
+                 (cc-facets-of-type (tail facets) card-type))))
+
+    ; ── RECURSION: open a channel -> the target cell-ref you render next ─────
+    ; The carrier calls cc-card on the resolved target; here the openable handle is the target ref.
+    (defn cc-open (channel) (channel-target channel))
+
+    0)

--- a/form/form-stdlib/tests/cell-card-band.fk
+++ b/form/form-stdlib/tests/cell-card-band.fk
@@ -1,0 +1,36 @@
+; tests/cell-card-band.fk — the render engine the living-mesh GUI rests on, four-way.
+; preludes: form-stdlib/core.fk form-stdlib/channel-interface.fk form-stdlib/cross-cell-interface.fk form-stdlib/cell-card.fk
+;
+; Verdict 111111: a sample cell -> its card has the right IDENTITY (id+name), the right FACET COUNT (3),
+; the right number of facets of a given CARD-TYPE read as DATA ("where" appears once), the right OPEN-
+; CHANNEL COUNT (2), an open-channel that carries its TARGET cell-ref (recursion is real — you can open
+; into it), and the channel's consent MODE resolved from the cross-cell-interface registry (sense ->
+; m-witness=1). One engine; card-types are facet data; the card is recursive.
+(do
+    ; a sample cell: a place-cell "hati-suci", three facets across THREE card-types (where/what/concepts),
+    ; two open channels (sense it; ask it) each bound to a target cell-ref you can open into.
+    (defn sample-cell ()
+        (cell-make "hati-suci" "Hati Suci"
+            (list
+                (facet-make "lat-lon"  "where"    "-8.51,115.26")
+                (facet-make "kind"     "what"     "gathering-place")
+                (facet-make "resonance" "concepts" "lc-arrival-as-recognition"))
+            (list
+                (open-channel "sense" "sensor-organ-channel")   ; sense the room's reading -> openable cell
+                (open-channel "ask"   "place-sense"))))          ; ask WHERE -> openable cell
+
+    (defn ccb (cond bit) (if cond bit 0))
+    (defn cell-card-band-check ()
+        (do
+            (let card (cc-card (sample-cell)))
+            (add (add (add (add (add
+                (ccb (and (str_eq (card-id card) "hati-suci")
+                          (str_eq (card-name card) "Hati Suci")) 1)            ; identity = id+name
+                (ccb (eq (card-facet-count card) 3) 10))                        ; the right facet count
+                (ccb (eq (cc-facets-of-type (card-facets card) "where") 1) 100)); card-type read as DATA
+                (ccb (eq (card-channel-count card) 2) 1000))                    ; the right open-channel count
+                (ccb (str_eq (cc-open (head (card-channels card)))
+                             "sensor-organ-channel") 10000))                    ; recursion: channel carries its target
+                (ccb (eq (channel-mode (head (card-channels card))) (m-witness)) 100000)))) ; mode from cci registry
+
+    (cell-card-band-check))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1163,3 +1163,4 @@ form-eval-full fks 131
 md-grammar fks 7
 four-way-verdict fks 11111
 text-normalize fks 511
+cell-card fks 111111


### PR DESCRIPTION
**Stone:** `cell-card` — living-mesh step 1, the render engine the whole GUI rests on.

ONE recipe `cc-card(cell)` → a CARD = `(identity, facets, open-channels)`, **recursive**: each open-channel carries a target cell-ref you open into its own card.

- **Discipline (core-abstraction-first):** card-TYPES (`where`/`what`/`when`/`concepts`/`siblings`/`attribution`/`self-image`/…) are **facet DATA** on the cell, never parallel card recipes. A new card-type is a facet row, not code. `cc-facets-of-type` reads the type as data — the engine never branches on it.
- **Open-channels ARE cross-cell-interface rows** (`sense`/`ask`/`share`/`learn`/`build`) bound to a target cell-ref, resolved from the `cci-registry` — the five ways a cell reaches another, read by the one engine. The target ref is the recursion handle (`cc-open`).
- Self-contained over `core` + `channel-interface` + `cross-cell-interface`.

**Four-way:** `core.fk+core.fk+channel-interface.fk+cross-cell-interface.fk+cell-card.fk+cell-card-band.fk → 111111` · `fourth arm: 1 band(s) four-way` · **0 divergent**.

Sample cell `hati-suci`: 3 facets across 3 card-types (where/what/concepts), 2 open channels (sense→sensor-organ-channel, ask→place-sense) each openable. Verdict bits prove identity, facet count, card-type-as-data, channel count, recursion target, and consent mode from the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)