### PR TITLE
tend(form): scene-features — the shape of the room, what is in it, common vs unique (four-way)

### DIFF
--- a/form/form-stdlib/scene-features.fk
+++ b/form/form-stdlib/scene-features.fk
@@ -1,0 +1,153 @@
+; scene-features.fk — the SHAPE of the room, what is in it, and which things are common vs unique, read
+; from the SAME downsampled NxN luminance grid the camera sensor-organ port produces (a thin carrier;
+; the grid arrives row-major as a flat list of ints, as every numeric band does).
+;
+; presence-feature.fk asks ONE question of the grid — is a BODY there (lower-center MAD above a wall
+; baseline). scene-features asks the room's OWN structure, the question that precedes presence: what is
+; the shape of this place, what objects sit in it, which are the common furniture and which are new.
+; It is the spatial sibling of room-register.fk: room-register turns already-fused feature bands into a
+; remembered room and recognizes the room on return (rr-signature / rr-distance over a banded signature);
+; scene-features READS the raw grid into the kind of banded structure rr-signature consumes — sf-shape is
+; the source of a room's banded shape, the upstream half of the same recognition rr-distance closes.
+;
+; This COMPOSES the existing tissue, it does not reinvent it:
+;   - presence-feature.fk's MEAN-ABSOLUTE-DEVIATION region variance (pf-sad / pf-sum / pf-region-var) is
+;     the exact spread measure used here — re-grown over a coarse BLOCK grid so the whole frame is read,
+;     not just the body region. An object is a block whose detail (MAD) lifts above a uniform wall: the
+;     SAME ge-cutoff pf-present? draws against an occupancy floor, drawn here per block against a detail
+;     floor. A high-MAD block is a THING (face/object texture); a low-MAD block is flat wall.
+;   - room-register.fk's rr-distance (summed L1 band residual) is the measure of "how differently does
+;     this read feel from that remembered room"; sf-common? / sf-unique? draw the SAME residual between a
+;     region's detail and the baseline frame's detail at the same region — a small residual means the
+;     region matches the stable baseline (furniture that was always there), a large one means it is novel.
+;   - sf-edge is the local gradient: a corner/wall edge is where luminance CHANGES across a step. A flat
+;     plane (uniform wall, a tabletop) reads gradient ~0; a wall-corner or object boundary reads high.
+;     sf-shape bands each coarse region by whether its summed gradient clears the edge floor — a coarse
+;     layout signature of FLAT-PLANE (0) vs EDGE (1) regions: the room's shape, the bands rr-signature eats.
+;
+; All integer. Gradient is forward absolute difference (|cell - right| + |cell - below|), MAD is the same
+; squares-free spread presence-feature proved, residual is room-register's L1 — no floats, no sqrt, exact
+; on every arm. Regions are derived from n (a 2x2 coarse block grid) so any even grid size composes.
+;
+; A SCENE-FEATURE READ is therefore three banded views of one grid:
+;   sf-shape   -> the room's coarse layout signature (flat-plane vs edge per block)  — the SHAPE
+;   sf-objects -> the blocks whose detail clears the floor                           — what is IN it
+;   sf-common? / sf-unique? -> a region's detail vs the baseline frame at that region — common vs new
+;
+; preludes: form-stdlib/core.fk
+;
+; Proven by: form-stdlib/tests/scene-features-band.fk (four-way at validate.sh, incl. fkwu)
+
+(do
+    ; ── GRADIENT: local forward absolute difference at (x,y) — |cell - right| + |cell - below|. A flat
+    ;    plane reads ~0; a wall-corner / object boundary reads high. Edge cells (last col/row) drop the
+    ;    missing neighbour term (compare only the neighbour that exists), so the gradient is honest at the
+    ;    frame border without inventing an off-grid value. ──
+    (defn sf-cell (grid n x y) (nth grid (add (mul y n) x)))
+
+    (defn sf-edge (grid n x y)
+        (add
+            (if (lt (add x 1) n) (abs (sub (sf-cell grid n x y) (sf-cell grid n (add x 1) y))) 0)
+            (if (lt (add y 1) n) (abs (sub (sf-cell grid n x y) (sf-cell grid n x (add y 1)))) 0)))
+
+    ; ── SUM the gradient over a sub-region (rows y0..y0+h-1, cols x0..x0+w-1), walking it row by row. ──
+    (defn sf-edge-row (grid n row x0 w xi acc)
+        (if (eq xi w) acc
+            (sf-edge-row grid n row x0 w (add xi 1)
+                (add acc (sf-edge grid n (add x0 xi) row)))))
+
+    (defn sf-edge-sum (grid n x0 y0 w h yi acc)
+        (if (eq yi h) acc
+            (sf-edge-sum grid n x0 y0 w h (add yi 1)
+                (add acc (sf-edge-row grid n (add y0 yi) x0 w 0 0)))))
+
+    ; ── REGION DETAIL: the mean absolute deviation of a sub-region from its own mean — the exact spread
+    ;    presence-feature proved (pf-sad / pf-sum / pf-region-var), re-grown here as the per-block detail.
+    ;    A uniform wall block reads 0; a textured object block reads high. ──
+    (defn sf-sad-row (grid n row x0 w xi mean acc)
+        (if (eq xi w) acc
+            (sf-sad-row grid n row x0 w (add xi 1) mean
+                (add acc (abs (sub (sf-cell grid n (add x0 xi) row) mean))))))
+
+    (defn sf-sad (grid n x0 y0 w h yi mean acc)
+        (if (eq yi h) acc
+            (sf-sad grid n x0 y0 w h (add yi 1) mean
+                (add acc (sf-sad-row grid n (add y0 yi) x0 w 0 mean 0)))))
+
+    (defn sf-sum-row (grid n row x0 w xi acc)
+        (if (eq xi w) acc
+            (sf-sum-row grid n row x0 w (add xi 1)
+                (add acc (sf-cell grid n (add x0 xi) row)))))
+
+    (defn sf-sum (grid n x0 y0 w h yi acc)
+        (if (eq yi h) acc
+            (sf-sum grid n x0 y0 w h (add yi 1)
+                (add acc (sf-sum-row grid n (add y0 yi) x0 w 0 0)))))
+
+    (defn sf-detail (grid n x0 y0 w h)
+        (if (eq (mul w h) 0) 0
+            (div (sf-sad grid n x0 y0 w h 0 (div (sf-sum grid n x0 y0 w h 0 0) (mul w h)) 0)
+                 (mul w h))))
+
+    ; ── COARSE BLOCKS: read the grid as a 2x2 block grid (each block is a half-frame quadrant). bx,by in
+    ;    {0,1} select the block; bw/bh are half the frame. This is the coarse layout the SHAPE bands and
+    ;    the OBJECT list both walk — derived from n so any even grid size composes. ──
+    (defn sf-half (n) (div n 2))
+    (defn sf-bx0  (n bx) (mul bx (sf-half n)))
+    (defn sf-by0  (n by) (mul by (sf-half n)))
+
+    ; the detail (MAD) of coarse block (bx,by).
+    (defn sf-block-detail (grid n bx by)
+        (sf-detail grid n (sf-bx0 n bx) (sf-by0 n by) (sf-half n) (sf-half n)))
+
+    ; the summed gradient of coarse block (bx,by).
+    (defn sf-block-edge (grid n bx by)
+        (sf-edge-sum grid n (sf-bx0 n bx) (sf-by0 n by) (sf-half n) (sf-half n) 0 0))
+
+    ; ── SHAPE: the room's coarse layout signature — for each of the four coarse blocks, 1 if its summed
+    ;    gradient clears the edge floor (an EDGE region — a wall-corner, an object boundary), else 0 (a
+    ;    FLAT PLANE — uniform wall, a flat surface). The list is the banded shape rr-signature consumes,
+    ;    walked in raster order (top-left, top-right, bottom-left, bottom-right). ──
+    (defn sf-shape-block? (grid n bx by edge-floor)
+        (if (ge (sf-block-edge grid n bx by) edge-floor) 1 0))
+
+    (defn sf-shape (grid n edge-floor)
+        (list (sf-shape-block? grid n 0 0 edge-floor) (sf-shape-block? grid n 1 0 edge-floor)
+              (sf-shape-block? grid n 0 1 edge-floor) (sf-shape-block? grid n 1 1 edge-floor)))
+
+    ; ── OBJECTS: the coarse blocks that hold a THING — detail (MAD) clears the detail floor — gathered as
+    ;    a list of block ids (by*2 + bx, raster order). A uniform wall block contributes nothing; a
+    ;    textured object block contributes its id. The SAME ge-cutoff presence-feature draws, drawn per
+    ;    block. The list is the room's inventory: where the things are. ──
+    (defn sf-object-id (bx by) (add (mul by 2) bx))
+
+    (defn sf-objects-acc (grid n detail-floor blocks)
+        (if (eq (len blocks) 0) (list)
+            (do
+                (let b (head blocks))
+                (let bx (nth b 0))
+                (let by (nth b 1))
+                (let rest (sf-objects-acc grid n detail-floor (tail blocks)))
+                (if (ge (sf-block-detail grid n bx by) detail-floor)
+                    (cons (sf-object-id bx by) rest)
+                    rest))))
+
+    (defn sf-objects (grid n detail-floor)
+        (sf-objects-acc grid n detail-floor
+            (list (list 0 0) (list 1 0) (list 0 1) (list 1 1))))
+
+    ; ── COMMON vs UNIQUE: a region's detail vs the BASELINE frame's detail at the same region. The
+    ;    residual is room-register's L1 measure (|now - baseline|) over the region's MAD. A small residual
+    ;    (within tolerance) means the region matches the stable baseline — furniture that was always there,
+    ;    COMMON. A large residual means the region is NOVEL — a new thing in the room, UNIQUE. The region
+    ;    is a coarse block (bx,by); the same block of the baseline grid is the remembered "always there". ──
+    (defn sf-region-residual (grid baseline n bx by)
+        (abs (sub (sf-block-detail grid n bx by) (sf-block-detail baseline n bx by))))
+
+    (defn sf-common? (grid baseline n bx by tolerance)
+        (if (ge (sf-region-residual grid baseline n bx by) tolerance) 0 1))
+
+    (defn sf-unique? (grid baseline n bx by tolerance)
+        (if (ge (sf-region-residual grid baseline n bx by) tolerance) 1 0))
+
+    0)

--- a/form/form-stdlib/tests/scene-features-band.fk
+++ b/form/form-stdlib/tests/scene-features-band.fk
@@ -1,0 +1,82 @@
+; preludes: form-stdlib/scene-features.fk
+;
+; scene-features-band — read the SHAPE of a room, the OBJECTS in it, and which are COMMON vs UNIQUE from
+; one downsampled n=4 luminance grid (16 ints, row-major; 2x2 coarse blocks, each block 2x2). Falsifiable.
+;
+; BASELINE frame — a remembered room: the whole top half and the bottom-left block are uniform wall (100);
+; one textured OBJECT sits in the bottom-right block (a top buffer row 100,100 then a texture row 250,10):
+;     100 100 100 100
+;     100 100 100 100
+;     100 100 100 100
+;     100 100 250  10
+;   Coarse blocks (raster TL,TR,BL,BR = ids 0,1,2,3):
+;     edge(summed gradient): TL 0   TR 0   BL 150  BR 480     detail(MAD): TL 0  TR 0  BL 0  BR 67
+;   The BL edge 150 is the object's left boundary bleeding one cell left (honest forward-difference); its
+;   block interior is still uniform wall so its DETAIL is 0 — BL is flat wall, BR is the one thing.
+;
+; SHAPE (edge-floor 300): only BR clears the floor -> (0 0 0 1): top wall + bottom-left wall are FLAT
+;   PLANES, the bottom-right object corner is the one EDGE region. The room's coarse layout signature.
+;
+; OBJECTS (detail-floor 30): baseline -> only BR (id 3) clears the detail floor -> (3): one thing, in the
+;   bottom-right, against three uniform wall blocks.
+;
+; SCENE frame — the same room, but a NEW object has appeared in the bottom-left block:
+;     100 100 100 100
+;     100 100 100 100
+;     100 100 100 100
+;     250  10 250  10
+;   Now BL detail lifts to 67 too. OBJECTS -> (2 3): the new bottom-left thing AND the stable
+;   bottom-right thing.
+;
+; COMMON vs UNIQUE (block residual vs the baseline frame at the same block, tolerance 30):
+;   BL: baseline-vs-baseline residual 0 -> COMMON (the wall that was always there matches itself).
+;   BL: scene-vs-baseline residual 67 -> UNIQUE (a new thing the baseline never held).
+;   BR: scene-vs-baseline residual 0 -> COMMON (the furniture that is always in the room).
+;
+; sf-edge sees the object corner directly: at cell (2,3) the gradient is 240 (>0); a flat wall block's
+; summed gradient is 0 — the gradient IS the flat-plane / edge distinction at the cell scale.
+;
+; Verdict 255 when every claim lands:
+;   1    SHAPE distinguishes flat plane vs edge: baseline shape == (0 0 0 1)
+;   2    OBJECTS finds the one baseline thing: baseline objects == (3)
+;   4    OBJECTS finds the new thing in the scene: scene objects == (2 3)
+;   8    a region matching the baseline is COMMON: sf-common? baseline BL == 1
+;   16   a novel region is UNIQUE: sf-unique? scene BL == 1
+;   32   stable furniture stays COMMON: sf-common? scene BR == 1
+;   64   sf-edge sees the object corner: sf-edge at (2,3) > 0
+;   128  a flat wall block has zero gradient: block-edge TL == 0
+(do
+    (let baseline (list 100 100 100 100
+                        100 100 100 100
+                        100 100 100 100
+                        100 100 250  10))
+    (let scene    (list 100 100 100 100
+                        100 100 100 100
+                        100 100 100 100
+                        250  10 250  10))
+
+    ; SHAPE of the baseline room — flat planes vs the one edge region.
+    (let shp (sf-shape baseline 4 300))
+    (let c0 (if (and (eq (nth shp 0) 0)
+                (and (eq (nth shp 1) 0)
+                (and (eq (nth shp 2) 0)
+                     (eq (nth shp 3) 1)))) 1 0))
+
+    ; OBJECTS — the baseline holds one thing (block 3); the scene holds two (blocks 2 and 3).
+    (let objs-base  (sf-objects baseline 4 30))
+    (let objs-scene (sf-objects scene 4 30))
+    (let c1 (if (and (eq (len objs-base) 1) (eq (nth objs-base 0) 3)) 2 0))
+    (let c2 (if (and (eq (len objs-scene) 2)
+                (and (eq (nth objs-scene 0) 2) (eq (nth objs-scene 1) 3))) 4 0))
+
+    ; COMMON vs UNIQUE — the bottom-left block matches the baseline wall (common), the scene's
+    ; bottom-left is novel (unique), the bottom-right furniture stays stable (common).
+    (let c3 (if (eq (sf-common? baseline baseline 4 0 1 30) 1) 8 0))
+    (let c4 (if (eq (sf-unique? scene    baseline 4 0 1 30) 1) 16 0))
+    (let c5 (if (eq (sf-common? scene    baseline 4 1 1 30) 1) 32 0))
+
+    ; sf-edge sees the object corner; a flat wall block has zero summed gradient.
+    (let c6 (if (gt (sf-edge baseline 4 2 3) 0) 64 0))
+    (let c7 (if (eq (sf-block-edge baseline 4 0 0) 0) 128 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1181,3 +1181,4 @@ sk-msl fks 127
 sense-loop fks 8191
 presence-feature fks 15
 trust-climb fks 8
+scene-features fks 255


### PR DESCRIPTION
## scene-features — a downsampled frame grid into room shape, objects, common-vs-unique

`scene-features.fk` reads the SAME downsampled NxN luminance grid the camera sensor-organ port produces into three banded views of one frame:

- **`sf-shape`** — a coarse 2x2 layout signature, flat-plane (0) vs edge (1) per block: the room's shape, the bands `rr-signature` consumes.
- **`sf-objects`** — the coarse blocks whose detail (MAD) clears the floor: the things in the room, against uniform wall.
- **`sf-common?` / `sf-unique?`** — a block's detail vs the baseline frame at the same block (room-register's L1 residual): furniture that was always there vs a new thing that just appeared.
- **`sf-edge`** — local forward absolute gradient (`|cell-right|+|cell-below|`): flat plane ~0, wall-corner / object boundary high.

### Composes existing tissue, no duplication
- **presence-feature.fk** — its squares-free MEAN-ABSOLUTE-DEVIATION region variance, re-grown over a coarse BLOCK grid so the whole frame is read (`sf-detail`). An object is a block whose detail lifts above flat wall — the same ge-cutoff `pf-present?` draws against an occupancy floor.
- **room-register.fk** — its `rr-distance` (summed L1 band residual) reused as `sf-region-residual` for common-vs-unique; `sf-shape` is the upstream source of the banded room signature `rr-distance` later closes on return.

All integer — gradient, MAD, L1 — no floats, no sqrt, exact on every arm.

### Band — `tests/scene-features-band.fk`
n=4 grid, uniform wall + one bottom-right object block → `sf-shape == (0 0 0 1)` (top + bottom-left flat, bottom-right the one edge region); `sf-objects` finds the one thing `(3)`. A scene frame with a NEW bottom-left object → `sf-objects` finds `(2 3)`; the matching bottom-left wall reads `sf-common? = 1`, the novel bottom-left reads `sf-unique? = 1`, the stable bottom-right furniture stays `sf-common? = 1`.

### Proof
`cd form && ./validate.sh form-stdlib/tests/scene-features-band.fk` →
`✓  core.fk+scene-features.fk+scene-features-band.fk  → 255`
**fourth arm: 1 band four-way (Go + Rust + TS + fkwu) — 1 ok, 0 divergent.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)