### PR TITLE
tend(form): device-identity — a stable unique identity per device-cell

### DIFF
--- a/form/form-stdlib/device-identity.fk
+++ b/form/form-stdlib/device-identity.fk
@@ -1,0 +1,95 @@
+; device-identity.fk — a STABLE UNIQUE identity for each device-cell, grounded in the
+; sanctioned per-device id, so a cell knows which physical device it runs inside (and,
+; with the spatial recipes, where it is).
+;
+; A device-cell EXTENDS the self-cell shape (identity-self.fk: isf-self / isf-identity —
+; identity is the head, everything else hangs off it). Here the head is the SANCTIONED
+; STABLE id the host carrier passes in: ANDROID_ID on Android, IOPlatformUUID on macOS,
+; identifierForVendor on iOS. That stable id IS the identity — it is what makes a reading
+; resolvable to one physical device across time, the same way mesh-join.fk gives the
+; device roster a name to find a member by.
+;
+; The id is grounded; the FACETS are carried INSIDE the body. A facet is an optional
+; (kind value) row — account, phone, model. Within the body these are rich (cell-card.fk
+; renders the cell + its facets; identity-self holds channels the same way). Crossing OUT,
+; the sense-discernment membrane gates them: an EXTERNAL audience sees only the stable id
+; (or a hash of it) — account and phone stripped. Identity facets are sovereign: rich
+; within the trust circle / one's own devices, consent-gated at the outward crossing.
+; This is exactly sense-discernment's rule — the gate lives at the OUTWARD binding, never
+; on the body's own knowing of its own device.
+;
+; Kin: identity-self.fk (the self-cell shape this extends), mesh-join.fk (the device
+; roster this gives a real per-device identity), cell-card.fk (renders the cell + facets),
+; sense-discernment.fk (the outward membrane — rich inside, stripped outside).
+;
+; Integers + strings + lists only, so the row crosses all four kernels deterministically.
+;
+; preludes: form-stdlib/core.fk
+;
+; Proven by: form-stdlib/tests/device-identity-band.fk
+
+(do
+    ; --- a FACET: one optional (kind value) row carried INSIDE the body ----------
+    ; kind — "account" | "phone" | "model" | … (a string); value — the held datum.
+    (defn di-facet-make  (kind value) (list kind value))
+    (defn di-facet-kind  (f) (nth f 0))
+    (defn di-facet-value (f) (nth f 1))
+
+    ; --- a DEVICE-CELL: identity (the stable id) is the HEAD, facets hang off ----
+    ; Extends the self-cell shape (isf-self): head = identity. Here identity is the
+    ; SANCTIONED stable id; platform names the host; facets are the rich inside body.
+    ;   (stable-id platform facets)
+    (defn di-cell (stable-id platform facets) (list stable-id platform facets))
+    (defn di-stable-id (cell) (nth cell 0))   ; the stable per-device id — the IDENTITY (head)
+    (defn di-platform  (cell) (nth cell 1))   ; "android" | "macos" | "windows" | …
+    (defn di-facets    (cell) (nth cell 2))   ; the optional (kind value) rows, inside the body
+
+    ; --- DI-FACET: read a facet (e.g. account) — INSIDE the body -----------------
+    ; Walk the facet rows for one of the given kind; (empty) when absent. Same recursive
+    ; head/tail shape as mj-roster-find — one engine reads the rows.
+    (defn di-facets-find (facets kind)
+        (if (eq (len facets) 0) (empty)
+            (if (str_eq (di-facet-kind (head facets)) kind)
+                (di-facet-value (head facets))
+                (di-facets-find (tail facets) kind))))
+    (defn di-facet (cell kind) (di-facets-find (di-facets cell) kind))
+    ; does the cell hold a facet of this kind, inside the body?
+    (defn di-has-facet? (cell kind)
+        (if (gt (len (di-facet cell kind)) 0) 1 0))
+
+    ; --- DI-RESOLVE: which device-cell a reading is from, by the stable id -------
+    ; The stable id is the UNIQUE match: a reading carries the device's stable id, and
+    ; di-resolve returns the one device-cell in the roster whose head equals it; (empty)
+    ; when no device-cell carries that id. This is what lets a reading know which physical
+    ; device it ran inside — the mesh-join roster gains a real per-device identity.
+    (defn di-resolve (stable-id roster)
+        (if (eq (len roster) 0) (empty)
+            (if (str_eq (di-stable-id (head roster)) stable-id) (head roster)
+                (di-resolve stable-id (tail roster)))))
+    (defn di-resolved? (cell) (if (gt (len cell) 0) 1 0))
+
+    ; --- DI-SHARE: cross to an audience, via the sense-discernment rule ----------
+    ; INTERNAL audience (the trust circle / one's own devices) → the RICH cell:
+    ;   identity + platform + all facets intact. Recognition of one's own device is care.
+    ; EXTERNAL audience (published / a stranger / an unknown binding) → only the stable
+    ;   id survives (account/phone/model stripped). Identity facets are sovereign: they do
+    ;   not bind onto the world. The stable id is what crosses — the cell is still
+    ;   recognizable as ONE device, but its private facets stay inside.
+    (defn di-internal? (audience) (if (str_eq audience "internal") 1 0))
+    (defn di-external? (audience) (if (str_eq audience "external") 1 0))
+
+    ; the external face: a device-cell carrying ONLY the stable id (no facets, empty list).
+    ; The stable id is the head still, so it resolves; the inside is stripped.
+    (defn di-outward-face (cell)
+        (di-cell (di-stable-id cell) (di-platform cell) (list)))
+
+    (defn di-share (cell audience)
+        (if (eq (di-external? audience) 1)
+            (di-outward-face cell)   ; outward: only the stable id, facets stripped
+            cell))                   ; internal (and default): the rich cell, facets intact
+
+    ; how many facets survive a share to this audience? (0 outward, all inside)
+    (defn di-shared-facet-count (cell audience)
+        (len (di-facets (di-share cell audience))))
+
+    0)

--- a/form/form-stdlib/tests/device-identity-band.fk
+++ b/form/form-stdlib/tests/device-identity-band.fk
@@ -1,0 +1,62 @@
+; device-identity-band — each device-cell has a STABLE UNIQUE identity from its
+; sanctioned per-device id; a reading resolves to the right device; facets are rich
+; INSIDE and stripped at the OUTWARD crossing.
+;
+; preludes: form-stdlib/core.fk form-stdlib/device-identity.fk
+;
+; Three device-cells, distinct stable ids + facets carried inside:
+;   mac     — IOPlatformUUID "MAC-UUID-1" + username facet "ursmuff"
+;   android — ANDROID_ID    "AND-ID-2"   + account  facet "sema@coherence"
+;   windows — IOPlatformUUID "WIN-UUID-3" (no account facet — held-open absence)
+;
+; Verdict 1023 when every claim lands:
+;   1    di-resolve matches the android reading to the android cell (by its stable id)
+;   2    di-resolve matches the mac reading to the mac cell (unique match, not the android)
+;   4    an unknown stable id resolves to (empty) — honest about absence
+;   8    di-facet reads the account INSIDE the body (android → "sema@coherence")
+;   16   di-facet on the windows cell (no account) → (empty): held-open absence, not faked
+;   32   INTERNAL share keeps the android cell RICH — both facets survive
+;   64   EXTERNAL share strips the android facets to zero (account/phone do not bind out)
+;   128  EXTERNAL share STILL carries the stable id — the device stays recognizable as ONE
+;   256  after EXTERNAL share, di-facet for the account is (empty) — the sovereignty check
+;   512  mac and windows are distinct device-cells with distinct stable ids (uniqueness)
+(do
+    ; --- the three device-cells: stable id = identity (head), facets inside -------
+    (let mac (di-cell "MAC-UUID-1" "macos"
+                (list (di-facet-make "username" "ursmuff")
+                      (di-facet-make "model"    "macbook"))))
+    (let android (di-cell "AND-ID-2" "android"
+                (list (di-facet-make "account" "sema@coherence")
+                      (di-facet-make "phone"   "+1-555-0102"))))
+    (let windows (di-cell "WIN-UUID-3" "windows"
+                (list (di-facet-make "model" "thinkpad"))))
+    (let roster (list mac android windows))
+
+    ; --- DI-RESOLVE: a reading carries its device's stable id -> the right cell ----
+    (let r-android (di-resolve "AND-ID-2" roster))
+    (let r-mac     (di-resolve "MAC-UUID-1" roster))
+    (let r-none    (di-resolve "GHOST-ID-9" roster))
+
+    (let c0 (if (str_eq (di-stable-id r-android) "AND-ID-2") 1 0))
+    (let c1 (if (and (str_eq (di-stable-id r-mac) "MAC-UUID-1")
+                     (str_eq (di-platform r-mac) "macos")) 2 0))
+    (let c2 (if (eq (di-resolved? r-none) 0) 4 0))
+
+    ; --- DI-FACET: read a facet INSIDE the body ----------------------------------
+    (let c3 (if (str_eq (di-facet r-android "account") "sema@coherence") 8 0))
+    (let c4 (if (eq (di-has-facet? windows "account") 0) 16 0))
+
+    ; --- DI-SHARE: rich INSIDE, stripped at the OUTWARD crossing ------------------
+    (let inside  (di-share android "internal"))
+    (let outside (di-share android "external"))
+
+    (let c5 (if (eq (di-shared-facet-count android "internal") 2) 32 0))
+    (let c6 (if (eq (di-shared-facet-count android "external") 0) 64 0))
+    (let c7 (if (str_eq (di-stable-id outside) "AND-ID-2") 128 0))
+    (let c8 (if (eq (di-has-facet? outside "account") 0) 256 0))
+
+    ; --- uniqueness: the device-cells carry distinct stable ids ------------------
+    (let c9 (if (and (str_eq (di-stable-id mac) "MAC-UUID-1")
+                     (str_eq (di-stable-id windows) "WIN-UUID-3")) 512 0))
+
+    (sum (list c0 c1 c2 c3 c4 c5 c6 c7 c8 c9)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1170,6 +1170,7 @@ cell-card fks 111111
 mesh-sense-7w fks 255
 mesh-join fks 1023
 sense-discernment fks 1023
+device-identity fks 1023
 presence-event fks 16383
 identity-match fks 511
 self-heard-learning fks 511


### PR DESCRIPTION
**Stone:** `device-identity` — give each device-cell a STABLE UNIQUE identity from its sanctioned per-device id, so a cell knows which physical device it runs inside (and, with the spatial recipes, where it is).

The stable per-device id (ANDROID_ID / IOPlatformUUID / identifierForVendor, passed in by the thin carrier) IS the identity. Optional account/phone/model facets are held INSIDE the body; the membrane gates external exposure.

**`device-identity.fk`:**
- `di-cell(stable-id, platform, facets)` — a device-cell, extending the self-cell shape (`identity-self.fk`): stable id is the head/identity, facets hang off.
- `di-resolve(stable-id, roster)` — which device-cell a reading is from, by the unique stable id.
- `di-facet(cell, kind)` — read a facet (account/phone/model) INSIDE the body.
- `di-share(cell, audience)` — via `sense-discernment`'s rule: INTERNAL → the rich facets; EXTERNAL → only the stable id, account/phone stripped. Identity facets are sovereign: rich within, gated out.

**Composes (existing bodies):** `identity-self.fk` · `mesh-join.fk` · `cell-card.fk` · `sense-discernment.fk`.

**Band:** `tests/device-identity-band.fk` — three device-cells (mac UUID+username, android ANDROID_ID+account, windows UUID) with distinct stable ids + facets. `di-resolve` matches each reading to the right cell; `di-facet` reads the account inside; `di-share` to an EXTERNAL audience strips the account/phone to just the stable id (the sovereignty check).

**Four-way:** `core.fk+device-identity.fk+device-identity-band.fk → 1023` — `1 ok, 0 divergent`. Manifest: `device-identity fks 1023`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)