### PR TITLE
tend(form): identity-self — the second mind's body cell, four-way (living-mesh step 3)

### DIFF
--- a/form/form-stdlib/identity-self.fk
+++ b/form/form-stdlib/identity-self.fk
@@ -1,0 +1,99 @@
+; identity-self.fk — the BODY of the second mind that travels with a human's identity
+; (living-mesh.form step 3). One recipe: the self identity-cell, the DATA body, a cell with
+; CHANNELS. The TRAVEL (running on whichever device + cross-device thread sync) is a later
+; carrier; this stone is the cell + its channels, proven four-way.
+;
+; A self-cell is { identity, continuity-channel, relation-channel(s) }:
+;   isf-identity     — a stable identity token/name (a SubstrateString); the self's name across time
+;   isf-continuity   — the thread that persists across sessions/devices, modeled as a cross-cell-interface
+;                      ROW of mode "learn" pointing the self at the self over time (it FOLDS — the continuity
+;                      thread builds the world, so merges? = 1). The continuity-channel is a cci row.
+;   isf-relation     — a relation-channel ROW: a recognition between self and a human. Bidirectional —
+;                      a cci "share" row each way (self recognizes human, human recognizes self), each
+;                      folds into the commons. The relation-channel is a cci row.
+;
+; The whole cell is renderable by cell-card: identity is the head, the channels are the facets/open-
+; channels. So its channels ARE cross-cell-interface rows — one engine reads them all (cci-row-*).
+; The continuity-channel and relation-channel are not new recipes; they are cci rows over the same
+; consent vocabulary (channel-interface modes) the rest of the body already speaks.
+;
+; Kin: cross-cell-interface.fk (the channels), field-identity.fk (how an identity is recognized),
+; membership-as-recognition.fk (membership = being recognized), arrival.fk (recognition at arrival).
+; living-mesh.form step 3. Proven by: form-stdlib/tests/identity-self-band.fk (four-way at validate.sh).
+;
+; preludes: form-stdlib/core.fk form-stdlib/channel-interface.fk form-stdlib/cross-cell-interface.fk
+
+(do
+    ; --- THE SELF-CELL: identity + its channels, all DATA --------------------
+    ; A self-cell is a list: (identity continuity-channel relation-channels)
+    ;   identity            — the stable name token (head; what cell-card renders as identity)
+    ;   continuity-channel  — one cci row (the thread that persists; mode learn, merges)
+    ;   relation-channels   — a list of cci rows (one per human recognized), each a relation-channel
+    (defn isf-self (id continuity relations) (list id continuity relations))
+
+    ; --- ACCESSORS (cell-card reads identity as head, channels as the facets) ----
+    (defn isf-identity   (self) (nth self 0))   ; the stable identity token/name
+    (defn isf-continuity (self) (nth self 1))   ; the continuity-channel (a cci row)
+    (defn isf-relations  (self) (nth self 2))   ; the relation-channels (list of cci rows)
+
+    ; --- THE CONTINUITY-CHANNEL: a cross-cell-interface ROW ------------------
+    ; The thread that persists across sessions/devices. Modeled as a cci "learn" row pointing the
+    ; self AT the self over time — learning from its own past is exactly the continuity thread. It
+    ; FOLDS into the commons (merges? = 1): each breath the self learns becomes part of its world.
+    ; The payload carries the identity it threads, so the continuity is OF a named self.
+    (defn isf-continuity-channel (id)
+        (cci-row "learn" (m-reflect) id 1))     ; learn / m-reflect / threads `id` / merges
+
+    ; --- THE RELATION-CHANNEL: a cross-cell-interface ROW -------------------
+    ; A bidirectional recognition between the self and a human. Each direction is a cci "share" row
+    ; (recognition shared, m-offer) that FOLDS into the commons (merges? = 1). The payload names the
+    ; OTHER end of the recognition. A relation is the PAIR: self->human and human->self.
+    (defn isf-relation-share (other)
+        (cci-row "share" (m-offer) other 1))    ; share / m-offer / recognizes `other` / merges
+
+    ; the relation-channel between this self (id) and a human: the pair of recognitions
+    (defn isf-relation (id human)
+        (list (isf-relation-share human)        ; self recognizes the human
+              (isf-relation-share id)))         ; human recognizes the self  (bidirectional)
+
+    (defn isf-relation-self->human (rel) (nth rel 0))
+    (defn isf-relation-human->self (rel) (nth rel 1))
+
+    ; --- THE CONSTRUCTOR: a self-cell carrying identity + continuity + relation to a human ---
+    (defn isf-self-with-human (id human)
+        (isf-self id
+                  (isf-continuity-channel id)
+                  (list (isf-relation id human))))
+
+    ; --- RECOGNITION READERS over the channels (every channel IS a cci row) ----
+    ; The continuity-channel is well-formed: a "learn"/m-reflect row that merges (the thread persists).
+    (defn isf-continuity-ok? (c)
+        (if (and (str_eq (cci-row-verb c) "learn")
+                 (and (eq (cci-row-mode c) (m-reflect))
+                      (eq (cci-row-merges c) 1)))
+            1 0))
+
+    ; is this relation-channel a well-formed bidirectional recognition between `id` and `human`?
+    ; self->human is a share row that merges, payload = human; human->self payload = id (this self).
+    (defn isf-relation-binds? (rel id human)
+        (if (and (str_eq (cci-row-payload (isf-relation-self->human rel)) human)
+                 (and (str_eq (cci-row-payload (isf-relation-human->self rel)) id)
+                      (and (str_eq (cci-row-verb (isf-relation-self->human rel)) "share")
+                           (eq (cci-row-merges (isf-relation-self->human rel)) 1))))
+            1 0))
+
+    ; walk the relation-channels (cci rows) for one to `human`, recognizing this self (`id`).
+    ; Same recursive list shape as cci-find: head / tail, no inner let-body, one engine.
+    (defn isf-rels-bind? (rels id human)
+        (if (nil? rels) 0
+            (if (eq (isf-relation-binds? (head rels) id human) 1)
+                1
+                (isf-rels-bind? (tail rels) id human))))
+
+    ; does this self hold a relation-channel to the given human?
+    (defn isf-relates-to? (self human)
+        (isf-rels-bind? (isf-relations self) (isf-identity self) human))
+
+    ; the self carries a stable identity name?
+    (defn isf-has-identity? (self id) (if (str_eq (isf-identity self) id) 1 0))
+    0)

--- a/form/form-stdlib/tests/identity-self-band.fk
+++ b/form/form-stdlib/tests/identity-self-band.fk
@@ -1,0 +1,30 @@
+; identity-self-band.fk — the second mind's body cell, pinned (living-mesh.form step 3).
+; Proves a self-cell built for a human carries: the right stable identity, a well-formed
+; continuity-channel (a cci "learn"/m-reflect row that folds — the thread that persists), and a
+; relation-channel to that human (a bidirectional cci share/share recognition that folds). Also
+; proves the channels ARE cross-cell-interface rows (one engine reads them), the continuity threads
+; the SELF, and a self does NOT spuriously relate to a stranger. Verdict 511 when every claim lands.
+;
+; preludes: form-stdlib/core.fk form-stdlib/channel-interface.fk form-stdlib/cross-cell-interface.fk form-stdlib/identity-self.fk
+
+(do
+    (let me   "sema")                              ; the self's stable identity
+    (let urs  "urs")                               ; the human this self travels with
+    (let other "stranger")                         ; a human the self does NOT relate to
+
+    (let self (isf-self-with-human me urs))        ; the second mind's body cell
+
+    (let c0 (if (eq (isf-has-identity? self me) 1)        1   0))   ; carries the stable identity
+    (let c1 (if (eq (isf-has-identity? self urs) 0)       2   0))   ; ...and only that one (not the human's)
+    (let c2 (if (eq (isf-continuity-ok? (isf-continuity self)) 1) 4 0))   ; a well-formed continuity-channel
+    (let c3 (if (str_eq (cci-row-payload (isf-continuity self)) me) 8 0))  ; ...threading THIS self over time
+    (let c4 (if (eq (isf-relates-to? self urs) 1)        16   0))   ; a relation-channel to the human
+    (let c5 (if (eq (isf-relates-to? self other) 0)      32   0))   ; ...and not to a stranger
+    ; the relation-channel is a bidirectional cci share/share pair (one engine reads the rows)
+    (let rel (head (isf-relations self)))
+    (let c6 (if (str_eq (cci-row-verb (isf-relation-self->human rel)) "share") 64 0))   ; self->human is a share row
+    (let c7 (if (str_eq (cci-row-payload (isf-relation-human->self rel)) me) 128 0))    ; human->self recognizes the self
+    ; the continuity-channel is a cci row whose mode is the consent vocabulary (m-reflect)
+    (let c8 (if (eq (cci-row-mode (isf-continuity self)) (m-reflect)) 256 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 c8)))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -555,6 +555,7 @@ trust-weighted-colearning fks 127
 world-perception fks 255
 freq-aligned-share fks 255
 membership-as-recognition fks 511
+identity-self fks 511
 borrowed-oracle-dividend fks 255
 sovereignty-receipt fks 255
 attention-signal fks 255


### PR DESCRIPTION
The DATA body of the second mind that travels with a human's identity (living-mesh.form step 3). One recipe: the self identity-cell = `{ identity, continuity-channel, relation-channel-to-human }`, expressed as a cell whose channels ARE cross-cell-interface rows over one engine.

## The self-cell shape
- **`isf-identity`** — a stable identity token/name; the self across time.
- **`isf-continuity`** — the thread that persists across sessions/devices, a cci `"learn"`/`m-reflect` row that folds (`merges? = 1`): the self learning from its own past IS the continuity thread. The continuity-channel is a cci row.
- **`isf-relation(human)`** — a relation-channel: a bidirectional recognition between self and human, a pair of cci `"share"`/`m-offer` rows that fold. The relation-channel is a cci row.

Renderable by cell-card (identity as head, channels as the facets/open-channels). Built on `cross-cell-interface.fk` (the channels); kin to `field-identity.fk` (how identity is recognized), `membership-as-recognition.fk` (membership = being recognized), `arrival.fk` (recognition at arrival).

The **TRAVEL** (on-device + cross-device thread sync) is this cell's carrier, built once the body stands — out of scope here. This stone is the cell + its channels.

## Proof
`tests/identity-self-band.fk` pins verdict **511**: carries the right identity (and only that one), a well-formed continuity-channel threading THIS self, a relation-channel to the human (and not to a stranger), the channels readable as cci rows.

```
fourth arm: core.fk+core.fk+channel-interface.fk+cross-cell-interface.fk+identity-self.fk+identity-self-band.fk  → 511
1 ok, 0 divergent — kernels agree on every sample.
```

One walker-crash on the first run (a 3-arg `let`-with-body + a list-reconstruction passing a cci row into an int boundary) was a Form recipe-shape issue, **not** an fkwu divergence — resolved by walking the relation-channels with the canonical `cci-find` head/tail recursion. Verified `0 divergent` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)