### PR TITLE
tend(form): presence-feature — region-occupancy that sees a STILL person (fks 15)

### DIFF
--- a/form/form-stdlib/presence-feature.fk
+++ b/form/form-stdlib/presence-feature.fk
@@ -1,0 +1,93 @@
+; presence-feature.fk — region-occupancy from a downsampled NxN luminance grid, the PRESENCE sibling of
+; surprise-kernel's motion gate.
+;
+; surprise-kernel.fk is PRESENCE-BLIND: it predicts the next frame as the prior frame (persistence) and
+; spends the GPU only where frame-to-frame surprise is high. A STILL person reads identical to an empty
+; room — both yield surprise 0 — so frame-diff alone can never emit an ENTERED/LEFT event. Observed
+; directly on a real camera frame: a present body BREAKS the room's visual uniformity. The occupied region
+; of a downsampled luminance grid carries HIGH local variance (face/body/clothing detail); empty walls are
+; uniform — LOW variance. That spatial signature is steady whether the person moves or not, so it separates
+; a still person from an empty room exactly where motion-surprise cannot.
+;
+; This COMPOSES the existing tissue, it does not reinvent it:
+;   - surprise-kernel.fk's sk-salience is the motion ATTEND gate (ge-cutoff on a per-frame MAGNITUDE).
+;     pf-present? is the sibling PRESENCE gate — the same ge-cutoff on a spatial OCCUPANCY magnitude — and
+;     pf-changed? is the presence twin of sk-attend?: it fires on presence-CHANGE (entered/left), the event
+;     a still frame hides from sk-surprise. The loop should attend on BOTH: motion-surprise AND occupancy-change.
+;   - mesh-sense-7w.fk fuses readings on the WHO / WHERE planes; a presence reading is the upstream evidence
+;     that someone is THERE to be placed on those planes — occupancy precedes identity.
+;   - the grid is the SAME NxN luminance grid the camera sensor-organ-channel port produces (a thin carrier);
+;     here it arrives as a flat row-major list of ints (a frame scaled to ints, as every numeric band does).
+;
+; All integer. Variance is the MEAN ABSOLUTE DEVIATION from the region mean (no squares, no floats): take the
+; region's mean (integer div by cell count), then the mean of |cell - mean| over the region. Occupancy is the
+; lower-center (body) MAD minus an upper-row (wall) baseline MAD — a present body lifts the lower variance above
+; the wall's; an empty room leaves both low and near-equal, occupancy ~0. The gate is a hard ge-cutoff against a
+; floor, identical 1/0 verdict on every kernel; the grid is pre-scaled ints.
+;
+; Honest lane: MAD not standard deviation — the simplest honest spread, no sqrt, integer-exact on every arm.
+; The wall baseline is SUBTRACTED so a globally noisy frame (sensor grain everywhere) does not read as a body;
+; only EXCESS lower-region detail counts. The floor is a hard ge-cutoff — an occupancy one under does not fire,
+; exactly as one far under does not. pf-changed? compares only the 1/0 present verdict across two frames, so a
+; still-present -> still-present pair yields NO event (the person did not enter or leave), while empty -> present
+; yields one — the presence-change signal motion-surprise structurally cannot produce.
+;
+; preludes: form-stdlib/core.fk
+;
+; Proven by: form-stdlib/tests/presence-feature-band.fk (four-way at validate.sh, incl. fkwu)
+
+(do
+    ; --- SUM-ABS-DEV: sum |cell - mean| over a sub-region, walking it row by row. ---
+    ;     The region is the rows y0..y0+h-1, cols x0..x0+w-1 of the row-major NxN grid; index = row*n + col.
+    ;     Accumulates the absolute deviation of every region cell from the supplied region mean.
+    (defn pf-sad-row (grid n row x0 w xi mean acc)
+        (if (eq xi w) acc
+            (pf-sad-row grid n row x0 w (add xi 1) mean
+                (add acc (abs (sub (nth grid (add (mul row n) (add x0 xi))) mean))))))
+
+    (defn pf-sad (grid n x0 y0 w h yi mean acc)
+        (if (eq yi h) acc
+            (pf-sad grid n x0 y0 w h (add yi 1) mean
+                (add acc (pf-sad-row grid n (add y0 yi) x0 w 0 mean 0)))))
+
+    ; --- SUM: sum the raw cell values over a sub-region (for the region mean). ---
+    (defn pf-sum-row (grid n row x0 w xi acc)
+        (if (eq xi w) acc
+            (pf-sum-row grid n row x0 w (add xi 1)
+                (add acc (nth grid (add (mul row n) (add x0 xi)))))))
+
+    (defn pf-sum (grid n x0 y0 w h yi acc)
+        (if (eq yi h) acc
+            (pf-sum grid n x0 y0 w h (add yi 1)
+                (add acc (pf-sum-row grid n (add y0 yi) x0 w 0 0)))))
+
+    ; --- REGION-VAR: the mean absolute deviation of a sub-region from its own mean (integer). ---
+    ;     count = w*h cells. mean = sum / count (integer div). MAD = sum|cell-mean| / count. Empty region -> 0.
+    (defn pf-region-var (grid n x0 y0 w h)
+        (if (eq (mul w h) 0) 0
+            (div (pf-sad grid n x0 y0 w h 0 (div (pf-sum grid n x0 y0 w h 0 0) (mul w h)) 0)
+                 (mul w h))))
+
+    ; --- OCCUPANCY: lower-center (body) variance MINUS upper-row (wall) baseline variance. ---
+    ;     A present body lifts the lower-center MAD above the uniform wall's; an empty room leaves both low and
+    ;     near-equal -> occupancy near 0. Subtracting the wall baseline rejects whole-frame sensor grain: only
+    ;     EXCESS lower detail reads as occupancy. Regions are derived from n so any grid size composes:
+    ;       wall   = top quarter, full width        (rows 0 .. n/4, all cols)
+    ;       body   = lower-center half-width block   (rows n/2.. n, cols n/4 .. 3n/4)
+    (defn pf-occupancy (grid n)
+        (sub (pf-region-var grid n (div n 4) (div n 2) (div n 2) (sub n (div n 2)))
+             (pf-region-var grid n 0 0 n (div n 4))))
+
+    ; --- PRESENT?: the presence ATTEND gate — occupancy meets-or-exceeds the floor -> 1 (someone is THERE). ---
+    ;     The spatial sibling of sk-salience: a hard ge-cutoff, an occupancy one under the floor does not fire.
+    (defn pf-present? (grid n floor)
+        (if (ge (pf-occupancy grid n) floor) 1 0))
+
+    ; --- CHANGED?: presence-CHANGE across two frames — 1 if present? differs (ENTERED or LEFT). ---
+    ;     Compares only the 1/0 verdict, so a still person (present -> present) emits NO event, while an
+    ;     empty -> present (or present -> empty) pair emits one. This is the event sk-surprise misses: a body
+    ;     that arrives and then holds still breaks uniformity steadily, but breaks frame-diff only on arrival.
+    (defn pf-changed? (prev grid n floor)
+        (if (eq (pf-present? prev n floor) (pf-present? grid n floor)) 0 1))
+
+    0)

--- a/form/form-stdlib/tests/presence-feature-band.fk
+++ b/form/form-stdlib/tests/presence-feature-band.fk
@@ -1,0 +1,34 @@
+; preludes: form-stdlib/presence-feature.fk
+;
+; presence-feature-band — region-occupancy separates a STILL person from an EMPTY room, the event the
+; motion-surprise gate (surprise-kernel) structurally cannot produce. n=4 grid (16 ints, row-major).
+;
+; Regions derived from n: wall = top row (rows 0, cols 0..3); body = lower-center block (rows 2..3, cols 1..2).
+; floor = 20.
+;
+;   present grid : uniform upper rows (all 100) + a high-variance lower-center block (10/250/250/10).
+;       body region {10,250,250,10}: mean 130, MAD = (120*4)/4 = 120. wall row {100,100,100,100}: MAD 0.
+;       occupancy = 120 - 0 = 120 >= 20 -> present? = 1.
+;   empty grid : uniform throughout (all 100). body MAD 0, wall MAD 0, occupancy 0 < 20 -> present? = 0.
+;   empty -> present : present? differs (0 then 1) -> changed? = 1 (someone ENTERED).
+;   present -> present : a still person, present? holds (1 then 1) -> changed? = 0 (no event).
+;
+; Verdict 15 when every claim lands:
+;   1   a present frame reads occupied               (pf-present? present 4 20 == 1)
+;   2   an empty room reads unoccupied               (pf-present? empty   4 20 == 0)
+;   4   empty -> present is an ENTERED event         (pf-changed? empty present 4 20 == 1)
+;   8   a still person is NO event                   (pf-changed? present present 4 20 == 0)
+(do
+    (let present (list 100 100 100 100
+                       100 100 100 100
+                       100  10 250 100
+                       100 250  10 100))
+    (let vacant  (list 100 100 100 100
+                       100 100 100 100
+                       100 100 100 100
+                       100 100 100 100))
+    (let c0 (if (eq (pf-present? present 4 20) 1)            1 0))
+    (let c1 (if (eq (pf-present? vacant 4 20) 0)             2 0))
+    (let c2 (if (eq (pf-changed? vacant present 4 20) 1)     4 0))
+    (let c3 (if (eq (pf-changed? present present 4 20) 0)    8 0))
+    (add c0 (add c1 (add c2 c3))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1178,3 +1178,4 @@ face-embed fks 255
 context-signature fks 255
 sk-msl fks 127
 sense-loop fks 8191
+presence-feature fks 15


### PR DESCRIPTION
## Stone: `presence-feature`

The native motion classifier (`surprise-kernel`, frame-to-frame diff) is **presence-blind**: a still person reads identical to an empty room (surprise 0), so it can't produce ENTERED/LEFT events. But a present person BREAKS the room's visual uniformity — the occupied region of a downsampled luminance grid carries HIGH local variance (face/body/clothing detail) while empty walls are uniform/LOW. Observed directly on a real camera frame. This brings it home as a Form-native feature.

### `presence-feature.fk` (self-contained over `core`)
- `pf-region-var(grid, n, x0, y0, w, h)` — mean-absolute-deviation of a sub-region from its mean (integer; no squares, no sqrt, no floats).
- `pf-occupancy(grid, n)` — lower-center (body) MAD **minus** upper-row (wall) baseline MAD. Subtracting the wall rejects whole-frame sensor grain; only EXCESS lower detail reads as occupancy.
- `pf-present?(grid, n, floor)` — the presence ATTEND gate, ge-cutoff sibling of `sk-salience`.
- `pf-changed?(prev, grid, n, floor)` — presence-CHANGE across two frames (ENTERED/LEFT), the event a still frame hides from `sk-surprise`.

The grid is the same NxN luminance grid the camera `sensor-organ-channel` port produces — a thin carrier, not this recipe's concern.

### Band: `tests/presence-feature-band.fk` — verdict **15**
n=4 grid (16 ints, row-major). wall = top row; body = lower-center block (rows 2-3, cols 1-2); floor = 20.
- present grid (uniform upper + high-variance lower-center 10/250/250/10) → body MAD 120, wall MAD 0, occupancy 120 → `pf-present? = 1` (bit 1)
- empty grid (uniform all 100) → occupancy 0 → `pf-present? = 0` (bit 2)
- empty → present → `pf-changed? = 1` (ENTERED, bit 4)
- present → present (still person) → `pf-changed? = 0` (no event, bit 8)

This proves presence detection separates a still person from an empty room — which motion-surprise structurally cannot.

### Four-way
```
  ✓  core.fk+presence-feature.fk+presence-feature-band.fk  → 15
  fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
  1 ok, 0 divergent — kernels agree on every sample.
```
go + rust + ts + fkwu all agree → 15. No divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)