### PR TITLE
tend(form): voice-self-learn — the mesh learns its OWN voice from 3 mics (four-way)

### DIFF
--- a/form/form-stdlib/tests/voice-self-learn-band.fk
+++ b/form/form-stdlib/tests/voice-self-learn-band.fk
@@ -1,0 +1,44 @@
+; preludes: form-stdlib/stt-agree.fk form-stdlib/champion-challenger.fk form-stdlib/voice-self-learn.fk
+;
+; voice-self-learn-band — the mesh learns its OWN voice, made falsifiable.
+;
+; The body EMITS a known utterance truth = "we are the iris" through TTS. Three mics (mac/android/windows)
+; hear it back from three angles and the native STT transcribes each:
+;   mic-a (we are the iris)   -> 100  heard it exactly
+;   mic-b (we are the iris)   -> 100  heard it exactly
+;   mic-c (we are an  iris)   ->  75  one word off — the error signal
+; At floor 80, vsl-agree = 2 (two mics matched the emission, the erroring mic flagged out). The emission
+; is the FREE label: no oracle was asked, the body already knew what it said.
+;
+; Then a sequence of emit-hear ticks. Each tick is a champion-challenger trial (oracle=1, native=win?):
+; over a window the native arm keeps reaching quorum on its own voice, vsl-confidence climbs, and authority
+; FLIPS to native (the rented STT/TTS retires) — trust-climb mirrored.
+;
+; Verdict 127 when every claim lands:
+;   1    two mics matched the emission, the erroring mic flagged out   (vsl-agree mics truth 80 == 2)
+;   2    a mic that heard exactly passes the floor                     (vsl-mic-ok? mic-a truth 80 == 1)
+;   4    the one-word-off mic is the error signal (below floor)        (vsl-mic-ok? mic-c truth 80 == 0)
+;   8    the emission is the self-label of the pair                    (vsl-said (vsl-pair truth mic-c) == truth)
+;   16   a 2-of-3 quorum tick is a win for the native arm             (vsl-tick-win? mics truth 80 2 == 1)
+;   32   native voice confidence climbs over the agreeing window       (vsl-confidence history == 6)
+;   64   over a long-enough proven window authority comes HOME         (vsl-learn history 6 0 == "challenger")
+(do
+    (let truth (list "we" "are" "the" "iris"))
+    (let mic-a (list "we" "are" "the" "iris"))   ; mac     — exact
+    (let mic-b (list "we" "are" "the" "iris"))   ; windows — exact
+    (let mic-c (list "we" "are" "an"  "iris"))   ; android — one word off (the error)
+    (let mics  (list mic-a mic-b mic-c))
+
+    ; a window of emit-hear ticks: this tick (2-of-3 quorum, won) plus five more that the native arm won,
+    ; the oracle assumed correct on its own emission. champion 6 / native 6 over six ticks.
+    (let tick    (vsl-trial mics truth 80 2))     ; (1 1) — native reached quorum on what we said
+    (let history (list tick tick tick tick tick tick))
+
+    (let c0 (if (eq (vsl-agree mics truth 80) 2) 1 0))
+    (let c1 (if (eq (vsl-mic-ok? mic-a truth 80) 1) 2 0))
+    (let c2 (if (eq (vsl-mic-ok? mic-c truth 80) 0) 4 0))
+    (let c3 (if (str_eq (head (vsl-said (vsl-pair truth mic-c))) (head truth)) 8 0))
+    (let c4 (if (eq (vsl-tick-win? mics truth 80 2) 1) 16 0))
+    (let c5 (if (eq (vsl-confidence history) 6) 32 0))
+    (let c6 (if (str_eq (vsl-learn history 6 0) "challenger") 64 0))
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 c6)))))))

--- a/form/form-stdlib/voice-self-learn.fk
+++ b/form/form-stdlib/voice-self-learn.fk
@@ -1,0 +1,74 @@
+; voice-self-learn.fk — the mesh learns its OWN voice by speaking and hearing itself from MANY mics.
+;
+; self-heard-learning turned INWARD. In stt-agree.fk the ground truth was a human/authoritative
+; transcript we had to be given; here the body KNOWS the ground truth — it is the text the body itself
+; EMITTED through TTS. So every emit-hear tick is FREE self-supervision: the body says a known utterance,
+; N mics (the 3 devices: mac/android/windows) hear it back from N angles, each mic's audio is transcribed
+; by the native STT, and every transcript is scored against (a) what we KNOW we said and (b) each other.
+; 3 mics agreeing AND matching the emission = high confidence; a mic that disagrees is an error signal,
+; flagged — a free label with no oracle in the loop.
+;
+; COMPOSES, never duplicates:
+;   stt-agree.fk        — sa-accuracy: the word-overlap accuracy of one transcript vs a reference 0..100.
+;                         Each mic transcript is scored against the KNOWN truth with exactly that metric.
+;   champion-challenger — cc-promote?/cc-authority: the native STT/TTS arm (challenger) takes authority
+;                         from the rented oracle (champion) only on PROVEN agreement over a window. Each
+;                         emit-hear tick whose native transcripts agreed with the emission is a won trial;
+;                         authority flips to native when the window is long enough and native has reached.
+;
+; vsl-agree     — over N mic transcripts + the known truth: how many mics matched the truth at the floor.
+;                 N matching + truth-match = high; a disagreeing mic lowers the count (the error signal).
+; vsl-pair      — a self-labeled (said -> heard) training pair; the body's own emission IS the label.
+; vsl-confidence— the climbing native voice confidence: agreeing ticks counted over the history.
+; vsl-learn     — refine native STT/TTS via the champion-challenger window; authority flips to native
+;                 (the rented STT/TTS retires) when native keeps matching its own emission.
+;
+; Integers only; str_eq + counting + the composed accuracy; no floats. (empty) for the empty mic list.
+; Self-contained over core + the two composed bodies. Four-way by tests/voice-self-learn-band.fk.
+;
+; preludes: form-stdlib/stt-agree.fk form-stdlib/champion-challenger.fk
+
+(do
+    ; --- a self-labeled training pair: what the body SAID -> what a mic HEARD. The emission is the label,
+    ;     so this pair needs no oracle. (truth heard) is the free supervised example. ---
+    (defn vsl-pair (truth heard) (list truth heard))
+    (defn vsl-said  (p) (nth p 0))
+    (defn vsl-heard (p) (nth p 1))
+
+    ; --- does ONE mic's transcript match the known emission at the agreement floor? Reuses stt-agree's
+    ;     word-overlap accuracy verbatim — the heard transcript is scored against the truth we emitted. ---
+    (defn vsl-mic-ok? (heard truth floor) (sa-agree? heard truth floor))
+
+    ; --- vsl-agree: over the N mic transcripts, HOW MANY matched the known emission at the floor.
+    ;     N mics agreeing + matching what we said = high (== N); a disagreeing mic does not count, so the
+    ;     gap from N is the error signal — which mics heard wrong. recursion is the loop; (empty) terminates. ---
+    (defn vsl-agree (mics truth floor)
+        (if (eq (len mics) 0) 0
+            (add (vsl-mic-ok? (head mics) truth floor)
+                 (vsl-agree (tail mics) truth floor))))
+
+    ; --- a tick is a WIN for the native arm when at least `quorum` of its mics heard the emission right
+    ;     (e.g. 2 of 3). The quorum is the cross-mic confidence: agreement across angles, free-labeled. ---
+    (defn vsl-tick-win? (mics truth floor quorum)
+        (if (ge (vsl-agree mics truth floor) quorum) 1 0))
+
+    ; --- one emit-hear tick as a champion-challenger trial = (champion-correct native-correct).
+    ;     The rented oracle is assumed correct on its own emission (champ = 1); the native arm earns its 1
+    ;     only when its mics reach quorum on what the body actually said. This is the bridge from a tick of
+    ;     self-heard agreement to the proven head-to-head window champion-challenger already walks. ---
+    (defn vsl-trial (mics truth floor quorum)
+        (list 1 (vsl-tick-win? mics truth floor quorum)))
+
+    ; --- vsl-confidence: the climbing native voice confidence = how many ticks in the history the native
+    ;     arm won (reached quorum on its own emission). A pure count over champion-challenger trials — it
+    ;     can only climb as more agreeing ticks arrive. history = (list trial ...). ---
+    (defn vsl-confidence (history) (cc-chall-score history))
+
+    ; --- vsl-learn: refine native STT/TTS via the champion-challenger window. Authority flips to the
+    ;     native arm — the rented STT/TTS retires — only when the window is long enough (>= min-ticks) AND
+    ;     the native confidence has REACHED the oracle within margin. Proven self-heard competition, never
+    ;     asserted: cc-authority returns "challenger" (native) once native keeps matching its own voice. ---
+    (defn vsl-learn (history min-ticks margin) (cc-authority history min-ticks margin))
+    (defn vsl-home? (history min-ticks margin) (cc-promote? history min-ticks margin))
+
+    0)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1183,3 +1183,4 @@ presence-feature fks 15
 trust-climb fks 8
 scene-features fks 255
 sound-classify fks 63
+voice-self-learn fks 127


### PR DESCRIPTION
**Stone:** `voice-self-learn` — self-heard-learning turned inward. The body emits a known utterance through TTS (it KNOWS the ground-truth text it said), 3 mics (mac/android/windows) hear it back from N angles, native STT transcribes each, and every transcript cross-checks against the known emission AND the other mics. 3 mics agreeing + matching what we said = high confidence — **free self-supervision, no oracle in the loop**. A disagreeing mic is an error signal, flagged. As agreeing emit-hear ticks accumulate over a window, native voice confidence climbs and authority flips home to the native STT/TTS; the rented arm retires.

**Composes, never duplicates:**
- `stt-agree.fk` — `sa-accuracy`/`sa-agree?`: each mic transcript scored vs the known emission with the existing word-overlap metric.
- `champion-challenger.fk` — `cc-authority`/`cc-promote?`: the native arm earns authority over a proven window.

**Recipe:** `vsl-agree(mics,truth,floor)` (how many mics matched the emission; gap from N = error signal) · `vsl-pair(truth,heard)` (self-labeled said→heard pair, the emission IS the label) · `vsl-confidence(history)` (climbing native confidence) · `vsl-learn(history,…)` (authority flips home when native keeps matching its own voice).

**Band** `tests/voice-self-learn-band.fk`: emit `"we are the iris"` heard by 3 mics — 2 exact (100), 1 one-word-off (75). At floor 80 `vsl-agree` = **2** (the erroring mic flagged out); over six agreeing ticks `vsl-confidence` climbs to **6** and authority comes **home** to `"challenger"`. Stable integer verdict **127**.

**Four-way** (`form/validate.sh form-stdlib/tests/voice-self-learn-band.fk`):
```
✓  core.fk+stt-agree.fk+champion-challenger.fk+voice-self-learn.fk+voice-self-learn-band.fk  → 127
fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)
1 ok, 0 divergent — kernels agree on every sample.
```
Go, Rust, TS, and fkwu all agree. No divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)