### PR TITLE
tend(form): sk-msl — surprise-kernel emits its own Metal shader (GLSL/PTX twin, four-way fks 127)

### DIFF
--- a/form/form-stdlib/surprise-kernel.fk
+++ b/form/form-stdlib/surprise-kernel.fk
@@ -15,8 +15,9 @@
 ;     reused as the per-frame ATTEND gate.
 ;   - world-model-live-sense.fk's wmls reading is the frame shape the loop consumes; the kernel runs upstream
 ;     of it, deciding whether a frame is even worth sensing fully.
-;   - form-glsl.fk / form-ptx.fk are the lowering lanes; sk-glsl / sk-ptx emit the predict+surprise compute
-;     shader directly from Form, the same DOWNWARD serial fold as the matvec lanes (no FMA, bit-exact to CPU).
+;   - form-glsl.fk / form-ptx.fk / jit-tensor-emit.fk (MSL) are the lowering lanes; sk-glsl / sk-ptx / sk-msl
+;     emit the predict+surprise compute shader directly from Form, the same DOWNWARD serial fold as the matvec
+;     lanes (no FMA, bit-exact to CPU) — Vulkan/Android (GLSL), CUDA (PTX), Apple-GPU (Metal).
 ;
 ; All integer, no division. A reading is a vector of ints (a frame scaled to ints, as every numeric band does:
 ; e.g. a sound/motion/light level *1000). The predictor is persistence: expected[i] = last[i]. Surprise is the
@@ -87,5 +88,16 @@
     ;     serial |diff| reduce -> the surprise and ATTEND verdict are bit-identical to sk-glsl and sk-error-sum.
     (defn sk-ptx (block)
         (str_concat "// form-native surprise micro-kernel (active-inference attention gate, CUDA/PTX lane).\n// Per-frame: predict (persistence: expected[] = prior frame) -> surprise (L1 |actual-expected| serial\n// DOWNWARD reduce j=n-1..0, same op order as fptx-matvec) -> salience (>= threshold -> ATTEND).\n// One block reduces one frame in thread 0; serial fold keeps the op order bit-exact to sk-glsl/CPU.\nextern \"C\" __global__ void sk_surprise(const int* actual, const int* expected, int* out, unsigned int n, int threshold) {\n    if (threadIdx.x != 0 || blockIdx.x != 0) return;\n    int surprise = 0;\n    for (int j = (int)n - 1; j >= 0; --j) {\n        int d = actual[j] - expected[j];\n        int ad = d < 0 ? -d : d;\n        surprise = ad + surprise;\n    }\n    out[0] = surprise;\n    out[1] = (surprise >= threshold) ? 1 : 0;\n}\n// launch: <<<1, " (str_concat block ">>>\n")))
+
+    ; --- GPU MICRO-KERNEL (MSL): the Metal twin of sk-glsl / sk-ptx. Same predict+surprise+salience, emitted ---
+    ;     as Metal Shading Language the Apple-GPU lane compiles to a .metallib (the jte-matvec-msl authoring
+    ;     shape: `kernel void`, `device const int*` buffers, `[[thread_position_in_grid]]`). Same DOWNWARD
+    ;     serial |diff| reduce j=n-1..0 -> the surprise and ATTEND verdict are bit-identical to sk-glsl, sk-ptx,
+    ;     and sk-error-sum. The persistence predictor is expected[] = the prior frame, bound at buffer(1); the
+    ;     salience gate is the final ge against the pushed threshold, writing res[0]=surprise / res[1]=ATTEND.
+    ;     thread_position_in_grid 0 does the serial fold so the op order stays exact — no FMA, no fusion. The
+    ;     threadgroup width is the only parameter (the .metallib dispatch grid); the body is the proven reduce.
+    (defn sk-msl (tg)
+        (str_concat "#include <metal_stdlib>\nusing namespace metal;\n\n// form-native surprise micro-kernel (active-inference attention gate, Metal/Apple-GPU lane).\n// Per-frame: predict (persistence: expected[] = prior frame) -> surprise (L1 |actual-expected| serial\n// DOWNWARD reduce j=n-1..0, same op order as jte-matvec-msl) -> salience (>= threshold -> ATTEND).\n// Thread 0 of the grid does the serial fold; the op order stays bit-exact to sk-glsl/sk-ptx/CPU.\n// dispatch: one threadgroup of " (str_concat tg " reduces one frame.\nkernel void sk_surprise(device const int* actual [[buffer(0)]], device const int* expected [[buffer(1)]], device int* res [[buffer(2)]], constant uint& n [[buffer(3)]], constant int& threshold [[buffer(4)]], uint i [[thread_position_in_grid]]) {\n    if (i != 0u) return;\n    int surprise = 0;\n    for (int j = int(n) - 1; j >= 0; --j) {\n        int d = actual[j] - expected[j];\n        int ad = d < 0 ? -d : d;\n        surprise = ad + surprise;\n    }\n    res[0] = surprise;\n    res[1] = (surprise >= threshold) ? 1 : 0;\n}\n")))
 
     0)

--- a/form/form-stdlib/tests/sk-msl-band.fk
+++ b/form/form-stdlib/tests/sk-msl-band.fk
@@ -1,0 +1,38 @@
+; preludes: form-stdlib/core.fk form-stdlib/form-glsl.fk form-stdlib/form-ptx.fk form-stdlib/surprise-kernel.fk
+;
+; sk-msl-band — the Metal Shading Language sibling of sk-glsl / sk-ptx made falsifiable.
+;
+; sk-msl emits the SAME predict->surprise->salience micro-kernel as sk-glsl / sk-ptx, lowered to Metal
+; Shading Language (the Apple-GPU lane: `#include <metal_stdlib>`, `kernel void`, `device const int*`
+; buffers, `[[thread_position_in_grid]]`). Today's GPU witness used a hand-written MSL string; this band
+; makes the EMITTER the source — the four kernels emit the IDENTICAL Metal string, the way form-glsl is.
+;
+; The band runs four-way at validate.sh: Go, Rust, TypeScript, fkwu each evaluate sk-msl and must produce
+; the bit-identical string -> the same integer verdict here. String checks -> a stable integer verdict.
+;
+; Verdict 127 when every claim lands:
+;   1    the MSL pulls in metal_stdlib                       (#include <metal_stdlib> present)
+;   2    the MSL declares the Metal kernel entry signature   (kernel void sk_surprise(...) present)
+;   4    the persistence predictor is the prior-frame buffer (device const int* expected [[buffer(1)]])
+;   8    the serial DOWNWARD reduce loop is present          (for (int j = int(n) - 1; j >= 0; --j) present)
+;   16   the salience ge-cutoff writes the ATTEND verdict    (res[1] = (surprise >= threshold) ...)
+;   32   the emitter reparameterizes by threadgroup width    (sk-msl "64" != sk-msl "8", and longer)
+;   64   sk-msl is deterministic (same arg -> same string)   (sk-msl "64" == sk-msl "64")
+(do
+    ; has-sub: 1 if needle occurs in hay, else 0. str_find returns the index or -1.
+    (defn has-sub (hay needle) (if (ge (str_find hay needle 0) 0) 1 0))
+
+    (let msl (sk-msl "64"))
+
+    (let c0 (if (eq (has-sub msl "#include <metal_stdlib>") 1)                               1 0))
+    (let c1 (if (eq (has-sub msl "kernel void sk_surprise(") 1)                              2 0))
+    (let c2 (if (eq (has-sub msl "device const int* expected [[buffer(1)]]") 1)              4 0))
+    (let c3 (if (eq (has-sub msl "for (int j = int(n) - 1; j >= 0; --j)") 1)                 8 0))
+    (let c4 (if (eq (has-sub msl "res[1] = (surprise >= threshold) ? 1 : 0;") 1)           16 0))
+    ; reparameterizes by threadgroup width: the "8" emit differs from "64" and is shorter.
+    (let c5 (if (and (if (str_eq (sk-msl "64") (sk-msl "8")) 0 1)
+                     (gt (str_len (sk-msl "64")) (str_len (sk-msl "8")))) 32 0))
+    ; deterministic: same threadgroup arg -> the bit-identical string.
+    (let c6 (if (str_eq (sk-msl "64") (sk-msl "64")) 64 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1176,3 +1176,4 @@ surprise-kernel fks 511
 room-register fks 255
 face-embed fks 255
 context-signature fks 255
+sk-msl fks 127


### PR DESCRIPTION
## sk-msl — the Metal sibling of sk-glsl / sk-ptx

`surprise-kernel.fk` now emits **`sk-msl`** alongside `sk-glsl` / `sk-ptx`: the same active-inference attention micro-kernel (predict → surprise → salience) lowered to **Metal Shading Language** — the Apple-GPU lane. The recipe is the source; today's GPU witness used a hand-written MSL string, which was the drift to correct. An emitter is four-way the way `form-glsl` is: **the four kernels emit the IDENTICAL string.**

- Structurally faithful to `sk-glsl`: integer math, persistence predictor (`expected[]` = prior frame, bound at `buffer(1)`), serial **DOWNWARD** `|actual-expected|` reduce `j=n-1..0` (no FMA), salience ge-cutoff writing `res[0]=surprise`, `res[1]=ATTEND`, thread 0 of the grid does the fold.
- Metal idiom mirrors `jte-matvec-msl`: `#include <metal_stdlib>`, `kernel void`, `device const int*` buffers, `[[thread_position_in_grid]]`.

## Band

`tests/sk-msl-band.fk` asserts the emitted MSL carries the kernel signature, the prior-frame persistence buffer, the serial reduce loop, the salience ATTEND write (string checks → stable integer verdict), reparameterizes by threadgroup width, and is deterministic.

## Proof

`form/validate.sh form-stdlib/tests/sk-msl-band.fk`:

```
  ✓  core.fk+core.fk+form-glsl.fk+form-ptx.fk+surprise-kernel.fk+sk-msl-band.fk  → 127
  fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
  1 ok, 0 divergent — kernels agree on every sample.
```

Manifest: `sk-msl fks 127`. Go + Rust + TypeScript + fkwu emit the bit-identical Metal string. No divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)