### PR TITLE
tend(form): identity-home — bring "who" home from the rented oracle to native, via the trust-climb

### DIFF
--- a/form/form-stdlib/identity-home.fk
+++ b/form/form-stdlib/identity-home.fk
@@ -1,0 +1,71 @@
+; identity-home.fk — bring identity recognition HOME from the rented oracle to native, via the
+; trust-climb. Today "who" is oracle-rented everywhere (the windows sense-stream reads rem=9 conf=0
+; sov=0; face-embed/speaker-embed make the native DECISION but ride the ORACLE's embedding). This
+; recipe makes "who" become CONFIDENTLY NATIVE over a window instead of rented — the exact flip
+; champion-challenger.fk proves, applied to identity. The native arm takes authority over "who is
+; present" only when it has PROVEN, over a trusted window, that its verdict matches the oracle's.
+;
+; The flip, not asserted: authority is the SAME competition champion-challenger runs. The champion is
+; the remote oracle's id (the incumbent, treated as ground truth); the challenger is the native arm's
+; id (face-embed / speaker-embed's nearest-by-cosine call). Per tick the native arm is "correct" iff
+; its id equals the oracle's — a FREE self-label (cross-witness-economy's bring-home loop: agreement
+; IS supervision, no rent spent to make it). Run cc-authority over that native-correct history and
+; authority flips to the native arm once it earns it; until then "who" stays rented to the champion.
+; The climbing native-correct count is the earned confidence (confidence-earned: is my "sure" earned —
+; here, has the native arm been right enough, over a long enough window, to be trusted with "who").
+;
+; COMPOSED, never re-derived:
+;   champion-challenger.fk  cc-authority / cc-promote? — authority flips to the native challenger only on
+;                           PROVEN head-to-head over a long-enough window (min-samples), never asserted.
+;   face-embed.fk / speaker-embed.fk — the native id is their nearest-by-cosine DECISION (oracle embedding);
+;                           this recipe is the modality-agnostic trust-climb ABOVE that decision.
+;   cross-witness-economy.fk — oracle-agreement is a free self-label; rent falls as native earns trust.
+;   confidence-earned.fk — the earned-correct count is the self-reliance the native arm has banked.
+;
+; Honest floor: a tick is a (remote-id native-id) string pair (the two arms' verdicts on one presence);
+; the wired version reads the oracle id and the native face/speaker id live per window. Ids compared by
+; str_eq; the history maps to champion-challenger trials (champion always correct = the oracle is ground
+; truth; challenger correct = the native id matched it), so the flip is the SAME proven count, four-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/champion-challenger.fk
+;
+; Self-contained over core + champion-challenger. Four-way by tests/identity-home-band.fk.
+
+(do
+    (defn ih-remote (tick) (nth tick 0))   ; the oracle's id on this presence (the rented champion)
+    (defn ih-native (tick) (nth tick 1))   ; the native arm's id on the same presence (the challenger)
+
+    ; --- WITNESS: a tick's (remote-id native-id) pair — the two arms' verdicts on one presence. The
+    ;     identity passes through unchanged; naming the pair is the witness an opaque arm can't show. ---
+    (defn ih-witness (obs) (list (ih-remote obs) (ih-native obs)))
+
+    ; --- CORRECT?: 1 iff the native id matches the oracle's — the FREE self-label. Native correctness
+    ;     is self-supervised by agreement with the champion (cross-witness-economy): no rent spent. ---
+    (defn ih-correct? (tick)
+        (if (str_eq (ih-native tick) (ih-remote tick)) 1 0))
+
+    ; --- map the (remote native) history into champion-challenger trials: champion (oracle) is always
+    ;     correct = 1 (it is ground truth here); challenger (native) correct = ih-correct?. This is the
+    ;     SAME (list champ-correct chall-correct) shape cc-* scores, so the flip is the proven count. ---
+    (defn ih-trials (history)
+        (if (eq (len history) 0) (empty)
+            (cons (list 1 (ih-correct? (head history)))
+                  (ih-trials (tail history)))))
+
+    ; --- CONFIDENCE: the climbing native correct-count over the window — the earned confidence. As the
+    ;     native id increasingly matches the oracle this rises; it is the banked self-reliance. ---
+    (defn ih-confidence (history)
+        (cc-chall-score (ih-trials history)))
+
+    ; --- AUTHORITY: who owns "who is present" right now. "challenger" (NATIVE, trusted, rent falls to the
+    ;     floor) once the native arm has matched the oracle over a long-enough window (>= min-samples,
+    ;     within margin); "champion" (REMOTE, still rented) until that competition is proven. The flip is
+    ;     cc-authority — identity is brought home only on earned trust, never asserted. ---
+    (defn ih-authority (history min-samples margin)
+        (cc-authority (ih-trials history) min-samples margin))
+
+    ; --- HOME?: 1 once "who" is native (authority flipped to the challenger) — the bring-home verdict. ---
+    (defn ih-home? (history min-samples margin)
+        (cc-promote? (ih-trials history) min-samples margin))
+
+    0)

--- a/form/form-stdlib/tests/identity-home-band.fk
+++ b/form/form-stdlib/tests/identity-home-band.fk
@@ -1,0 +1,53 @@
+; tests/identity-home-band.fk — bring "who" home from the rented oracle to native, made falsifiable.
+; preludes: form-stdlib/core.fk form-stdlib/champion-challenger.fk form-stdlib/identity-home.fk
+;
+; Two sequences of ticks = (remote-id native-id) — the oracle's verdict and the native arm's verdict
+; on the same presence, over a window. min-samples 8, margin 0 (mirror of the trust-climb: the native
+; arm must equal-or-exceed the always-correct oracle over a window >= 8 to take "who" home).
+;
+;   homed     — 8 ticks where the native id MATCHES the oracle ("ilena" == "ilena") every time. The
+;               native arm is correct 8/8, the window is long enough (>= 8) and reaches the champion
+;               at margin 0, so authority FLIPS to "challenger" at tick 8 — "who" is now native, rent
+;               falls. ih-confidence climbs to 8. This is the bring-home.
+;   rented    — 8 ticks where the native id keeps DISAGREEING with the oracle ("ilena" vs "axiel"…).
+;               native correct 0/8, never reaches the champion, so authority STAYS "champion" — "who"
+;               is still rented to the oracle. ih-confidence stays 0.
+;   climbing  — the flip is at the WINDOW, not before: the same homed history truncated to 7 ticks is
+;               NOT yet promoted (window too short), proving min-samples is load-bearing — the trust is
+;               earned over the window, never asserted early.
+; Ids compared by str_eq; counts are exact integers — identical on every kernel.
+;
+; Verdict 127 when every claim lands:
+;   1    the witness names both arms' verdicts          (ih-witness on a tick == (remote native))
+;   2    a matching tick is native-correct, a mismatch is not  (ih-correct? matched==1, mismatched==0)
+;   4    native confidence climbs to the full window    (ih-confidence homed == 8)
+;   8    earned over the window -> "who" goes NATIVE     (ih-home? homed==1 AND authority=="challenger")
+;   16   native keeps disagreeing -> "who" stays RENTED  (ih-home? rented==0 AND authority=="champion")
+;   32   rented confidence never climbs                  (ih-confidence rented == 0)
+;   64   the flip is at the WINDOW, not one tick early   (authority over 7 ticks == "champion")
+(do
+    ; 8 ticks: native id == oracle id every time -> native earns "who"
+    (let homed (list
+        (list "ilena" "ilena") (list "ilena" "ilena") (list "ilena" "ilena") (list "ilena" "ilena")
+        (list "ilena" "ilena") (list "ilena" "ilena") (list "ilena" "ilena") (list "ilena" "ilena")))
+    ; 8 ticks: native id never matches the oracle -> "who" stays rented
+    (let rented (list
+        (list "ilena" "axiel") (list "ilena" "axiel") (list "ilena" "urs")   (list "ilena" "axiel")
+        (list "ilena" "urs")   (list "ilena" "axiel") (list "ilena" "axiel") (list "ilena" "urs")))
+    ; the homed history one tick short of the trust window
+    (let almost (list
+        (list "ilena" "ilena") (list "ilena" "ilena") (list "ilena" "ilena") (list "ilena" "ilena")
+        (list "ilena" "ilena") (list "ilena" "ilena") (list "ilena" "ilena")))
+
+    (let w (ih-witness (head homed)))
+    (let c0 (if (and (str_eq (nth w 0) "ilena") (str_eq (nth w 1) "ilena")) 1 0))
+    (let c1 (if (and (eq (ih-correct? (head homed)) 1)
+                     (eq (ih-correct? (head rented)) 0)) 2 0))
+    (let c2 (if (eq (ih-confidence homed) 8) 4 0))
+    (let c3 (if (and (eq (ih-home? homed 8 0) 1)
+                     (str_eq (ih-authority homed 8 0) "challenger")) 8 0))
+    (let c4 (if (and (eq (ih-home? rented 8 0) 0)
+                     (str_eq (ih-authority rented 8 0) "champion")) 16 0))
+    (let c5 (if (eq (ih-confidence rented) 0) 32 0))
+    (let c6 (if (str_eq (ih-authority almost 8 0) "champion") 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1184,3 +1184,4 @@ trust-climb fks 8
 scene-features fks 255
 sound-classify fks 63
 voice-self-learn fks 127
+identity-home fks 127


### PR DESCRIPTION
identity-home.fk applies champion-challenger's proven trust-flip to identity. Today "who" is oracle-rented everywhere (windows sense-stream: rem=9 conf=0 sov=0; face-embed/speaker-embed make the native decision but ride the oracle's embedding). This recipe makes "who" become confidently NATIVE over a window instead of rented.

A tick is `(remote-id native-id)` — the oracle's verdict and the native arm's verdict on one presence. `ih-correct?` is 1 when native matches the oracle (a free self-label). `ih-confidence` is the climbing native-correct count (the earned confidence). `ih-authority` runs `cc-authority` over that history: `"challenger"` (NATIVE, rent falls) once native earns it over the window, else `"champion"` (REMOTE, rented). `ih-home?` is the bring-home verdict.

**Band** `tests/identity-home-band.fk` → **127**, 0 divergent:
- homed: native matches oracle 8/8 → confidence climbs to 8 → authority **flips to "challenger" at tick 8** (min-samples 8)
- rented: native keeps disagreeing → **stays "champion"** (still rented), confidence stays 0
- the flip is at the **window**, not a tick early (7-tick history stays "champion")

**Composed, never re-derived:** champion-challenger.fk (cc-authority/cc-promote? — the flip), face-embed.fk / speaker-embed.fk (the native id decision), cross-witness-economy.fk (agreement is a free self-label), confidence-earned.fk (the banked self-reliance).

four-way: `core.fk+champion-challenger.fk+identity-home.fk+identity-home-band.fk → 127` (fkwu + go + rust + ts; 1 ok, 0 divergent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)