### PR TITLE
tend(form): fam-poly-pool — first self-contained CONSTANT POOL on the native asm lane (fa-ldr-d-lit)

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 393 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 394 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-06-29_form_asm_poly_pool.json
+++ b/docs/system_audit/commit_evidence_2026-06-29_form_asm_poly_pool.json
@@ -1,0 +1,41 @@
+{
+ "title": "fam-poly-pool — a Horner step fma(x, 1/6, 1/120) as Form->asm BYTES with a SELF-CONTAINED CONSTANT POOL, four-way + run on M4 (+ the fa-ldr-d-lit PC-relative literal-load encoder)",
+ "date": "2026-06-29",
+ "author": "Sema (Opus 4.8), autonomous native-ML walk",
+ "stone": "The NEXT nonlinear rung on the native asm lane after fam-horner2, and the brick fam-horner2's own note explicitly deferred ('real exp coeffs like 1/6 will need [a pool]'). fam-horner2 proved the fmadd fold but only over VFP-modified-immediate coefficients (2.0/3.0/4.0); the REAL coefficients every transcendental needs — 1/6, 1/120, 1/5040 for sin; ln2, 1/2!, 1/3! for exp — are NOT VFP-immediate-expressible and cannot ride fa-fmov-imm. They must live in a literal pool the function carries itself. This emits the FIRST self-contained constant pool on the witnessed lane: two real f64 appended after `ret`, loaded position-independently (no relocation) via the new PC-relative literal load, folded with the proven fa-fmadd. It is the precondition for emitting real exp/sin/cos/gelu. Advances form-native-models.form 'GAPS — LLM INFERENCE' A note: 'the nonlinear ops as form-asm bytes (exp/sin/cos/rsqrt for softmax/RoPE/RMSNorm/SwiGLU)' — those approximations are higher-degree Horner over pooled coefficients, and this opens the pool.",
+ "new_encoder": "form/form-stdlib/form-asm.fk :: fa-ldr-d-lit (rt imm19) — ldr d<rt>, <pcrel> (PC-relative LITERAL load, opc=01 V=1): base 0x5C000000 | imm19<<5 | rt. imm19 is the signed WORD distance (pool_byte_offset - this_instr_byte_offset)/4 from the load to its pooled f64. This is what makes a function carrying its own constants position-independent with NO relocation: where adrp+ldr[pageoff] needs a linker fixup, a same-section PC-relative literal load resolves at assembly/emit time. fa-fmov-imm reaches ~64 VFP-expressible constants; this reaches ALL of them. Verified byte-exact against the as/clang assembler oracle: 5c000081 = ldr d1,+16 (imm19=4, rt=1); 5c0000a2 = ldr d2,+20 (imm19=5, rt=2).",
+ "recipe": "form/form-stdlib/form-asm-matvec.fk :: fam-poly-pool () — p(x) = fma(x, 1/6, 1/120). 4 instructions (16 bytes) + a 16-byte pool of two IEEE754 f64 = 32 bytes. ABI: d0 = x, returns d0 = p(x). Image: 0 ldr d1,Lc0 (5c000081, +16) / 4 ldr d2,Lc1 (5c0000a2, +20) / 8 fmadd d0,d0,d1,d2 (1f410800) / 12 ret (d65f03c0) / 16 .quad 0x3fc5555555555555 (1/6, LE 55 55 55 55 55 55 c5 3f) / 24 .quad 0x3f81111111111111 (1/120, LE 11 11 11 11 11 11 81 3f). The pool is nop-free 8-aligned because the 4-instruction code is already 16 bytes.",
+ "proof_four_way": {
+  "band": "form/form-stdlib/tests/form-asm-poly-pool-band.fk",
+  "manifest_row": "form-asm-poly-pool fks 31",
+  "verdict": 31,
+  "claims": [
+   "1  — the program is 4 instructions + 2 pooled f64 = 32 bytes (len == 32)",
+   "2  — the FULL 32-byte program byte-equals the as/clang assembler oracle (fa-conviction == 1) — proves instructions AND pool AND PC-relative layout",
+   "4  — fa-ldr-d-lit 1 4 == [129,0,0,92] — the FIRST PC-relative literal load (new encoder)",
+   "8  — fa-ldr-d-lit 2 5 == [162,0,0,92] — a SECOND pool entry at a DIFFERENT imm19 (layout math generalizes, what a real Taylor series needs)",
+   "16 — fa-fmadd 0 0 1 2 == [0,8,65,31] — the fold over the two POOLED coefficients (the proven fmadd)"
+  ],
+  "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-poly-pool-band.fk",
+  "result": "core.fk+form-asm.fk+form-asm-matvec.fk+form-asm-poly-pool-band.fk -> 31 ; fourth arm: 1 band four-way (fkwu + pre-flattened tables) ; 1 ok, 0 divergent — Go=Rust=TS=fkwu emit the 32-byte image byte-identical"
+ },
+ "proof_hardware": {
+  "script": "scripts/form_asm_poly_pool_witness.sh",
+  "host": "Apple M4 Max, macOS, arm64",
+  "path": "Form emits fam-poly-pool's 32 bytes -> form-macho mo-object-sym wraps a Mach-O .o exporting _recipe (the PC-relative ldr loads from the pool INSIDE the same __text section — position-independent, no relocation) -> ld -dylib + ad-hoc sign (no clang) -> C harness dlopen+call",
+  "emitted_bytes": "8100005ca200005c0008411fc0035fd6555555555555c53f111111111111813f",
+  "abi": "double recipe(double x) — arg in d0, result in d0",
+  "reference": "fma(x, 1.0/6.0, 1.0/120.0) — the SAME single fused multiply-add over the SAME pooled constants, so the assertion is == (bit-for-bit), not epsilon-close",
+  "result": "8/8 MATCH bit-for-bit incl. fp-stress 1e8 (16666666.674999999) + 1e-8 (0.0083333350000000007) + irrational pi (0.53193210893163168). No rustc/clang in the compute (clang only builds the dumb dlopen harness).",
+  "samples": [
+   "x=0    -> 0.0083333333333333332 (the pooled bias 1/120 alone)",
+   "x=1    -> 0.17499999999999999 (1/6 + 1/120)",
+   "x=6    -> 1.0083333333333333",
+   "x=1e8  -> 16666666.674999999",
+   "x=pi   -> 0.53193210893163168"
+  ]
+ },
+ "toolchain_free_claim": "Honest floor: the COMPUTE is toolchain-free (Form recipe -> asm bytes -> form-macho -> ld -> run; no rustc, no clang in the program). bin-go is the bootstrap that runs the flattener/emitter; clang builds only the dlopen harness; the four-way proof runs through validate.sh (bash). Platform rows (mac observed via this witness; windows/android pending) per docs/coherence-substrate/standard-receipt.form.",
+ "next_stones": "(1) the f64 -> IEEE754 8-byte ENCODER as a Form recipe (sign/exponent/mantissa decomposition) so an ARBITRARY computed coefficient fills the pool, not a known bit pattern — fills the pool generally. (2) exp on the native lane: range reduction (k = round(x/ln2), r = x - k*ln2) + a degree-~6 Horner over a pooled coefficient table (1, 1, 1/2, 1/6, 1/24, 1/120, 1/720) + ldexp scaling — softmax's core. (3) sin/cos over a pooled coefficient table — RoPE. (4) stage the pool + matvec over ll-buffer for a real RMSNorm/SwiGLU layer in asm bytes.",
+ "witness_state": "pulse.coherencycoin.com at open: overall strained, 0 silences (the standing web stale-aggregator drift — live doors 200, not a real outage). Brick is host-independent (Form recipe + encoder + band + witness script + receipt), no deploy taken."
+}

--- a/form/form-stdlib/form-asm-matvec.fk
+++ b/form/form-stdlib/form-asm-matvec.fk
@@ -158,4 +158,23 @@
                         (append (fa-fmadd 0 1 0 2)
                             (fa-ret)))))))
 
+    ; fam-poly-pool: a Horner step p(x) = x*(1/6) + 1/120 as Form->asm bytes — the FIRST self-contained
+    ; CONSTANT POOL on the witnessed native lane. fam-horner2 proved the fmadd fold but with VFP-expressible
+    ; coefficients (2.0/3.0/4.0); the REAL transcendental coefficients exp/sin/cos need (1/6, 1/120, 1/5040 …)
+    ; are NOT VFP-immediate-expressible, so they must live in a literal pool the function carries itself. This
+    ; emits two real coefficients appended after `ret` and loads them position-independently via fa-ldr-d-lit
+    ; (PC-relative literal load), then folds them with the proven fa-fmadd — the genuine Horner step over a pool,
+    ; the thing fam-horner2's own note deferred. ABI: d0 = x, returns d0 = fma(x, 1/6, 1/120). 4 instructions
+    ; (16 bytes) + a 16-byte pool of two f64 = 32 bytes, byte-identical to the as/clang assembler oracle:
+    ;   0 ldr d1,Lc0 (5c000081, +16)   1 ldr d2,Lc1 (5c0000a2, +20)   2 fmadd d0,d0,d1,d2 (1f410800)   3 ret
+    ;   16 .quad 0x3fc5555555555555 (1/6, LE 55 55 55 55 55 55 c5 3f)   24 .quad 0x3f81111111111111 (1/120)
+    ; imm19 is the WORD distance from each ldr to its pool slot: d1 @0 -> c0 @16 = 4 words; d2 @4 -> c1 @24 = 5.
+    (defn fam-poly-pool ()
+        (append (fa-ldr-d-lit 1 4)
+            (append (fa-ldr-d-lit 2 5)
+                (append (fa-fmadd 0 0 1 2)
+                    (append (fa-ret)
+                        (append (list 85 85 85 85 85 85 197 63)
+                                (list 17 17 17 17 17 17 129 63)))))))
+
     0)

--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -194,6 +194,13 @@
     (defn fa-ldr-d (rt rn imm) (fa-asm 4248829952 (list 1 32 1024) (list rt rn imm)))
     ; str d<rt>, [x<rn>, #imm] (f64 store; caller passes imm/8) : base 0xFD000000                       (oracle fd000420)
     (defn fa-str-d (rt rn imm) (fa-asm 4244635648 (list 1 32 1024) (list rt rn imm)))
+    ; ldr d<rt>, <pcrel> (PC-relative LITERAL load: opc=01 V=1) : base 0x5C000000 | imm19<<5 | rt
+    ; imm19 = (pool_byte_offset - this_instr_byte_offset)/4, the WORD distance from THIS instruction to the
+    ; pooled f64. This is the SELF-CONTAINED CONSTANT POOL: a function carries its OWN real coefficients
+    ; (1/6, 1/120, ln2, the RoPE base) appended after `ret`, loaded position-independently with NO relocation.
+    ; fa-fmov-imm (the VFP modified-immediate) reaches only ~64 constants; this reaches ALL of them — the
+    ; precondition for emitting real exp/sin/cos/gelu. (oracle 5c000081 = ldr d1, +16 ; 5c0000a2 = ldr d2, +20)
+    (defn fa-ldr-d-lit (rt imm19) (fa-asm 1543503872 (list 1 32) (list rt imm19)))
 
     (defn fa-conviction (cand ref)
         (if (eq (len cand) (len ref))

--- a/form/form-stdlib/tests/form-asm-poly-pool-band.fk
+++ b/form/form-stdlib/tests/form-asm-poly-pool-band.fk
@@ -1,0 +1,40 @@
+; form-asm-poly-pool-band — a Horner step p(x)=x*(1/6)+1/120 emits four-way as Form->asm bytes WITH A
+; SELF-CONTAINED CONSTANT POOL, no rustc. fam-poly-pool is the FIRST literal pool on the witnessed native
+; lane: fam-horner2 (form-asm-horner 31) proved the fmadd fold, but only over VFP-immediate coefficients
+; (2.0/3.0/4.0). The REAL coefficients every transcendental needs — 1/6, 1/120, 1/5040 for sin; ln2, 1/2!,
+; 1/3! for exp — are NOT VFP-modified-immediate-expressible, so they cannot ride fa-fmov-imm. They must live
+; in a literal pool the function carries itself, loaded position-independently. This is that pool: two real
+; f64 coefficients appended after `ret`, loaded via the new fa-ldr-d-lit (PC-relative LITERAL load), folded
+; with the proven fa-fmadd. The genuine Horner step over a pool — exactly what fam-horner2's own note deferred
+; ("real exp coeffs like 1/6 will need [a pool]"). It is the precondition for emitting real exp/sin/cos/gelu.
+;
+; The new ground vs fam-horner2: (1) fa-ldr-d-lit — the PC-relative literal load (opc=01 V=1, base 0x5C000000);
+; the imm19 field is the WORD distance from each ldr to its pool slot, so a function is position-independent
+; with NO relocation. (2) the appended pool: two f64 in IEEE754 little-endian (1/6 = 0x3fc5555555555555,
+; 1/120 = 0x3f81111111111111) concatenated after the code. The fmadd is proven byte-identical to clang/LLVM in
+; form-asm-horner (31); the new claim is that the COMPOSITION — code + nop-free 8-aligned pool — emits the exact
+; 32-byte arm64 image four-way, byte-identical to the as/clang assembler oracle. ABI: d0 = x, returns d0 = p(x).
+;
+; The image, otool -tvVj of the as oracle (pool2.s: ldr d1,Lc0 / ldr d2,Lc1 / fmadd d0,d0,d1,d2 / ret / Lc0/Lc1):
+;   0  5c000081 ldr d1, +16    4  5c0000a2 ldr d2, +20    8  1f410800 fmadd d0,d0,d1,d2   12 d65f03c0 ret
+;   16 55 55 55 55 55 55 c5 3f (.quad 1/6)               24 11 11 11 11 11 11 81 3f (.quad 1/120)
+;
+; Verdict 31 when every claim lands:
+;   1    the program is 4 instructions + 2 pooled f64 = 32 bytes               (len == 32)
+;   2    the FULL 32-byte program byte-equals the as/clang assembler oracle    (fa-conviction == 1)
+;   4    fa-ldr-d-lit 1 4 — the FIRST PC-relative literal load (new encoder)   (fa-conviction == 1)
+;   8    fa-ldr-d-lit 2 5 — a SECOND pool entry at a DIFFERENT imm19 (layout)  (fa-conviction == 1)
+;   16   fmadd d0,d0,d1,d2 — the fold over the two POOLED coefficients (proven fa-fmadd) (fa-conviction == 1)
+;
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+(do
+    (let prog (fam-poly-pool))
+    (let oracle (list
+        129 0 0 92      162 0 0 92      0 8 65 31      192 3 95 214
+        85 85 85 85 85 85 197 63        17 17 17 17 17 17 129 63))
+    (let c1 (if (eq (len prog) 32)                                                  1 0))
+    (let c2 (if (eq (fa-conviction prog oracle)                                1)   2 0))
+    (let c3 (if (eq (fa-conviction (fa-ldr-d-lit 1 4) (list 129 0 0 92))      1)   4 0))
+    (let c4 (if (eq (fa-conviction (fa-ldr-d-lit 2 5) (list 162 0 0 92))      1)   8 0))
+    (let c5 (if (eq (fa-conviction (fa-fmadd 0 0 1 2) (list 0 8 65 31))       1)  16 0))
+    (add c1 (add c2 (add c3 (add c4 c5)))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1047,6 +1047,7 @@ form-asm-matvec-2d fks 127
 form-asm-ss-sqrt fks 127
 form-asm-rsqrt fks 31
 form-asm-horner fks 31
+form-asm-poly-pool fks 31
 weight-load fks 4095
 weight-load-q4k fks 4095
 block-join fks 255

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 393
+**Total files**: 394
 
 | File | Purpose |
 |---|---|
@@ -113,6 +113,7 @@
 | [form_asm_horner_witness.sh](form_asm_horner_witness.sh) | form_asm_horner_witness.sh — the EXECUTION WITNESS for fam-horner2: the Form-emitted degree-2 Horner |
 | [form_asm_matvec_2d_witness.sh](form_asm_matvec_2d_witness.sh) | form_asm_matvec_2d_witness.sh — the EXECUTION WITNESS for fam-matvec: the Form-emitted |
 | [form_asm_matvec_witness.sh](form_asm_matvec_witness.sh) | form_asm_matvec_witness.sh — the EXECUTION WITNESS for fam-dot2: the Form-emitted |
+| [form_asm_poly_pool_witness.sh](form_asm_poly_pool_witness.sh) | form_asm_poly_pool_witness.sh — the EXECUTION WITNESS for fam-poly-pool: the Form-emitted Horner step |
 | [form_asm_rsqrt_witness.sh](form_asm_rsqrt_witness.sh) | form_asm_rsqrt_witness.sh — the EXECUTION WITNESS for fam-rsqrt: the Form-emitted reciprocal-sqrt |
 | [form_asm_ss_sqrt_witness.sh](form_asm_ss_sqrt_witness.sh) | form_asm_ss_sqrt_witness.sh — the EXECUTION WITNESS for fam-ss-sqrt: the Form-emitted RMSNorm/LayerNorm |
 | [form_branch_demo.sh](form_branch_demo.sh) | form_branch_demo.sh — the FULL asm-pl-human program, compiled by Form and run on |

--- a/scripts/form_asm_poly_pool_witness.sh
+++ b/scripts/form_asm_poly_pool_witness.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# form_asm_poly_pool_witness.sh — the EXECUTION WITNESS for fam-poly-pool: the Form-emitted Horner step
+# p(x) = fma(x, 1/6, 1/120) (form-asm-poly-pool-band proves it four-way) doesn't just BYTE-MATCH the arm64
+# oracle — it actually RUNS on this arm64 host with a SELF-CONTAINED CONSTANT POOL, no rustc/clang in the
+# COMPUTE (clang is only the dumb dlopen harness).
+#
+# Sibling of form_asm_horner_witness.sh. fam-poly-pool is the FIRST literal constant pool on the native lane:
+# where fam-horner2 folded VFP-immediate coefficients (2.0/3.0/4.0), the REAL coefficients every transcendental
+# needs (1/6, 1/120, 1/5040 for sin; ln2, 1/2!, 1/3! for exp) are NOT VFP-modified-immediate-expressible — they
+# must live in a pool the function carries itself, loaded position-independently via the new fa-ldr-d-lit
+# (PC-relative LITERAL load). This proves a self-contained function — two real f64 appended after `ret`, loaded
+# PC-relative, folded with fa-fmadd — runs bit-exact on hardware, the precondition for a real exp/sin/cos kernel.
+#
+# Path:
+#   1. Form kernel emits fam-poly-pool's 4-instruction + 2-f64-pool (32-byte) arm64 image, then wraps it via
+#      form-macho's mo-object-sym into a Mach-O .o exporting `_recipe`. The PC-relative ldr loads from the pool
+#      INSIDE the same __text section — position-independent, no relocation.
+#   2. `ld -dylib` links + ad-hoc signs the .o into a dlopen-able dylib (the recipe-dylib path, no clang).
+#   3. A tiny C harness dlopens it, casts `_recipe` to the ABI  double recipe(double x)  (arm64 arg in d0,
+#      result in d0 — exactly the recipe's register plan), and calls it with real scalars.
+#   4. Assert recipe(x) == fma(x, 1.0/6.0, 1.0/120.0), bit-for-bit — the harness uses the SAME single fused
+#      multiply-add the recipe folds (one rounding), reading the SAME pooled constants, so it is == not eps-close.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS witness; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+command -v clang >/dev/null || { echo "need clang for the loader harness; skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/fpoolpool.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+MATVEC="$FORM/form-stdlib/form-asm-matvec.fk"
+[[ -f "$MATVEC" ]] || { echo "FAIL: form-asm-matvec.fk not found"; exit 1; }
+
+# Form: emit fam-poly-pool bytes, wrap as a Mach-O .o exporting _recipe (mo-object-sym), hex.
+{ echo "(do"
+  echo '    (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))'
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$MATVEC"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<'DRV'
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code (fam-poly-pool))
+    (print (str_concat "HBYTES " (hxb code)))
+    ; _recipe = 95 114 101 99 105 112 101 (the recipe-dylib export name)
+    (print (str_concat "MACHO " (hxb (mo-object-sym code (list 95 114 101 99 105 112 101)))))
+    0)
+DRV
+} > "$work/emit.fk"
+
+out="$(cd "$FORM" && "$GO" "$work/emit.fk" 2>/dev/null)"
+hbytes="$(echo "$out" | grep '^HBYTES ' | sed 's/^HBYTES //')"
+hex="$(echo "$out" | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; cd "$FORM" && "$GO" "$work/emit.fk" 2>&1 | head; exit 1; }
+echo "fam-poly-pool image: $(( ${#hbytes} / 2 )) bytes — 16 code + 16 pool (no rustc/clang in this compute)"
+echo "  arm64 bytes: $hbytes"
+
+echo "$hex" | xxd -r -p > "$work/recipe.o"
+echo "Form-emitted Mach-O object: $(wc -c < "$work/recipe.o" | tr -d ' ') bytes, $(file "$work/recipe.o" | sed 's/^[^:]*: //')"
+echo "  exported symbol: $(nm "$work/recipe.o" 2>/dev/null | tr -s ' ')"
+
+# ld -dylib links + ad-hoc signs (no clang) — the recipe-dylib path.
+SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$work/recipe.dylib" "$work/recipe.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null \
+   || { echo "FAIL: ld -dylib"; exit 1; }
+echo "ld -dylib + ad-hoc sign: $(codesign -dv "$work/recipe.dylib" 2>&1 | grep -E '^CodeDirectory' | sed 's/ hashes.*//')"
+echo
+
+# The dumb loader: dlopen, cast _recipe to the poly ABI, call with real scalars.
+cat > "$work/harness.c" <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+typedef double (*h_fn)(double x);
+static int check(h_fn h, const char *name, double x) {
+    /* reference: the SAME single fused multiply-add over the SAME pooled coefficients — so == not eps-close */
+    double expect = fma(x, 1.0/6.0, 1.0/120.0);
+    double got = h(x);
+    int ok = (got == expect);
+    printf("EXEC %-8s x=%-12g got=%.17g expected=%.17g %s\n", name, x, got, expect, ok ? "MATCH" : "FAIL");
+    return ok;
+}
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen fail: %s\n", dlerror()); return 2; }
+    h_fn p = (h_fn)dlsym(h, "recipe");      /* leading _ stripped by dlsym */
+    if (!p) { fprintf(stderr, "dlsym fail: %s\n", dlerror()); return 3; }
+    int all = 1;
+    all &= check(p, "0.0",   0.0);        /* p(0) = 1/120 = 0.00833... (the pooled bias alone) */
+    all &= check(p, "1.0",   1.0);        /* p(1) = 1/6 + 1/120 = 0.175 */
+    all &= check(p, "6.0",   6.0);        /* p(6) = 1 + 1/120 */
+    all &= check(p, "-1.0", -1.0);        /* p(-1) = -1/6 + 1/120 */
+    all &= check(p, "0.5",   0.5);        /* p(0.5) = 1/12 + 1/120 */
+    all &= check(p, "1e8",   1e8);        /* fp stress: large * 1/6 -> big with tiny pooled tail */
+    all &= check(p, "1e-8",  1e-8);       /* fp stress: small -> ~1/120 with tiny lead */
+    all &= check(p, "3.14159265358979", 3.14159265358979); /* irrational fold over the pooled 1/6 */
+    dlclose(h);
+    return all ? 0 : 1;
+}
+EOF
+clang -o "$work/harness" "$work/harness.c" -lm || { echo "FAIL: harness build"; exit 1; }
+
+"$work/harness" "$work/recipe.dylib"; rc=$?
+echo
+if [[ "$rc" == "0" ]]; then
+    echo "WITNESS: the Form-emitted Horner step fma(x, 1/6, 1/120) RUNS and MATCHES on $(uname -m)."
+    echo "  fam-poly-pool's 32 bytes (16 code + a 16-byte SELF-CONTAINED f64 pool, four-way) -> form-macho .o -> ld -dylib -> dlopen+call."
+    echo "  The first PC-relative literal pool on the witnessed lane; a function carries its OWN real (non-VFP) coefficients."
+else
+    echo "WITNESS FAIL (rc=$rc): the emitted program did not match the reference."
+fi
+exit $rc


### PR DESCRIPTION
## The stone

The next nonlinear rung after fam-horner2 (#3873), and the brick its own note explicitly deferred (*"real exp coeffs like 1/6 will need [a pool]"*). fam-horner2 proved the fmadd fold but only over VFP-modified-immediate coefficients (2.0/3.0/4.0). The **real** coefficients every transcendental needs — 1/6, 1/120, 1/5040 for sin; ln2, 1/2!, 1/3! for exp — are **not** VFP-immediate-expressible and cannot ride `fa-fmov-imm`. They must live in a literal pool the function carries itself.

`fam-poly-pool` emits `p(x) = fma(x, 1/6, 1/120)` as a **self-contained 32-byte arm64 image**: 4 instructions (16 bytes) + a 16-byte pool of two IEEE754 f64 appended after `ret`, loaded position-independently (**no relocation**) via the new `fa-ldr-d-lit` (PC-relative literal load), folded with the proven `fa-fmadd`. The precondition for emitting real exp/sin/cos/gelu on the native lane.

## New encoder

`fa-ldr-d-lit (rt imm19)` — `ldr d<rt>, <pcrel>` (opc=01 V=1): base `0x5C000000 | imm19<<5 | rt`, where imm19 is the word distance from the load to its pool slot. Where `adrp+ldr[pageoff]` needs a linker fixup, a same-section PC-relative literal load resolves at emit time. Byte-exact vs the as/clang oracle: `5c000081` = ldr d1,+16 ; `5c0000a2` = ldr d2,+20.

## Two proofs

**Four-way** — `form-asm-poly-pool fks 31`, 0 divergent. Go=Rust=TS=fkwu emit the 32-byte image byte-identical, incl. full byte-equality to the assembler oracle (`ldr d1,+16 / ldr d2,+20 / fmadd / ret / .quad 1/6 / .quad 1/120`).

```
cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk \
  form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-poly-pool-band.fk
→ 31 ; 1 ok, 0 divergent — fourth arm crossed
```

**Hardware** — `scripts/form_asm_poly_pool_witness.sh`: 8/8 MATCH bit-for-bit on the M4 Max (form-macho .o → ld -dylib → dlopen+call), incl. fp-stress 1e8/1e-8 + irrational π. No rustc/clang in the compute. Emitted bytes: `8100005ca200005c0008411fc0035fd6555555555555c53f111111111111813f`.

Siblings (horner/rsqrt/ss-sqrt) re-checked four-way after the additive edits. Receipt: `commit_evidence_2026-06-29_form_asm_poly_pool.json`.

## Next stones (named in the receipt)
1. f64 → IEEE754 8-byte **encoder** as a Form recipe, so an arbitrary *computed* coefficient fills the pool.
2. **exp** on the native lane: range reduction + degree-~6 Horner over a pooled coefficient table — softmax's core.
3. sin/cos over a pooled table — RoPE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)