### PR TITLE
tend(form): device-model — the mesh's spatial self-image

### DIFF
--- a/form/form-stdlib/device-model.fk
+++ b/form/form-stdlib/device-model.fk
@@ -1,0 +1,152 @@
+; device-model.fk — the mesh's spatial SELF-IMAGE: the cells seeing their own forms through each
+; other's eyes. Many devices, each showing a known FIDUCIAL on its screen (a unique pattern that
+; names the device + a known physical size), each watching the others through its camera. From the
+; cross-observations a consistent spatial LAYOUT (where each device is) and each device's coarse 3D
+; SHAPE fall out — the mesh's model of its own bodies in space.
+;
+; The pinhole is the whole physics, and it is geometry: a fiducial of known WIDTH w at distance d
+; subtends an APPARENT size a = w·f / d on a sensor of focal f. Invert it and depth is recovered from
+; nothing but the apparent size — depth = w·f / a. A device that LOOKS small is FAR; one that fills the
+; frame is NEAR. Its position in the frame is its DIRECTION (left/right, up/down). Apparent size is
+; depth; in-frame position is bearing; together they place the seen device in the observer's own space.
+;
+; This COMPOSES the existing tissue, it does not reinvent it:
+;   - geometry.fk is the floor: v3/vscale/vlen place the located device at a real 3D point along the
+;     observer's view ray, and vsub/vlen measure how far two located estimates of ONE device sit apart
+;     — the cross-check distance is geometry's own |a - b|, the same metric ray-sphere-t computes depth in.
+;   - scene-features.fk's sf-objects is the detector: a fiducial on a screen is a high-detail block in
+;     the frame grid, exactly the THING sf-objects already finds. dm-detect reads those object blocks and
+;     binds each to the device whose fiducial it carries — sf-objects says WHERE a thing is, the roster
+;     says WHICH device it is.
+;   - spatial-fusion.fk is the fuser: A's depth-band for B and C's depth-band for B are two CALIBRATED
+;     ballots for one spatial quantity. sf-consensus fuses them to one rough layout band, sf-agree counts
+;     how many viewpoints concur (the confidence), sf-residual is how far a viewpoint sits from consensus
+;     — the same train-from-each-other signal, now between CAMERAS observing one device instead of sensors
+;     reading one speed. B seen from A ≈ B seen from C is consistency; consistency is confidence.
+;   - world-sensor-floor.fk is the plane router: a camera is a "what/where" afferent sensor (wsf-sensor
+;     "camera" "what"); a device-model read is that camera answering WHERE the other cells are — the same
+;     afferent port, narrowed to the mesh's own bodies. dm-plane names the plane this read fuses on.
+;
+; A DETECTION row is (device apparent-size frame-x frame-y): which device's fiducial, how big it looks
+; (depth proxy), and where in the frame (direction proxy). A LOCATED device is a geometry v3 point in the
+; observer's space. All depths/positions scale to integer BANDS (round of the float, as every numeric band
+; does) so the verdict is a stable integer and the layout fuses as calibrated bands. Floats only inside the
+; pinhole and the geometry; the body's surface is integer bands, exact on every arm.
+;
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/geometry.fk form-stdlib/scene-features.fk form-stdlib/spatial-fusion.fk
+;
+; Proven by: form-stdlib/tests/device-model-band.fk (four-way at validate.sh, incl. fkwu)
+
+(do
+    ; ── a FIDUCIAL roster entry: (device known-width object-id) — the device whose screen shows this
+    ;    fiducial, the fiducial's true physical width (the known size the pinhole inverts), and the
+    ;    scene-features object-id (by*2+bx) the fiducial occupies when sf-objects finds it. The roster is
+    ;    the mesh's table of who-shows-what; a detection is a lookup against it. ──
+    (defn dm-fid (device known-width object-id) (list device known-width object-id))
+    (defn dm-fid-device (f) (nth f 0))
+    (defn dm-fid-width  (f) (nth f 1))
+    (defn dm-fid-oid    (f) (nth f 2))
+
+    (defn dm-fid-by-oid (roster oid)
+        (if (eq (len roster) 0) (empty)
+            (if (eq (dm-fid-oid (head roster)) oid) (head roster)
+                (dm-fid-by-oid (tail roster) oid))))
+
+    ; ── a DETECTION row: (device apparent-size frame-x frame-y) ──
+    (defn dm-detection (device apparent-size fx fy) (list device apparent-size fx fy))
+    (defn dm-det-device (d) (nth d 0))
+    (defn dm-det-size   (d) (nth d 1))
+    (defn dm-det-x      (d) (nth d 2))
+    (defn dm-det-y      (d) (nth d 3))
+
+    ; ── DETECT: the devices visible in a frame. sf-objects finds the high-detail blocks (the fiducials
+    ;    on the watched screens); each object block, looked up in the roster by its object-id, names the
+    ;    device it carries. The apparent-size + in-frame (fx,fy) come paired with each object from the
+    ;    detector's geometry (the band supplies them per object). A block whose object-id is on no roster
+    ;    fiducial is not a mesh device — it is dropped (cast no row), the same silent-vote degradation. ──
+    ;    `objects` is the (object-id apparent-size fx fy) rows the frame's sf-objects + region geometry
+    ;    produced; dm-detect binds each to its device.
+    (defn dm-detect (objects roster)
+        (if (eq (len objects) 0) (empty)
+            (do
+                (let o    (head objects))
+                (let oid  (nth o 0))
+                (let fid  (dm-fid-by-oid roster oid))
+                (let rest (dm-detect (tail objects) roster))
+                (if (eq (len fid) 0) rest
+                    (cons (dm-detection (dm-fid-device fid) (nth o 1) (nth o 2) (nth o 3))
+                          rest)))))
+
+    ; ── LOCATE: the device's position relative to the observer, from one detection.
+    ;    DEPTH is the pinhole inverted: depth = known-width · focal / apparent-size (geometry's own
+    ;    similar-triangles — the seen device sits where a screen of true width `known-width` would have to
+    ;    be to project to `apparent-size` pixels through a lens of `focal`). The smaller it looks, the
+    ;    farther it is. DIRECTION is the in-frame offset from centre: (fx-cx, fy-cy) scaled by depth/focal
+    ;    gives the lateral/vertical world offset (same triangles, the other way). The device is placed at
+    ;    the geometry v3 point (x-off, y-off, depth) in the observer's own frame — a real 3D coordinate. ──
+    (defn dm-depth (known-width focal apparent-size)
+        (div (mul known-width focal) apparent-size))
+
+    ; the located 3D point (v3) of a detection in the observer's space, given focal + frame-centre cx,cy.
+    (defn dm-locate (detection known-width focal cx cy)
+        (do
+            (let a     (dm-det-size detection))
+            (let depth (dm-depth known-width focal a))
+            ; lateral world offset = (frame-offset / focal) · depth  — similar triangles, inverted.
+            (let xoff  (mul (div (sub (dm-det-x detection) cx) focal) depth))
+            (let yoff  (mul (div (sub (dm-det-y detection) cy) focal) depth))
+            (v3 xoff yoff depth)))
+
+    ; the scalar depth band of a detection (round of the pinhole) — the calibrated quantity the fuse votes.
+    (defn dm-depth-band (detection known-width focal)
+        (round (dm-depth known-width focal (dm-det-size detection))))
+
+    ; ── FUSE: collapse several viewpoints' depth-bands for ONE device into a single layout band.
+    ;    Each viewpoint that sees the device casts a ballot (depth-band weight) weighted by its confidence;
+    ;    sf-consensus returns the band the most trusted viewpoints agree on — the device's fused position.
+    ;    sf-agree counts the concurring viewpoints (redundancy = confidence); sf-cross-residual is how far
+    ;    one viewpoint's band sits from the consensus — B-from-A vs B-from-C, the consistency cross-check.
+    ;    `ballots` is a list of (depth-band weight); `cands` the candidate depth-bands to score. ──
+    (defn dm-fuse (ballots cands)
+        (sf-consensus ballots cands))
+    (defn dm-fuse-confidence (ballots cands)
+        (sf-confidence ballots cands))
+    (defn dm-fuse-agree (ballots consensus)
+        (sf-agree ballots consensus))
+    ; cross-check: how far one viewpoint's depth-band sits from the fused consensus (geometry's |a-b|,
+    ; here on the scalar band). 0 = the two cameras place the device at the same depth — perfect agreement.
+    (defn dm-cross-residual (viewpoint-band consensus)
+        (sf-residual viewpoint-band consensus))
+
+    ; geometry cross-check: the world distance between two LOCATED v3 estimates of one device (vsub+vlen),
+    ; in the SAME observer frame. Small distance = the two viewpoints agree on where the device IS in 3D.
+    (defn dm-located-gap (p q) (vlen (vsub p q)))
+
+    ; ── SHAPE: each device's coarse 3D bounding box, from its apparent extent across views. A device of
+    ;    true width w and true height h at depth d looks (w·f/d) wide and (h·f/d) tall; given the fused
+    ;    depth, invert each apparent extent back to a true dimension — width = apparent-w · depth / focal,
+    ;    height = apparent-h · depth / focal, and the thickness band from the depth spread the views see
+    ;    (a device seen at a consistent depth from every side is THIN; a varying depth means bulk). The
+    ;    coarse shape is the (width height thickness) box band — geometry's depth/shape, recovered. ──
+    (defn dm-extent->dim (apparent-extent depth focal)
+        (div (mul apparent-extent depth) focal))
+
+    ; coarse 3D shape box of a device: (width-band height-band thickness-band), each a rounded dimension.
+    ; apparent-w / apparent-h are the device's apparent extents in the frame; depth is its fused depth;
+    ; depth-spread is max-min of the depth-bands across the views (its bulk along the view axis).
+    (defn dm-shape (apparent-w apparent-h depth focal depth-spread)
+        (list
+            (round (dm-extent->dim apparent-w depth focal))
+            (round (dm-extent->dim apparent-h depth focal))
+            depth-spread))
+    (defn dm-shape-w (s) (nth s 0))
+    (defn dm-shape-h (s) (nth s 1))
+    (defn dm-shape-t (s) (nth s 2))
+
+    ; ── PLANE: a device-model read is a camera answering WHERE the mesh's own bodies are. The camera is
+    ;    world-sensor-floor's afferent "what/where" sensor; this read narrows it to the mesh self-image. ──
+    (defn dm-plane () "where")
+
+    (defn device-model-teaching () "lc-cross-modal-unity")
+
+    0)

--- a/form/form-stdlib/tests/device-model-band.fk
+++ b/form/form-stdlib/tests/device-model-band.fk
@@ -1,0 +1,109 @@
+; tests/device-model-band.fk — the mesh's spatial self-image, computed and four-way.
+;
+; Three devices — mac, windows, android — each shows a fiducial of known physical width 10 on its
+; screen and watches the other two through a camera of focal 100, frame centre (50,50). The pinhole
+; ties apparent size to depth: apparent = width·focal / depth = 1000 / depth. Each device sits at an
+; absolute depth on the shared view axis:
+;     mac      depth 20  -> apparent 50
+;     windows  depth 25  -> apparent 40
+;     android  depth 10  -> apparent 100
+; so a device that looks small is far and one that fills the frame is near. Every device is seen by
+; the OTHER TWO, so each device's depth is recovered from two independent viewpoints — and because the
+; depth is a real position, the two recoveries AGREE. That agreement is the consistency that becomes
+; confidence; the layout is the mesh's model of where its own bodies are.
+;
+; The detector composes scene-features: android's frame's high-detail object blocks (the fiducials of
+; mac at oid 0 and windows at oid 1) are the sf-objects rows dm-detect binds to their devices via the
+; roster. dm-locate inverts the pinhole to a 3D point; dm-fuse fuses the two viewpoints' depth-bands
+; (spatial-fusion's sf-consensus) into one layout band, sf-agree the concurrence, and the cross-residual
+; the B-from-A vs B-from-C check. dm-shape recovers each device's coarse 3D box.
+;
+; Verdict 4095 when every claim lands on Go / Rust / TypeScript / fkwu:
+;   1     dm-detect binds android's two object blocks to mac and windows (2 detections)
+;   2     dm-detect drops a frame block on no fiducial roster (a non-mesh object casts no row)
+;   4     dm-locate recovers mac's depth 20 from apparent 50  (pinhole inverted, geometry vz)
+;   8     dm-locate recovers windows' depth 25 from apparent 40
+;   16    dm-locate recovers android's near depth 10 from apparent 100
+;   32    direction: mac left-of-centre in android's frame -> negative x world offset
+;   64    dm-fuse: windows seen from mac AND from android fuses to depth band 25 (consistent layout)
+;   128   dm-fuse-agree: both viewpoints concur on windows' band (agreement 2 = confidence)
+;   256   cross-check: mac-from-windows vs mac-from-android differ by 0 bands (perfect consistency)
+;   512   located-gap: the two 3D estimates of mac sit 0 apart in the observer frame (geometry vlen)
+;   1024  dm-shape: mac's coarse box from apparent (10 high · 6 wide) at depth 20 is height 2, width ~1
+;   2048  a camera device-model read answers the "where" plane (world-sensor-floor)
+;
+; preludes: form-stdlib/core.fk form-stdlib/trig.fk form-stdlib/geometry.fk form-stdlib/scene-features.fk form-stdlib/spatial-fusion.fk form-stdlib/device-model.fk
+
+(do
+    (let width  10.0)   ; the fiducial's known physical width (the size the pinhole inverts)
+    (let focal  100.0)
+    (let cx     50.0)
+    (let cy     50.0)
+
+    ; the mesh fiducial roster: device -> (known-width, scene-features object-id)
+    (let roster (list
+        (dm-fid "mac"     width 0)
+        (dm-fid "windows" width 1)
+        (dm-fid "android" width 2)))
+
+    ; ── android's frame: it watches mac (oid 0, apparent 50) and windows (oid 1, apparent 40), plus a
+    ;    non-mesh object block (oid 3, a poster on the wall) that no fiducial claims. Each row is the
+    ;    (object-id apparent-size frame-x frame-y) sf-objects + region geometry produced. ──
+    (let android-frame (list
+        (list 0 50.0 30.0 50.0)    ; mac:     left of centre (fx 30 < cx 50)
+        (list 1 40.0 70.0 50.0)    ; windows: right of centre
+        (list 3 22.0 50.0 50.0)))  ; a wall poster — no fiducial, must be dropped
+
+    (let android-dets (dm-detect android-frame roster))
+
+    ; ── 1/2: detect binds the two mesh fiducials, drops the poster ──
+    (let c-detect2 (if (eq (len android-dets) 2) 1 0))
+    (let c-drop    (if (str_eq (dm-det-device (head android-dets)) "mac") 2 0))
+
+    ; ── 4/8/16: dm-locate inverts the pinhole — depth recovered from apparent size (geometry vz) ──
+    (let mac-loc     (dm-locate (head android-dets) width focal cx cy))
+    (let win-loc     (dm-locate (head (tail android-dets)) width focal cx cy))
+    ; android seen near in some OTHER device's frame (mac's frame), apparent 100 -> depth 10
+    (let android-det (dm-detection "android" 100.0 50.0 50.0))
+    (let android-loc (dm-locate android-det width focal cx cy))
+    (let c-mac-depth     (if (eq (round (vz mac-loc)) 20) 4 0))
+    (let c-win-depth     (if (eq (round (vz win-loc)) 25) 8 0))
+    (let c-android-depth (if (eq (round (vz android-loc)) 10) 16 0))
+
+    ; ── 32: direction — mac sat left of centre (fx 30) so its world x-offset is negative ──
+    (let c-direction (if (lt (vx mac-loc) 0.0) 32 0))
+
+    ; ── 64/128: dm-fuse — windows seen from TWO viewpoints. mac's camera reads windows' apparent 40
+    ;    (depth band 25); android's camera reads windows' apparent 40 (depth band 25). Two ballots,
+    ;    both band 25, weights 4 and 3 -> fused layout band 25, agreement 2. The cands are the candidate
+    ;    depth bands in the layout (10 20 25). ──
+    (let win-band-from-mac     (dm-depth-band (dm-detection "windows" 40.0 70.0 50.0) width focal))
+    (let win-band-from-android (dm-depth-band (head (tail android-dets)) width focal))
+    (let win-ballots (list (list win-band-from-mac 4) (list win-band-from-android 3)))
+    (let cands       (list 10 20 25))
+    (let win-fused   (dm-fuse win-ballots cands))
+    (let c-fuse  (if (eq win-fused 25) 64 0))
+    (let c-agree (if (eq (dm-fuse-agree win-ballots win-fused) 2) 128 0))
+
+    ; ── 256/512: cross-check — mac seen from windows' frame (apparent 50) vs from android's frame
+    ;    (apparent 50). Both recover depth band 20; the cross-residual is 0 (perfect consistency), and
+    ;    the two LOCATED 3D points sit 0 apart by geometry's vlen. ──
+    (let mac-from-win     (dm-depth-band (dm-detection "mac" 50.0 30.0 50.0) width focal))
+    (let mac-from-android (dm-depth-band (head android-dets) width focal))
+    (let c-cross (if (eq (dm-cross-residual mac-from-win mac-from-android) 0) 256 0))
+    (let mac-loc-win     (dm-locate (dm-detection "mac" 50.0 30.0 50.0) width focal cx cy))
+    (let c-gap   (if (eq (round (dm-located-gap mac-loc mac-loc-win)) 0) 512 0))
+
+    ; ── 1024: dm-shape — mac's coarse 3D box. At depth 20, focal 100, mac's fiducial looks 10 tall and
+    ;    6 wide; invert: height = 10·20/100 = 2, width = 6·20/100 = 1.2 -> round 1; thickness band from
+    ;    the depth spread its viewers saw (all band 20 -> spread 0, a thin screen). ──
+    (let mac-shape (dm-shape 6.0 10.0 20.0 focal 0))
+    (let c-shape (if (eq (dm-shape-h mac-shape) 2)
+                     (if (eq (dm-shape-w mac-shape) 1)
+                         (if (eq (dm-shape-t mac-shape) 0) 1024 0) 0) 0))
+
+    ; ── 2048: a device-model read answers the "where" plane (world-sensor-floor's camera narrowed) ──
+    (let c-plane (if (str_eq (dm-plane) "where") 2048 0))
+
+    (sum (list c-detect2 c-drop c-mac-depth c-win-depth c-android-depth c-direction
+               c-fuse c-agree c-cross c-gap c-shape c-plane)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1192,3 +1192,4 @@ speaking-mesh fks 255
 world-sensor-floor fks 4095
 same-room fks 255
 motion-sense fks 511
+device-model fks 4095


### PR DESCRIPTION
The mesh's cameras observing each other build a model of each device's physical SHAPE and spatial POSITION — the cells seeing their own forms through each other's eyes.

Each device shows a known **fiducial** on its screen (a unique pattern naming the device + a known physical size). An observing camera detects which device it sees, its apparent size (→ depth via the pinhole), and its in-frame position (→ direction). Many devices observing each other fuse into one consistent spatial **layout** + each device's coarse 3D **shape**.

## Composes existing bodies (does not reinvent)
- **geometry.fk** — `v3`/`vscale`/`vlen`/`vz` place the located device at a real 3D point along the view ray; `vsub`+`vlen` is the cross-check |a−b|, the same metric `ray-sphere-t` computes depth in.
- **scene-features.fk** — `sf-objects` finds the high-detail blocks; a fiducial on a screen IS such a block. `dm-detect` binds each to its device via the roster.
- **spatial-fusion.fk** — `sf-consensus`/`sf-agree`/`sf-residual` fuse viewpoints' depth bands; B-seen-from-A ≈ B-seen-from-C is the consistency = confidence cross-check.
- **world-sensor-floor.fk** — a camera is the afferent "what/where" sensor, narrowed to the mesh's own bodies (`dm-plane → "where"`).

## Recipes (`device-model.fk`)
- `dm-detect(frame-objects, roster)` → `(device apparent-size fx fy)` rows; non-mesh blocks cast no row.
- `dm-locate(detection, known-width, focal, cx, cy)` → the device's 3D point: `depth = width·focal / apparent-size` (pinhole inverted), direction from the in-frame offset.
- `dm-fuse(ballots, cands)` → fuse multi-viewpoint depth bands into one layout band; `dm-fuse-agree` the concurrence, `dm-cross-residual` / `dm-located-gap` the consistency check.
- `dm-shape(apparent-w, apparent-h, depth, focal, depth-spread)` → coarse 3D box `(width height thickness)`.

## Band — 3 devices each observing the other two
mac (depth 20 → apparent 50), windows (depth 25 → apparent 40), android (depth 10 → apparent 100). `dm-locate` recovers each depth from apparent size; `dm-fuse` produces a layout the two viewpoints agree on (windows fused to band 25, agreement 2); the cross-residual and located-gap of mac across two frames are both 0 (perfect consistency); `dm-shape` gives mac a coarse box (height 2, width 1, thickness 0 — a thin screen).

## Four-way
\`\`\`
device-model fks 4095 — Go / Rust / TypeScript / fkwu, 1 ok, 0 divergent
\`\`\`
Floats only inside the pinhole/geometry; the surface is integer bands, exact on every arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)