### PR TITLE
tend(form): form-asm-fmov-dx — GP<->FP bit-reinterpret pair, four-way + bit-exact on M4 (the 2^k/ldexp keystone)

### DIFF
--- a/docs/system_audit/commit_evidence_2026-06-30_form_asm_fmov_dx.json
+++ b/docs/system_audit/commit_evidence_2026-06-30_form_asm_fmov_dx.json
@@ -1,0 +1,39 @@
+{
+  "title": "form-asm-fmov-dx — the GP<->FP bit-reinterpret pair emits four-way as Form->asm bytes + runs bit-exact on the M4 (the last non-synthesizable exp-lane primitive: 2^k/ldexp)",
+  "date": "2026-06-30",
+  "author": "Sema (Opus 4.8), autonomous native-frontier walk",
+  "stone": "The named next stone in fam-frintn's own receipt (commit_evidence_2026-06-30_form_asm_frintn.json, next_stones[3]: 'ldexp / 2^k scaling on the asm lane — build the f64 from k's integer exponent field'). The native exp lane reduces as k = round(x*log2e) (fam-frintn, on the lane), r = x - k*ln2 over the pooled ln2/log2e (fam-pool-fma, on the lane), exp(x) = 2^k * Horner(r) (the Horner poly, on the lane). The LAST missing piece is BUILDING 2^k = REINTERPRET((k+1023)<<52). Every other op on the lane either computes on f64 values or numerically converts (fa-scvtf gives the integer VALUE as a float, the WRONG thing for an exponent field). The one primitive that could NOT be synthesized from existing bytes is moving raw bits BETWEEN the integer and f64 register files. This brick adds that door — fa-fmov-d-x (bits->f64) and its matched reverse fa-fmov-x-d (f64->bits). Advances form-native-models.form 'GAPS — LLM INFERENCE' rung A (the nonlinear ops as form-asm bytes): the 2^k scaling exp/softmax need, plus the bit-manipulation floor (sign, NaN/inf, softmax max-subtract) every float recipe wants.",
+  "new_encoder": [
+    "fa-fmov-d-x (rd rn) — FMOV D<rd>, X<rn> (GP i64 bits -> f64 register, BIT REINTERPRET, NOT a numeric convert; bit pattern preserved). base 0x9E670000 | rn<<5 | rd, packed (1 32). Oracle: clang -O2 lowers `double f(unsigned long x){double d;__builtin_memcpy(&d,&x,8);return d;}` to `9e670000 fmov d0,x0`. DISTINCT from fa-scvtf (0x9E620000, which numerically converts the integer VALUE 5 -> 5.0); fmov-d-x preserves the BITS (0x3FF0000000000000 -> 1.0). This is the reusable win: the integer-bits-into-f64 door that 2^k/ldexp and every float-bit recipe need.",
+    "fa-fmov-x-d (rd rn) — FMOV X<rd>, D<rn> (f64 bits -> GP i64 register, BIT REINTERPRET, the reverse door). base 0x9E660000 | rn<<5 | rd. Oracle: `unsigned long f(double d){unsigned long x;__builtin_memcpy(&x,&d,8);return x;}` -> `9e660000 fmov x0,d0`. DISTINCT word from fmov d,x (opcode field 110 vs 111) — emitting the wrong one reverses the transfer direction. Matched pair: writes bits in / reads bits out, the floor for sign extraction, NaN/inf tests, comparison-free max."
+  ],
+  "recipe": "fam-fmov-bits () = (append (fa-fmov-d-x 0 0) (fa-ret)) in form-asm-matvec.fk — ABI x0 = i64 bits, returns d0 = the f64 those bits encode. 2 instructions = 8 bytes, byte-identical to the clang -O2 memcpy-reinterpret oracle.",
+  "proof_four_way": [
+    {
+      "band": "form/form-stdlib/tests/form-asm-fmov-dx-band.fk (NEW)",
+      "manifest_row": "form-asm-fmov-dx fks 15",
+      "verdict": 15,
+      "oracle": "clang -O2 otool -tvVj of `double f(unsigned long x){double d;__builtin_memcpy(&d,&x,8);return d;}` = `9e670000 fmov d0,x0` + `d65f03c0 ret` = 8 bytes, LE list (0 0 103 158 192 3 95 214). Reverse `9e660000 fmov x0,d0` LE (0 0 102 158).",
+      "claims": [
+        "1 — the program is 2 instructions = 8 bytes (len == 8)",
+        "2 — the FULL 8-byte program byte-equals the clang -O2 oracle (fa-conviction == 1)",
+        "4 — fmov d0,x0 (9e670000) — the new bits->f64 reinterpret encoder, byte-exact (fa-conviction == 1)",
+        "8 — fmov x0,d0 (9e660000) — the reverse f64->bits encoder, a DISTINCT word, byte-exact (fa-conviction == 1)"
+      ],
+      "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-fmov-dx-band.fk",
+      "result": "-> 15 ; fourth arm: 1 band four-way (fkwu, bootstrap binary darwin-arm64, no clang) ; 1 ok, 0 divergent — Go=Rust=TS=fkwu agree on the 8-byte image. Crossed FIRST TRY (loop-free, no forward-reference/recursion surface)."
+    }
+  ],
+  "proof_on_hardware": {
+    "script": "scripts/form_asm_fmov_dx_witness.sh",
+    "image": "0000679e (fmov d0,x0) c0035fd6 (ret) = 8 bytes",
+    "path": "Form kernel emits fam-fmov-bits' 8-byte program -> form-macho mo-object-sym -> Mach-O .o (241 bytes) exporting _recipe -> ld -dylib + ad-hoc sign -> dlopen+call. No rustc/clang in the COMPUTE (clang only builds the dumb dlopen harness; the reinterpret is the Form-emitted fmov d0,x0).",
+    "result": "12/12 MATCH on M4 (arm64 macOS). (1) raw bit patterns reinterpret bit-for-bit: 0x3FF0000000000000->1.0, 0x4000...->2.0, 0xC000...->-2.0, 0x3FF8...->1.5, 0x0->0.0, 0x7FF0...->inf. (2) the EXACT native-ldexp use: recipe((k+1023)<<52) == ldexp(1.0,k) == 2^k for k in {0,5,-3,10,-10} -> {1, 32, 0.125, 1024, 0.0009765625}, bit-for-bit.",
+    "note": "The first GP<->FP bit-reinterpret on the witnessed native lane. The exp range-reduction SCALING (2^k) is now sovereign native bytes — with fam-frintn (k=round), fam-pool-fma (r), and the Horner poly already four-way + witnessed, every range-reduction primitive exp needs is form-emitted."
+  },
+  "no_regression": "Scoped validate carries core.fk + form-asm.fk + form-asm-matvec.fk; the additive encoder edit (two new defns, no change to existing fa-* bases) leaves every prior form-asm band's image identical. Siblings frintn/exp-coef-pool/poly-pool/horner/rsqrt/ss-sqrt/matvec re-check four-way unchanged.",
+  "design_note": "Design-with-reference held: before authoring, clang -O2 was probed (otool -tvVj) on the memcpy-reinterpret in both directions to pin the EXACT byte-shape and confirm the DISTINCT words — fmov d,x = 9e670000 (opcode 111), fmov x,d = 9e660000 (opcode 110), both distinct from fa-scvtf's 9e620000 numeric convert. The bit-derived bases (0x9E670000 / 0x9E660000) matched the otool oracle exactly. READ-THE-BODY held: confirmed only fa-fmov (d->d, 0x1E604000) and fa-fmov-imm existed — no GP<->FP variant — so this was a real gap, not a re-impl. The four-way proof and the 12-case hardware witness were both seconds; finding the named ripe stone (frintn's next_stones[3]) and pinning the two distinct bit-reinterpret words was the cost.",
+  "toolchain_free_claim": "body / c-bootstrap (fkwu crosses the band four-way as the darwin-arm64 bootstrap binary) / toolchain-free in the COMPUTE (the emit + reinterpret are Form bytes; clang is the oracle that PINS the bytes and the dumb dlopen harness, never the compute; ld/codesign carry resource-access per host-kernel.form) / platforms{mac: OBSERVED 12/12 on M4 arm64; windows: pending standing form-cli build floor; android: pending} / honest-floor: four-way + native witnessed on mac; windows/android rows pending per standard-receipt.",
+  "next_stones": "(1) exp on the native lane is now FULLY UNBLOCKED — every primitive is form-emitted + witnessed: k = round(x*log2e) (fam-frintn), r = x - k*ln2 (fam-pool-fma pooled ln2/log2e), Horner(r) (the poly lane), 2^k = reinterpret((k+1023)<<52) (THIS brick). The remaining work is COMPOSING them into one fam-exp program + a runtime shift to assemble (k+1023)<<52 in-register. (2) a runtime LSL-immediate (or 64-bit MUL by 2^52) encoder so the asm lane itself builds the exponent field k currently shifted by the harness — fa-fcvtzs (f64->i64) + fa-add-x-imm (+1023) exist; only the <<52 is missing in-register. (3) generalize fam-pool-fma to an n-coefficient pool (a Horner fold over a list of computed f64) — the shape a degree-~6 exp/sin Taylor series needs. (4) stage pool + matvec over ll-buffer for a real RMSNorm/SwiGLU layer.",
+  "witness_state": "at open: breathing, 0 silences. host-independent brick (form-asm bytes + local Mach-O witness); no deploy."
+}

--- a/form/form-stdlib/form-asm-matvec.fk
+++ b/form/form-stdlib/form-asm-matvec.fk
@@ -201,4 +201,16 @@
         (append (fa-frintn 0 0)
             (fa-ret)))
 
+    ; fam-fmov-bits: REINTERPRET the i64 in x0 as the f64 it bit-encodes, as Form->asm bytes — the keystone
+    ; the native 2^k/ldexp step needs. exp(x) = 2^k * Horner(r); fam-frintn gives k = round(x*log2e), the
+    ; pooled fma gives r, the Horner poly is on the lane — the only missing piece is BUILDING 2^k, which is
+    ; (k+1023)<<52 assembled in an integer register then read as an f64. fa-scvtf would give the integer's
+    ; VALUE as a float (wrong); fa-fmov-d-x preserves the BITS, so the assembled exponent field becomes the
+    ; power of two. ABI: x0 = raw i64 bits, returns d0 = the f64 those bits encode. 2 instructions = 8 bytes,
+    ; byte-identical to clang -O2 for `double f(unsigned long x){double d;__builtin_memcpy(&d,&x,8);return d;}`:
+    ;   0 fmov d0,x0 (9e670000)   1 ret (d65f03c0)
+    (defn fam-fmov-bits ()
+        (append (fa-fmov-d-x 0 0)
+            (fa-ret)))
+
     0)

--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -190,6 +190,19 @@
     (defn fa-scvtf (rd rn) (fa-asm 2657222656 (list 1 32) (list rd rn)))
     ; fcvtzs x<rd>, d<rn> (f64 -> signed i64, toward zero) : base 0x9E780000 | rn<<5 | rd (oracle 9e780020)
     (defn fa-fcvtzs (rd rn) (fa-asm 2658664448 (list 1 32) (list rd rn)))
+    ; fmov d<rd>, x<rn> (GP i64 bits -> f64 register, BIT REINTERPRET — NOT a numeric convert) :
+    ; base 0x9E670000 | rn<<5 | rd  (oracle 9e670000 = fmov d0,x0). The keystone for 2^k/ldexp: build the
+    ; IEEE754 exponent field ((k+1023)<<52) in an integer register, then REINTERPRET those bits as the f64
+    ; 2^k. DISTINCT from fa-scvtf, which numerically converts the integer VALUE (5 -> 5.0); here the bit
+    ; pattern is PRESERVED (0x3FF0000000000000 -> 1.0). Also the floor for every float-bit recipe: sign
+    ; extraction, softmax max-subtract, NaN/inf tests — the bit-ops q4k-dequant had to fold in integer
+    ; arithmetic for lack of this door. fcvtzs reads bits OUT of an integer; this writes bits INTO an f64.
+    (defn fa-fmov-d-x (rd rn) (fa-asm 2657550336 (list 1 32) (list rd rn)))
+    ; fmov x<rd>, d<rn> (f64 bits -> GP i64 register, BIT REINTERPRET) : base 0x9E660000 | rn<<5 | rd
+    ; (oracle 9e660000 = fmov x0,d0). The reverse door: read an f64's raw bits to test sign/exponent/mantissa
+    ; with integer ops. DISTINCT word from fmov d,x (opcode 110 vs 111) — emitting the wrong one reverses the
+    ; transfer direction. Matched pair: fa-fmov-d-x writes bits in, fa-fmov-x-d reads bits out.
+    (defn fa-fmov-x-d (rd rn) (fa-asm 2657484800 (list 1 32) (list rd rn)))
     ; frintn d<rd>, d<rn> (round f64 to nearest INTEGRAL, ties to EVEN; result stays f64) :
     ; base 0x1E644000 | rn<<5 | rd  (oracle 1e644000 = frintn d0,d0). The range-reduction rounding floor:
     ; exp/softmax compute k = round(x*log2e), then r = x - k*ln2 over the pooled ln2/log2e (fam-pool-fma).

--- a/form/form-stdlib/tests/form-asm-fmov-dx-band.fk
+++ b/form/form-stdlib/tests/form-asm-fmov-dx-band.fk
@@ -1,0 +1,35 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+;
+; form-asm-fmov-dx-band — the GP<->FP BIT-REINTERPRET pair emits four-way as Form->asm bytes, no rustc.
+; fa-fmov-d-x is the keystone the native 2^k/ldexp step needs — the LAST missing piece of the exp lane.
+; The native exp reduces as k = round(x*log2e) (fam-frintn, on the lane), r = x - k*ln2 over the pooled
+; ln2/log2e (fam-pool-fma, on the lane), exp(x) = 2^k * Horner(r) (the Horner poly, on the lane). The one
+; primitive that could NOT be synthesized from existing bytes is BUILDING 2^k: assemble the IEEE754 exponent
+; field (k+1023)<<52 in an integer register, then REINTERPRET those bits as the f64 2^k. fa-scvtf converts the
+; integer VALUE (numeric); fa-fmov-d-x preserves the BIT PATTERN — a different instruction, a different word.
+;
+; The new ground vs the prior bricks: every float op so far (fmul/fadd/fmadd/fsqrt/frintn/scvtf/fcvtzs) either
+; computes on f64 values or numerically converts. fa-fmov-d-x is the FIRST op that moves raw bits BETWEEN the
+; integer and f64 register files with NO numeric transformation — the door to 2^k, sign extraction, softmax
+; max-subtract, NaN/inf tests (the bit-ops q4k-dequant had to fold in integer arithmetic for lack of it).
+; ABI: x0 = i64 bits, returns d0 = the f64 those bits encode.
+;
+; The 2-instruction program, otool -tvVj of the clang -O2 oracle
+; (`double f(unsigned long x){double d;__builtin_memcpy(&d,&x,8);return d;}`):
+;   9e670000 fmov d0,x0     d65f03c0 ret
+; The reverse encoder (read bits OUT) is fmov x0,d0 (9e660000), the matched door for f64->bits.
+;
+; Verdict 15 when every claim lands:
+;   1    the program is 2 instructions = 8 bytes                                     (len == 8)
+;   2    the FULL program byte-equals the 8-byte clang oracle                        (fa-conviction == 1)
+;   4    fmov d0,x0 — the new bits->f64 reinterpret encoder (9e670000)               (fa-conviction == 1)
+;   8    fmov x0,d0 — the reverse f64->bits encoder, a DISTINCT word (9e660000)      (fa-conviction == 1)
+(do
+    (let prog (fam-fmov-bits))
+    (let oracle (list
+        0 0 103 158    192 3 95 214))
+    (let c0 (if (eq (len prog) 8)                                              1 0))
+    (let c1 (if (eq (fa-conviction prog oracle)                          1)    2 0))
+    (let c2 (if (eq (fa-conviction (fa-fmov-d-x 0 0) (list 0 0 103 158)) 1)    4 0))
+    (let c3 (if (eq (fa-conviction (fa-fmov-x-d 0 0) (list 0 0 102 158)) 1)    8 0))
+    (add c0 (add c1 (add c2 c3))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1055,6 +1055,7 @@ form-asm-horner fks 31
 form-asm-poly-pool fks 31
 form-asm-exp-coef-pool fks 31
 form-asm-frintn fks 7
+form-asm-fmov-dx fks 15
 weight-load fks 4095
 weight-load-q4k fks 4095
 block-join fks 255

--- a/scripts/form_asm_fmov_dx_witness.sh
+++ b/scripts/form_asm_fmov_dx_witness.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# form_asm_fmov_dx_witness.sh — the EXECUTION WITNESS for fam-fmov-bits: the Form-emitted GP->FP bit
+# reinterpret (form-asm-fmov-dx-band proves it four-way) doesn't just BYTE-MATCH the arm64 oracle — it
+# actually RUNS the reinterpret on this arm64 host, no rustc/clang in the COMPUTE (clang is only the dumb
+# dlopen harness).
+#
+# Sibling of form_asm_frintn_witness.sh. fa-fmov-d-x is the keystone the native 2^k/ldexp step needs — the
+# LAST missing primitive of the exp lane. exp(x) = 2^k * Horner(r): fam-frintn gives k = round(x*log2e),
+# fam-pool-fma gives r over pooled ln2/log2e, the Horner poly is on the lane. The only piece that could NOT
+# be synthesized from existing bytes is BUILDING 2^k = REINTERPRET((k+1023)<<52). fa-scvtf converts the
+# integer VALUE (wrong); fa-fmov-d-x preserves the BITS, so the assembled exponent field becomes the power
+# of two. This witness proves that on real silicon: (1) raw bit patterns reinterpret bit-for-bit to the f64
+# they encode, and (2) the actual 2^k construction (k+1023)<<52 -> recipe -> ldexp(1,k) holds for real k.
+#
+# Path:
+#   1. Form kernel emits fam-fmov-bits' 2-instruction (8-byte) arm64 program, then wraps it via form-macho's
+#      mo-object-sym into a Mach-O .o exporting `_recipe`.
+#   2. `ld -dylib` links + ad-hoc signs the .o into a dlopen-able dylib (the recipe-dylib path, no clang).
+#   3. A tiny C harness dlopens it, casts `_recipe` to the ABI  double recipe(unsigned long bits)  (arm64
+#      integer arg lands in x0, f64 result in d0 — exactly the recipe's register plan: fmov d0,x0; ret).
+#   4. Assert recipe(bits) == the f64 those bits encode (memcpy reinterpret), bit-for-bit. The 2^k cases
+#      additionally assert recipe((k+1023)<<52) == ldexp(1.0, k) — the exact next-stone use.
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS witness; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+command -v clang >/dev/null || { echo "need clang for the loader harness; skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/ffmovdx.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+MATVEC="$FORM/form-stdlib/form-asm-matvec.fk"
+[[ -f "$MATVEC" ]] || { echo "FAIL: form-asm-matvec.fk not found"; exit 1; }
+
+# Form: emit fam-fmov-bits bytes, wrap as a Mach-O .o exporting _recipe (mo-object-sym), hex.
+{ echo "(do"
+  echo '    (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))'
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$MATVEC"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<'DRV'
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code (fam-fmov-bits))
+    (print (str_concat "FNBYTES " (hxb code)))
+    ; _recipe = 95 114 101 99 105 112 101 (the recipe-dylib export name)
+    (print (str_concat "MACHO " (hxb (mo-object-sym code (list 95 114 101 99 105 112 101)))))
+    0)
+DRV
+} > "$work/emit.fk"
+
+out="$(cd "$FORM" && "$GO" "$work/emit.fk" 2>/dev/null)"
+fnbytes="$(echo "$out" | grep '^FNBYTES ' | sed 's/^FNBYTES //')"
+hex="$(echo "$out" | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; cd "$FORM" && "$GO" "$work/emit.fk" 2>&1 | head; exit 1; }
+echo "fam-fmov-bits program: $(( ${#fnbytes} / 2 )) bytes (no rustc/clang in this compute)"
+echo "  arm64 bytes: $fnbytes"
+
+echo "$hex" | xxd -r -p > "$work/recipe.o"
+echo "Form-emitted Mach-O object: $(wc -c < "$work/recipe.o" | tr -d ' ') bytes, $(file "$work/recipe.o" | sed 's/^[^:]*: //')"
+echo "  exported symbol: $(nm "$work/recipe.o" 2>/dev/null | tr -s ' ')"
+
+# ld -dylib links + ad-hoc signs (no clang) — the recipe-dylib path.
+SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$work/recipe.dylib" "$work/recipe.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null \
+   || { echo "FAIL: ld -dylib"; exit 1; }
+echo "ld -dylib + ad-hoc sign: $(codesign -dv "$work/recipe.dylib" 2>&1 | grep -E '^CodeDirectory' | sed 's/ hashes.*//')"
+echo
+
+# The dumb loader: dlopen, cast _recipe to the bit-reinterpret ABI, call with raw bit patterns AND the 2^k
+# construction (k+1023)<<52 the native ldexp step will assemble.
+cat > "$work/harness.c" <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+typedef double (*fn_fn)(unsigned long bits);
+static int check_bits(fn_fn fn, const char *name, unsigned long bits) {
+    /* reference: the SAME bit reinterpret the recipe computes — so == not epsilon-close */
+    double expect; __builtin_memcpy(&expect, &bits, 8);
+    double got = fn(bits);
+    int ok = (got == expect) || (expect != expect && got != got); /* NaN==NaN by bit identity */
+    printf("EXEC bits 0x%016lx  got=%.17g expected=%.17g  %-6s %s\n", bits, got, expect, name, ok ? "MATCH" : "FAIL");
+    return ok;
+}
+static int check_pow2(fn_fn fn, long k) {
+    /* the EXACT native-ldexp use: 2^k = reinterpret((k+1023)<<52) */
+    unsigned long bits = (unsigned long)(k + 1023) << 52;
+    double got = fn(bits);
+    double expect = ldexp(1.0, (int)k);   /* == 2^k */
+    int ok = (got == expect);
+    printf("EXEC 2^%-4ld (k+1023)<<52=0x%016lx  got=%.17g expected=%.17g  %s\n", k, bits, got, expect, ok ? "MATCH" : "FAIL");
+    return ok;
+}
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen fail: %s\n", dlerror()); return 2; }
+    fn_fn fn = (fn_fn)dlsym(h, "recipe");      /* leading _ stripped by dlsym */
+    if (!fn) { fprintf(stderr, "dlsym fail: %s\n", dlerror()); return 3; }
+    int all = 1;
+    /* raw bit patterns -> the f64 they encode */
+    all &= check_bits(fn, "1.0",  0x3FF0000000000000UL);
+    all &= check_bits(fn, "2.0",  0x4000000000000000UL);
+    all &= check_bits(fn, "3.0",  0x4008000000000000UL);
+    all &= check_bits(fn, "-2.0", 0xC000000000000000UL);
+    all &= check_bits(fn, "1.5",  0x3FF8000000000000UL);
+    all &= check_bits(fn, "0.0",  0x0000000000000000UL);
+    all &= check_bits(fn, "inf",  0x7FF0000000000000UL);
+    /* the keystone: the native 2^k/ldexp construction the exp lane needs */
+    all &= check_pow2(fn, 0);     /* 2^0  = 1   */
+    all &= check_pow2(fn, 5);     /* 2^5  = 32  */
+    all &= check_pow2(fn, -3);    /* 2^-3 = 0.125 */
+    all &= check_pow2(fn, 10);    /* 2^10 = 1024 */
+    all &= check_pow2(fn, -10);   /* 2^-10 = small */
+    dlclose(h);
+    return all ? 0 : 1;
+}
+EOF
+clang -o "$work/harness" "$work/harness.c" -lm || { echo "FAIL: harness build"; exit 1; }
+
+"$work/harness" "$work/recipe.dylib"; rc=$?
+echo
+if [[ "$rc" == "0" ]]; then
+    echo "WITNESS: the Form-emitted GP->FP bit reinterpret RUNS and MATCHES on $(uname -m)."
+    echo "  fam-fmov-bits' 8 bytes (form-asm, four-way) -> form-macho .o -> ld -dylib -> dlopen+call."
+    echo "  The 2^k cases prove the native ldexp construction: (k+1023)<<52 reinterprets to 2^k bit-for-bit;"
+    echo "  with fam-frintn (k=round) + fam-pool-fma (r) + Horner already on the lane, the exp range-reduction"
+    echo "  scaling is now sovereign native bytes. The last non-synthesizable primitive — moving raw bits"
+    echo "  between the integer and f64 register files — is form-emitted and witnessed on real silicon."
+else
+    echo "WITNESS FAIL (rc=$rc): the emitted program did not match the reference."
+fi
+exit $rc


### PR DESCRIPTION
## The stone

The last non-synthesizable primitive of the native exp lane: **2^k / ldexp**.

`exp(x) = 2^k · Horner(r)` where `k = round(x·log2e)`, `r = x − k·ln2`. On the form-asm lane:
- `k = round(...)` → **fam-frintn** (#3932) ✓
- `r` over pooled ln2/log2e → **fam-pool-fma** (#3928) ✓
- `Horner(r)` → the poly lane (form-asm-horner/exp-coef-pool) ✓
- **`2^k` → was missing.** Building it means assembling the IEEE754 exponent field `(k+1023)<<52` in an integer register, then *reinterpreting* those bits as f64. Every existing op either computes on f64 values or numerically converts (`fa-scvtf` gives 5→5.0); none move raw bits between the register files.

## What this adds

The matched bit-reinterpret pair, byte-pinned to clang `-O2`:
- `fa-fmov-d-x` — `FMOV Dd,Xn` (`0x9E670000`): i64 bits → f64 register. `0x3FF0000000000000 → 1.0`.
- `fa-fmov-x-d` — `FMOV Xd,Dn` (`0x9E660000`): f64 bits → i64 register (the reverse door for sign/NaN/inf tests, softmax max-subtract).

Distinct words from each other (opcode 111 vs 110) and from `fa-scvtf`'s numeric convert.

## Proof — both gates

**Four-way:** `form-asm-fmov-dx` band → **15**, fourth arm four-way, **0 divergent** (Go=Rust=TS=fkwu agree on the 8-byte image, first try).

**Hardware (M4 arm64):** 12/12 bit-exact via `scripts/form_asm_fmov_dx_witness.sh` — Form bytes → form-macho .o → `ld -dylib` → dlopen+call, **no clang in the compute**. Raw patterns reinterpret bit-for-bit, and the exact native-ldexp use holds: `recipe((k+1023)<<52) == ldexp(1,k) == 2^k` for k ∈ {0,5,−3,10,−10}.

Receipt: `docs/system_audit/commit_evidence_2026-06-30_form_asm_fmov_dx.json`. Band registered in `form/fourth-arm-bands.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)