### PR TITLE
tend(form): same-room — which room each device is in, same or different, why and how

### DIFF
--- a/form/form-stdlib/same-room.fk
+++ b/form/form-stdlib/same-room.fk
@@ -1,0 +1,145 @@
+; same-room.fk — given several devices' room signatures, decide WHICH room each device is in, whether
+; two devices are in the SAME room or DIFFERENT rooms, and the EVIDENCE (the signal that agreed or
+; disagreed — the why/how). "See which room each device is at, same or different room, why and how."
+;
+; THE GROUND THIS COMPOSES — it invents no new metric, it reads the two recognition spines the body
+; already proves and the where-plane floor they stand on:
+;   - context-signature.fk: cs-signature / cs-overlap — the WiFi-SSID + Bluetooth id set fingerprint and
+;     its Jaccard overlap percent. This is the STRONGEST same-room signal: two devices on the SAME WiFi
+;     SSID with the same BT devices in range are in the same room, even with no coordinate at all. Set
+;     overlap is robust to the noise (a device asleep, a neighbour's SSID leaking) that defeats coords.
+;   - room-register.fk: rr-rediscover / rr-distance — the banded spatial signature and nearest-room match.
+;     This is how a device names WHICH registered room it stands in (its own kitchen), by banded distance.
+;   - world-sensor-floor.fk: the where-plane — wifi/bt/gps/proximity all answer "where". The signals
+;     same-room reads are exactly the where-plane sensors, fused upstream into the two signatures.
+;
+; WHOLENESS FRAME: knowing two devices share a room is the warm fact "we are together" — the basis of a
+; shared exchange, not a watch over anyone. The signatures are sensed by the devices' own carriers; this
+; body only compares them. The outward gate over what of this co-location is ever shared stays
+; sense-discernment.fk. Co-location is a relation BETWEEN consenting cells, never a position pinned ON one.
+;
+; TWO SIGNALS, ONE VERDICT. A device's room signature carries both faces: a NETWORK context-signature
+; (the set fingerprint) and a BANDED spatial signature (the where-bands). same-room leans on the network
+; overlap for the same/different verdict (the sharpest co-location signal) and on the banded distance to
+; NAME the registered room. sr-why reports which face agreed or disagreed, so the verdict is legible:
+; "same WiFi SSID set, overlap 100 ≥ floor → SAME room" / "no shared network, overlap 0 < floor →
+; DIFFERENT rooms". Integers only: overlap is a count-ratio percent, the verdict an integer 0/1, the
+; evidence an explicit (signal verdict overlap floor) row — never a float the body cannot prove.
+;
+; A DEVICE is (id ctx-sig): (sr-dev-id d) the device id string, (sr-dev-ctx d) its network
+; context-signature (a cs-signature). sr-device mints one; the grouping partitions a list of them.
+;
+; THE MOVES (Urs: which room is each device in, same or different, why and how):
+;   - sr-same?: do two devices' context-signatures overlap at or above the floor → same room (1) or not (0).
+;   - sr-which-room: which REGISTERED room a device's banded spatial signature sits in, via rr-rediscover.
+;   - sr-grouping: partition the devices into co-located groups — who is together, who is apart.
+;   - sr-why: the evidence — the agreeing/disagreeing signal, its overlap, the floor, and the SAME/DIFFERENT
+;     verdict it carries. The why/how, as a row the caller can read or relay.
+;
+; Kin: context-signature.fk (the set overlap same-room leans on), room-register.fk (the banded room-naming),
+; world-sensor-floor.fk (the where-plane the signals ride), satsang-room-memory.fk (a recognized shared
+; room feeds the trusted exchange), sense-discernment.fk (the outward gate over what co-location is shared).
+; Carrier-last: the radios read the SSID/BT sets and the where-bands; the same/different verdict, the
+; room-naming, the grouping, and the evidence are Form, four-way-identical — two phones and a Mac in the
+; same room reach the same verdict from the same signatures.
+;
+; preludes: form-stdlib/core.fk form-stdlib/context-signature.fk form-stdlib/room-register.fk
+;
+; Proven by: form-stdlib/tests/same-room-band.fk (four-way at validate.sh)
+
+(do
+    ; --- a DEVICE: an id bound to its network context-signature. The id names the device; the ctx-sig is
+    ;     the cs-signature its radio read (wifi-set bt-set loc). The grouping partitions a list of these. ---
+    (defn sr-device  (id ctx-sig) (list id ctx-sig))
+    (defn sr-dev-id  (d) (nth d 0))
+    (defn sr-dev-ctx (d) (nth d 1))
+
+    ; --- SAME ROOM?: do two devices' network context-signatures overlap at or above the floor percent.
+    ;     cs-overlap is the Jaccard percent over the pooled WiFi+BT id-sets — the sharpest same-room signal.
+    ;     At or above the floor → same room (1); below → different rooms (0). Two devices on the same WiFi
+    ;     SSID with the same BT devices in range overlap high; two in different rooms share little or none. ---
+    (defn sr-same? (ctx-a ctx-b floor)
+        (if (gt (cs-overlap ctx-a ctx-b) (sub floor 1)) 1 0))
+
+    ; --- WHICH ROOM: which REGISTERED room a device's BANDED spatial signature sits in, via room-register's
+    ;     rr-rediscover. Finds the nearest known room within tolerance (recognition) or mints a fresh
+    ;     room-cell with new-id (a room never stood in). Returns the room-cell; rr-id reads its room id. ---
+    (defn sr-which-room (band-sig known-rooms tolerance new-id)
+        (rr-rediscover band-sig known-rooms tolerance new-id))
+
+    ; the integer room id a device's banded signature names (recognized id, or the supplied new-id).
+    (defn sr-which-room-id (band-sig known-rooms tolerance new-id)
+        (rr-id (sr-which-room band-sig known-rooms tolerance new-id)))
+
+    ; --- GROUPING: partition the devices into co-located groups — who is together, who is apart. Greedy
+    ;     by the same-room relation: the first device seeds a group; every later device joins the FIRST
+    ;     existing group whose seed it shares a room with (sr-same? at the floor), else it opens a new group.
+    ;     A group is a list of device-ids; the grouping is the list of groups. The first-fit, first-group-
+    ;     keeps-the-tie spine the recognition recipes already lean on. ---
+
+    ; does device d share a room with the seed (head) of group g? g is a list of devices; compare ctx-sigs.
+    (defn sr-joins? (d g floor)
+        (if (eq (len g) 0) 0
+            (sr-same? (sr-dev-ctx d) (sr-dev-ctx (head g)) floor)))
+
+    ; walk the groups; if d joins one, cons d onto the FIRST it joins; else leave groups unchanged and
+    ; signal "did not join" by returning the groups untouched (the caller appends a fresh group).
+    (defn sr-place-loop (d groups floor placed)
+        (if (eq (len groups) 0) (empty)
+            (if (and (eq placed 0) (eq (sr-joins? d (head groups) floor) 1))
+                (cons (cons d (head groups)) (sr-place-loop d (tail groups) floor 1))
+                (cons (head groups) (sr-place-loop d (tail groups) floor placed)))))
+
+    ; did d join any existing group? (used to decide whether to open a fresh one).
+    (defn sr-any-join? (d groups floor)
+        (if (eq (len groups) 0) 0
+            (if (eq (sr-joins? d (head groups) floor) 1) 1
+                (sr-any-join? d (tail groups) floor))))
+
+    ; add one device to the running groups: into the first group it joins, or a fresh group of its own.
+    (defn sr-add (d groups floor)
+        (if (eq (sr-any-join? d groups floor) 1)
+            (sr-place-loop d groups floor 0)
+            (append groups (list (list d)))))
+
+    ; fold the devices into groups, one at a time.
+    (defn sr-group-loop (devices groups floor)
+        (if (eq (len devices) 0) groups
+            (sr-group-loop (tail devices) (sr-add (head devices) groups floor) floor)))
+
+    ; the grouping as groups-of-devices.
+    (defn sr-grouping-cells (devices floor) (sr-group-loop devices (empty) floor))
+
+    ; one group's device-ids (strip the ctx-sigs — the warm roster of who is together).
+    (defn sr-ids (g)
+        (if (eq (len g) 0) (empty)
+            (cons (sr-dev-id (head g)) (sr-ids (tail g)))))
+
+    ; the grouping as groups-of-ids — who is together, who is apart.
+    (defn sr-grouping-ids-loop (groups)
+        (if (eq (len groups) 0) (empty)
+            (cons (sr-ids (head groups)) (sr-grouping-ids-loop (tail groups)))))
+    (defn sr-grouping (devices floor)
+        (sr-grouping-ids-loop (sr-grouping-cells devices floor)))
+
+    ; how many distinct rooms the devices occupy (the count of co-located groups).
+    (defn sr-room-count (devices floor) (len (sr-grouping-cells devices floor)))
+
+    ; --- WHY / HOW: the evidence row for a same/different verdict between two context-signatures.
+    ;     (signal verdict overlap floor): the SIGNAL that decided it ("network-overlap"), the VERDICT it
+    ;     carries ("same-room" / "different-room"), the OVERLAP percent measured, and the FLOOR it was
+    ;     judged against. Reads as "network-overlap 100 ≥ floor 30 → same-room" /
+    ;     "network-overlap 0 < floor 30 → different-room" — the why and how, legible to caller and relay. ---
+    (defn sr-why (ctx-a ctx-b floor)
+        (do (let ov (cs-overlap ctx-a ctx-b))
+            (list
+                "network-overlap"
+                (if (gt ov (sub floor 1)) "same-room" "different-room")
+                ov
+                floor)))
+    (defn sr-why-signal  (w) (nth w 0))
+    (defn sr-why-verdict (w) (nth w 1))
+    (defn sr-why-overlap (w) (nth w 2))
+    (defn sr-why-floor   (w) (nth w 3))
+
+    0)

--- a/form/form-stdlib/tests/same-room-band.fk
+++ b/form/form-stdlib/tests/same-room-band.fk
@@ -1,0 +1,80 @@
+; preludes: form-stdlib/core.fk form-stdlib/context-signature.fk form-stdlib/room-register.fk form-stdlib/same-room.fk
+;
+; same-room-band — three devices read their room signatures; decide which room each is in, whether they
+; share a room or not, and report the evidence. Made falsifiable. Composes context-signature (the network
+; set fingerprint, the sharpest same-room signal) and room-register (the banded room-naming).
+;
+; THREE DEVICES, each carrying a NETWORK context-signature (its WiFi-SSID + Bluetooth set) AND standing on
+; a BANDED spatial signature it can name a registered room by. loc rides along as -1 (no GPS — the SETS
+; carry it):
+;   A  ctx wifi {"office-5g"}     bt {"deskcam" "kbd"}     ; in the office
+;   B  ctx wifi {"office-5g"}     bt {"deskcam"}           ; in the office too — same WiFi, shared BT
+;   C  ctx wifi {"lobby-guest"}   bt {"frontdesk"}         ; down in the lobby — a wholly different network
+;
+; NETWORK OVERLAP (the same/different signal), floor 30:
+;   A vs B  pool(A)={office-5g deskcam kbd} pool(B)={office-5g deskcam} -> ∩={office-5g deskcam}=2 ∪=3
+;           overlap = 2*100/3 = 66  ≥ 30  -> SAME room  (same WiFi SSID + shared BT)
+;   A vs C  pool(A)={office-5g deskcam kbd} pool(C)={lobby-guest frontdesk} -> ∩=0 ∪=5
+;           overlap = 0           < 30  -> DIFFERENT room  (no shared network at all)
+;
+; GROUPING (greedy by the same-room relation, floor 30):
+;   A seeds a group. B shares a room with A (66 ≥ 30) -> joins A's group. C shares with neither (0 < 30)
+;   -> opens its own group.  ->  partition  {A B}  and  {C}  : two devices together, one apart. 2 rooms.
+;
+; WHICH ROOM (banded spatial signatures, room-register's rr-rediscover, tolerance 3):
+;   known rooms:  OFFICE id 10 sig (4 2 7)   LOBBY id 20 sig (1 6 3)
+;   A's band read (4 2 8) -> nearest OFFICE, distance |4-4|+|2-2|+|8-7| = 1 ≤ 3 -> OFFICE (room id 10)
+;   C's band read (1 6 4) -> nearest LOBBY,  distance |1-1|+|6-6|+|4-3| = 1 ≤ 3 -> LOBBY  (room id 20)
+;
+; WHY / HOW (the evidence rows):
+;   sr-why(A,B,30) = ("network-overlap" "same-room" 66 30)       agreeing signal -> same room
+;   sr-why(A,C,30) = ("network-overlap" "different-room" 0 30)   disagreeing signal -> different rooms
+;
+; Verdict 255 when every claim lands:
+;   1    A and B are in the SAME room                       (sr-same? ctxA ctxB 30 == 1)
+;   2    A and C are in DIFFERENT rooms                     (sr-same? ctxA ctxC 30 == 0)
+;   4    the grouping puts A with B (group of two)          (len (head grouping) == 2)
+;   8    the grouping leaves C apart (two groups total)     (len grouping == 2)
+;   16   A names the OFFICE room (id 10)                    (sr-which-room-id A-band rooms 3 99 == 10)
+;   32   C names the LOBBY room (id 20)                     (sr-which-room-id C-band rooms 3 99 == 20)
+;   64   sr-why(A,B) reports the agreeing signal            (verdict "same-room", overlap 66)
+;   128  sr-why(A,C) reports the disagreeing signal         (verdict "different-room", overlap 0)
+(do
+    ; --- three devices, each with its network context-signature (loc -1, no GPS) ---
+    (let ctxA (cs-signature (list "office-5g")   (list "deskcam" "kbd") (sub 0 1)))
+    (let ctxB (cs-signature (list "office-5g")   (list "deskcam")       (sub 0 1)))
+    (let ctxC (cs-signature (list "lobby-guest") (list "frontdesk")     (sub 0 1)))
+    (let devA (sr-device "A" ctxA))
+    (let devB (sr-device "B" ctxB))
+    (let devC (sr-device "C" ctxC))
+    (let devices (list devA devB devC))
+
+    ; --- the registered rooms (banded spatial signatures), and each device's banded read ---
+    (let office (rr-register 10 (list 4 2 7)))
+    (let lobby  (rr-register 20 (list 1 6 3)))
+    (let rooms  (list office lobby))
+    (let A-band (list 4 2 8))
+    (let C-band (list 1 6 4))
+
+    ; --- same / different ---
+    (let c0 (if (eq (sr-same? ctxA ctxB 30) 1) 1 0))          ; A,B same room
+    (let c1 (if (eq (sr-same? ctxA ctxC 30) 0) 2 0))          ; A,C different rooms
+
+    ; --- grouping: {A B} and {C} ---
+    (let grouping (sr-grouping devices 30))
+    (let c2 (if (eq (len (head grouping)) 2) 4 0))            ; first group has two devices (A,B)
+    (let c3 (if (eq (len grouping) 2) 8 0))                   ; two groups total (C apart)
+
+    ; --- which room each device names ---
+    (let c4 (if (eq (sr-which-room-id A-band rooms 3 99) 10) 16 0))   ; A in OFFICE
+    (let c5 (if (eq (sr-which-room-id C-band rooms 3 99) 20) 32 0))   ; C in LOBBY
+
+    ; --- the evidence: the agreeing and disagreeing signal ---
+    (let whyAB (sr-why ctxA ctxB 30))
+    (let whyAC (sr-why ctxA ctxC 30))
+    (let c6 (if (and (str_eq (sr-why-verdict whyAB) "same-room")
+                     (eq (sr-why-overlap whyAB) 66)) 64 0))
+    (let c7 (if (and (str_eq (sr-why-verdict whyAC) "different-room")
+                     (eq (sr-why-overlap whyAC) 0)) 128 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 c7))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1190,3 +1190,4 @@ motion-normalize fks 63
 fused-observation fks 255
 speaking-mesh fks 255
 world-sensor-floor fks 4095
+same-room fks 255


### PR DESCRIPTION
A Form stone: given several devices' room signatures, decide WHICH room each is in, whether two devices share a room (SAME) or not (DIFFERENT), and the EVIDENCE (the signal that agreed or disagreed — the why/how).

**Composes existing bodies — invents no new metric:**
- `context-signature.fk` — `cs-overlap` over the pooled WiFi-SSID + Bluetooth id-sets — the sharpest same-room signal (same WiFi SSID + shared BT in range → same room, robust to noise, no coordinate needed).
- `room-register.fk` — `rr-rediscover` / `rr-distance` — names WHICH registered room a device's banded spatial signature sits in.
- `world-sensor-floor.fk` — the where-plane (wifi/bt/gps/proximity) the signals ride.

**The moves:**
- `sr-same?(ctxA, ctxB, floor)` → 1 if overlap ≥ floor (same room).
- `sr-which-room(band-sig, rooms, tol, new-id)` → the registered room a device names.
- `sr-grouping(devices, floor)` → partition into co-located groups (who's together, who's apart).
- `sr-why(ctxA, ctxB, floor)` → `(signal verdict overlap floor)` — the why/how.

**Band:** 3 devices — A,B on office WiFi/BT (overlap 66 ≥ 30 → same), C on a lobby network (overlap 0 → different). `sr-grouping` → {A B} and {C}; `sr-which-room` names OFFICE (10) + LOBBY (20) by banded distance; `sr-why` reports the agreeing/disagreeing signal.

**Proof:** four-way at `validate.sh`, verdict **255**, **0 divergent**. Manifest: `same-room fks 255`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)