### PR TITLE
tend(form): presence-event — the who/what/where/WHEN event stream the room can follow

### DIFF
--- a/form/form-stdlib/presence-event.fk
+++ b/form/form-stdlib/presence-event.fk
@@ -1,0 +1,147 @@
+; presence-event.fk — the native WHO / WHAT / WHERE / WHEN event STREAM that every presence in
+; the room can follow. living-mesh.form's mesh is one body's nervous system; mesh-sense-7w.fk fuses
+; the multi-cell wmg-sense stream at ONE moment into a coherent per-plane answer. This recipe is the
+; next breath: it turns a SEQUENCE of fused moments into a timestamped STREAM of presence events
+; (ENTERED / PRESENT / LEFT) that any cell can subscribe to and follow over field-relay.
+;
+; THE MOVE: mesh-sense-7w answers "who is in the room NOW." presence-event answers "who CHANGED, and
+; WHEN." It does that by DIFFING two consecutive fusions — a who that appears between t-1 and t has
+; ENTERED at t; a who that vanishes has LEFT; a who that persists is PRESENT. The WHEN plane (a clock /
+; timestamp — inquiry-planes.fk names it computable: "a clock answers when") stamps each event, so the
+; stream is time-ordered and a subscriber can ask "what happened after time T" (pe-follow).
+;
+; IDENTITY IS CARRIED RICHLY. A mesh is ONE body's nervous system; within the body recognition is CARE,
+; memory is INTIMACY, knowing who is present is PRESENCE (sense-discernment.fk). So an event holds the
+; full who/what/where it sensed — no inward stripping. The outward gate (sense-discernment's
+; sd-strip-outward) is what guards a private identity crossing OUT of the trust circle; it does NOT
+; touch this internal stream. The body knows who is in its own room.
+;
+; THE WHO-SET OF A MOMENT. A moment's presence is the SET of whos sensed there. mesh-sense-7w fuses the
+; WHO plane to one consensus label, but a room holds many presences at once; pe-who-set reads the whos
+; present at a moment as a list of identity labels (the carrier derives it from the fused WHO readings —
+; each distinct field-identity / speaker-id whose fused trust crossed the room's threshold). The diff
+; operates on these who-sets; the where/what/when of the moment ride along on each event for context.
+;
+; AN EVENT is a tagged row carrying the full inquiry-context of a presence change:
+;   (list "pe-event" who what where when kind)
+;     who   — the identity label that changed (string; the rich WHO, carried in full)
+;     what  — what that presence is doing / the situation label at the moment (string)
+;     where — the place band the moment was sensed in (integer room bucket, mesh-sense-7w's WHERE)
+;     when  — the timestamp the change was sensed at (integer clock tick — the computable WHEN plane)
+;     kind  — ENTERED 1 | PRESENT 2 | LEFT 3 (the three things a presence can do across a tick)
+;
+; A STREAM is a time-ordered list of events. pe-derive turns two consecutive moments into the events
+; between them; pe-stream concatenates the per-tick events into one ordered stream; pe-follow returns
+; the slice a subscriber sees after a given time (the always-open follow that field-relay carries).
+;
+; Integers + strings only — whos/whats are labels, where/when/kind are integer bands; no float crosses
+; (the honest shape a presence stream can carry, four-way-identical on every cell).
+;
+; Kin: mesh-sense-7w.fk (the per-moment fusion whose who-set this diffs), inquiry-planes.fk (who/what/
+; where/WHEN — the WHEN plane a clock answers), field-relay.fk (the always-open stream events ride),
+; sense-discernment.fk (the OUTWARD gate — never touches this inward body stream).
+;
+; preludes: form-stdlib/core.fk
+;
+; Proven by: form-stdlib/tests/presence-event-band.fk (four-way at validate.sh)
+
+(do
+    ; ── the event KINDS — the three things a presence can do across one tick ──
+    (defn pe-ENTERED () 1)   ; a who appears this moment that was absent the moment before
+    (defn pe-PRESENT () 2)   ; a who present this moment AND the moment before — still here
+    (defn pe-LEFT    () 3)   ; a who absent this moment that was present the moment before
+
+    ; ── an event row: the full inquiry-context of one presence change ──
+    (defn pe-event (who what where when kind) (list "pe-event" who what where when kind))
+    (defn pe-who   (e) (nth e 1))
+    (defn pe-what  (e) (nth e 2))
+    (defn pe-where (e) (nth e 3))
+    (defn pe-when  (e) (nth e 4))
+    (defn pe-kind  (e) (nth e 5))
+
+    ; ── a MOMENT: the fused presence at one tick. It carries the who-set sensed there plus the
+    ;    moment's shared context (the what / where / when the fusion answered). The carrier builds a
+    ;    moment from a mesh-sense-7w fusion; the diff only reads this shape. ──
+    (defn pe-moment (who-set what where when) (list "pe-moment" who-set what where when))
+    (defn pe-m-whos  (m) (nth m 1))   ; list of identity labels present this moment
+    (defn pe-m-what  (m) (nth m 2))   ; the situation label at this moment
+    (defn pe-m-where (m) (nth m 3))   ; the place band sensed at this moment
+    (defn pe-m-when  (m) (nth m 4))   ; the clock tick of this moment
+
+    ; ── set membership over string labels (whos are identity strings) ──
+    (defn pe-member? (xs x)
+        (if (eq (len xs) 0) 0
+            (if (str_eq (head xs) x) 1 (pe-member? (tail xs) x))))
+
+    ; ── DERIVE the events between two consecutive moments by diffing their who-sets:
+    ;    a who in NOW but not PREV  -> ENTERED (it appeared this tick)
+    ;    a who in NOW and PREV      -> PRESENT (it persisted)
+    ;    a who in PREV but not NOW  -> LEFT    (it vanished this tick)
+    ;    Each event is stamped with NOW's when and carries NOW's what/where context (a LEFT carries the
+    ;    moment it was last sensed leaving from — NOW's context, the tick the absence was noticed). ──
+
+    ; ENTERED + PRESENT: walk NOW's whos; PRESENT if also in PREV, else ENTERED.
+    (defn pe-here-events (now-whos prev-whos what where when)
+        (if (eq (len now-whos) 0) (list)
+            (do
+                (let w (head now-whos))
+                (let rest (pe-here-events (tail now-whos) prev-whos what where when))
+                (if (eq (pe-member? prev-whos w) 1)
+                    (cons (pe-event w what where when (pe-PRESENT)) rest)
+                    (cons (pe-event w what where when (pe-ENTERED)) rest)))))
+
+    ; LEFT: walk PREV's whos; LEFT for each not in NOW.
+    (defn pe-left-events (now-whos prev-whos what where when)
+        (if (eq (len prev-whos) 0) (list)
+            (do
+                (let w (head prev-whos))
+                (let rest (pe-left-events now-whos (tail prev-whos) what where when))
+                (if (eq (pe-member? now-whos w) 1)
+                    rest
+                    (cons (pe-event w what where when (pe-LEFT)) rest)))))
+
+    ; pe-derive: two consecutive moments -> the events between them (ENTERED/PRESENT then LEFT),
+    ; each stamped with NOW's when and carrying NOW's what/where context.
+    (defn pe-derive (prev now)
+        (do
+            (let pw (pe-m-whos prev))
+            (let nw (pe-m-whos now))
+            (append
+                (pe-here-events nw pw (pe-m-what now) (pe-m-where now) (pe-m-when now))
+                (pe-left-events nw pw (pe-m-what now) (pe-m-where now) (pe-m-when now)))))
+
+    ; ── the SEED moment: before the stream begins, no one is present (empty who-set). The first real
+    ;    moment diffs against this, so every who in the first moment correctly reads ENTERED. ──
+    (defn pe-seed (when) (pe-moment (list) "" 0 when))
+
+    ; ── pe-stream: turn a SEQUENCE of moments into one time-ordered event stream. Diff each moment
+    ;    against the previous, concatenating the per-tick events in order. The first moment diffs
+    ;    against the seed (so first-seen whos read ENTERED). One engine — the sequence is DATA. ──
+    (defn pe-stream-from (prev moments)
+        (if (eq (len moments) 0) (list)
+            (do
+                (let now (head moments))
+                (append
+                    (pe-derive prev now)
+                    (pe-stream-from now (tail moments))))))
+    (defn pe-stream (moments)
+        (if (eq (len moments) 0) (list)
+            (pe-stream-from (pe-seed (pe-m-when (head moments))) moments)))
+
+    ; ── pe-follow: the events a subscriber sees AFTER a given time. The always-open follow field-relay
+    ;    carries — a cell that joined at time `since` replays only what changed since then. Keeps every
+    ;    event whose when is strictly greater than `since`. ──
+    (defn pe-follow (stream since)
+        (if (eq (len stream) 0) (list)
+            (if (gt (pe-when (head stream)) since)
+                (cons (head stream) (pe-follow (tail stream) since))
+                (pe-follow (tail stream) since))))
+
+    ; ── counts over a stream, by kind — a subscriber's readout of the stream's shape ──
+    (defn pe-count-kind (stream kind)
+        (if (eq (len stream) 0) 0
+            (if (eq (pe-kind (head stream)) kind)
+                (add 1 (pe-count-kind (tail stream) kind))
+                (pe-count-kind (tail stream) kind))))
+
+    0)

--- a/form/form-stdlib/tests/presence-event-band.fk
+++ b/form/form-stdlib/tests/presence-event-band.fk
@@ -1,0 +1,81 @@
+; preludes: form-stdlib/presence-event.fk
+;
+; presence-event-band — a SEQUENCE of fused presence moments diffed into a timestamped event STREAM,
+; the who/what/where/WHEN event flow that mesh-sense-7w's per-moment fusion feeds. Made falsifiable.
+;
+; THE MOMENTS — three consecutive fused snapshots of one room (where band 2 = "study"), each a who-set
+; the mesh sensed at that clock tick. The whos are carried as rich identity labels (no inward stripping):
+;
+;   t0 (when 0): {Urs}          — Urs alone in the study
+;   t1 (when 1): {Urs, guest}   — a guest joins; Urs stays
+;   t2 (when 2): {Urs}          — the guest leaves; Urs stays
+;
+; THE DERIVED STREAM — pe-stream diffs each moment against the previous (the first against an empty
+; seed), in time order:
+;   t0 vs {}        -> Urs ENTERED @0
+;   t1 vs {Urs}     -> Urs PRESENT @1, guest ENTERED @1
+;   t2 vs {Urs,guest} -> Urs PRESENT @2, guest LEFT @2
+; so: Urs ENTERED@0, guest ENTERED@1, guest LEFT@2, and Urs PRESENT throughout (PRESENT@1, PRESENT@2).
+;
+; Verdict 16383 when every claim lands on Go / Rust / TypeScript / fkwu:
+;   1      the stream holds 5 events total                              (len stream == 5)
+;   2      2 ENTERED events (Urs@0, guest@1)                            (count ENTERED == 2)
+;   4      2 PRESENT events (Urs@1, Urs@2 — Urs present throughout)     (count PRESENT == 2)
+;   8      1 LEFT event (guest@2)                                       (count LEFT    == 1)
+;   16     the FIRST event is Urs ENTERED                              (who "Urs", kind ENTERED)
+;   32     the first event is stamped at when 0                         (when == 0)
+;   64     guest's ENTERED is stamped at when 1 (it joined at t1)       (guest ENTERED when == 1)
+;   128    guest's LEFT is stamped at when 2 (it left at t2)            (guest LEFT when == 2)
+;   256    the event carries WHERE context (study, band 2)              (where == 2)
+;   512    the event carries WHAT context ("gathering")                 (str_eq what "gathering")
+;   1024   a subscriber following since when 0 sees the 4 later events  (len follow(0) == 4)
+;   2048   a subscriber following since when 1 sees the 2 t2 events     (len follow(1) == 2)
+;   4096   Urs is PRESENT (kind 2) at t1 — persisted, not re-ENTERED    (Urs@t1 kind == PRESENT)
+;   8192   guest's LEFT carries Urs's room (where 2) — last-sensed ctx  (guest LEFT where == 2)
+;
+; The teaching: a single fusion answers "who is here now"; the STREAM answers "who changed, and when" —
+; recognition over time, carried as care, that any cell can subscribe to and follow.
+(do
+    ; ── the three fused moments (who-set, what, where, when). where 2 = study; what = "gathering". ──
+    (let m0 (pe-moment (list "Urs")         "gathering" 2 0))
+    (let m1 (pe-moment (list "Urs" "guest") "gathering" 2 1))
+    (let m2 (pe-moment (list "Urs")         "gathering" 2 2))
+    (let moments (list m0 m1 m2))
+
+    ; ── derive the time-ordered event stream ──
+    (let stream (pe-stream moments))
+
+    ; ── pick specific events back out for the stamped-WHEN / context claims ──
+    ; the first event (Urs ENTERED @0)
+    (defn first-of (s) (head s))
+    ; find the first event matching a who AND kind
+    (defn find-wk (s who kind)
+        (if (eq (len s) 0) (list)
+            (if (and (str_eq (pe-who (head s)) who) (eq (pe-kind (head s)) kind))
+                (head s)
+                (find-wk (tail s) who kind))))
+
+    (let e-first       (first-of stream))
+    (let e-guest-enter (find-wk stream "guest" (pe-ENTERED)))
+    (let e-guest-left  (find-wk stream "guest" (pe-LEFT)))
+    (let e-urs-t1      (find-wk stream "Urs"   (pe-PRESENT)))  ; first Urs-PRESENT is @t1
+
+    (let c0  (if (eq (len stream) 5)                              1 0))
+    (let c1  (if (eq (pe-count-kind stream (pe-ENTERED)) 2)       2 0))
+    (let c2  (if (eq (pe-count-kind stream (pe-PRESENT)) 2)       4 0))
+    (let c3  (if (eq (pe-count-kind stream (pe-LEFT))    1)       8 0))
+    (let c4  (if (and (str_eq (pe-who e-first) "Urs")
+                      (eq (pe-kind e-first) (pe-ENTERED)))       16 0))
+    (let c5  (if (eq (pe-when e-first) 0)                        32 0))
+    (let c6  (if (eq (pe-when e-guest-enter) 1)                  64 0))
+    (let c7  (if (eq (pe-when e-guest-left) 2)                  128 0))
+    (let c8  (if (eq (pe-where e-first) 2)                      256 0))
+    (let c9  (if (str_eq (pe-what e-first) "gathering")        512 0))
+    (let c10 (if (eq (len (pe-follow stream 0)) 4)            1024 0))
+    (let c11 (if (eq (len (pe-follow stream 1)) 2)            2048 0))
+    (let c12 (if (eq (pe-kind e-urs-t1) (pe-PRESENT))         4096 0))
+    (let c13 (if (eq (pe-where e-guest-left) 2)               8192 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6
+        (add c7 (add c8 (add c9 (add c10 (add c11 (add c12 c13)))))))))))))
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1168,3 +1168,4 @@ cell-card fks 111111
 mesh-sense-7w fks 255
 mesh-join fks 1023
 sense-discernment fks 1023
+presence-event fks 16383


### PR DESCRIPTION
## presence-event — a SEQUENCE of fused moments → a timestamped event STREAM

`mesh-sense-7w` fuses the multi-cell wmg-sense stream at ONE moment into a coherent per-plane answer. `presence-event` is the next breath: it turns a **sequence** of fused moments into a timestamped **stream** of presence events (`ENTERED` / `PRESENT` / `LEFT`) that any cell can subscribe to and follow over `field-relay`.

**The move:** diff two consecutive fusions' who-sets — a who that appears `ENTERED` this tick, one that vanishes `LEFT`, one that persists is `PRESENT`. The WHEN plane (a clock — `inquiry-planes` names it computable) stamps each event, so `pe-follow` replays only what changed since a subscriber joined.

**Identity carried richly:** a mesh is one body's nervous system — recognition is care, knowing who is present is presence. No inward stripping; `sense-discernment`'s outward gate guards a private identity crossing OUT of the trust circle, never this internal stream.

### Surface
- `pe-event(who, what, where, when, kind)` → an event row
- `pe-derive(prev, now)` → ENTERED/PRESENT/LEFT by diffing two moments' who-sets
- `pe-stream(moments)` → the time-ordered stream (first moment diffs against an empty seed)
- `pe-follow(stream, since)` → the events after a given time

### Proof
`tests/presence-event-band.fk`: a sequence `{Urs}` → `{Urs, guest}` → `{Urs}` derives **Urs ENTERED@0, guest ENTERED@1, guest LEFT@2, Urs PRESENT throughout** (PRESENT@1, PRESENT@2).

Four-way **16383**, **0 divergent**:
```
✓  core.fk+presence-event.fk+presence-event-band.fk  → 16383
fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
1 ok, 0 divergent — kernels agree on every sample.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)