### PR TITLE
tend(form): motion-normalize — exposure-invariant motion (fkwu four-way, 63)

### DIFF
--- a/form/form-stdlib/motion-normalize.fk
+++ b/form/form-stdlib/motion-normalize.fk
@@ -1,0 +1,73 @@
+; motion-normalize.fk — make surprise-kernel's motion detection EXPOSURE-INVARIANT, the LIGHT-BLIND
+; sibling of sk-surprise's raw frame-diff.
+;
+; surprise-kernel.fk's sk-surprise is the per-frame L1 prediction error: sum |frame[i] - prev[i]|. It
+; spends the GPU wherever frame-to-frame change is high — but it cannot tell MOTION from EXPOSURE. Observed
+; directly on a real camera: a dark frame and the same room after the auto-exposure brightened it differ in
+; EVERY cell by roughly the same amount; sk-surprise summed that whole-frame brightness lift to ~9500 though
+; nothing in the room moved. The LIGHT changed, not the scene. A raw frame-diff gate fires on the sunrise.
+;
+; The fix is mean-removal. A uniform brightness offset K added to every cell is exactly the camera
+; auto-exposing dark -> bright. Subtract each frame's own global mean before the diff and that offset
+; cancels: if frame[i] = prev[i] + K for all i, then mean(frame) = mean(prev) + K, so
+;   (frame[i] - mean(frame)) = (prev[i] + K) - (mean(prev) + K) = prev[i] - mean(prev).
+; The two mean-removed grids are identical -> mn-surprise = 0. The exposure shift vanishes. A LOCAL change
+; (one region brightening while the overall mean holds) does NOT cancel — it survives normalization as true
+; motion. Mean-removal keeps the structure, drops the level.
+;
+; This COMPOSES the existing tissue, it does not reinvent it:
+;   - surprise-kernel.fk's sk-error-sum is the L1 |actual - expected| fold; mn-surprise is that exact fold
+;     run over the two NORMALIZED grids instead of the raw frames. The salience/ATTEND gate downstream is
+;     unchanged — sk-salience reads mn-surprise the same way it reads sk-surprise, now light-blind.
+;   - presence-feature.fk's pf-sum / pf-region-var take a region MEAN by integer div (sum / count); mn-mean
+;     is the same integer-mean shape over the WHOLE flat grid. No squares, no floats — the MAD-style
+;     mean-removal, integer-exact on every arm.
+;   - the grid is the SAME row-major NxN luminance frame (flat list of int-scaled cells) the camera
+;     sensor-organ-channel port produces and presence-feature consumes.
+;
+; All integer. Mean-removal goes negative (a below-mean cell) — kept honest by the sk-error abs in the L1
+; fold, exactly as sk-error-sum already takes |diff|. Integer division leaves the mean truncated, but a
+; UNIFORM offset shifts the mean by exactly K (no remainder drift), so the exposure case cancels exactly;
+; local structure survives untouched. n is the cell count of the flat grid (NxN = n).
+;
+; preludes: form-stdlib/core.fk form-stdlib/surprise-kernel.fk
+;
+; Proven by: form-stdlib/tests/motion-normalize-band.fk (four-way at validate.sh, incl. fkwu)
+
+(do
+    ; --- SUM: sum the raw cell values over the flat grid (for the global mean). ---
+    ;     The pf-sum integer-accumulate shape, flattened to the whole grid: walk all n cells, add each.
+    (defn mn-sum (grid i acc)
+        (if (eq i (len grid)) acc
+            (mn-sum grid (add i 1) (add acc (nth grid i)))))
+
+    ; --- MEAN: the grid's global mean luminance (integer). sum / n, integer div. Empty grid -> 0. ---
+    ;     The pf-region-var mean shape (sum / count) taken over the whole frame. A uniform +K offset lifts
+    ;     this mean by exactly K, which is what makes the exposure shift cancel in mn-normalize.
+    (defn mn-mean (grid n)
+        (if (eq n 0) 0
+            (div (mn-sum grid 0 0) n)))
+
+    ; --- NORMALIZE: each cell minus the grid mean — a mean-removed grid. ---
+    ;     A UNIFORM brightness offset on every cell cancels exactly (mean lifts by the same K), so exposure
+    ;     shifts vanish; LOCAL structure (one region above/below the mean) survives. Cells go negative below
+    ;     the mean — honest, the downstream L1 fold takes |diff|. Empty grid -> ().
+    ;     Walks head/tail and cons-es each mean-removed cell in natural order (no append): the same
+    ;     head/tail spine sk-error-sum folds over, here building the mean-removed grid the fold consumes.
+    (defn mn-norm-walk (grid mean)
+        (if (eq (len grid) 0) (empty)
+            (cons (sub (head grid) mean)
+                  (mn-norm-walk (tail grid) mean))))
+
+    (defn mn-normalize (grid n)
+        (if (eq n 0) (empty)
+            (mn-norm-walk grid (mn-mean grid n))))
+
+    ; --- SURPRISE: sk-surprise-style L1 diff over the two NORMALIZED grids — true motion, exposure-invariant. ---
+    ;     Mean-remove both frames, then run sk-error-sum (the |actual - expected| L1 fold) over them. A
+    ;     uniform exposure lift cancels in normalization -> ~0; a real local change survives -> large. This
+    ;     is the light-blind twin of sk-surprise: the SAME error fold, fed mean-removed grids.
+    (defn mn-surprise (prev frame n)
+        (sk-error-sum (mn-normalize frame n) (mn-normalize prev n)))
+
+    0)

--- a/form/form-stdlib/tests/motion-normalize-band.fk
+++ b/form/form-stdlib/tests/motion-normalize-band.fk
@@ -1,0 +1,67 @@
+; preludes: form-stdlib/core.fk form-stdlib/surprise-kernel.fk form-stdlib/motion-normalize.fk
+;
+; motion-normalize-band — mean-removal makes the motion gate EXPOSURE-INVARIANT: the camera auto-exposing
+; dark -> bright no longer reads as motion, while a real local change still does. n=16 flat grid (4x4).
+;
+; This falsifies the real, observed bug: two frames that differ only in OVERALL brightness (the camera
+; auto-exposing) produced a huge surprise though nothing moved. Mean-remove each frame first and that
+; uniform offset cancels exactly; only LOCAL change (true motion) survives the normalization.
+;
+;   EXPOSURE  prev_e, frame_e = prev_e + 30 in EVERY cell (the camera brightened dark -> bright):
+;       raw sk-error-sum(frame_e, prev_e) = 16*30 = 480  -> large, the bug: light read as motion.
+;       mn-surprise(prev_e, frame_e, 16)  = 0            -> the +30 lifts each mean by 30, cancels exactly.
+;       The light changed, not the room. Mean-removal makes the gate light-blind.
+;
+;   MOTION    prev_m (uniform 100), frame_m: a bright block appears (+80 in cells 5,6,9,10) while a dark
+;             block holds the overall mean (-80 in cells 0,1,2,3) — same total brightness, real LOCAL change:
+;       mean(prev_m) = mean(frame_m) = 100 (sums identical) -> exposure did NOT change, only structure did.
+;       mn-surprise(prev_m, frame_m, 16) = 640                  -> large, true motion survives normalization.
+;
+; The single integer verdict encodes both: exposure -> low (0), motion -> high (640). A gate that fired on
+; the sunrise now fires only on the body that walked in.
+;
+; Verdict 63 when every claim lands:
+;   1    raw frame-diff INFLATES on a pure exposure shift   (sk-error-sum frame_e prev_e == 480, the bug)
+;   2    mn-surprise CANCELS the exposure shift -> ~0        (mn-surprise prev_e frame_e 16 == 0, fixed: low)
+;   4    the mean lifts by exactly the offset               (mn-mean frame_e - mn-mean prev_e == 30)
+;   8    mn-normalize is offset-invariant cell-for-cell      (mn-normalize frame_e == mn-normalize prev_e)
+;   16   a real LOCAL change leaves the mean untouched       (mn-mean prev_m == mn-mean frame_m == 100)
+;   32   mn-surprise SURVIVES on true motion -> high         (mn-surprise prev_m frame_m 16 == 640)
+(do
+    ; EXPOSURE pair: frame_e is prev_e with a uniform +30 brightness lift in every cell (auto-exposure).
+    (let prev_e  (list 120 118 121 119
+                       122 117 120 123
+                       119 121 118 120
+                       121 119 122 118))
+    (let frame_e (list 150 148 151 149
+                       152 147 150 153
+                       149 151 148 150
+                       151 149 152 148))
+
+    ; MOTION pair: prev_m uniform (100); frame_m gains a bright block (+80) and holds the mean with a dark
+    ; block (-80) — identical total brightness, a real local change. Exposure unchanged, structure changed.
+    (let prev_m  (list 100 100 100 100
+                       100 100 100 100
+                       100 100 100 100
+                       100 100 100 100))
+    (let frame_m (list  20  20  20  20
+                       100 180 180 100
+                       100 180 180 100
+                       100 100 100 100))
+
+    ; raw frame-diff (the prediction is the prior frame, sk-error-sum over the RAW grids) inflates on exposure.
+    (let c0 (if (eq (sk-error-sum frame_e prev_e) 480)              1 0))
+    ; mn-surprise cancels the uniform offset -> 0 (the bug is fixed: exposure reads LOW).
+    (let c1 (if (eq (mn-surprise prev_e frame_e 16) 0)              2 0))
+    ; the +30 offset lifts the grid mean by exactly 30 (no remainder drift) -> the cancellation is exact.
+    (let c2 (if (eq (sub (mn-mean frame_e 16) (mn-mean prev_e 16)) 30) 4 0))
+    ; mn-normalize is offset-invariant cell-for-cell: head of each mean-removed grid matches (120-119 ==
+    ; 150-149 == 1), proving the +30 vanishes per cell, not just in the summed diff.
+    (let c3 (if (eq (head (mn-normalize prev_e 16)) (head (mn-normalize frame_e 16))) 8 0))
+    ; a true local change leaves the overall mean untouched (both 100) -> it is motion, not exposure.
+    (let c4 (if (and (eq (mn-mean prev_m 16) 100)
+                     (eq (mn-mean frame_m 16) 100))                16 0))
+    ; mn-surprise SURVIVES on true motion -> high (640): local change is not cancelled by normalization.
+    (let c5 (if (eq (mn-surprise prev_m frame_m 16) 640)          32 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 c5))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1186,3 +1186,4 @@ sound-classify fks 63
 voice-self-learn fks 127
 identity-home fks 127
 perception-cascade fks 1048575
+motion-normalize fks 63


### PR DESCRIPTION
## motion-normalize — make surprise-kernel's motion gate EXPOSURE-INVARIANT

Fixes a real, observed error: two camera frames differing only in OVERALL brightness (auto-exposure dark→bright) produced a surprise of ~9500 though nothing moved. The light changed, not the room.

**The fix — mean-removal.** A uniform brightness offset K added to every cell is exactly auto-exposure. Subtract each frame's own global mean before the diff and that offset cancels: `frame[i] = prev[i] + K` → `mean(frame) = mean(prev) + K` → `frame[i] - mean(frame) = prev[i] - mean(prev)`. The two mean-removed grids are identical → surprise 0. A LOCAL change (region brightening while the mean holds) does not cancel — it survives as true motion.

**Composes both grounds, no duplication:**
- `surprise-kernel.fk` — `mn-surprise` runs `sk-error-sum` (the L1 `|actual-expected|` fold) over the two NORMALIZED grids instead of raw frames. Mean-removal goes negative; the `sk-error` abs keeps it honest.
- `presence-feature.fk` — `mn-mean` reuses the integer-mean shape (`sum / count`) over the whole flat grid.

**Band (`motion-normalize-band.fk`), verdict 63, four-way incl. fkwu:**
- EXPOSURE: `frame = prev + 30` in every cell → raw `sk-error-sum = 480` (the bug, large) vs `mn-surprise = 0` (fixed, **low**).
- MOTION: same overall mean (100→100), a local block change → `mn-surprise = 640` (true motion **high**).

```
core.fk+surprise-kernel.fk+motion-normalize.fk+motion-normalize-band.fk → 63
fourth arm: 1 band four-way (fkwu + pre-flattened tables)
1 ok, 0 divergent — kernels agree on every sample.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)