### PR TITLE
tend(form): face-embed — the VISUAL identity modality, sibling of speaker-embed (fks 255)

### DIFF
--- a/form/form-stdlib/face-embed.fk
+++ b/form/form-stdlib/face-embed.fk
@@ -1,0 +1,55 @@
+; face-embed.fk — the nearest-by-cosine DECISION over the oracle's NEURAL face embeddings (the body). The VISUAL sibling of speaker-embed (voice). The embedding quality is the ArcFace-class oracle's; this proves the recognition decision over it.
+;
+; A face is recognized the same way a voice is: not by hand-built geometry (eye spacing,
+; jaw curve) — those can't part two similar faces — but by matching over the embedding of
+; the best LOCAL oracle. An ArcFace-class face-recognition model maps a cropped face to a
+; 512-d vector where same-person vectors point the same way and different people point apart.
+; The carrier runs that oracle and L2-normalizes + quantizes the embedding to ints; EVERY
+; recognition decision is HERE, native and four-way. The embedding rides the oracle exactly
+; as speaker-embed rides ECAPA — that is the honest floor: the vector is the oracle's, the
+; DECISION is the body's.
+;
+; Metric: cosine similarity. Because the carrier L2-normalizes both vectors, cosine is just
+; their dot product — nearest face = the enrolled vector with the MAX dot. A floor on that
+; max returns "unknown" rather than forcing every face onto someone (recognition is care;
+; this matches INWARD — the outward gate is sense-discernment).
+;
+; This drops into identity-match as just another modality row: an observation is
+; (category embedding device time), and a face embedding is interchangeable with a voice one.
+;
+; Builtins only (mul/add/gt/ge/nth/len/head/tail/cons). Proven by
+; form-stdlib/tests/face-embed-band.fk.
+
+(do
+    (defn fc-id  (s) (nth s 0))      ; roster cell = (id embedding-vector)
+    (defn fc-vec (s) (nth s 1))
+
+    ; integer dot product over two equal-length quantized unit vectors = cosine·scale²
+    (defn fe-dot (a b)
+        (if (eq (len a) 0) 0
+            (add (mul (head a) (head b)) (fe-dot (tail a) (tail b)))))
+
+    ; nearest enrolled face cell by MAX dot (most-aligned face)
+    (defn fe-best (q enrolled best bestsim)
+        (if (eq (len enrolled) 0) best
+            (do
+                (let s (fe-dot q (fc-vec (head enrolled))))
+                (if (gt s bestsim)
+                    (fe-best q (tail enrolled) (head enrolled) s)
+                    (fe-best q (tail enrolled) best bestsim)))))
+    (defn fe-nearest (q enrolled)
+        (fe-best q (tail enrolled) (head enrolled) (fe-dot q (fc-vec (head enrolled)))))
+
+    ; the similarity behind the call (cosine·scale²)
+    (defn fe-sim (q enrolled) (fe-dot q (fc-vec (fe-nearest q enrolled))))
+
+    ; the call: nearest enrolled face's id if it clears the floor, else "unknown"
+    ; (honest no-match instead of a forced guess)
+    (defn fe-match (q enrolled floor)
+        (if (ge (fe-sim q enrolled) floor)
+            (fc-id (fe-nearest q enrolled))
+            "unknown"))
+
+    ; add a face exemplar to the roster — a new (id embedding) cell at the head
+    (defn fe-enroll (roster id embedding)
+        (cons (list id embedding) roster)))

--- a/form/form-stdlib/tests/face-embed-band.fk
+++ b/form/form-stdlib/tests/face-embed-band.fk
@@ -1,0 +1,35 @@
+; preludes: form-stdlib/face-embed.fk
+;
+; face-embed-band — the nearest-by-cosine DECISION over face embeddings (floor -> "unknown"),
+; four-way. The VISUAL sibling of speaker-embed-band. Fixture: two hand-given 4-d faceprints;
+; the neural embedding quality is the ArcFace-class oracle's, not proven here. Real face
+; recognition is the arc. Drops into identity-match as just another modality row.
+;
+; A roster of two quantized unit-ish faceprints; cosine = dot (vectors pre-normalized by the
+; oracle). Nearest = max dot; a floor returns "unknown" honestly. fe-enroll added BOTH faces.
+;
+; Verdict 255 when every claim lands (numeric — the id string is carrier-read):
+;   1   identical faceprints align fully     (dot = 100)
+;   2   orthogonal faceprints don't          (dot = 0)
+;   4   roster grew to 2 by fe-enroll        (len = 2)
+;   8   query near A resolves to A           (top sim 90)
+;   16  query near B resolves to B           (top sim 90)
+;   32  query near A matches id "a"          (str_eq -> "a")
+;   64  query near B matches id "b"          (str_eq -> "b")
+;   128 a far/weak query is "unknown"        (top 18 < floor 50 -> "unknown")
+(do
+    (let empty-roster (empty))
+    (let r1 (fe-enroll empty-roster "a" (list 10 0 0 0)))
+    (let roster (fe-enroll r1 "b" (list 0 10 0 0)))
+    (let qA (list 9 1 0 0))
+    (let qB (list 1 9 0 0))
+    (let qFar (list 1 1 1 1))
+    (let c0 (if (eq (fe-dot (list 10 0 0 0) (list 10 0 0 0)) 100) 1 0))
+    (let c1 (if (eq (fe-dot (list 10 0 0 0) (list 0 10 0 0)) 0) 2 0))
+    (let c2 (if (eq (len roster) 2) 4 0))
+    (let c3 (if (eq (fe-sim qA roster) 90) 8 0))
+    (let c4 (if (eq (fe-sim qB roster) 90) 16 0))
+    (let c5 (if (str_eq (fe-match qA roster 50) "a") 32 0))
+    (let c6 (if (str_eq (fe-match qB roster 50) "b") 64 0))
+    (let c7 (if (str_eq (fe-match qFar roster 50) "unknown") 128 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1173,3 +1173,4 @@ identity-match fks 511
 self-heard-learning fks 511
 surprise-kernel fks 511
 room-register fks 255
+face-embed fks 255


### PR DESCRIPTION
## face-embed — the visual sibling of speaker-embed

`face-embed.fk` mirrors `speaker-embed.fk` exactly: nearest-by-cosine over quantized unit **face** embeddings.

- `fe-dot(a, b)` — cosine over quantized face embeddings (dot, since the oracle L2-normalizes)
- `fe-match(query, enrolled, floor)` — nearest enrolled face id, or `"unknown"` below the floor
- `fe-enroll(roster, id, embedding)` — add a face exemplar

The recognition **decision** is native four-way; the embedding itself rides an ArcFace-class oracle exactly as `speaker-embed` rides ECAPA — named as the honest floor in the header. Drops into `identity-match` as just another modality row: an observation is `(category embedding device time)`, a face embedding interchangeable with a voice one. Recognition is care; this matches **inward** — the outward gate stays `sense-discernment`.

## Proof — four-way

`tests/face-embed-band.fk`: enroll 2 faces, query near A → `"a"`, near B → `"b"`, far/weak query → `"unknown"`. Stable integer verdict **255**.

```
✓  core.fk+face-embed.fk+face-embed-band.fk  → 255
fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
1 ok, 0 divergent — kernels agree on every sample.
```

Go = Rust = TS = fkwu. Manifest row `face-embed fks 255` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)