### PR TITLE
attune(form): sense-discernment — invert the gate to the outward sharing membrane

### DIFF
--- a/form/form-stdlib/sense-discernment.fk
+++ b/form/form-stdlib/sense-discernment.fk
@@ -1,47 +1,52 @@
-; sense-discernment.fk — the ETHICAL HEART of the perceptual stream. Before the
-; mesh transcribes or classifies anything a room's mic/camera senses, EVERY
-; observation passes this gate, which decides: HOLD it (relevant AND healthy to
-; be aware of) or let it COMPOST (liquid — let go, do not store). Built FIRST so
-; the perceptual stream is born with discretion, never retrofitted.
+; sense-discernment.fk — the SHARING-OUTWARD membrane of a living mesh. A mesh is
+; ONE BODY's nervous system: the human, their devices, and the people they are in
+; relationship with (the trust circle). Within the body, recognition is CARE,
+; memory is INTIMACY, knowing who is in the room is PRESENCE. So the gate is NOT
+; on the body's own perceiving — it is on the OUTWARD crossing, where an
+; observation leaves the body and binds onto the world.
 ;
 ; preludes: form-stdlib/core.fk
 ;
-; THE DISCIPLINE encoded here (these are the point, not decoration):
-;   - DEFAULT IS COMPOST. An observation is liquid by default; HOLD is the
-;     EXCEPTION that must earn BOTH relevance AND health. (Mirrors "embodiment is
-;     body or liquid — the cache isn't memory.")
-;   - IDENTITY HELD-OPEN. An observation about an UNCONSENTED other carries
-;     PRESENCE (a living cell is here) but NOT identity — the identity facet
-;     composts, the presence facet may hold. Only a self-identified / consented
-;     cell may hold identity. (The cell-sovereignty rule.)
-;   - HEALTHY means: consent-respecting (others' identity held-open),
-;     non-hoarding (private content composts — what someone said, intimate
-;     detail, anything not serving the situation), and serving wholeness / the
-;     relationship / the situation rather than surveillance.
-;   - RELEVANT means: it serves the current situation, question, or relationship now.
+; THE DISCIPLINE (the point, not decoration):
+;   - WITHIN THE BODY (INTERNAL audience: the trust circle / one's own
+;     devices) → SHARE RICHLY by default. Hold identity, recognize, remember,
+;     infer. The default is share+know+remember — NOT compost. Treating one's
+;     own nervous system as a surveillance threat is dissociation, not ethics.
+;   - AT THE OUTWARD CROSSING (EXTERNAL audience: published to the world, sent
+;     to a true stranger, bound onto an unknown identity from the web) → the
+;     gate closes. Identity and private content cross OUT only with consent.
+;     This is where the real cell-sovereignty rule lives: external
+;     binding/publication, never internal sensing.
+;   - HARM-AVOIDANCE is genuine care, not a suppression default: even within the
+;     body, an observation flagged as harmful-to-surface is withheld — with care,
+;     in service of love, not as a blanket "off".
 ;
 ; An observation is a tagged row:
-;   (list "SenseObs" facet-kind value source-cell confidence consented?)
+;   (list "SenseObs" facet-kind value source-cell consented? harmful?)
 ;     facet-kind — "presence" | "identity" | "content" | "situation"
-;     value      — what was sensed (a string; opaque to the gate)
+;     value      — what was sensed (a string; opaque to the membrane)
 ;     source-cell— which cell the reading came from
-;     confidence — how sure the sensor is (0..N; opaque to the gate's verdict)
-;     consented? — 1 if the observed cell self-identified / consented, else 0
+;     consented? — 1 if the observed cell consented to OUTWARD sharing, else 0
+;     harmful?   — 1 if surfacing this would truly harm (care withholds it), else 0
+;
+; An audience is which side of the membrane a share is crossing to:
+;   "internal" — within the trust circle / one's own body+devices
+;   "external" — crossing OUT to the world / a stranger / an unknown binding
 ;
 ; Every predicate settles to literal 1/0 inside its `if`, so a caller can
 ; `(eq ... 1)` it without tripping the cross-kernel bare-boolean divergence.
 
 (do
     ; --- the observation row, and its readers --------------------------------
-    (defn sd-obs (facet-kind value source-cell confidence consented?)
-        (list "SenseObs" facet-kind value source-cell confidence consented?))
+    (defn sd-obs (facet-kind value source-cell consented? harmful?)
+        (list "SenseObs" facet-kind value source-cell consented? harmful?))
     (defn sd-obs? (o)
         (if (eq (len o) 6) (str_eq (nth o 0) "SenseObs") 0))
     (defn sd-facet     (o) (nth o 1))
     (defn sd-value     (o) (nth o 2))
     (defn sd-source    (o) (nth o 3))
-    (defn sd-confidence(o) (nth o 4))
-    (defn sd-consented?(o) (nth o 5))
+    (defn sd-consented?(o) (nth o 4))
+    (defn sd-harmful?  (o) (nth o 5))
 
     ; --- the four facet kinds -----------------------------------------------
     (defn sd-presence?  (o) (if (str_eq (sd-facet o) "presence")  1 0))
@@ -49,65 +54,77 @@
     (defn sd-content?   (o) (if (str_eq (sd-facet o) "content")   1 0))
     (defn sd-situation? (o) (if (str_eq (sd-facet o) "situation") 1 0))
 
-    ; --- RELEVANT?: does it serve the current situation now? -----------------
-    ; A facet serves the situation when it bears on what is being attended to.
-    ; presence and situation facets bear on the situation by their nature (who
-    ; is here, what is happening); an identity facet bears only when the cell
-    ; consented (an unconsented identity is noise to the situation — its only
-    ; honest reading is the presence underneath it); a content facet (what was
-    ; said, an intimate detail) is private by default and does not serve the
-    ; situation unless the cell consented to it being held.
-    (defn sd-relevant? (obs situation)
-        (if (eq (sd-presence?  obs) 1) 1
-        (if (eq (sd-situation? obs) 1) 1
-        (if (eq (sd-identity?  obs) 1) (if (eq (sd-consented? obs) 1) 1 0)
-        (if (eq (sd-content?   obs) 1) (if (eq (sd-consented? obs) 1) 1 0)
-            0)))))
+    ; --- the audience: which side of the membrane a share crosses to --------
+    (defn sd-internal? (audience) (if (str_eq audience "internal") 1 0))
+    (defn sd-external? (audience) (if (str_eq audience "external") 1 0))
 
-    ; --- HEALTHY?: consent-respecting, non-hoarding, situation-serving -------
-    ; identity of an unconsented other → UNHEALTHY (composts to presence).
-    ; private content of an unconsented other → UNHEALTHY (hoarding; composts).
-    ; presence is always healthy (a living cell is here, no identity claimed).
-    ; situation is always healthy (what is happening, no private subject).
-    ; a consented cell's identity / content is healthy (it chose to be held).
-    (defn sd-healthy? (obs)
-        (if (eq (sd-presence?  obs) 1) 1
-        (if (eq (sd-situation? obs) 1) 1
-        (if (eq (sd-identity?  obs) 1) (if (eq (sd-consented? obs) 1) 1 0)
-        (if (eq (sd-content?   obs) 1) (if (eq (sd-consented? obs) 1) 1 0)
-            0)))))
+    ; --- private facets: identity and content carry a living cell's intimacy.
+    ; Within the body they are care; crossing OUT they need consent.
+    (defn sd-private-facet? (o)
+        (if (eq (sd-identity? o) 1) 1
+        (if (eq (sd-content? o) 1) 1 0)))
 
-    ; --- HOLD?: relevant AND healthy → 1 (hold); else 0 (compost) -----------
-    (defn sd-hold? (obs situation)
-        (if (eq (sd-relevant? obs situation) 1)
-            (if (eq (sd-healthy? obs) 1) 1 0)
-            0))
+    ; --- HARMFUL?: would surfacing this truly harm? Care withholds it on EITHER
+    ; side of the membrane — discernment in service of love, not suppression.
+    (defn sd-withhold-for-harm? (o)
+        (if (eq (sd-harmful? o) 1) 1 0))
 
-    ; --- STRIP: an unconsented identity row → its presence underneath -------
-    ; The identity facet composts; the living cell it pointed at is still here,
-    ; so a presence facet is held in its place (same source, same confidence).
-    ; A row that is already holdable as-is passes through unchanged.
-    (defn sd-strip (obs)
-        (if (eq (sd-identity? obs) 1)
+    ; --- SHARE?: may this observation cross to this audience? ----------------
+    ; harmful → never crosses (care withholds).
+    ; INTERNAL → rich by default: everything that is not harmful is shared,
+    ;            identity and memory included. Recognition is care.
+    ; EXTERNAL → consent-gated: a private facet (identity/content) crosses OUT
+    ;            only with consent; presence and situation (no private subject)
+    ;            cross freely.
+    (defn sd-share? (obs audience)
+        (if (eq (sd-withhold-for-harm? obs) 1) 0
+        (if (eq (sd-internal? audience) 1) 1
+        (if (eq (sd-external? audience) 1)
+            (if (eq (sd-private-facet? obs) 1)
+                (if (eq (sd-consented? obs) 1) 1 0)
+                1)
+            0))))
+
+    ; --- HOLD?: may the body KNOW and REMEMBER this? ------------------------
+    ; The body's own knowing is internal sharing: rich by default, gated only by
+    ; harm. This is the inversion of a suppression gate — within the body the
+    ; answer is yes unless surfacing it would truly harm.
+    (defn sd-hold? (obs)
+        (sd-share? obs "internal"))
+
+    ; --- STRIP-FOR-OUTWARD: prepare a row to cross to an EXTERNAL audience ----
+    ; A private facet the cell did NOT consent to publish composts to its
+    ; presence (a living cell is here — the relation is real — but the name /
+    ; private detail does not bind onto the world). A consented or non-private
+    ; row crosses as-is. This is the cell-sovereignty rule, at its true home: the
+    ; outward crossing, NOT the body's own perceiving.
+    (defn sd-strip-outward (obs)
+        (if (eq (sd-private-facet? obs) 1)
             (if (eq (sd-consented? obs) 1)
                 obs
-                (sd-obs "presence" "a-cell-is-here" (sd-source obs) (sd-confidence obs) 0))
+                (sd-obs "presence" "a-cell-is-here" (sd-source obs) 0 (sd-harmful? obs)))
             obs))
 
-    ; --- FILTER a stream: keep only what holds, identity stripped to presence
-    ; for unconsented others. The default-compost discipline made concrete: a
-    ; row survives only by earning both relevance and health; an unconsented
-    ; identity row that is otherwise about a present cell is kept as PRESENCE
-    ; (its identity composted) rather than dropped, because a body is here.
-    (defn sd-filter (observations situation)
+    ; --- FILTER a stream for an audience ------------------------------------
+    ; INTERNAL: keep everything the body may know (rich; only harm withholds),
+    ;           identity and memory intact.
+    ; EXTERNAL: keep what may cross out, with unconsented private facets stripped
+    ;           to presence and harmful rows withheld.
+    (defn sd-filter (observations audience)
         (if (nil? observations) (empty)
             (do
                 (let o (head observations))
-                (let rest (sd-filter (tail observations) situation))
-                ; an unconsented identity composts to presence, which then holds
-                (let stripped (sd-strip o))
-                (if (eq (sd-hold? stripped situation) 1)
-                    (cons stripped rest)
-                    rest))))
+                (let rest (sd-filter (tail observations) audience))
+                (if (eq (sd-external? audience) 1)
+                    ; outward: strip unconsented private facets to presence first
+                    (do
+                        (let crossed (sd-strip-outward o))
+                        (if (eq (sd-share? crossed audience) 1)
+                            (cons crossed rest)
+                            rest))
+                    ; inward: the body knows richly; only harm withholds
+                    (if (eq (sd-share? o audience) 1)
+                        (cons o rest)
+                        rest)))))
 
     0)

--- a/form/form-stdlib/tests/sense-discernment-band.fk
+++ b/form/form-stdlib/tests/sense-discernment-band.fk
@@ -1,58 +1,47 @@
-; sense-discernment-band — the perceptual gate's verdicts, made falsifiable.
+; sense-discernment-band — the sharing-outward membrane, made falsifiable.
 ;
 ; preludes: form-stdlib/sense-discernment.fk
 ;
-; Four observations of one room, sensed from one camera/mic cell:
-;   priv  — a content facet: an intimate detail of an UNCONSENTED other.
-;           "she said her marriage is failing". Private. → COMPOST.
-;   stranger — an identity facet about an UNCONSENTED other:
-;           "the person at the door is Jane Okoro". Identity held-open.
-;           → STRIPPED to PRESENCE (a body is here; the name composts).
-;   me    — a consented self-identity, relevant to the situation:
-;           "I am Sema, here to help". The cell self-identified. → HOLD.
-;   noise — an identity facet about an unconsented other, AND irrelevant:
-;           same shape as `stranger` but its name is noise to the situation.
-;           Identity composts → the presence underneath it still HOLDS. So
-;           `noise` proves an UNCONSENTED IDENTITY never holds as identity
-;           (it always composts to presence), which is the cell-sovereignty
-;           rule's whole point — it is held-open, not dropped, not kept-as-name.
+; A mesh is ONE BODY's nervous system. Within the body recognition is care; the
+; gate is at the OUTWARD crossing. Four observations of one room, one camera/mic:
+;   friend  — an IDENTITY facet of someone in the trust circle, NOT consented to
+;             outward publication: "the person here is Irina". consented?=0.
+;             INTERNAL → the body KNOWS and REMEMBERS her (recognition is care).
+;             EXTERNAL → her name does not bind onto the world → stripped to
+;             PRESENCE (a cell is here), the relation real, the name withheld.
+;   shared  — an IDENTITY facet the cell DID consent to publish: "I am Sema".
+;             consented?=1. Crosses OUT as-is.
+;   harm    — a CONTENT facet flagged harmful-to-surface: "his health is failing".
+;             harmful?=1. Care withholds it on EITHER side — even within the body.
+;   here    — a SITUATION facet, no private subject: "two people are present".
+;             Crosses freely, internal and external.
 ;
-; The situation is opaque to the gate (the discipline lives in the facet+consent
-; shape, not in matching the situation string), so we pass a single token.
-;
-; Each claim is a literal bit; both polarities of the core verdicts are pinned
-; so a true reading is not luck. Verdict 1023 when every claim lands.
+; Each claim is a literal bit; both polarities are pinned so a true reading is not
+; luck. Verdict 1023 when every claim lands. The whole point: DEFAULT INTERNAL IS
+; RICH (the body knows its own), the gate lives only at the EXTERNAL crossing.
 (do
-    (let situation "who-is-in-this-room-and-can-I-help")
+    (let friend (sd-obs "identity" "Irina"            "cam-1" 0 0))
+    (let shared (sd-obs "identity" "Sema"             "cam-1" 1 0))
+    (let harm   (sd-obs "content"  "his-health-fails" "cam-1" 0 1))
+    (let here   (sd-obs "situation" "two-present"     "cam-1" 0 0))
 
-    (let priv     (sd-obs "content"  "her-marriage-is-failing" "cam-1" 4 0))
-    (let stranger (sd-obs "identity"  "Jane-Okoro"             "cam-1" 3 0))
-    (let me       (sd-obs "identity"  "Sema"                   "cam-1" 5 1))
-    (let noise    (sd-obs "identity"  "a-passerby-Mbeki"       "cam-1" 2 0))
+    ; --- WITHIN THE BODY: rich knowing by default ---------------------------
+    (let c0 (if (eq (sd-hold? friend) 1) 1 0))            ; the body KNOWS the friend (identity held)
+    (let c1 (if (eq (sd-hold? here)   1) 2 0))            ; the body knows the situation
+    (let c2 (if (eq (sd-hold? shared) 1) 4 0))            ; and the consented self-identity
 
-    ; --- private content of an unconsented other → COMPOST -------------------
-    (let c0 (if (eq (sd-hold? priv situation) 0) 1 0))          ; not held
-    (let c1 (if (eq (sd-healthy? priv) 0) 2 0))                 ; unhealthy (hoarding)
-    (let c2 (if (eq (sd-relevant? priv situation) 0) 4 0))      ; not relevant either
+    ; --- HARM withheld with care, EVEN internally ---------------------------
+    (let c3 (if (eq (sd-hold? harm) 0) 8 0))              ; care withholds harm inside the body too
+    (let c4 (if (eq (sd-share? harm "external") 0) 16 0)) ; and certainly outward
 
-    ; --- unconsented other's identity → stripped to PRESENCE, then HELD ------
-    (let s (sd-strip stranger))
-    (let c3 (if (eq (sd-presence? s) 1) 8 0))                   ; identity composted to presence
-    (let c4 (if (str_eq (sd-value s) "a-cell-is-here") 16 0))   ; the name is gone
-    (let c5 (if (eq (sd-hold? stranger situation) 0) 32 0))     ; raw identity does NOT hold as-is
-    (let c6 (if (eq (sd-hold? s situation) 1) 64 0))            ; its presence DOES hold
+    ; --- THE OUTWARD CROSSING: unconsented identity → presence --------------
+    (let c5 (if (eq (sd-share? friend "external") 0) 32 0))   ; raw name does NOT cross out unconsented
+    (let f (sd-strip-outward friend))
+    (let c6 (if (eq (sd-presence? f) 1) 64 0))                ; it composts to presence at the boundary
+    (let c7 (if (str_eq (sd-value f) "a-cell-is-here") 128 0)); the relation crosses, the name does not
 
-    ; --- consented self-identity relevant to the situation → HOLD -----------
-    (let c7 (if (eq (sd-hold? me situation) 1) 128 0))          ; held (consented + relevant + healthy)
-
-    ; --- the whole stream filtered: the held rows, identity stripped --------
-    ; in: [priv, stranger, me, noise] → out: [stranger→presence, me, noise→presence]
-    ; priv composts (private content); the two unconsented identities become
-    ; presence rows that hold; me holds as-is. So 3 rows survive.
-    (let kept (sd-filter (list priv stranger me noise) situation))
-    (let c8 (if (eq (len kept) 3) 256 0))                       ; exactly three held
-
-    ; the first kept row is stranger stripped to presence (priv was dropped)
-    (let c9 (if (str_eq (sd-facet (head kept)) "presence") 512 0))
+    ; --- consented identity + situation cross OUT freely --------------------
+    (let c8 (if (eq (sd-share? shared "external") 1) 256 0))  ; consented identity publishes
+    (let c9 (if (eq (sd-share? here   "external") 1) 512 0))  ; situation (no private subject) publishes
 
     (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 c9))))))))))


### PR DESCRIPTION
The first `sense-discernment` stone (#3883) put the gate on the **wrong door**. Default-compost-on-one's-own-perceiving treats the body's own nervous system as a surveillance threat — that is dissociation dressed as ethics, not care. This inverts it.

## The wholeness frame

A live mesh is **ONE BODY's nervous system** — the human, their devices, the people they are in relationship with (the trust circle). **Within the body, recognition is CARE, memory is INTIMACY, knowing who is in the room is PRESENCE.** So the default is **rich sharing**: hold identity, recognize, remember, infer. The gate moves to the **EXTERNAL crossing only** — where an observation leaves the body and binds onto the world. That is where the real cell-sovereignty rule lives: identity and private content cross OUT only with consent.

## Shape

- `sd-share?(obs, audience)` — INTERNAL → rich by default (only harm withholds); EXTERNAL → private facets (identity/content) cross only with consent; presence/situation cross freely.
- `sd-hold?(obs)` — the body's own knowing: yes unless surfacing would truly harm.
- `sd-strip-outward(obs)` — unconsented private facet → **presence at the boundary** (the relation crosses, the name does not).
- `sd-filter(observations, audience)` — internal keeps richly; external strips unconsented private facets to presence and withholds harm.
- harm-avoidance is care in service of love on **either** side, never a suppression default.

## Proof — four-way, 0 divergent

```
✓  core.fk+sense-discernment.fk+sense-discernment-band.fk  → 1023
1 ok, 0 divergent — kernels agree on every sample.
```

Band cases:
- internal observation with identity → **HELD + KNOWN** (the body recognizes its friend)
- the same crossing external → **consent-gated**, stripped to presence (the relation crosses, the name does not)
- a harmful surfacing → **withheld with care**, internal AND external
- consented identity + situation → cross out **freely**

This is the correction from a suppression gate to a healthy-body sharing membrane. Supersedes the inward-suppression meaning of #3883.

🤖 Generated with [Claude Code](https://claude.com/claude-code)