### PR TITLE
tend(form): fam-pool-fma — the constant pool fills from VALUES via f64-bytes; real exp constants four-way + on the M4

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-30_fam_pool_fma_exp_coef.json
+++ b/docs/system_audit/commit_evidence_2026-06-30_fam_pool_fma_exp_coef.json
@@ -1,0 +1,45 @@
+{
+ "title": "fam-pool-fma — the coefficient-parameterized constant-pool emitter fills its pool from VALUES via f64-bytes; real exp constants (ln2, log2e) emit four-way + run bit-exact on the M4",
+ "date": "2026-06-30",
+ "author": "Sema (Opus 4.8), autonomous native-ML walk",
+ "stone": "The named next stone in f64-bytes's own receipt (next_stones[3]: 'wire f64-bytes INTO the fam-poly-pool emitter so the pool is generated from values, not hand literals — the recipe is ready; this is the carrier edit'), taken as a CORE-LIFT. f64-bytes (f64-bytes 127) computes the 8 IEEE754 pool bytes from a value; fam-poly-pool (form-asm-poly-pool 31) still HAND-wrote its pool as known byte lists. This wires the two together: fam-pool-fma a b is the one parameterized engine whose two pooled f64 are (f64-bytes a) ++ (f64-bytes b) — coefficients become DATA, so the pool can carry ANY constant, including the irregular-mantissa transcendental constants no repeating-nibble hand-pattern can produce. fam-poly-pool is now the named (1/6, 1/120) instance of that engine. The brick PROVES the new power on a real exp constant pair: ln2 = 0.6931471805599453 and log2e = 1.4426950408889634 — exactly the two constants exp's range reduction uses (x = n*ln2 + r, n = round(x*log2e)) — emit byte-exact in a self-contained pool, four-way, AND run bit-exact on the M4. Advances form-native-models.form 'GAPS — LLM INFERENCE' rung A (the nonlinear ops as form-asm bytes): the carrier that lets exp/sin/cos/gelu pull COMPUTED coefficients from a pool.",
+ "new_encoder": "NONE — no new arm64 encoder and no new asm bytes. The 16 code bytes (ldr d1,+16 / ldr d2,+20 / fmadd d0,d0,d1,d2 / ret) are the already-proven self-contained-pool shape from fam-poly-pool / form-asm-horner. The only change is that the 16 POOL bytes are now COMPUTED by f64-bytes from the coefficient values instead of hand-typed. This is a carrier/core-lift edit, a pure Form recipe composition.",
+ "core_lift": "form/form-stdlib/form-asm-matvec.fk :: (defn fam-pool-fma (a b) ...) — the coefficient-parameterized Horner-step emitter. fam-poly-pool collapses to (fam-pool-fma (div 1.0 6.0) (div 1.0 120.0)). One engine, coefficients as DATA; fam-poly-pool and the exp-coefficient pool are instances, not parallel code paths (vitality-per-pixel: no special-cased emitter per constant pair).",
+ "proof_four_way": [
+  {
+   "band": "form/form-stdlib/tests/form-asm-poly-pool-band.fk (REWIRED — unchanged verdict 31)",
+   "manifest_row": "form-asm-poly-pool fks 31",
+   "verdict": 31,
+   "note": "The 1/6,1/120 pool is now COMPUTED by f64-bytes; the band's byte-equality of the full 32-byte image against the independent literal assembler oracle (claim 2) is exactly the proof that f64-bytes fills the pool correctly. Preludes expanded deps-first: format-arith.fk f64-bytes.fk form-asm.fk form-asm-matvec.fk.",
+   "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f64-bytes.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-poly-pool-band.fk",
+   "result": "-> 31 ; fourth arm four-way (fkwu) ; 1 ok, 0 divergent."
+  },
+  {
+   "band": "form/form-stdlib/tests/form-asm-exp-coef-pool-band.fk (NEW)",
+   "manifest_row": "form-asm-exp-coef-pool fks 31",
+   "verdict": 31,
+   "oracle": "code bytes proven in form-asm-poly-pool (16) ++ Python struct.pack('<d', ln2) ++ struct.pack('<d', log2e) — the independent IEEE754 little-endian image. ln2 = ef 39 fa fe 42 2e e6 3f ; log2e = fe 82 2b 65 47 15 f7 3f.",
+   "claims": [
+    "1  — fam-pool-fma(ln2, log2e) is 4 instructions + 2 pooled f64 = 32 bytes",
+    "2  — the FULL 32-byte image byte-equals the independent struct.pack oracle (fa-conviction == 1)",
+    "4  — f64-bytes computes ln2's irregular-mantissa 8 bytes (NOT a hand repeating-nibble) (fa-conviction == 1)",
+    "8  — f64-bytes computes log2e's irregular-mantissa 8 bytes (fa-conviction == 1)",
+    "16 — the SAME engine, given 1/6 & 1/120, still emits the proven poly-pool image (core-lift, one engine) (fa-conviction == 1)"
+   ],
+   "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/format-arith.fk form-stdlib/f64-bytes.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-exp-coef-pool-band.fk",
+   "result": "-> 31 ; fourth arm four-way (fkwu) ; 1 ok, 0 divergent — Go=Rust=TS=fkwu compute the computed-pool image identically. Crossed FIRST TRY (loop-free, no forward-reference/recursion surface in the new band)."
+  }
+ ],
+ "proof_on_hardware": {
+  "script": "scripts/form_asm_exp_coef_pool_witness.sh",
+  "image": "8100005c a200005c 0008411f c0035fd6 | ef39fafe422ee63f (ln2 LE, COMPUTED by f64-bytes) | fe822b654715f73f (log2e LE, COMPUTED by f64-bytes) = 32 bytes",
+  "path": "Form kernel emits fam-pool-fma(ln2,log2e) (pool COMPUTED by f64-bytes) -> form-macho mo-object-sym -> Mach-O .o exporting _recipe -> ld -dylib + ad-hoc sign -> dlopen+call. No rustc/clang in the COMPUTE (clang only builds the dumb dlopen harness).",
+  "result": "8/8 MATCH on M4 (arm64 macOS): recipe(x) == fma(x, ln2, log2e) bit-for-bit at x in {0, 1, 2, -1, 0.5, 1e8, 1e-8, pi}. The computed-pool transcendental coefficients load+fold correctly on the metal.",
+  "note": "The code path (ldr/fmadd/ret) was already witnessed in form_asm_poly_pool_witness.sh; the new ground is that f64-bytes computed the pool bytes from irregular-mantissa transcendental constants and they execute bit-exact."
+ },
+ "no_regression": "form-asm-matvec.fk now references f64-bytes inside fam-pool-fma's body. Re-validated the four siblings that prelude form-asm-matvec.fk WITHOUT f64-bytes — form-asm-horner (31), form-asm-rsqrt (31), form-asm-ss-sqrt (127), form-asm-matvec-2d (127) — all four-way, 0 divergent, fkwu crossed. The uncalled f64-bytes reference does not break fkwu's positional flatten for bands that never reach fam-pool-fma.",
+ "design_note": "Design-with-reference held AGAIN: before authoring, f64-bytes(ln2) and f64-bytes(log2e) were probed through the kernel (verdict 3, 0 divergent) to confirm the encoder computes the irregular-mantissa exp constants bit-exact — 1/6 and 1/120 have repeating mantissas, ln2's mantissa (62E42FEFA39EF) does not, so it is the genuine new test. The struct.pack oracle bytes were computed first. The four-way proof and the hardware witness were both seconds; reading the body to confirm the named stone (f64-bytes's own next_stones[3]) and finding the core-lift shape was the cost.",
+ "toolchain_free_claim": "Honest floor: Form recipes proven four-way (Go=Rust=TS=fkwu) through validate.sh (bash) PLUS an on-M4 execution witness (form-macho -> ld -dylib -> dlopen, no rustc/clang in the compute). bin-go is the bootstrap that runs the flattener/emitter. Platform rows (mac four-way + on-hardware observed; windows/android form-cli pending) per docs/coherence-substrate/standard-receipt.form.",
+ "next_stones": "(1) exp on the native lane — now fully UNBLOCKED for arbitrary coefficients: range reduction (k = round(x*log2e), r = x - k*ln2 using the pooled ln2/log2e) + a degree-~6 Horner over a fam-pool-fma-style multi-coefficient pool (1, 1, 1/2, 1/6, 1/24, 1/120) whose bytes f64-bytes computes + ldexp scaling (2^k) — softmax's core. (2) generalize fam-pool-fma to an n-coefficient pool (a Horner over a list of computed f64) — the shape a real Taylor series needs. (3) round-to-nearest-integer on the asm lane (frintn) for the range-reduction k. (4) stage pool + matvec over ll-buffer for a real RMSNorm/SwiGLU layer.",
+ "witness_state": "pulse.coherencycoin.com at open AND close: overall breathing, 0 silences; direct doors web 200, api-health 200. Brick is host-independent (Form recipes + 2 bands + witness + receipt + manifest row), no deploy taken."
+}

--- a/form/form-stdlib/form-asm-matvec.fk
+++ b/form/form-stdlib/form-asm-matvec.fk
@@ -169,12 +169,24 @@
     ;   0 ldr d1,Lc0 (5c000081, +16)   1 ldr d2,Lc1 (5c0000a2, +20)   2 fmadd d0,d0,d1,d2 (1f410800)   3 ret
     ;   16 .quad 0x3fc5555555555555 (1/6, LE 55 55 55 55 55 55 c5 3f)   24 .quad 0x3f81111111111111 (1/120)
     ; imm19 is the WORD distance from each ldr to its pool slot: d1 @0 -> c0 @16 = 4 words; d2 @4 -> c1 @24 = 5.
-    (defn fam-poly-pool ()
+    ;
+    ; fam-pool-fma: the COEFFICIENT-PARAMETERIZED engine — a Horner step fma(x, a, b) whose two pooled f64 are
+    ; COMPUTED FROM THE VALUES a, b by f64-bytes (f64-bytes 127), not hand-typed. This is the core-lift fam-poly-pool's
+    ; own kin named (f64-bytes.fk: "a HAND pattern only emits a KNOWN constant"): the coefficients become DATA, so the
+    ; pool can carry ANY value — including the irregular-mantissa transcendental constants exp/sin need (ln2, log2e,
+    ; 1/5040) that no repeating-nibble hand-pattern can produce. The 16 code bytes are the proven self-contained-pool
+    ; shape (ldr d1,+16 / ldr d2,+20 / fmadd d0,d0,d1,d2 / ret); the 16 pool bytes are (f64-bytes a) ++ (f64-bytes b).
+    ; ABI: d0 = x, returns d0 = fma(x, a, b). One engine; fam-poly-pool and the exp-coefficient pool are instances.
+    (defn fam-pool-fma (a b)
         (append (fa-ldr-d-lit 1 4)
             (append (fa-ldr-d-lit 2 5)
                 (append (fa-fmadd 0 0 1 2)
                     (append (fa-ret)
-                        (append (list 85 85 85 85 85 85 197 63)
-                                (list 17 17 17 17 17 17 129 63)))))))
+                        (append (f64-bytes a) (f64-bytes b)))))))
+
+    ; fam-poly-pool: the named 1/6,1/120 instance of fam-pool-fma — the coefficients now COMPUTED by f64-bytes,
+    ; not the hand byte-lists this once carried. The emitted 32-byte image is byte-identical to before (the
+    ; assembler oracle is unchanged); the proof that f64-bytes fills the pool correctly is that byte-identity holds.
+    (defn fam-poly-pool () (fam-pool-fma (div 1.0 6.0) (div 1.0 120.0)))
 
     0)

--- a/form/form-stdlib/tests/form-asm-exp-coef-pool-band.fk
+++ b/form/form-stdlib/tests/form-asm-exp-coef-pool-band.fk
@@ -1,0 +1,41 @@
+; form-asm-exp-coef-pool-band — the coefficient-parameterized constant-pool emitter fam-pool-fma carries a REAL
+; transcendental coefficient pair (ln2, log2e — exp's range-reduction constants) into a self-contained arm64
+; literal pool, COMPUTED by f64-bytes, byte-identical to the independent struct.pack oracle, four-way. No rustc.
+;
+; The lane so far: fam-poly-pool (form-asm-poly-pool 31) proved the FIRST self-contained constant pool, but it
+; HAND-wrote its coefficients as known little-endian byte lists (1/6 = 55 55 55 55 55 55 c5 3f). f64-bytes
+; (f64-bytes 127) lifted those bytes to a COMPUTED encoding. This band closes the loop: fam-pool-fma (the
+; coefficient-parameterized engine — one engine, coefficients as DATA) fills the pool by calling f64-bytes on
+; the VALUES, so the pool can carry ANY constant — including the irregular-mantissa transcendental constants no
+; repeating-nibble hand-pattern can produce. ln2 = 0.6931471805599453 (mantissa 62E42FEFA39EF) and
+; log2e = 1.4426950408889634 (mantissa 71547652B82FE) are EXACTLY the two constants exp's range reduction uses
+; (x = n*ln2 + r, n = round(x*log2e)) — the next nonlinear rung, here proven to emit byte-exact in the pool.
+;
+; The image, fam-pool-fma 0.6931471805599453 1.4426950408889634 (same proven code shape as poly-pool, new pool):
+;   0 ldr d1,+16 (5c000081)   4 ldr d2,+20 (5c0000a2)   8 fmadd d0,d0,d1,d2 (1f410800)   12 ret (d65f03c0)
+;   16 ef 39 fa fe 42 2e e6 3f (.quad ln2)               24 fe 82 2b 65 47 15 f7 3f (.quad log2e)
+;
+; Verdict 31 when every claim lands:
+;   1    the program is 4 instructions + 2 pooled f64 = 32 bytes                              (len == 32)
+;   2    the FULL 32-byte program byte-equals the independent struct.pack('<d') oracle        (fa-conviction == 1)
+;   4    f64-bytes computes ln2's irregular-mantissa 8 bytes (NOT a hand repeating-nibble)    (fa-conviction == 1)
+;   8    f64-bytes computes log2e's irregular-mantissa 8 bytes                                (fa-conviction == 1)
+;   16   the SAME engine, given 1/6 & 1/120, still emits the proven poly-pool image (core-lift) (fa-conviction == 1)
+;
+; preludes: form-stdlib/format-arith.fk form-stdlib/f64-bytes.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+(do
+    (let prog (fam-pool-fma 0.6931471805599453 1.4426950408889634))
+    (let oracle (list
+        129 0 0 92      162 0 0 92      0 8 65 31      192 3 95 214
+        239 57 250 254 66 46 230 63     254 130 43 101 71 21 247 63))
+    (let pp-oracle (list
+        129 0 0 92      162 0 0 92      0 8 65 31      192 3 95 214
+        85 85 85 85 85 85 197 63        17 17 17 17 17 17 129 63))
+    (let c1 (if (eq (len prog) 32)                                                          1 0))
+    (let c2 (if (eq (fa-conviction prog oracle)                                       1)   2 0))
+    (let c3 (if (eq (fa-conviction (f64-bytes 0.6931471805599453)
+                                   (list 239 57 250 254 66 46 230 63))               1)   4 0))
+    (let c4 (if (eq (fa-conviction (f64-bytes 1.4426950408889634)
+                                   (list 254 130 43 101 71 21 247 63))               1)   8 0))
+    (let c5 (if (eq (fa-conviction (fam-pool-fma (div 1.0 6.0) (div 1.0 120.0)) pp-oracle) 1) 16 0))
+    (add c1 (add c2 (add c3 (add c4 c5)))))

--- a/form/form-stdlib/tests/form-asm-poly-pool-band.fk
+++ b/form/form-stdlib/tests/form-asm-poly-pool-band.fk
@@ -26,7 +26,7 @@
 ;   8    fa-ldr-d-lit 2 5 — a SECOND pool entry at a DIFFERENT imm19 (layout)  (fa-conviction == 1)
 ;   16   fmadd d0,d0,d1,d2 — the fold over the two POOLED coefficients (proven fa-fmadd) (fa-conviction == 1)
 ;
-; preludes: form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+; preludes: form-stdlib/format-arith.fk form-stdlib/f64-bytes.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
 (do
     (let prog (fam-poly-pool))
     (let oracle (list

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1053,6 +1053,7 @@ form-asm-ss-sqrt fks 127
 form-asm-rsqrt fks 31
 form-asm-horner fks 31
 form-asm-poly-pool fks 31
+form-asm-exp-coef-pool fks 31
 weight-load fks 4095
 weight-load-q4k fks 4095
 block-join fks 255

--- a/scripts/form_asm_exp_coef_pool_witness.sh
+++ b/scripts/form_asm_exp_coef_pool_witness.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# form_asm_exp_coef_pool_witness.sh — the EXECUTION WITNESS for fam-pool-fma carrying REAL transcendental
+# coefficients. The coefficient-parameterized constant-pool emitter (form-asm-exp-coef-pool-band proves it
+# four-way) fills its pool by computing the 8 IEEE754 bytes from the VALUES via f64-bytes — so the pool can
+# carry ANY constant, not just the repeating-nibble ones a hand-pattern can write. Here it carries ln2 and
+# log2e — the two constants exp's range reduction uses (x = n*ln2 + r, n = round(x*log2e)). This proves the
+# self-contained, computed-pool image RUNS bit-exact on this arm64 host, no rustc/clang in the COMPUTE.
+#
+# Sibling of form_asm_poly_pool_witness.sh. The ONLY change from poly-pool's image is the POOL CONTENTS (the
+# code path ldr/fmadd/ret is already witnessed in poly-pool); the new ground is that f64-bytes computed those
+# pool bytes from irregular-mantissa transcendental constants, and they load+fold correctly on the metal.
+#
+# Path:
+#   1. Form kernel emits fam-pool-fma's 4-instruction + 2-f64-pool (32-byte) arm64 image (the pool COMPUTED by
+#      f64-bytes from ln2, log2e), then wraps it via form-macho's mo-object-sym into a Mach-O .o exporting _recipe.
+#   2. `ld -dylib` links + ad-hoc signs the .o into a dlopen-able dylib (the recipe-dylib path, no clang).
+#   3. A tiny C harness dlopens it, casts _recipe to  double recipe(double x), and calls it with real scalars.
+#   4. Assert recipe(x) == fma(x, ln2, log2e), bit-for-bit — the harness uses the SAME single fused multiply-add
+#      reading the SAME pooled doubles, so it is == not eps-close.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS witness; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+command -v clang >/dev/null || { echo "need clang for the loader harness; skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/fexppool.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+MATVEC="$FORM/form-stdlib/form-asm-matvec.fk"
+[[ -f "$MATVEC" ]] || { echo "FAIL: form-asm-matvec.fk not found"; exit 1; }
+
+# Form: emit fam-pool-fma(ln2, log2e) bytes, wrap as a Mach-O .o exporting _recipe (mo-object-sym), hex.
+# fam-pool-fma calls f64-bytes (needs format-arith + f64-bytes, deps-first) to compute the pool from the values.
+{ echo "(do"
+  echo '    (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))'
+  cat "$FORM/form-stdlib/format-arith.fk"
+  cat "$FORM/form-stdlib/f64-bytes.fk"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$MATVEC"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<'DRV'
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code (fam-pool-fma 0.6931471805599453 1.4426950408889634))
+    (print (str_concat "HBYTES " (hxb code)))
+    ; _recipe = 95 114 101 99 105 112 101 (the recipe-dylib export name)
+    (print (str_concat "MACHO " (hxb (mo-object-sym code (list 95 114 101 99 105 112 101)))))
+    0)
+DRV
+} > "$work/emit.fk"
+
+out="$(cd "$FORM" && "$GO" "$work/emit.fk" 2>/dev/null)"
+hbytes="$(echo "$out" | grep '^HBYTES ' | sed 's/^HBYTES //')"
+hex="$(echo "$out" | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; cd "$FORM" && "$GO" "$work/emit.fk" 2>&1 | head; exit 1; }
+echo "fam-pool-fma(ln2,log2e) image: $(( ${#hbytes} / 2 )) bytes — 16 code + 16 COMPUTED pool (no rustc/clang in this compute)"
+echo "  arm64 bytes: $hbytes"
+
+echo "$hex" | xxd -r -p > "$work/recipe.o"
+echo "Form-emitted Mach-O object: $(wc -c < "$work/recipe.o" | tr -d ' ') bytes, $(file "$work/recipe.o" | sed 's/^[^:]*: //')"
+echo "  exported symbol: $(nm "$work/recipe.o" 2>/dev/null | tr -s ' ')"
+
+# ld -dylib links + ad-hoc signs (no clang) — the recipe-dylib path.
+SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$work/recipe.dylib" "$work/recipe.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null \
+   || { echo "FAIL: ld -dylib"; exit 1; }
+echo "ld -dylib + ad-hoc sign: $(codesign -dv "$work/recipe.dylib" 2>&1 | grep -E '^CodeDirectory' | sed 's/ hashes.*//')"
+echo
+
+# The dumb loader: dlopen, cast _recipe to the recipe ABI, call with real scalars.
+# The reference uses the EXACT doubles the pool carries (bit-identical to f64-bytes' encoding), one fma -> == not eps.
+cat > "$work/harness.c" <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <math.h>
+typedef double (*h_fn)(double x);
+static const double LN2   = 0.6931471805599453;
+static const double LOG2E = 1.4426950408889634;
+static int check(h_fn h, const char *name, double x) {
+    double expect = fma(x, LN2, LOG2E);
+    double got = h(x);
+    int ok = (got == expect);
+    printf("EXEC %-8s x=%-12g got=%.17g expected=%.17g %s\n", name, x, got, expect, ok ? "MATCH" : "FAIL");
+    return ok;
+}
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen fail: %s\n", dlerror()); return 2; }
+    h_fn p = (h_fn)dlsym(h, "recipe");      /* leading _ stripped by dlsym */
+    if (!p) { fprintf(stderr, "dlsym fail: %s\n", dlerror()); return 3; }
+    int all = 1;
+    all &= check(p, "0.0",   0.0);        /* p(0) = log2e (the pooled bias alone) */
+    all &= check(p, "1.0",   1.0);        /* p(1) = ln2 + log2e */
+    all &= check(p, "2.0",   2.0);        /* p(2) = 2*ln2 + log2e */
+    all &= check(p, "-1.0", -1.0);        /* p(-1) = -ln2 + log2e */
+    all &= check(p, "0.5",   0.5);        /* p(0.5) = ln2/2 + log2e */
+    all &= check(p, "1e8",   1e8);        /* fp stress: large * ln2 with tiny pooled tail */
+    all &= check(p, "1e-8",  1e-8);       /* fp stress: small -> ~log2e with tiny lead */
+    all &= check(p, "3.14159265358979", 3.14159265358979); /* irrational fold over the pooled ln2 */
+    dlclose(h);
+    return all ? 0 : 1;
+}
+EOF
+clang -o "$work/harness" "$work/harness.c" -lm || { echo "FAIL: harness build"; exit 1; }
+
+"$work/harness" "$work/recipe.dylib"; rc=$?
+echo
+if [[ "$rc" == "0" ]]; then
+    echo "WITNESS: the Form-emitted Horner step fma(x, ln2, log2e) RUNS and MATCHES on $(uname -m)."
+    echo "  fam-pool-fma's 32 bytes (16 code + a 16-byte COMPUTED f64 pool, four-way) -> form-macho .o -> ld -dylib -> dlopen+call."
+    echo "  The pool's transcendental coefficients were COMPUTED from the values by f64-bytes — any constant, not just hand patterns."
+else
+    echo "WITNESS FAIL (rc=$rc): the emitted program did not match the reference."
+fi
+exit $rc


### PR DESCRIPTION
## The stone

The named next stone in **f64-bytes's own receipt** (`next_stones[3]`: *"wire f64-bytes INTO the fam-poly-pool emitter so the pool is generated from values, not hand literals — the recipe is ready; this is the carrier edit"*), taken as a **core-lift**.

`f64-bytes` (form-asm `f64-bytes` 127) computes a coefficient's 8 IEEE754 little-endian pool bytes from the value. `fam-poly-pool` (`form-asm-poly-pool` 31) still **hand-wrote** its pool as known byte lists. This wires them together.

## What lands

- **`fam-pool-fma a b`** — the one coefficient-parameterized Horner-step engine whose two pooled f64 are `(f64-bytes a) ++ (f64-bytes b)`. Coefficients become **DATA**, so the pool carries **any** constant — including the irregular-mantissa transcendental constants no repeating-nibble hand-pattern can produce. `fam-poly-pool` collapses to its named `(1/6, 1/120)` instance (image byte-identical; rewired band still **31 four-way**).
- **New band `form-asm-exp-coef-pool` (31, four-way)** proves the new power on a REAL exp constant pair: **ln2 = 0.6931471805599453** and **log2e = 1.4426950408889634** — exactly the constants exp's range reduction uses (`x = n·ln2 + r, n = round(x·log2e)`) — emit byte-exact in a self-contained pool, computed by `f64-bytes`.

## Proof — four-way + on hardware

- `form-asm-poly-pool` → **31**, fourth arm four-way (fkwu), 0 divergent (rewired; pool now computed).
- `form-asm-exp-coef-pool` → **31**, fourth arm four-way (fkwu), 0 divergent (new).
- **Hardware witness** `scripts/form_asm_exp_coef_pool_witness.sh`: **8/8 MATCH on the M4** — `recipe(x) == fma(x, ln2, log2e)` bit-for-bit, form-macho → `ld -dylib` → dlopen, no rustc/clang in the compute.
- **No regression**: siblings `form-asm-horner` (31), `form-asm-rsqrt` (31), `form-asm-ss-sqrt` (127), `form-asm-matvec-2d` (127) re-checked four-way after the shared-file edit.

## Unblocks

exp on the native lane: a Horner over a pooled coefficient table whose bytes `f64-bytes` computes — softmax's core.

Receipt: `docs/system_audit/commit_evidence_2026-06-30_fam_pool_fma_exp_coef.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)