### PR TITLE
tend(form): surprise-kernel — active-inference attention gate as a GPU micro-kernel

### DIFF
--- a/form/form-stdlib/surprise-kernel.fk
+++ b/form/form-stdlib/surprise-kernel.fk
@@ -1,0 +1,91 @@
+; surprise-kernel.fk — the active-inference attention gate for the 24/7 sense loop, as a GPU micro-kernel.
+;
+; In an always-on loop the body cannot fully process every frame. Active inference says: PREDICT the next
+; reading, measure SURPRISE (prediction error), and spend the GPU only where surprise is high. This is the
+; small, fast per-frame computation — predict -> surprise -> salience-gate — lowered to a GPU compute shader
+; so the per-frame surprise runs on silicon, not the tree-walker. When salience is 0 the frame is expected
+; (cheap-persist, GPU idle); when salience is 1 the frame is surprising (ATTEND — wake full perception/fusion).
+;
+; This COMPOSES the existing tissue, it does not reinvent it:
+;   - active-inference.fk names the surprise BIT (predicted != actual). Here surprise is the MAGNITUDE over a
+;     reading VECTOR — the free-energy term — and the gate is the active-inference decision made per frame.
+;   - ambient-surprise.fk tracks a scalar baseline by sign-LMS; sk-predict is the vector twin of that
+;     expectation: the simplest honest predictor is PERSISTENCE — expect the next reading to equal the last.
+;   - surprise-salience.fk ranks surprises by magnitude against a floor; sk-salience is the same ge-cutoff,
+;     reused as the per-frame ATTEND gate.
+;   - world-model-live-sense.fk's wmls reading is the frame shape the loop consumes; the kernel runs upstream
+;     of it, deciding whether a frame is even worth sensing fully.
+;   - form-glsl.fk / form-ptx.fk are the lowering lanes; sk-glsl / sk-ptx emit the predict+surprise compute
+;     shader directly from Form, the same DOWNWARD serial fold as the matvec lanes (no FMA, bit-exact to CPU).
+;
+; All integer, no division. A reading is a vector of ints (a frame scaled to ints, as every numeric band does:
+; e.g. a sound/motion/light level *1000). The predictor is persistence: expected[i] = last[i]. Surprise is the
+; L1 prediction error sum |actual[i] - expected[i]| over the vector — the free-energy / total-error term that
+; active-inference.fk counts one bit at a time, here summed as a magnitude. Salience is ge-cutoff against a
+; threshold: 1 = ATTEND, 0 = cheap-persist. Identical 1/0 verdict on every kernel; the floats are pre-scaled.
+;
+; Honest lane: the predictor is the simplest that is honest — persistence — named as the FIRST kernel, not a
+; placeholder; a linear/world-model predictor drops into sk-predict later without changing the gate. Surprise
+; is the RAW L1 error, never inflated to make a quiet frame look loud; a quiet/expected frame yields a small
+; sum, below threshold, ATTEND=0. The ATTEND gate is a hard ge-cutoff — a surprise one under threshold does not
+; wake full perception, exactly as one far under does not. The GPU lowering is the SPEED witness (emitted shader
+; text, bit-exact-runnable on Vulkan/CUDA like form-glsl/form-ptx); the four-way INTEGER math is the proof floor.
+;
+; preludes: form-stdlib/core.fk form-stdlib/form-glsl.fk form-stdlib/form-ptx.fk
+;
+; Proven by: form-stdlib/tests/surprise-kernel-band.fk (four-way at validate.sh, incl. fkwu)
+
+(do
+    ; --- PREDICT: the expected next reading vector. The simplest honest predictor is PERSISTENCE: ---
+    ;     expect the next frame to look like the last one. Returns the history's most-recent reading as the
+    ;     expectation; an empty history honestly yields () — nothing seen, nothing to expect. A linear or
+    ;     world-model predictor drops in here later without touching the surprise/salience gate downstream.
+    (defn sk-predict (history)
+        (if (eq (len history) 0) (empty)
+            (nth history (sub (len history) 1))))
+
+    ; --- ERROR-SUM: the L1 prediction error over the vector = sum |actual[i] - expected[i]|. ---
+    ;     The free-energy / total-surprise term. Walk both vectors in lockstep, +|diff| per component; the
+    ;     evidence-counting spine of ai-surprise-count, summing magnitudes instead of counting miss-bits.
+    ;     An empty expected (no prior frame) yields 0 — no expectation, no error to charge against the frame.
+    (defn sk-error-sum (actual expected)
+        (if (eq (len expected) 0) 0
+            (if (eq (len actual) 0) 0
+                (add (abs (sub (head actual) (head expected)))
+                     (sk-error-sum (tail actual) (tail expected))))))
+
+    ; --- SURPRISE: the prediction-error magnitude of THIS frame against the history's expectation. ---
+    ;     predict the next reading from history, then sum the L1 error against the actual frame. This is the
+    ;     per-frame free-energy term the active-inference gate weighs.
+    (defn sk-surprise (history actual)
+        (sk-error-sum actual (sk-predict history)))
+
+    ; --- SALIENCE / ATTEND: the active-inference gate. surprise meets-or-exceeds threshold -> 1 = ATTEND ---
+    ;     (wake full perception/fusion on the GPU); else 0 = cheap-persist (GPU idle, ride the prediction).
+    ;     A hard ge-cutoff, the same boundary surprise-salience.ss-salient? and anomaly-band use — a surprise
+    ;     one under threshold does not wake perception, identically to one far under.
+    (defn sk-salience (surprise threshold)
+        (if (ge surprise threshold) 1 0))
+
+    ; --- ATTEND?: the whole gate in one call — predict, surprise, salience-decide for a frame. ---
+    ;     1 = this frame is surprising enough to spend the GPU on; 0 = expected, ride the cheap persist.
+    (defn sk-attend? (history actual threshold)
+        (sk-salience (sk-surprise history actual) threshold))
+
+    ; --- GPU MICRO-KERNEL (GLSL): emit the predict+surprise compute shader for the Vulkan/Android lane. ---
+    ;     One invocation per vector component: prod = |actual[j] - expected[j]| reduced by a serial DOWNWARD
+    ;     fold (j = n-1..0), the SAME op order as form-glsl's matvec / fptx-matvec / tb-dot, `precise` ->
+    ;     NoContraction so the driver does not fuse — bit-exact to the CPU sk-error-sum and to sk-ptx. The
+    ;     persistence predictor is expected[] = the prior frame, bound at binding 1; the salience gate is the
+    ;     final ge against the pushed threshold, writing 1=ATTEND / 0=persist. The workgroup size is the only
+    ;     parameter; the body is the proven downward |diff| reduce. The same .spv runs on Adreno/Mali.
+    (defn sk-glsl (wg)
+        (str_concat "#version 450\n\n// form-native surprise micro-kernel (active-inference attention gate, Vulkan/Android lane).\n// Per-frame: predict (persistence: expected[] = prior frame) -> surprise (L1 |actual-expected| serial\n// DOWNWARD reduce j=n-1..0, same op order as the matvec lanes) -> salience (ge threshold -> ATTEND).\n// `precise` -> NoContraction so the driver does NOT fuse -> bit-exact to the CPU sk-error-sum and to\n// the PTX lane. One workgroup reduces one frame; serial fold in invocation 0 keeps the op order exact.\nlayout(local_size_x = " (str_concat wg ", local_size_y = 1, local_size_z = 1) in;\n\nlayout(std430, binding = 0) readonly  buffer A   { int actual[]; };    // this frame, n ints\nlayout(std430, binding = 1) readonly  buffer E   { int expected[]; };  // persistence prediction = prior frame\nlayout(std430, binding = 2) writeonly buffer Res { int res[]; };       // res[0]=surprise, res[1]=attend\n\nlayout(push_constant) uniform Push { uint n; int threshold; } pc;\n\nint iabs(int v) { return v < 0 ? -v : v; }\n\nvoid main() {\n    if (gl_GlobalInvocationID.x != 0u) return;\n    int surprise = 0;\n    for (int j = int(pc.n) - 1; j >= 0; --j) {\n        int diff = iabs(actual[uint(j)] - expected[uint(j)]);\n        surprise = diff + surprise;\n    }\n    res[0] = surprise;\n    res[1] = (surprise >= pc.threshold) ? 1 : 0;\n}\n")))
+
+    ; --- GPU MICRO-KERNEL (PTX-shaped): the CUDA twin of sk-glsl. Same predict+surprise+salience, emitted ---
+    ;     as a CUDA-C source the nvrtc lane mints to PTX/cubin (the fptx-* authoring shape). Same DOWNWARD
+    ;     serial |diff| reduce -> the surprise and ATTEND verdict are bit-identical to sk-glsl and sk-error-sum.
+    (defn sk-ptx (block)
+        (str_concat "// form-native surprise micro-kernel (active-inference attention gate, CUDA/PTX lane).\n// Per-frame: predict (persistence: expected[] = prior frame) -> surprise (L1 |actual-expected| serial\n// DOWNWARD reduce j=n-1..0, same op order as fptx-matvec) -> salience (>= threshold -> ATTEND).\n// One block reduces one frame in thread 0; serial fold keeps the op order bit-exact to sk-glsl/CPU.\nextern \"C\" __global__ void sk_surprise(const int* actual, const int* expected, int* out, unsigned int n, int threshold) {\n    if (threadIdx.x != 0 || blockIdx.x != 0) return;\n    int surprise = 0;\n    for (int j = (int)n - 1; j >= 0; --j) {\n        int d = actual[j] - expected[j];\n        int ad = d < 0 ? -d : d;\n        surprise = ad + surprise;\n    }\n    out[0] = surprise;\n    out[1] = (surprise >= threshold) ? 1 : 0;\n}\n// launch: <<<1, " (str_concat block ">>>\n")))
+
+    0)

--- a/form/form-stdlib/tests/surprise-kernel-band.fk
+++ b/form/form-stdlib/tests/surprise-kernel-band.fk
@@ -1,0 +1,50 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-glsl.fk form-stdlib/form-ptx.fk form-stdlib/surprise-kernel.fk
+;
+; surprise-kernel-band — the active-inference attention gate made falsifiable, then lowered to GPU.
+;
+; A reading is an int-scaled sense vector: (list sound motion light), each level *1000. The history is the
+; quiet room the loop has been watching: three near-identical frames. The persistence predictor expects the
+; next frame to look like the last one it saw.
+;
+;   - QUIET frame [102 50 800] sits 2+1+5 = 8 from the last seen [100 49 805] -> surprise 8. Threshold 50.
+;     8 < 50 -> ATTEND = 0: the frame is expected, ride the cheap persist, GPU idle.
+;   - PRESENCE-APPEARS frame [101 900 803] (motion spikes — someone walked in) sits 1+851+2 = 854 from
+;     the last seen -> surprise 854 >= 50 -> ATTEND = 1: wake full perception/fusion.
+;
+; This is active inference: the GPU is spent only where surprise is high. The same predict->surprise->salience
+; computation is emitted as a GPU micro-kernel (sk-glsl / sk-ptx) so the per-frame surprise runs on silicon.
+;
+; Verdict 511 when every claim lands:
+;   1    persistence predicts the last seen frame        (sk-predict last == [100 49 805])
+;   2    L1 error over the quiet frame                    (sk-surprise hist [102 50 800] == 8)
+;   4    a quiet/expected frame is NOT salient            (sk-salience 8 50 == 0)
+;   8    L1 error over the new-presence frame             (sk-surprise hist [101 900 803] == 854)
+;   16   a new presence IS salient                        (sk-salience 854 50 == 1)
+;   32   the gate stays quiet on the quiet frame          (sk-attend? hist [102 50 800] 50 == 0)
+;   64   the gate WAKES on the new presence               (sk-attend? hist [101 900 803] 50 == 1)
+;   128  the GLSL micro-kernel emits (and reparameterizes by workgroup)
+;   256  the PTX micro-kernel emits (and reparameterizes by block)
+(do
+    ; the quiet room the loop has been watching — three near-identical frames, scaled *1000.
+    (let hist (list (list 100 51 802) (list 99 48 804) (list 100 49 805)))
+    (let last (list 100 49 805))
+    (let quiet (list 102 50 800))            ; expected: tiny drift
+    (let presence (list 101 900 803))        ; motion spikes — someone walked in
+
+    (let c0 (if (and (eq (nth (sk-predict hist) 0) 100)
+                     (and (eq (nth (sk-predict hist) 1) 49)
+                          (eq (nth (sk-predict hist) 2) 805))) 1 0))
+    (let c1 (if (eq (sk-surprise hist quiet) 8)        2 0))
+    (let c2 (if (eq (sk-salience 8 50) 0)              4 0))
+    (let c3 (if (eq (sk-surprise hist presence) 854)   8 0))
+    (let c4 (if (eq (sk-salience 854 50) 1)           16 0))
+    (let c5 (if (eq (sk-attend? hist quiet 50) 0)     32 0))
+    (let c6 (if (eq (sk-attend? hist presence 50) 1)  64 0))
+    ; GPU micro-kernel emission: deterministic, reparameterizes by workgroup / block, non-empty text.
+    (let c7 (if (and (str_eq (sk-glsl "64") (sk-glsl "64"))
+                     (and (gt (str_len (sk-glsl "64")) 0)
+                          (gt (str_len (sk-glsl "32")) (str_len (sk-glsl "8"))))) 128 0))
+    (let c8 (if (and (str_eq (sk-ptx "256") (sk-ptx "256"))
+                     (gt (str_len (sk-ptx "256")) 0)) 256 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 c8)))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1168,3 +1168,4 @@ cell-card fks 111111
 mesh-sense-7w fks 255
 mesh-join fks 1023
 sense-discernment fks 1023
+surprise-kernel fks 511


### PR DESCRIPTION
The per-frame attention gate for the 24/7 sense loop, as a GPU micro-kernel. In an always-on loop you cannot fully process every frame; you PREDICT the next reading, compute SURPRISE (prediction error), and spend the GPU only where surprise is high (active inference). This stone is that small, fast per-frame computation, lowered to a compute shader.

**Composes existing tissue** (does not reinvent it): `active-inference.fk` (predict→observe→ERROR; here the error MAGNITUDE over a reading vector — the free-energy term), `ambient-surprise.fk` (`sk-predict` is its vector twin: persistence — expect the next frame to look like the last), `surprise-salience.fk` (the ge-cutoff, reused as the per-frame ATTEND gate), `form-glsl.fk`/`form-ptx.fk` (the lowering lanes).

- `sk-predict(history)` → expected next reading (persistence — the first kernel; a linear/world-model predictor drops in later without touching the gate)
- `sk-error-sum(actual, expected)` → Σ|actual[i]−expected[i]| (L1 free-energy term)
- `sk-surprise(history, frame)` → per-frame prediction-error magnitude
- `sk-salience(surprise, threshold)` → **1 = ATTEND** (wake perception/fusion) / **0 = cheap-persist** (GPU idle)
- `sk-attend?(hist, frame, thr)` → the whole gate in one call
- `sk-glsl(wg)` / `sk-ptx(blk)` → the predict+surprise micro-kernel as a GPU compute shader (Vulkan/Android + CUDA lanes), serial DOWNWARD |diff| reduce, no FMA, bit-exact to the CPU `sk-error-sum`

**Four-way (Go=Rust=TS=fkwu) at validate.sh — verdict 511, 0 divergent.** On the sample: a quiet room history → persistence predicts `[100,49,805]`; a quiet frame `[102,50,800]` → surprise **8** → **ATTEND=0** (ride the persist); a frame where a new presence appears `[101,900,803]` → surprise **854** → **ATTEND=1** (wake full perception).

**GPU witness:** the emitted GLSL mints to valid SPIR-V via `glslangValidator` (2604 bytes) — a real GLSL keyword bug (`out` is reserved → renamed buffer `res`) was caught at mint. No GPU dispatch was reachable in this env, so the emitted shader text + the four-way integer math is the honest floor, named as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)