### PR TITLE
tend(form): micro-kernel-arena — the instrument to find native-advantage classification

### DIFF
--- a/form/form-stdlib/micro-kernel-arena.fk
+++ b/form/form-stdlib/micro-kernel-arena.fk
@@ -1,0 +1,205 @@
+; micro-kernel-arena.fk — the scientific INSTRUMENT for finding NATIVE-ADVANTAGE classification.
+;
+; This is NOT a model-port and NOT a CNN rebuild. It is the harness that runs candidate classification
+; micro-kernels HEAD-TO-HEAD on the SAME input, OBSERVES each one's TRANSPARENT decision (the WHY —
+; which prototype, what surprise, which votes — not just a label), MEASURES which is right when, and
+; PROMOTES winners over a window. It exploits exactly what native execution offers that an opaque
+; CNN/LLM forward pass CANNOT: per-step transparency, live A/B comparison, online improvement, and
+; mesh-agreement-as-supervision. The discovery output is not an aggregate score but a REGIME SPLIT —
+; WHEN does architecture A beat architecture B — so we learn what works when and why.
+;
+; KERNEL-AS-DATA. A candidate is a DATA row, never a hardcoded branch:
+;   (id kind)  where
+;     id    a stable string naming the candidate instance ("proto-vote", "surprise-ai", ...).
+;     kind  a tag string naming the candidate ARCHITECTURE the arena knows how to run. The arena
+;           dispatches classify/why on `kind` — adding a new architecture is adding a new dispatch
+;           arm + one roster row, never editing the head-to-head/measure/regime logic. The arena
+;           never special-cases an id; it asks the roster row for its kind and runs that architecture.
+;     (Verb-headed dispatch, not first-class closure application — four-way-safe: Go/Rust/TS/fkwu all
+;      require a verb symbol in head position; `((f x) y)` is rejected by the S-expr arms. The roster
+;      stays DATA; the dispatch stays a switch.)
+;
+; THE TWO ARCHITECTURES THE ARENA KNOWS (kind tags), both reading input (point prior):
+;   "proto-vote"   — PROTOTYPE-VOTE. Label = nearest of two static prototypes (lo @(0 0), hi @(10 10))
+;                    by L1 distance over the point. WHY = matched prototype id; confidence = vote margin.
+;                    A STATIC-position architecture: answers by absolute position, blind to motion.
+;   "surprise-ai"  — ACTIVE-INFERENCE. Predicts the next point as the prior (persistence); SURPRISE =
+;                    L1 prediction error. Label "hi" when surprise >= threshold (the point MOVED — a
+;                    salient event), else "lo". WHY = surprise level; confidence = distance from
+;                    threshold. A MOTION architecture: answers by CHANGE, blind to position.
+; These DISAGREE by construction — one reads position, one reads motion — so each wins a regime the
+; other loses. That regime split is the whole point of the instrument.
+;
+; This COMPOSES the existing observe / classify / promote tissue, it does not reinvent it:
+;   - runtime-witness.fk    — the eyes-on-execution. mka-observe surfaces the why-trace the way rw-* makes
+;                             a running kernel observable: watch the kernel THINK, the transparency the
+;                             native path has and a forward pass does not.
+;   - champion-challenger.fk — cc-promote? / cc-authority decide the window winner. mka-promote IS that
+;                             proven head-to-head gate, applied to candidate ARCHITECTURES instead of one
+;                             challenger: authority flips only on earned competition, ties go to the
+;                             challenger that REACHED the incumbent over a trusted window.
+;   - cross-witness-economy  — agreement = the measure. Here `truth` per sample is the mesh's agreed label
+;                             (cross-witness supervision); a candidate is "right" iff its label == truth.
+;   - identity-match.fk / sound-classify.fk / surprise-kernel.fk are the kinds of micro-kernel that ride in
+;                             as candidate architectures: prototype/nearest-exemplar, prototype-vote, active-inference.
+;
+; preludes: form-stdlib/core.fk form-stdlib/champion-challenger.fk form-stdlib/runtime-witness.fk
+;
+; Proven by: form-stdlib/tests/micro-kernel-arena-band.fk (four-way at validate.sh, incl. fkwu)
+
+(do
+    ; ── L1 helpers over a 2-d integer point, and the shared input shape (point prior) ───────────────
+    (defn mka-pt-x (p) (nth p 0))
+    (defn mka-pt-y (p) (nth p 1))
+    (defn mka-pt-l1 (a b) (add (abs (sub (mka-pt-x a) (mka-pt-x b))) (abs (sub (mka-pt-y a) (mka-pt-y b)))))
+    (defn mka-in-point (in) (nth in 0))   ; this frame's point
+    (defn mka-in-prior (in) (nth in 1))   ; the persistence prediction = the prior frame's point
+
+    ; ── the two static prototypes and the surprise threshold the arena's architectures use ──────────
+    (defn mka-proto-lo () (list 0 0))
+    (defn mka-proto-hi () (list 10 10))
+    (defn mka-surp-threshold () 6)
+
+    ; ── ARCHITECTURE "proto-vote": nearest static prototype by L1 over the point ─────────────────────
+    (defn mka-proto-label (in)
+        (if (le (mka-pt-l1 (mka-in-point in) (mka-proto-lo))
+                (mka-pt-l1 (mka-in-point in) (mka-proto-hi))) "lo" "hi"))
+    ; why = (why-text confidence). why-text names the matched prototype; confidence = |dist-lo - dist-hi|.
+    (defn mka-proto-why (in)
+        (do
+            (let dlo (mka-pt-l1 (mka-in-point in) (mka-proto-lo)))
+            (let dhi (mka-pt-l1 (mka-in-point in) (mka-proto-hi)))
+            (list (str_concat "proto:" (if (le dlo dhi) "lo" "hi")) (abs (sub dlo dhi)))))
+
+    ; ── ARCHITECTURE "surprise-ai": surprise = L1 prediction error of persistence ────────────────────
+    (defn mka-surp-surprise (in) (mka-pt-l1 (mka-in-point in) (mka-in-prior in)))
+    (defn mka-surp-label (in)
+        (if (ge (mka-surp-surprise in) (mka-surp-threshold)) "hi" "lo"))
+    ; why = (why-text confidence). why-text names the surprise level; confidence = distance from threshold.
+    (defn mka-surp-why (in)
+        (do
+            (let s (mka-surp-surprise in))
+            (list (str_concat "surprise:" (if (ge s (mka-surp-threshold)) "hi" "lo"))
+                  (abs (sub s (mka-surp-threshold))))))
+
+    ; ── A CANDIDATE is DATA: (id kind). id names the instance, kind names the architecture to run. ──
+    (defn mka-kernel (id kind) (list id kind))
+    (defn mka-kernel-id   (k) (nth k 0))
+    (defn mka-kernel-kind (k) (nth k 1))
+
+    ; ── verb-headed dispatch on kind: classify-fn / why-fn selected by the architecture tag. New
+    ;    architectures drop in as a new dispatch arm + a roster id — the arena logic never changes. ──
+    (defn mka-classify (kernel input)
+        (if (str_eq (mka-kernel-kind kernel) "proto-vote") (mka-proto-label input)
+            (mka-surp-label input)))
+    (defn mka-why (kernel input)
+        (if (str_eq (mka-kernel-kind kernel) "proto-vote") (mka-proto-why input)
+            (mka-surp-why input)))
+
+    ; ── A TRANSPARENT decision: (label why confidence). `why` is the inspectable reason — the thing a
+    ;    CNN forward pass cannot expose. confidence is the candidate's own strength on this input. ──
+    (defn mka-decision (label why confidence) (list label why confidence))
+    (defn mka-dec-label      (d) (nth d 0))
+    (defn mka-dec-why        (d) (nth d 1))
+    (defn mka-dec-confidence (d) (nth d 2))
+
+    ; ── mka-candidate: run ONE candidate on an input -> its TRANSPARENT decision. why-fn returns
+    ;    (why-text confidence); we surface label + why + confidence as one decision row — the kernel
+    ;    deciding, in the open. ──
+    (defn mka-candidate (kernel input)
+        (do
+            (let label (mka-classify kernel input))
+            (let wc    (mka-why kernel input))            ; (why-text confidence)
+            (mka-decision label (head wc) (head (tail wc)))))
+
+    ; ── mka-ab: run BOTH candidates on the SAME input — a LIVE A/B. Returns
+    ;    (decisionA decisionB winner), winner "A"/"B"/"both"/"neither" by which label matches truth. ──
+    (defn mka-ab (kernelA kernelB input truth)
+        (do
+            (let dA (mka-candidate kernelA input))
+            (let dB (mka-candidate kernelB input))
+            (let aOk (str_eq (mka-dec-label dA) truth))
+            (let bOk (str_eq (mka-dec-label dB) truth))
+            (list dA dB
+                  (if aOk (if bOk "both" "A")
+                          (if bOk "B" "neither")))))
+    (defn mka-ab-decA   (r) (nth r 0))
+    (defn mka-ab-decB   (r) (nth r 1))
+    (defn mka-ab-winner (r) (nth r 2))
+
+    ; ── A LABELED sample is (input truth). truth is the mesh-agreed label (cross-witness supervision). ──
+    (defn mka-sample (input truth) (list input truth))
+    (defn mka-sample-input (s) (head s))
+    (defn mka-sample-truth (s) (head (tail s)))
+
+    ; ── mka-correct?: did this candidate get this sample right? 1/0. truth is the agreement-measure. ──
+    (defn mka-correct? (kernel sample)
+        (if (str_eq (mka-dec-label (mka-candidate kernel (mka-sample-input sample)))
+                    (mka-sample-truth sample)) 1 0))
+
+    ; ── mka-measure: accuracy over a labeled dataset — the proven INTEGER count of correct samples
+    ;    (no ratio: identical on every kernel). Per-instance WHERE/WHY is mka-measure-trace below. ──
+    (defn mka-measure (kernel dataset)
+        (if (eq (len dataset) 0) 0
+            (add (mka-correct? kernel (head dataset))
+                 (mka-measure kernel (tail dataset)))))
+
+    ; per-instance transparency: a trace row per sample — (truth decision correct?). WHERE right/wrong + WHY.
+    (defn mka-measure-trace (kernel dataset)
+        (if (eq (len dataset) 0) (list)
+            (cons (list (mka-sample-truth (head dataset))
+                        (mka-candidate kernel (mka-sample-input (head dataset)))
+                        (mka-correct? kernel (head dataset)))
+                  (mka-measure-trace kernel (tail dataset)))))
+
+    ; ── mka-observe: surface the WHY-trace of a decision (the runtime-witness read) — watch the kernel
+    ;    THINK. Returns (label why) — the inspectable reason a forward pass lacks. Same eyes-on-execution
+    ;    stance as rw-last/rw-hot?: the running decision made observable. ──
+    (defn mka-observe (decision)
+        (list (mka-dec-label decision) (mka-dec-why decision)))
+    (defn mka-observe-label (decision) (mka-dec-label decision))
+    (defn mka-observe-why   (decision) (mka-dec-why decision))
+
+    ; ── mka-promote: champion-challenger over the A/B history. A history row is (a-correct b-correct),
+    ;    EXACTLY champion-challenger's (champion-correct challenger-correct) trial — candidate-A is the
+    ;    incumbent champion, candidate-B the challenger. cc-authority returns "challenger" once B has
+    ;    REACHED A over a long-enough window (proven competition); else "champion". We map its answer back
+    ;    to the candidate ids so the discovery output names the architecture, not a role. ──
+    (defn mka-ab-history (kernelA kernelB dataset)
+        (if (eq (len dataset) 0) (list)
+            (cons (list (mka-correct? kernelA (head dataset))
+                        (mka-correct? kernelB (head dataset)))
+                  (mka-ab-history kernelA kernelB (tail dataset)))))
+
+    (defn mka-promote (kernelA kernelB dataset min-samples margin)
+        (do
+            (let h (mka-ab-history kernelA kernelB dataset))
+            (if (str_eq (cc-authority h min-samples margin) "challenger")
+                (mka-kernel-id kernelB)
+                (mka-kernel-id kernelA))))
+
+    ; ── mka-when: the DISCOVERY output. Over a dataset, count samples where ONLY A is right (A's regime),
+    ;    where ONLY B is right (B's regime), where both, where neither. A regime split (A-only and B-only
+    ;    both > 0) is the finding: different architectures win different input regimes — never a single
+    ;    aggregate score. Returns (a-only b-only both neither). ──
+    (defn mka-when-fold (kernelA kernelB dataset ao bo bt nt)
+        (if (eq (len dataset) 0) (list ao bo bt nt)
+            (do
+                (let s (head dataset))
+                (let a (mka-correct? kernelA s))
+                (let b (mka-correct? kernelB s))
+                (mka-when-fold kernelA kernelB (tail dataset)
+                    (add ao (if (and (eq a 1) (eq b 0)) 1 0))
+                    (add bo (if (and (eq a 0) (eq b 1)) 1 0))
+                    (add bt (if (and (eq a 1) (eq b 1)) 1 0))
+                    (add nt (if (and (eq a 0) (eq b 0)) 1 0))))))
+    (defn mka-when (kernelA kernelB dataset)
+        (mka-when-fold kernelA kernelB dataset 0 0 0 0))
+    (defn mka-when-a-only  (w) (nth w 0))
+    (defn mka-when-b-only  (w) (nth w 1))
+    (defn mka-when-both    (w) (nth w 2))
+    (defn mka-when-neither (w) (nth w 3))
+    ; a genuine regime SPLIT: each architecture wins some sample the other loses — the native-advantage finding.
+    (defn mka-when-split? (w) (if (and (gt (mka-when-a-only w) 0) (gt (mka-when-b-only w) 0)) 1 0))
+
+    0)

--- a/form/form-stdlib/tests/micro-kernel-arena-band.fk
+++ b/form/form-stdlib/tests/micro-kernel-arena-band.fk
@@ -1,0 +1,106 @@
+; preludes: form-stdlib/core.fk form-stdlib/champion-challenger.fk form-stdlib/runtime-witness.fk form-stdlib/micro-kernel-arena.fk
+;
+; micro-kernel-arena-band — the native-advantage discovery instrument, four-way. Two candidate
+; micro-kernels of DIFFERENT architecture race head-to-head on the SAME labeled inputs; they DISAGREE on
+; some samples; the arena runs the A/B transparently, scores each, surfaces each one's WHY, finds the
+; regime split (when A wins vs when B wins), and promotes the window winner. This is the scientific harness
+; for finding which native architecture wins, when, and why — never a CNN rebuild.
+;
+; THE TWO CANDIDATE ARCHITECTURES (kernel-as-DATA rows the arena dispatches on `kind`, never special-cases):
+;
+;   PROTO  — kind "proto-vote": a PROTOTYPE-VOTE kernel. The input is (point prior); it reads the POINT.
+;            Two static prototypes: "lo" @(0 0), "hi" @(10 10). Label = nearest by L1; WHY = matched
+;            prototype id; confidence = vote margin. A STATIC-position architecture, blind to motion.
+;
+;   SURP   — kind "surprise-ai": an ACTIVE-INFERENCE kernel. The SAME (point prior); it PREDICTS the next
+;            point as the prior (persistence) and measures SURPRISE = L1 prediction error. Label "hi" when
+;            surprise >= threshold (the point MOVED — salient), else "lo". WHY = surprise level; confidence
+;            = distance from threshold. A MOTION architecture, blind to position.
+;
+; These two architectures DISAGREE by construction — PROTO reads position, SURP reads motion — so each
+; wins a regime the other loses. That split is the whole point of the instrument.
+;
+; Verdict 8191 when every claim lands (numeric):
+;   1    mka-candidate runs PROTO transparently: a point near (10 10) -> label "hi", why names "hi"
+;   2    mka-candidate runs SURP transparently: a moved point -> label "hi" (surprise high)
+;   4    mka-ab on a sample where they AGREE ("hi") -> winner "both"
+;   8    mka-ab on a sample where ONLY PROTO is right -> winner "A"   (a still point near (10 10): position=hi, motion=lo)
+;   16   mka-ab on a sample where ONLY SURP is right -> winner "B"    (a big move ending near (0 0): position=lo, motion=hi)
+;   32   mka-measure: PROTO scores 4 of 6 on the labeled set
+;   64   mka-measure: SURP  scores 4 of 6 on the labeled set        (equal aggregate — the SPLIT is the story, not the score)
+;   128  mka-observe surfaces PROTO's WHY (the matched prototype id is inspectable — transparency a forward lacks)
+;   256  mka-observe surfaces SURP's WHY  (the surprise value is inspectable)
+;   512  mka-when finds A-only > 0      (PROTO wins a regime SURP loses)
+;   1024 mka-when finds B-only > 0      (SURP wins a regime PROTO loses)
+;   2048 mka-when-split? == 1           (a genuine regime split — different architectures, different regimes)
+;   4096 mka-promote over the window names the challenger (SURP) — on the even aggregate (4=4) with
+;        margin 0 the challenger REACHES the incumbent, so the proven head-to-head gate flips authority.
+;        The aggregate tie is exactly when the gate's window matters: equal scores, the challenger earns it.
+(do
+    ; ── the two candidate rows: DATA (id kind). The arena dispatches classify/why on kind. ──────────
+    (let PROTO (mka-kernel "proto-vote"  "proto-vote"))
+    (let SURP  (mka-kernel "surprise-ai" "surprise-ai"))
+
+    ; ── the labeled set. input = (point prior), truth = the mesh-agreed label. Tuned for a clean
+    ;    equal-aggregate split — PROTO 4/6, SURP 4/6, with A-only=1, B-only=1, both=3, neither=1. The two
+    ;    architectures reach the same total accuracy yet WIN DIFFERENT SAMPLES: that disagreement is the
+    ;    discovery (position-architecture vs motion-architecture, each winning the other's blind spot).
+    ;  s0  near hi, still           -> truth "hi" : PROTO right (pos hi), SURP wrong (no motion)    [A-only]
+    ;  s1  big move -> near lo       -> truth "hi" : PROTO wrong (pos lo), SURP right (moved)        [B-only]
+    ;  s2  big move -> near hi       -> truth "hi" : PROTO right, SURP right                         [both]
+    ;  s3  still at lo               -> truth "lo" : PROTO right (pos lo), SURP right (no motion)     [both]
+    ;  s4  big move -> near hi       -> truth "hi" : PROTO right, SURP right                          [both]
+    ;  s5  big move -> mid-hi        -> truth "lo" : PROTO wrong (pos hi), SURP wrong (moved)         [neither]
+    (let s0 (mka-sample (list (list 10 9) (list 10 9)) "hi"))   ; still near hi:   PROTO hi (ok),  SURP lo (miss)
+    (let s1 (mka-sample (list (list 1 0)  (list 9 9))  "hi"))   ; moved to lo:     PROTO lo (miss), SURP hi (ok)
+    (let s2 (mka-sample (list (list 9 10) (list 0 0))  "hi"))   ; moved to hi:     PROTO hi (ok),  SURP hi (ok)
+    (let s3 (mka-sample (list (list 0 1)  (list 0 1))  "lo"))   ; still at lo:     PROTO lo (ok),  SURP lo (ok)
+    (let s4 (mka-sample (list (list 9 9)  (list 0 0))  "hi"))   ; moved to hi:     PROTO hi (ok),  SURP hi (ok)
+    (let s5 (mka-sample (list (list 8 8)  (list 0 0))  "lo"))   ; moved to mid-hi: PROTO hi (miss), SURP hi (miss)
+    (let dataset (list s0 s1 s2 s3 s4 s5))
+
+    ; ── claim 1: mka-candidate runs PROTO transparently on a near-hi point (still) ──
+    (let dProto (mka-candidate PROTO (list (list 9 10) (list 9 10))))
+    (let c0 (if (and (str_eq (mka-dec-label dProto) "hi")
+                     (str_eq (mka-observe-why dProto) "proto:hi")) 1 0))
+
+    ; ── claim 2: mka-candidate runs SURP transparently on a moved point ──
+    (let dSurp (mka-candidate SURP (list (list 9 9) (list 0 0))))
+    (let c1 (if (str_eq (mka-dec-label dSurp) "hi") 2 0))
+
+    ; ── claim 4: A/B where they AGREE -> "both" (s2: both right) ──
+    (let abBoth (mka-ab PROTO SURP (mka-sample-input s2) (mka-sample-truth s2)))
+    (let c2 (if (str_eq (mka-ab-winner abBoth) "both") 4 0))
+
+    ; ── claim 8: A/B where ONLY PROTO is right (s0) -> "A" ──
+    (let abA (mka-ab PROTO SURP (mka-sample-input s0) (mka-sample-truth s0)))
+    (let c3 (if (str_eq (mka-ab-winner abA) "A") 8 0))
+
+    ; ── claim 16: A/B where ONLY SURP is right (s1) -> "B" ──
+    (let abB (mka-ab PROTO SURP (mka-sample-input s1) (mka-sample-truth s1)))
+    (let c4 (if (str_eq (mka-ab-winner abB) "B") 16 0))
+
+    ; ── claim 32 / 64: each candidate's accuracy over the set (equal aggregate, the split is the story) ──
+    (let protoScore (mka-measure PROTO dataset))
+    (let surpScore  (mka-measure SURP  dataset))
+    (let c5 (if (eq protoScore 4) 32 0))
+    (let c6 (if (eq surpScore  4) 64 0))
+
+    ; ── claim 128 / 256: mka-observe surfaces each one's WHY (transparency a forward pass lacks) ──
+    (let c7 (if (str_eq (mka-observe-why (mka-candidate PROTO (mka-sample-input s0))) "proto:hi") 128 0))
+    (let surpObs (mka-observe (mka-candidate SURP (mka-sample-input s1))))
+    (let c8 (if (str_eq (head surpObs) "hi") 256 0))   ; SURP's decision on the big-move sample is inspectable
+
+    ; ── claim 512 / 1024 / 2048: the regime split — A wins a regime, B wins a regime ──
+    (let w (mka-when PROTO SURP dataset))
+    (let c9  (if (gt (mka-when-a-only w) 0) 512 0))
+    (let c10 (if (gt (mka-when-b-only w) 0) 1024 0))
+    (let c11 (if (eq (mka-when-split? w) 1) 2048 0))
+
+    ; ── claim 4096: mka-promote names the window winner. On the even aggregate (PROTO 4 = SURP 4) with
+    ;    margin 0, the challenger (SURP) REACHES the incumbent over a trusted 6-sample window, so the
+    ;    proven cc gate flips authority to "surprise-ai" — competition earned, never asserted. ──
+    (let winner (mka-promote PROTO SURP dataset 6 0))
+    (let c12 (if (str_eq winner "surprise-ai") 4096 0))
+
+    (add c0 (add c1 (add c2 (add c3 (add c4 (add c5 (add c6 (add c7 (add c8 (add c9 (add c10 (add c11 c12)))))))))))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1198,3 +1198,4 @@ device-model fks 4095
 device-identity-learn fks 511
 remote-mind-sensors fks 4095
 world-model fks 8191
+micro-kernel-arena fks 8191


### PR DESCRIPTION
The scientific INSTRUMENT for finding NATIVE-ADVANTAGE classification — not a model-port, not a CNN rebuild. It races classification micro-kernels HEAD-TO-HEAD on the same labeled inputs, observes each one's TRANSPARENT decision (the *why* — matched prototype / surprise value / vote margin, not just a label), measures which is right when, and promotes the window winner. It exploits exactly what native execution offers that an opaque forward pass cannot: per-step transparency, live A/B, online improvement, mesh-agreement-as-supervision.

## Kernel-as-DATA
A candidate is `(id kind)`; the arena dispatches `classify`/`why` on the architecture tag — verb-headed, four-way-safe (no first-class closure application; the S-expr arms reject `((f x) y)`). The roster stays data, the dispatch stays a switch. A new architecture = a new dispatch arm + one roster row; the head-to-head / measure / regime logic never changes.

## Recipes
- `mka-candidate` → transparent `(label why confidence)`
- `mka-ab` → live A/B + which matches truth
- `mka-measure` (+ `mka-measure-trace`) → accuracy + per-instance where/why
- `mka-observe` → the why-trace (watch the kernel think)
- `mka-promote` → champion-challenger window winner (`cc-authority`)
- `mka-when` → the regime split (the discovery)

Composes `champion-challenger.fk`, `runtime-witness.fk`, and cross-witness truth-as-measure.

## The discovery
Two DIFFERENT-architecture candidates that DISAGREE by construction: **PROTO** (prototype-vote, reads position) vs **SURP** (active-inference surprise, reads motion). Equal aggregate (4/6 each) yet a genuine **regime split** — PROTO wins the still-near-hi sample SURP loses; SURP wins the big-move-to-lo sample PROTO loses. `mka-when` surfaces it; `mka-promote` flips authority to the challenger on the even window. The finding is *when* each architecture wins, never a single score.

## Proof
`micro-kernel-arena fks 8191` — four-way (Go + Rust + TS + fkwu), `1 ok, 0 divergent`, `fourth arm: 1 band(s) four-way (fkwu + pre-flattened tables)`.

Follow-up (separate repo, not checked out here): the coherence-kernel migration — noted, not stubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)