### PR TITLE
tend(form): register room-register in the four-way manifest (fks 255)

### DIFF
--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1172,3 +1172,4 @@ presence-event fks 16383
 identity-match fks 511
 self-heard-learning fks 511
 surprise-kernel fks 511
+room-register fks 255


### PR DESCRIPTION
room-register.fk + band landed in #3887 but the squash dropped its manifest row in conflict resolution. Restore the row so the recipe is part of the four-way floor. Re-validated 255, 0 divergent on current main.