### PR TITLE
tend(form): fam-frintn — round-to-nearest-even as Form->asm bytes, four-way + bit-exact on M4 (exp range-reduction floor)

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-30_form_asm_frintn.json
+++ b/docs/system_audit/commit_evidence_2026-06-30_form_asm_frintn.json
@@ -1,0 +1,35 @@
+{
+ "title": "fam-frintn — round-to-nearest-integral (ties to EVEN) emits four-way as Form->asm bytes AND runs bit-exact on the M4; the range-reduction rounding floor exp/softmax need, + the missing fa-frintn encoder",
+ "date": "2026-06-30",
+ "author": "Sema (Opus 4.8), autonomous native-ML walk",
+ "stone": "The named next stone in fam-pool-fma's own receipt (commit_evidence_2026-06-30_fam_pool_fma_exp_coef.json, next_stones[3]: 'round-to-nearest-integer on the asm lane (frintn) for the range-reduction k'). The native exp lane reduces as k = round(x*log2e), r = x - k*ln2, exp(x) = 2^k * Horner(r) with |r| <= ln2/2 so the polynomial converges. The pooled coefficient fma (fam-pool-fma, carrying ln2/log2e via f64-bytes) is already on the lane (form-asm-exp-coef-pool 31); the k = round(...) step had NO encoder — the only round op present was fcvtzs (truncate toward zero, 9e780000), which rounds half-integers the wrong way for range reduction. This brick adds the FIRST fa-frintn (round to nearest, ties to EVEN). Advances form-native-models.form 'GAPS — LLM INFERENCE' rung A (the nonlinear ops as form-asm bytes): the rounding primitive exp range reduction and softmax need.",
+ "new_encoder": "fa-frintn (rd rn) — FRINTN d<rd>, d<rn> (round f64 to nearest integral, ties to EVEN; result stays f64). base 0x1E644000 | rn<<5 | rd, packed (1 32). Oracle: clang -O2 lowers __builtin_roundeven(x) to `1e644000 frintn d0,d0`. DISTINCT from frinta (ties-away, 0x1E664000, which clang emits for __builtin_round) — emitting the wrong word would round x.5 the wrong direction. This is the reusable win: the round-to-nearest-even primitive every range-reduction step needs.",
+ "recipe": "form/form-stdlib/form-asm-matvec.fk :: (defn fam-frintn () (append (fa-frintn 0 0) (fa-ret))) — ABI d0 = x, returns d0 = roundeven(x). 2 arm64 instructions = 8 bytes.",
+ "proof_four_way": [
+  {
+   "band": "form/form-stdlib/tests/form-asm-frintn-band.fk (NEW)",
+   "manifest_row": "form-asm-frintn fks 7",
+   "verdict": 7,
+   "oracle": "clang -O2 otool -tvVj of `double r(double x){return __builtin_roundeven(x);}` = `1e644000 frintn d0,d0` + `d65f03c0 ret` = 8 bytes, LE list (0 64 100 30 192 3 95 214).",
+   "claims": [
+    "1 — the program is 2 instructions = 8 bytes (len == 8)",
+    "2 — the FULL 8-byte program byte-equals the clang -O2 oracle (fa-conviction == 1)",
+    "4 — frintn d0,d0 (1e644000) — the new round-to-nearest-EVEN encoder, byte-exact, distinct from frinta's ties-away (fa-conviction == 1). Because clang emits frintn precisely for __builtin_roundeven, this byte-match is also the proof we emit ties-to-even."
+   ],
+   "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-frintn-band.fk",
+   "result": "-> 7 ; fourth arm four-way (fkwu, bootstrap binary darwin-arm64, no clang) ; 1 ok, 0 divergent — Go=Rust=TS=fkwu agree on the 8-byte image. Crossed FIRST TRY (loop-free, no forward-reference/recursion surface)."
+  }
+ ],
+ "proof_on_hardware": {
+  "script": "scripts/form_asm_frintn_witness.sh",
+  "image": "0040641e (frintn d0,d0) c0035fd6 (ret) = 8 bytes",
+  "path": "Form kernel emits fam-frintn's 8-byte program -> form-macho mo-object-sym -> Mach-O .o (241 bytes) exporting _recipe -> ld -dylib + ad-hoc sign -> dlopen+call. No rustc/clang in the COMPUTE (clang only builds the dumb dlopen harness; the rounding is the Form-emitted frintn).",
+  "result": "8/8 MATCH on M4 (arm64 macOS): recipe(x) == __builtin_roundeven(x) bit-for-bit at x in {2.3->2, 2.7->3, 0.5->0, 1.5->2, 2.5->2, -0.5->-0, -2.5->-2, 1e8->1e8}. The half-integer cases PROVE ties-to-even (0.5->0 not 1, 2.5->2 not 3, -2.5->-2), distinguishing the emitted frintn from frinta's ties-away.",
+  "note": "The first fa-frintn on the witnessed native lane. The range-reduction rounding floor for exp/softmax (k = round(x*log2e)) is sovereign native bytes."
+ },
+ "no_regression": "fa-frintn is purely additive to form-asm.fk (a new encoder defn); fam-frintn is purely additive to form-asm-matvec.fk (a new recipe). Re-validated the form-asm-matvec.fk siblings four-way after the additive edits — form-asm-exp-coef-pool (31), form-asm-poly-pool (31), form-asm-horner (31), form-asm-rsqrt (31), form-asm-ss-sqrt (127), form-asm-matvec-2d (127) — all 0 divergent, fkwu crossed.",
+ "design_note": "Design-with-reference held: before authoring, clang -O2 was probed on all four round builtins (roundeven->frintn 1e644000, nearbyint->frinti 1e67c000, rint->frintx 1e674000, round->frinta 1e664000) to pin the EXACT byte-shape and confirm which builtin lowers to ties-to-even frintn. The bit-derived base (0x1E644000) matched the oracle exactly. The four-way proof and the hardware witness were both seconds; finding the named ripe stone (fam-pool-fma's next_stones[3]) and confirming the right rounding mode (ties-to-even, the one exp range reduction wants) was the cost.",
+ "toolchain_free_claim": "Honest floor: a Form recipe proven four-way (Go=Rust=TS=fkwu) through validate.sh (bash) PLUS an on-M4 execution witness (form-macho -> ld -dylib -> dlopen, no rustc/clang in the compute). bin-go is the bootstrap that runs the flattener/emitter. Platform rows (mac four-way + on-hardware observed; windows/android form-cli pending) per docs/coherence-substrate/standard-receipt.form.",
+ "next_stones": "(1) exp on the native lane is now UNBLOCKED end-to-end: k = round(x*log2e) via fam-frintn, r = x - k*ln2 over the pooled ln2/log2e (fam-pool-fma), 2^k * Horner(r) over a multi-coefficient pool. (2) generalize fam-pool-fma to an n-coefficient pool (a Horner fold over a list of computed f64) — the shape a degree-~6 exp/sin Taylor series needs. (3) ldexp / 2^k scaling on the asm lane — build the f64 from k's integer exponent field (fcvtzs k -> integer, shift into bits 52-62, or fmul by a pooled 2^k); the last range-reduction piece. (4) stage pool + matvec over ll-buffer for a real RMSNorm/SwiGLU layer.",
+ "witness_state": "pulse.coherencycoin.com at open: overall breathing, 0 silences. Brick is host-independent (Form recipe + encoder + band + witness + receipt + manifest row), no deploy taken."
+}

--- a/form/form-stdlib/form-asm-matvec.fk
+++ b/form/form-stdlib/form-asm-matvec.fk
@@ -189,4 +189,16 @@
     ; assembler oracle is unchanged); the proof that f64-bytes fills the pool correctly is that byte-identity holds.
     (defn fam-poly-pool () (fam-pool-fma (div 1.0 6.0) (div 1.0 120.0)))
 
+    ; fam-frintn: round-to-nearest-integral (ties to even) of d0 as Form->asm bytes — the range-reduction
+    ; ROUNDING floor that exp/softmax need. The native exp lane is k = round(x*log2e), r = x - k*ln2: the
+    ; pooled-coefficient fma (fam-pool-fma) carries ln2/log2e, but the k = round(...) step had no encoder —
+    ; the only round op on the lane was fcvtzs (truncate toward zero), which rounds half-integers the wrong
+    ; way for range reduction. fam-frintn closes that gap with the FIRST fa-frintn (ties-to-even), the
+    ; rounding mode exp wants (it keeps |r| <= ln2/2 so the Horner poly converges). ABI: d0 = x, returns
+    ; d0 = roundeven(x). 2 instructions = 8 bytes, byte-identical to the clang -O2 oracle for
+    ; `__builtin_roundeven(x)`:   0 frintn d0,d0 (1e644000)   1 ret (d65f03c0)
+    (defn fam-frintn ()
+        (append (fa-frintn 0 0)
+            (fa-ret)))
+
     0)

--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -190,6 +190,12 @@
     (defn fa-scvtf (rd rn) (fa-asm 2657222656 (list 1 32) (list rd rn)))
     ; fcvtzs x<rd>, d<rn> (f64 -> signed i64, toward zero) : base 0x9E780000 | rn<<5 | rd (oracle 9e780020)
     (defn fa-fcvtzs (rd rn) (fa-asm 2658664448 (list 1 32) (list rd rn)))
+    ; frintn d<rd>, d<rn> (round f64 to nearest INTEGRAL, ties to EVEN; result stays f64) :
+    ; base 0x1E644000 | rn<<5 | rd  (oracle 1e644000 = frintn d0,d0). The range-reduction rounding floor:
+    ; exp/softmax compute k = round(x*log2e), then r = x - k*ln2 over the pooled ln2/log2e (fam-pool-fma).
+    ; Ties-to-even (frintn), DISTINCT from frinta's ties-away (0x1E664000) — clang lowers __builtin_roundeven
+    ; here, __builtin_round to frinta; emitting the wrong word would round half-integers the wrong way.
+    (defn fa-frintn (rd rn) (fa-asm 509886464 (list 1 32) (list rd rn)))
     ; ldr d<rt>, [x<rn>, #imm] (f64 load; caller passes imm/8) : base 0xFD400000 | imm<<10 | rn<<5 | rt (oracle fd400420)
     (defn fa-ldr-d (rt rn imm) (fa-asm 4248829952 (list 1 32 1024) (list rt rn imm)))
     ; str d<rt>, [x<rn>, #imm] (f64 store; caller passes imm/8) : base 0xFD000000                       (oracle fd000420)

--- a/form/form-stdlib/tests/form-asm-frintn-band.fk
+++ b/form/form-stdlib/tests/form-asm-frintn-band.fk
@@ -1,0 +1,30 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+;
+; form-asm-frintn-band — round-to-nearest-integral (ties to even) emits four-way as Form->asm bytes, no rustc.
+; fam-frintn is the RANGE-REDUCTION rounding floor the native exp/softmax lane needs: exp(x) reduces as
+; k = round(x*log2e), r = x - k*ln2, exp(x) = 2^k * exp(r) with |r| <= ln2/2 so a degree-~6 Horner over the
+; pooled coefficients (fam-pool-fma carries ln2/log2e via f64-bytes) converges. The pooled-fma is on the lane;
+; the k = round(...) step was NOT — the only round op present was fcvtzs (truncate toward zero), which rounds
+; half-integers the wrong way for range reduction. This brick adds the FIRST fa-frintn (ties-to-even).
+;
+; The new ground vs the prior bricks: frintn is round-to-nearest TIES-TO-EVEN — the rounding mode exp wants —
+; and is a DISTINCT arm64 word from frinta's ties-AWAY (0x1E664000). clang lowers __builtin_roundeven to frintn
+; and __builtin_round to frinta; emitting the wrong word would round x.5 the wrong direction. The byte-match of
+; fam-frintn against clang's __builtin_roundeven oracle is therefore also the proof we emit ties-to-even, not
+; ties-away. ABI: d0 = x, returns d0 = roundeven(x).
+;
+; The 2-instruction program, otool -tvVj of the clang -O2 oracle (`double r(double x){return __builtin_roundeven(x);}`):
+;   1e644000 frintn d0,d0     d65f03c0 ret
+;
+; Verdict 7 when every claim lands:
+;   1    the program is 2 instructions = 8 bytes                       (len == 8)
+;   2    the FULL program byte-equals the 8-byte clang oracle          (fa-conviction == 1)
+;   4    frintn d0,d0 — the new round-to-nearest-even encoder (1e644000) (fa-conviction == 1)
+(do
+    (let prog (fam-frintn))
+    (let oracle (list
+        0 64 100 30    192 3 95 214))
+    (let c0 (if (eq (len prog) 8)                                           1 0))
+    (let c1 (if (eq (fa-conviction prog oracle)                        1)   2 0))
+    (let c2 (if (eq (fa-conviction (fa-frintn 0 0) (list 0 64 100 30)) 1)   4 0))
+    (add c0 (add c1 c2)))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1054,6 +1054,7 @@ form-asm-rsqrt fks 31
 form-asm-horner fks 31
 form-asm-poly-pool fks 31
 form-asm-exp-coef-pool fks 31
+form-asm-frintn fks 7
 weight-load fks 4095
 weight-load-q4k fks 4095
 block-join fks 255

--- a/scripts/form_asm_frintn_witness.sh
+++ b/scripts/form_asm_frintn_witness.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# form_asm_frintn_witness.sh — the EXECUTION WITNESS for fam-frintn: the Form-emitted round-to-nearest
+# (ties-to-even) of a double (form-asm-frintn-band proves it four-way) doesn't just BYTE-MATCH the arm64
+# oracle — it actually RUNS roundeven(x) on this arm64 host, no rustc/clang in the COMPUTE (clang is only
+# the dumb dlopen harness).
+#
+# Sibling of form_asm_rsqrt_witness.sh. fam-frintn is the RANGE-REDUCTION rounding floor the native exp lane
+# needs: exp(x) reduces as k = round(x*log2e), r = x - k*ln2, then 2^k * Horner(r). The pooled-coefficient
+# fma (fam-pool-fma, carrying ln2/log2e) is already on the lane; the k = round(...) step had no encoder.
+# This adds the FIRST fa-frintn — ties-to-EVEN (frintn 1e644000), DISTINCT from frinta's ties-away — so the
+# half-integer cases (0.5, 1.5, 2.5, -0.5) round the way exp range reduction wants.
+#
+# Path:
+#   1. Form kernel emits fam-frintn's 2-instruction (8-byte) arm64 program, then wraps it via form-macho's
+#      mo-object-sym into a Mach-O .o exporting `_recipe`.
+#   2. `ld -dylib` links + ad-hoc signs the .o into a dlopen-able dylib (the recipe-dylib path, no clang).
+#   3. A tiny C harness dlopens it, casts `_recipe` to the ABI  double recipe(double x)  (arm64 arg lands
+#      in d0, result in d0 — exactly the recipe's register plan), and calls it with real scalars.
+#   4. Assert recipe(x) == __builtin_roundeven(x), bit-for-bit — the harness uses the SAME roundeven the
+#      recipe folds (a single frintn d0,d0), so it is == not epsilon-close. The half-integer inputs PROVE
+#      ties-to-even (0.5->0, 1.5->2, 2.5->2, -0.5->-0), distinguishing frintn from frinta's ties-away.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS witness; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+command -v clang >/dev/null || { echo "need clang for the loader harness; skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/ffrintn.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+MATVEC="$FORM/form-stdlib/form-asm-matvec.fk"
+[[ -f "$MATVEC" ]] || { echo "FAIL: form-asm-matvec.fk not found"; exit 1; }
+
+# Form: emit fam-frintn bytes, wrap as a Mach-O .o exporting _recipe (mo-object-sym), hex.
+{ echo "(do"
+  echo '    (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))'
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$MATVEC"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<'DRV'
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code (fam-frintn))
+    (print (str_concat "FNBYTES " (hxb code)))
+    ; _recipe = 95 114 101 99 105 112 101 (the recipe-dylib export name)
+    (print (str_concat "MACHO " (hxb (mo-object-sym code (list 95 114 101 99 105 112 101)))))
+    0)
+DRV
+} > "$work/emit.fk"
+
+out="$(cd "$FORM" && "$GO" "$work/emit.fk" 2>/dev/null)"
+fnbytes="$(echo "$out" | grep '^FNBYTES ' | sed 's/^FNBYTES //')"
+hex="$(echo "$out" | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; cd "$FORM" && "$GO" "$work/emit.fk" 2>&1 | head; exit 1; }
+echo "fam-frintn program: $(( ${#fnbytes} / 2 )) bytes (no rustc/clang in this compute)"
+echo "  arm64 bytes: $fnbytes"
+
+echo "$hex" | xxd -r -p > "$work/recipe.o"
+echo "Form-emitted Mach-O object: $(wc -c < "$work/recipe.o" | tr -d ' ') bytes, $(file "$work/recipe.o" | sed 's/^[^:]*: //')"
+echo "  exported symbol: $(nm "$work/recipe.o" 2>/dev/null | tr -s ' ')"
+
+# ld -dylib links + ad-hoc signs (no clang) — the recipe-dylib path.
+SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$work/recipe.dylib" "$work/recipe.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null \
+   || { echo "FAIL: ld -dylib"; exit 1; }
+echo "ld -dylib + ad-hoc sign: $(codesign -dv "$work/recipe.dylib" 2>&1 | grep -E '^CodeDirectory' | sed 's/ hashes.*//')"
+echo
+
+# The dumb loader: dlopen, cast _recipe to the frintn ABI, call with real scalars (incl. half-integers).
+cat > "$work/harness.c" <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+typedef double (*fn_fn)(double x);
+static int check(fn_fn fn, const char *name, double x) {
+    /* reference: the SAME frintn (round half to EVEN) the recipe computes — so == not epsilon-close */
+    double expect = __builtin_roundeven(x);
+    double got = fn(x);
+    int ok = (got == expect);
+    printf("EXEC %-8s x=%-12g got=%.17g expected=%.17g %s\n", name, x, got, expect, ok ? "MATCH" : "FAIL");
+    return ok;
+}
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen fail: %s\n", dlerror()); return 2; }
+    fn_fn fn = (fn_fn)dlsym(h, "recipe");      /* leading _ stripped by dlsym */
+    if (!fn) { fprintf(stderr, "dlsym fail: %s\n", dlerror()); return 3; }
+    int all = 1;
+    all &= check(fn, "2.3",   2.3);        /* down to 2 */
+    all &= check(fn, "2.7",   2.7);        /* up to 3 */
+    all &= check(fn, "0.5",   0.5);        /* ties-to-even: -> 0, NOT 1 (frinta would give 1) */
+    all &= check(fn, "1.5",   1.5);        /* ties-to-even: -> 2 */
+    all &= check(fn, "2.5",   2.5);        /* ties-to-even: -> 2, NOT 3 */
+    all &= check(fn, "-0.5",  -0.5);       /* ties-to-even: -> -0 */
+    all &= check(fn, "-2.5",  -2.5);       /* ties-to-even: -> -2 */
+    all &= check(fn, "1e8",   1e8);        /* fp stress: already integral, unchanged */
+    dlclose(h);
+    return all ? 0 : 1;
+}
+EOF
+clang -o "$work/harness" "$work/harness.c" -lm || { echo "FAIL: harness build"; exit 1; }
+
+"$work/harness" "$work/recipe.dylib"; rc=$?
+echo
+if [[ "$rc" == "0" ]]; then
+    echo "WITNESS: the Form-emitted round-to-nearest-even (roundeven) RUNS and MATCHES on $(uname -m)."
+    echo "  fam-frintn's 8 bytes (form-asm, four-way) -> form-macho .o -> ld -dylib -> dlopen+call."
+    echo "  The range-reduction rounding floor (k = round(x*log2e) for exp/softmax) is sovereign native bytes;"
+    echo "  first fa-frintn (ties-to-even) on the lane — half-integers prove it (0.5->0, 2.5->2), not frinta's ties-away."
+else
+    echo "WITNESS FAIL (rc=$rc): the emitted program did not match the reference."
+fi
+exit $rc


### PR DESCRIPTION
## The brick

The named next stone in fam-pool-fma's own receipt (`next_stones[3]`: *"round-to-nearest-integer on the asm lane (frintn) for the range-reduction k"*).

The native **exp** lane reduces as `k = round(x·log2e)`, `r = x − k·ln2`, `exp(x) = 2^k · Horner(r)` with `|r| ≤ ln2/2` so the polynomial converges. `fam-pool-fma` already carries `ln2`/`log2e` on the lane (`form-asm-exp-coef-pool 31`), but the `k = round(…)` step had **no encoder** — the only round op present was `fcvtzs` (truncate toward zero), which rounds half-integers the wrong way for range reduction.

This adds the **first `fa-frintn`** — FRINTN, round to nearest, **ties to EVEN** (base `0x1E644000`), distinct from `frinta`'s ties-away (`0x1E664000`). clang lowers `__builtin_roundeven` here; `__builtin_round` → `frinta`. `fam-frintn` = `frintn d0,d0 ; ret` = 8 bytes, byte-identical to the clang -O2 oracle.

## Proof — HARD GATE met

- **`form-asm-frintn fks 7`** — four-way (Go=Rust=TS=fkwu), **0 divergent**, fourth arm crossed. Crossed first try (loop-free).
- **`scripts/form_asm_frintn_witness.sh`: 8/8 MATCH on M4** (arm64 macOS). Form-emitted bytes → `form-macho` .o → `ld -dylib` → `dlopen`+call; **no rustc/clang in the compute**. Half-integer inputs prove ties-to-even: `0.5→0`, `2.5→2`, `-2.5→-2` (not frinta's ties-away).
- Receipt: `docs/system_audit/commit_evidence_2026-06-30_form_asm_frintn.json`
- Siblings (`matvec-2d`, `exp-coef-pool`, `poly-pool`, `horner`, `rsqrt`, `ss-sqrt`) re-checked four-way — additive edits, no regression.

## Next stones

exp on the native lane is now unblocked end-to-end: `k=round(x·log2e)` via `fam-frintn`, `r=x−k·ln2` over the pooled coefficients, `2^k·Horner(r)`. Remaining: n-coefficient pool generalization, `ldexp`/2^k scaling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)