### PR TITLE
tend(form): world-sensor-floor — the FLOOR every platform + sensor stands on (four-way 4095)

### DIFF
--- a/form/form-stdlib/tests/world-sensor-floor-band.fk
+++ b/form/form-stdlib/tests/world-sensor-floor-band.fk
@@ -1,0 +1,83 @@
+; tests/world-sensor-floor-band.fk — the floor every platform and sensor stands on, four-way.
+;
+; preludes: form-stdlib/core.fk form-stdlib/spatial-fusion.fk form-stdlib/confidence-weighted-vote.fk form-stdlib/mesh-sense-7w.fk form-stdlib/fused-observation.fk form-stdlib/world-sensor-floor.fk
+;
+; The floor: a world resource is an afferent port, mapped to an inquiry plane, producing a
+; mesh-safe reading that fuses (fused-observation.fk's fo-reading + fo-fuse). The roster maps
+; each standard sensor to the RIGHT plane; a full platform routes + fuses; a partial platform
+; names what it is missing.
+;
+; Verdict 4095 when every claim lands on Go / Rust / TypeScript / fkwu:
+;   1     wifi routes to the "where" plane (place)
+;   2     bluetooth routes to "who" (who is present)
+;   4     battery routes to "vitality" (the carrier's own health — host-resource-access cond-2)
+;   8     mic routes to "who" (who is speaking) and camera to "what"
+;   16    a routed reading is an fo-reading row carrying its plane, value, source, confidence
+;   32    windows (wifi/bt/battery/memory/camera/mic) carries 6 floor sensors
+;   64    windows floor state is floor-partial (gps/proximity/magnetometer/barometer missing)
+;   128   windows names exactly 4 missing floor sensors
+;   256   mac (camera/mic) is floor-partial carrying 2
+;   512   mac names "gps" among its missing floor sensors
+;   1024  the windows routed where/who/what readings fuse into ONE observed cell (fo-fuse)
+;   2048  the fused observed cell names the located place, the present who, and the seen what
+
+(do
+    (let roster (wsf-roster))
+
+    ; ── 1/2/4/8: the roster maps each standard sensor to the RIGHT inquiry plane ──
+    (let wifi-where (if (str_eq (wsf-plane-of roster "wifi") "where") 1 0))
+    (let bt-who     (if (str_eq (wsf-plane-of roster "bluetooth") "who") 2 0))
+    (let bat-vital  (if (str_eq (wsf-plane-of roster "battery") "vitality") 4 0))
+    (let mic-cam    (if (and (str_eq (wsf-plane-of roster "mic") "who")
+                             (str_eq (wsf-plane-of roster "camera") "what")) 8 0))
+
+    ; ── 16: a routed reading is an fo-reading row (plane value source confidence) ──
+    (let wifi-sensor (wsf-find roster "wifi"))
+    (let wifi-read   (wsf-route wifi-sensor 2 900))
+    (let row-shaped  (if (and (str_eq (rd-plane wifi-read) "where")
+                              (and (eq (rd-value wifi-read) 2)
+                                   (and (str_eq (rd-source wifi-read) "wifi")
+                                        (eq (rd-confidence wifi-read) 900)))) 16 0))
+
+    ; ── windows: a full platform — wifi/bt/battery/memory/camera/mic ──
+    (let windows (list "wifi" "bluetooth" "battery" "memory" "camera" "mic"))
+    (let win-floor (wsf-floor-complete? windows roster))
+    (let win-carried (if (eq (wfc-carried win-floor) 6) 32 0))
+    (let win-partial (if (str_eq (wfc-state win-floor) "floor-partial") 64 0))
+    (let win-missing (if (eq (len (wfc-missing win-floor)) 4) 128 0))
+
+    ; ── mac: a partial platform — camera/mic only — with the missing sensors named ──
+    (let mac (list "camera" "mic"))
+    (let mac-floor (wsf-floor-complete? mac roster))
+    (let mac-partial (if (and (str_eq (wfc-state mac-floor) "floor-partial")
+                              (eq (wfc-carried mac-floor) 2)) 256 0))
+    (let mac-names-gps (if (eq (wsf-has? (wfc-missing mac-floor) "gps") 1) 512 0))
+
+    ; ── the windows routed readings fuse into ONE observed cell (fo-fuse) ──
+    ; where <- wifi (band 2), who <- bluetooth+mic (label "ilena"), what <- camera ("face").
+    ; battery/memory ride the vitality plane alongside — same reading shape, streaming.
+    (let routed (list
+        (wsf-route (wsf-find roster "wifi")      2       800)
+        (wsf-route (wsf-find roster "bluetooth") "ilena" 600)
+        (wsf-route (wsf-find roster "mic")       "ilena" 700)
+        (wsf-route (wsf-find roster "camera")    "face"  900)
+        (wsf-route (wsf-find roster "battery")   77      1000)
+        (wsf-route (wsf-find roster "memory")    40      1000)))
+    (let fused (wsf-fuse routed))
+    (let fused-one (if (and (str_eq (head fused) "observed")
+                            (eq (fo-o-where fused) 2)) 1024 0))
+    (let fused-named (if (and (str_eq (fo-o-who fused) "ilena")
+                              (str_eq (fo-o-what fused) "face")) 2048 0))
+
+    (add wifi-where
+    (add bt-who
+    (add bat-vital
+    (add mic-cam
+    (add row-shaped
+    (add win-carried
+    (add win-partial
+    (add win-missing
+    (add mac-partial
+    (add mac-names-gps
+    (add fused-one
+        fused-named))))))))))))

--- a/form/form-stdlib/world-sensor-floor.fk
+++ b/form/form-stdlib/world-sensor-floor.fk
@@ -1,0 +1,119 @@
+; world-sensor-floor.fk — the standing FLOOR every platform and every sensor stands on.
+;
+; PR #12 (coherence-kernel) wired Windows wifi/bt/battery/memory as host sensors. This
+; canonicalizes that one-platform pattern into the INVARIANT contract, so adding ANY sensor
+; on ANY platform is "implement the carrier, the rest is already proven."
+;
+; THE CONTRACT (host-kernel.form organs-and-ports · sensor-organ-channel.fk · inquiry-planes.fk
+; · fused-observation.fk):
+;   A world resource is a VIA-HOST afferent PORT (world-sensors / world-audio / world-video,
+;   direction afferent: world -> cell). It MAPS to an INQUIRY-PLANE (the kind of question it
+;   answers). It produces a MESH-SAFE READING that fuses and streams.
+;
+;   INVARIANT: port (afferent) + plane + reading-shape + fusion.
+;   PER-PLATFORM: the carrier (the OS API) — the only thing a new platform implements.
+;
+; This COMPOSES the existing tissue, it does not reinvent it:
+;   - the READING is fused-observation.fk's `fo-reading (plane value source-cell confidence)` —
+;     the narrowed organ row the mesh already fuses (no new reading engine).
+;   - the FUSION is fused-observation.fk's `fo-fuse` — the SAME per-plane fusion that collapses
+;     all senses into ONE observed cell (observed PRESENT WHO WHAT WHERE CONFIDENCE).
+;   - the PLANES are inquiry-planes.fk's words. where/who/what already fuse via fo-fuse;
+;     "vitality" extends the seven with the body's own health plane — battery/memory answer
+;     "how alive is the carrier right now", which IS host-resource-access condition-2
+;     (measure-its-health-on-the-body). A vitality reading rides the same reading shape and
+;     streams; the four-plane fuse stays exactly fo-fuse.
+;
+; Integers + strings only; confidences are counts on a scale (the carrier's own trust weight).
+;
+; preludes: form-stdlib/core.fk form-stdlib/spatial-fusion.fk form-stdlib/confidence-weighted-vote.fk form-stdlib/mesh-sense-7w.fk form-stdlib/fused-observation.fk
+;
+; Proven by: form-stdlib/tests/world-sensor-floor-band.fk
+
+(do
+    ; ── a world-sensor spec: an afferent VIA-HOST port routed to its inquiry plane ──
+    ; The port is invariant (direction afferent, organ world-sensors); the carrier varies
+    ; per platform. The spec names what a sensor IS, before any carrier exists.
+    (defn wsf-sensor (name plane)
+        (list "world-sensor" name "afferent" plane))
+    (defn wsf-name   (s) (nth s 1))
+    (defn wsf-dir    (s) (nth s 2))            ; always "afferent" — world -> cell
+    (defn wsf-plane  (s) (nth s 3))            ; the inquiry plane the sensor answers
+    (defn wsf-afferent? (s) (if (str_eq (wsf-dir s) "afferent") 1 0))
+
+    ; ── the canonical floor roster — standard world-sensors mapped to inquiry planes ──
+    ; where: position/place sensors. who: identity/presence sensors. what: scene sensors.
+    ; vitality: the carrier's own health (host-resource-access condition-2).
+    (defn wsf-roster ()
+        (list
+            (wsf-sensor "wifi"         "where")     ; nearby networks -> place
+            (wsf-sensor "bluetooth"    "who")       ; nearby devices  -> who is present
+            (wsf-sensor "gps"          "where")     ; coordinate      -> place
+            (wsf-sensor "camera"       "what")      ; image scene     -> what is here
+            (wsf-sensor "mic"          "who")       ; voices          -> who is speaking
+            (wsf-sensor "battery"      "vitality")  ; charge          -> body health
+            (wsf-sensor "memory"       "vitality")  ; free RAM        -> body health
+            (wsf-sensor "proximity"    "where")     ; near/far        -> place
+            (wsf-sensor "magnetometer" "where")     ; heading         -> place
+            (wsf-sensor "barometer"    "where")))   ; altitude        -> place
+
+    (defn wsf-find (roster name)
+        (if (eq (len roster) 0) (empty)
+            (if (str_eq (wsf-name (head roster)) name) (head roster)
+                (wsf-find (tail roster) name))))
+
+    ; the plane a named sensor answers, looked up in a roster ("" if not on the floor)
+    (defn wsf-plane-of (roster name)
+        (do (let found (wsf-find roster name))
+            (if (eq (len found) 0) "" (wsf-plane found))))
+
+    ; ── a mesh-safe reading routed to its plane ──
+    ; THIS IS fused-observation.fk's fo-reading: (reading plane value source "organ" confidence) —
+    ; the plane it answers, the value sensed, the carrier source-cell, and the carrier's confidence.
+    ; The floor produces exactly the row the mesh already fuses; no new reading engine.
+    (defn wsf-route (sensor value confidence)
+        (fo-reading (wsf-plane sensor) value (wsf-name sensor) confidence))
+
+    ; ── per-platform floor state: which floor sensors a platform carries vs is missing ──
+    ; platform-sensors is the list of sensor NAMES the platform's carriers actually provide.
+    (defn wsf-has? (names name)
+        (if (eq (len names) 0) 0
+            (if (str_eq (head names) name) 1 (wsf-has? (tail names) name))))
+
+    ; how many roster sensors the platform carries
+    (defn wsf-carried-count (platform-sensors roster)
+        (if (eq (len roster) 0) 0
+            (add (wsf-has? platform-sensors (wsf-name (head roster)))
+                 (wsf-carried-count platform-sensors (tail roster)))))
+
+    ; the names of the roster sensors the platform is missing
+    (defn wsf-missing (platform-sensors roster)
+        (if (eq (len roster) 0) (empty)
+            (if (eq (wsf-has? platform-sensors (wsf-name (head roster))) 1)
+                (wsf-missing platform-sensors (tail roster))
+                (cons (wsf-name (head roster))
+                      (wsf-missing platform-sensors (tail roster))))))
+
+    ; floor-complete? -> a state row (state carried total missing).
+    ; state is "floor-complete" when every roster sensor is carried, else "floor-partial".
+    (defn wsf-floor-complete? (platform-sensors roster)
+        (do (let carried (wsf-carried-count platform-sensors roster))
+            (let total (len roster))
+            (list
+                (if (eq carried total) "floor-complete" "floor-partial")
+                carried
+                total
+                (wsf-missing platform-sensors roster))))
+    (defn wfc-state    (f) (nth f 0))
+    (defn wfc-carried  (f) (nth f 1))
+    (defn wfc-total    (f) (nth f 2))
+    (defn wfc-missing  (f) (nth f 3))
+    (defn wfc-complete? (f) (if (str_eq (wfc-state f) "floor-complete") 1 0))
+
+    ; ── fuse the routed readings into ONE observed cell ──
+    ; THIS IS fused-observation.fk's fo-fuse: the SAME per-plane fusion that collapses all senses
+    ; into one (observed PRESENT WHO WHAT WHERE CONFIDENCE). The floor's readings become the one
+    ; observed cell the mesh already understands — no second fusion engine. where/who/what fuse
+    ; directly; vitality readings ride the same shape and stream alongside.
+    (defn wsf-fuse (routed) (fo-fuse routed))
+)

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1189,3 +1189,4 @@ perception-cascade fks 1048575
 motion-normalize fks 63
 fused-observation fks 255
 speaking-mesh fks 255
+world-sensor-floor fks 4095


### PR DESCRIPTION
Canonicalizes coherence-kernel **PR #12** (Windows wifi/bt/battery/memory as host sensors) into the standing **FLOOR** every platform and every sensor stands on.

## The contract (INVARIANT)
A world resource is a **VIA-HOST afferent PORT** (`host-kernel.form` organs-and-ports), it maps to an **INQUIRY-PLANE** (`inquiry-planes.fk`), and it produces a **MESH-SAFE READING** that fuses (`fused-observation.fk`). The **carrier** (the OS API) is per-platform; **port + plane + reading-shape + fusion** are invariant. Adding any sensor on any platform is *"implement the carrier, the rest is already proven."*

## Composes, does not reinvent
- reading = `fo-reading (plane value source confidence)` (fused-observation.fk)
- fusion  = `fo-fuse` → one `(observed PRESENT WHO WHAT WHERE CONFIDENCE)` cell
- planes  = `inquiry-planes.fk`'s words; **vitality** extends the seven with the carrier's own health (host-resource-access condition-2: battery/memory)

## The five decisions
- `wsf-sensor(name, plane)` — an afferent port routed to its plane
- `wsf-roster()` — the canonical floor: wifi/gps/proximity/magnetometer/barometer→**where**, bluetooth/mic→**who**, camera→**what**, battery/memory→**vitality**
- `wsf-route(sensor, value, conf)` — an `fo-reading` row routed to its plane
- `wsf-floor-complete?(platform-sensors, roster)` — per-platform floor state (carried vs missing named)
- `wsf-fuse(routed)` — `fo-fuse` over the routed readings → one observed cell

## Proof
- windows (wifi/bt/battery/memory/camera/mic) → floor-partial carrying 6, 4 missing named
- mac (camera/mic) → floor-partial carrying 2, names gps among missing
- routed where/who/what readings fuse into one observed cell

**fourth arm: world-sensor-floor four-way 4095, 0 divergent** (Go / Rust / TypeScript / fkwu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)