### PR TITLE
tend(form): form-asm-relu — first nonlinearity on the native asm lane (relu=fmax(x,0)), four-way 15 + bit-exact on M4

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -48,7 +48,7 @@
 | [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 166 | Web routes — every visible page in the app |
-| [scripts/INDEX.md](scripts/INDEX.md) | 399 | Scripts — operational tools, generators, syncers |
+| [scripts/INDEX.md](scripts/INDEX.md) | 400 | Scripts — operational tools, generators, syncers |
 
 ## Convention
 

--- a/docs/system_audit/commit_evidence_2026-07-01_form_asm_relu.json
+++ b/docs/system_audit/commit_evidence_2026-07-01_form_asm_relu.json
@@ -1,0 +1,36 @@
+{
+ "title": "fam-relu — the rectified-linear activation relu(x) = max(x, 0) emits four-way as Form->asm bytes AND runs bit-exact on the M4; the first NONLINEARITY on the native lane, + the missing fa-fmax / fa-fmin encoders",
+ "date": "2026-07-01",
+ "author": "Sema (Opus 4.8), autonomous native-ML walk",
+ "stone": "form-native-models.form 'GAPS — LLM INFERENCE' rung A: the nonlinear ops as form-asm bytes. The form-asm float lane carried arithmetic (fadd/fsub/fmul/fdiv/fmadd), the transcendental floor (fsqrt/frintn/fmov-d-x, and exp's range reduction, fam-exp-reduce 31), and comparison (fcmp) — but had NO min/max, so no ACTIVATION and no stable-softmax max-subtract. A transformer/MLP block is (matvec, add-bias, NONLINEARITY) repeated; the matvec lane is on bytes (form-asm-matvec), the nonlinearity was not. This brick adds the plain arm64 FP min/max (fa-fmax / fa-fmin) and composes the simplest nonlinearity, relu(x) = max(x, 0), as a runnable native function. The SAME fa-fmax is the max-subtract that keeps softmax numerically stable (subtract max_j(logit_j) so exp never overflows) and, paired with fa-fmin, the clamp clamp(x,lo,hi) = fmin(fmax(x,lo),hi).",
+ "new_encoder": "fa-fmax (rd rn rm) — FMAX d<rd>, d<rn>, d<rm> (larger of two f64, propagates NaN). base 0x1E604800 (509626368) | rm<<16 | rn<<5 | rd, packed (1 32 65536). fa-fmin (rd rn rm) — FMIN, base 0x1E605800 (509630464). Oracle (arm64 assembler, otool of the M4-assembled words): fmax d0,d0,d1 = 1e614800, fmin d0,d0,d1 = 1e615800. Oracle-as-teacher, not master: clang -O2 lowers `x>0?x:0` to `movi d1,#0` + `fmaxNM d0,d0,d1` (1e616800) — the NaN-QUIETING variant, a HEALTHY DIFFERENCE from plain fmax (identical on every finite input, differing only on NaN: fmax propagates, fmaxnm quiets). fmax/fmin are the FUNDAMENTAL primitives the model block composes from; fmaxnm is the variant. The reusable win: the branchless min/max the activation + clamp + softmax-stability floor is built from, with no fcmp+branch and no data-dependent control flow.",
+ "recipe": "form/form-stdlib/form-asm-matvec.fk :: (defn fam-relu () (append (fa-fmov-d-x 1 31) (append (fa-fmax 0 0 1) (fa-ret)))) — the zero is reinterpreted from the xzr register (reg 31) through the existing fa-fmov-d-x (fmov d1, xzr = 9e6703e1); no new constant machinery. ABI d0 = x, returns d0 = max(x, 0). 3 arm64 instructions = 12 bytes.",
+ "proof_four_way": [
+  {
+   "band": "form/form-stdlib/tests/form-asm-relu-band.fk (NEW)",
+   "manifest_row": "form-asm-relu fks 15",
+   "verdict": 15,
+   "oracle": "M4-assembled words (otool -tvVj): fmov d1,xzr (9e6703e1) + fmax d0,d0,d1 (1e614800) + ret (d65f03c0) = 12 bytes, LE list (225 3 103 158 0 72 97 30 192 3 95 214).",
+   "claims": [
+    "1 — the program is 3 instructions = 12 bytes (len == 12)",
+    "2 — the FULL 12-byte program byte-equals the M4-assembled oracle (fa-conviction == 1)",
+    "4 — fmax d0,d0,d1 (1e614800) — the new plain-max encoder, byte-exact (fa-conviction == 1)",
+    "8 — fmin d0,d0,d1 (1e615800) — the twin plain-min encoder for clamp, byte-exact (fa-conviction == 1)"
+   ],
+   "command": "cd form && ./validate.sh form-stdlib/core.fk form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk form-stdlib/tests/form-asm-relu-band.fk",
+   "result": "-> 15 ; fourth arm four-way (fkwu, bootstrap binary darwin-arm64, no clang) ; 1 ok, 0 divergent — Go=Rust=TS=fkwu agree on the 12-byte image. Loop-free (no forward-reference/recursion surface). First run returned 15-masked verdict 1 from a decimal-conversion slip in the fa-fmax base (510330880 vs the correct 0x1E604800 = 509626368); the four kernels AGREED on the wrong bytes (deterministic emit) which is exactly how a wrong constant shows — caught by the byte oracle, fixed, re-crossed to 15."
+  }
+ ],
+ "proof_on_hardware": {
+  "script": "scripts/form_asm_relu_witness.sh",
+  "image": "e103679e (fmov d1,xzr) 0048611e (fmax d0,d0,d1) c0035fd6 (ret) = 12 bytes",
+  "path": "Form kernel emits fam-relu's 12-byte program -> form-macho mo-object-sym -> Mach-O .o (245 bytes) exporting _recipe -> ld -dylib + ad-hoc sign -> dlopen+call. No rustc/clang in the COMPUTE (clang only builds the dumb dlopen harness; the activation is the Form-emitted fmax). otool of the .o confirms the words disassemble to fmov/fmax/ret (the assembler is the byte oracle).",
+  "result": "7/7 MATCH on M4 (arm64 macOS): recipe(x) == (x > 0.0 ? x : 0.0) bit-for-bit at x in {3.0->3, -2.0->0, 0.0->0, -0.0->0, 0.5->0.5, -1e8->0, 1e8->1e8}. The x=0 and signed-zero -0.0 cases check the boundary (relu(0)=0, relu(-0)=0); large +/- confirm pass-through and clamp.",
+  "note": "The first NONLINEARITY on the witnessed native lane. relu is the smallest runnable witness of fa-fmax; the same encoder carries stable-softmax's max-subtract and the clamp — the activation floor of a model block, now sovereign native bytes."
+ },
+ "no_regression": "fa-fmax / fa-fmin are purely additive to form-asm.fk (two new encoder defns); fam-relu is purely additive to form-asm-matvec.fk (a new recipe). Re-validated form-asm-matvec.fk siblings four-way after the additive edits — form-asm-exp-reduce (31), form-asm-fmov-dx (15), form-asm-frintn (7) — all 0 divergent, fkwu crossed.",
+ "design_note": "Design-with-reference held: before authoring, `fmax d0,d0,d1` / `fmin d0,d0,d1` / `fmov d1,xzr` were assembled with clang -c on THIS M4 and read back with otool to pin the EXACT byte-shape (1e614800 / 1e615800 / 9e6703e1); clang's own relu lowering was probed (movi + fmaxnm) and named as the healthy difference. The bit-derived bases had to be re-derived after a hand-decimal slip — the byte oracle caught it instantly. Finding a genuinely uncontested stone was most of the discernment: the exp-lane (sibling claude/form-asm-exp-reduce), full-llama-generation (codex), and Metal GPU dispatch (codex) frontiers were all actively tended tonight; the min/max activation floor is non-transcendental (not the exp sibling's turf), not a llama-gen composition, and reuses the merged fa-fmov-d-x for zero.",
+ "toolchain_free_claim": "Honest floor: a Form recipe proven four-way (Go=Rust=TS=fkwu) through validate.sh (bash) PLUS an on-M4 execution witness (form-macho -> ld -dylib -> dlopen, no rustc/clang in the compute). bin-go is the bootstrap that runs the flattener/emitter. Platform rows (mac four-way + on-hardware observed; windows/android form-cli pending) per docs/coherence-substrate/standard-receipt.form.",
+ "next_stones": "(1) fam-gelu / fam-silu on the lane — now that exp's range reduction (fam-exp-reduce) and the pooled Horner are on bytes, the smooth activations gelu(x) = x*Phi(x) and silu(x) = x*sigmoid(x) compose from exp + fmul + the pooled poly. (2) a fam-softmax-max reduction: fold fa-fmax over an ll-buffer of logits (max_j) then subtract-and-exp — the numerically-stable softmax the attention block needs, fa-fmax's headline consumer. (3) fam-clamp using fa-fmin+fa-fmax over a pooled (lo,hi). (4) stage the matvec + bias + fam-relu over ll-buffer for a real MLP layer end-to-end on bytes.",
+ "witness_state": "pulse.coherencycoin.com at open: overall STRAINED, 0 recorded silences, web organ not breathing (noted, not repaired this run — no deploy taken; brick is host-independent: Form recipe + two encoders + band + witness + receipt + manifest row)."
+}

--- a/form/form-stdlib/form-asm-matvec.fk
+++ b/form/form-stdlib/form-asm-matvec.fk
@@ -236,4 +236,19 @@
                                 (append (fa-fmadd 0 1 2 0)          ; d0 = k*(-ln2)+x = x - k*ln2 = r
                                     (fa-ret)))))))))
 
+    ; fam-relu: the rectified-linear ACTIVATION relu(x) = max(x, 0) as Form->asm bytes — the first NONLINEARITY
+    ; on the native lane. Every transformer/MLP block needs a nonlinearity; relu is the simplest, and it is one
+    ; fmax against zero. The zero is materialized by reinterpreting the xzr register (reg 31) as an f64 through
+    ; the existing fa-fmov-d-x (fmov d1, xzr = 9e6703e1) — no new constant machinery. Then fmax d0,d0,d1 keeps
+    ; the larger, so negatives clamp to 0 and positives pass. The SAME fa-fmax is stable-softmax's max-subtract
+    ; and (with fa-fmin) the clamp; relu is its smallest runnable witness. ABI: d0 = x, returns d0 = max(x, 0).
+    ; 3 instructions = 12 bytes:  0 fmov d1,xzr (9e6703e1)   1 fmax d0,d0,d1 (1e614800)   2 ret (d65f03c0).
+    ; clang -O2 lowers `x>0?x:0` to movi-zero + fmaxnm (the NaN-QUIETING variant, 1e616800) — identical on every
+    ; finite input; fmax is the fundamental primitive (oracle-as-teacher: the arm64 assembler confirms the word,
+    ; the healthy difference is fmax propagates NaN where clang's fmaxnm quiets it).
+    (defn fam-relu ()
+        (append (fa-fmov-d-x 1 31)
+            (append (fa-fmax 0 0 1)
+                (fa-ret))))
+
     0)

--- a/form/form-stdlib/form-asm.fk
+++ b/form/form-stdlib/form-asm.fk
@@ -189,6 +189,15 @@
     (defn fa-fmul (rd rn rm) (fa-asm 509609984 (list 1 32 65536) (list rd rn rm)))
     ; fdiv d<rd>, d<rn>, d<rm> : base 0x1E601800                         (oracle 1e621820)
     (defn fa-fdiv (rd rn rm) (fa-asm 509614080 (list 1 32 65536) (list rd rn rm)))
+    ; fmax d<rd>, d<rn>, d<rm> (larger of the two, propagates NaN) : base 0x1E604800 (oracle 1e614800 = fmax d0,d0,d1)
+    ; fmin d<rd>, d<rn>, d<rm> (smaller of the two, propagates NaN) : base 0x1E605800 (oracle 1e615800 = fmin d0,d0,d1)
+    ; the plain min/max — the branchless ACTIVATION + CLAMP + stable-softmax floor. relu(x) = fmax(x, 0.0) in one
+    ; op (fam-relu below); clamp(x,lo,hi) = fmin(fmax(x,lo),hi); stable softmax subtracts fmax over the logits so
+    ; exp never overflows. clang lowers `x>0?x:0` to fmaxNM (the NaN-QUIETING variant, 1e616800) + movi-zero — a
+    ; healthy difference from plain fmax: identical on every finite input, differing only on NaN (fmax propagates,
+    ; fmaxnm quiets). fmax/fmin are the FUNDAMENTAL primitives the model block composes from; fmaxnm is the variant.
+    (defn fa-fmax (rd rn rm) (fa-asm 509626368 (list 1 32 65536) (list rd rn rm)))
+    (defn fa-fmin (rd rn rm) (fa-asm 509630464 (list 1 32 65536) (list rd rn rm)))
     ; fmadd d<rd>, d<rn>, d<rm>, d<ra> (rd = rn*rm + ra, one rounding) : base 0x1F400000 | rm<<16 | ra<<10 | rn<<5 | rd
     ; the fused multiply-add — the workhorse clang fuses every dot/Horner step to (oracle 1f420401 = fmadd d1,d0,d2,d1).
     ; one hardware op = one rounding, so a polynomial folded with it is byte-distinct from fmul-then-fadd. Horner over

--- a/form/form-stdlib/tests/form-asm-relu-band.fk
+++ b/form/form-stdlib/tests/form-asm-relu-band.fk
@@ -1,0 +1,39 @@
+; preludes: form-stdlib/form-asm.fk form-stdlib/form-asm-matvec.fk
+;
+; form-asm-relu-band — the rectified-linear ACTIVATION relu(x) = max(x, 0) emits four-way as Form->asm bytes,
+; no rustc. fam-relu is the FIRST NONLINEARITY on the native asm lane: every transformer/MLP block needs one,
+; and relu is the simplest — a single fmax against zero. The new primitives are fa-fmax / fa-fmin, the plain
+; arm64 FP min/max; the SAME fa-fmax is stable-softmax's max-subtract (subtract max_j(logit_j) so exp never
+; overflows) and, paired with fa-fmin, the clamp clamp(x,lo,hi) = fmin(fmax(x,lo),hi). relu is their smallest
+; runnable witness; the execution witness (scripts/form_asm_relu_witness.sh) runs it bit-exact on this M4.
+;
+; The new ground vs the prior float bricks: every op so far (fmul/fadd/fmadd/fsqrt/frintn/fmov-d-x) computes or
+; converts a single value; fa-fmax / fa-fmin SELECT between two values by magnitude — the branchless conditional
+; the activation/clamp/softmax-stability floor is built from (no fcmp+branch, no data-dependent control flow).
+; The zero relu needs is materialized by reinterpreting the xzr register (reg 31) through the existing
+; fa-fmov-d-x (fmov d1, xzr = 9e6703e1) — no new constant machinery.
+;
+; Oracle-as-teacher, not master: clang -O2 lowers `double r(double x){return x>0.0?x:0.0;}` to
+;   2f00e401 movi d1,#0   1e616800 fmaxNM d0,d0,d1   d65f03c0 ret
+; — the NaN-QUIETING fmaxnm, a HEALTHY DIFFERENCE from plain fmax: identical on every finite input, differing
+; only on NaN (fmax propagates it, fmaxnm returns the number). fmax/fmin are the FUNDAMENTAL primitives the
+; model block composes from; the arm64 assembler (otool of the M4-assembled words) is the byte oracle here,
+; confirming fa-fmax = fmax (1e604800 base) and fa-fmin = fmin (1e605800 base), not clang's variant choice.
+;
+; The 3-instruction program (fam-relu), ABI d0 = x -> d0 = max(x, 0):
+;   0 fmov d1,xzr (9e6703e1)   1 fmax d0,d0,d1 (1e614800)   2 ret (d65f03c0)
+;
+; Verdict 15 when every claim lands:
+;   1    the program is 3 instructions = 12 bytes                                (len == 12)
+;   2    the FULL program byte-equals the 12-byte M4-assembled oracle            (fa-conviction == 1)
+;   4    fmax d0,d0,d1 — the new plain-max encoder (1e614800)                     (fa-conviction == 1)
+;   8    fmin d0,d0,d1 — the twin plain-min encoder (1e615800), for clamp        (fa-conviction == 1)
+(do
+    (let prog (fam-relu))
+    (let oracle (list
+        225 3 103 158    0 72 97 30    192 3 95 214))
+    (let c0 (if (eq (len prog) 12)                                        1 0))
+    (let c1 (if (eq (fa-conviction prog oracle)                     1)    2 0))
+    (let c2 (if (eq (fa-conviction (fa-fmax 0 0 1) (list 0 72 97 30)) 1)  4 0))
+    (let c3 (if (eq (fa-conviction (fa-fmin 0 0 1) (list 0 88 97 30)) 1)  8 0))
+    (add c0 (add c1 (add c2 c3))))

--- a/form/fourth-arm-bands.txt
+++ b/form/fourth-arm-bands.txt
@@ -1057,6 +1057,7 @@ form-asm-exp-coef-pool fks 31
 form-asm-frintn fks 7
 form-asm-fmov-dx fks 15
 form-asm-exp-reduce fks 31
+form-asm-relu fks 15
 weight-load fks 4095
 weight-load-q4k fks 4095
 block-join fks 255

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 399
+**Total files**: 400
 
 | File | Purpose |
 |---|---|
@@ -118,6 +118,7 @@
 | [form_asm_matvec_2d_witness.sh](form_asm_matvec_2d_witness.sh) | form_asm_matvec_2d_witness.sh — the EXECUTION WITNESS for fam-matvec: the Form-emitted |
 | [form_asm_matvec_witness.sh](form_asm_matvec_witness.sh) | form_asm_matvec_witness.sh — the EXECUTION WITNESS for fam-dot2: the Form-emitted |
 | [form_asm_poly_pool_witness.sh](form_asm_poly_pool_witness.sh) | form_asm_poly_pool_witness.sh — the EXECUTION WITNESS for fam-poly-pool: the Form-emitted Horner step |
+| [form_asm_relu_witness.sh](form_asm_relu_witness.sh) | form_asm_relu_witness.sh — the EXECUTION WITNESS for fam-relu: the Form-emitted rectified-linear activation |
 | [form_asm_rsqrt_witness.sh](form_asm_rsqrt_witness.sh) | form_asm_rsqrt_witness.sh — the EXECUTION WITNESS for fam-rsqrt: the Form-emitted reciprocal-sqrt |
 | [form_asm_ss_sqrt_witness.sh](form_asm_ss_sqrt_witness.sh) | form_asm_ss_sqrt_witness.sh — the EXECUTION WITNESS for fam-ss-sqrt: the Form-emitted RMSNorm/LayerNorm |
 | [form_branch_demo.sh](form_branch_demo.sh) | form_branch_demo.sh — the FULL asm-pl-human program, compiled by Form and run on |

--- a/scripts/form_asm_relu_witness.sh
+++ b/scripts/form_asm_relu_witness.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# form_asm_relu_witness.sh — the EXECUTION WITNESS for fam-relu: the Form-emitted rectified-linear activation
+# relu(x) = max(x, 0) (form-asm-relu-band proves it four-way) doesn't just BYTE-MATCH the arm64 words — it
+# actually RUNS relu(x) on this arm64 host, no rustc/clang in the COMPUTE (clang is only the dumb dlopen harness).
+#
+# Sibling of form_asm_frintn_witness.sh. fam-relu is the FIRST NONLINEARITY on the native asm lane: every
+# transformer/MLP block needs one, and relu is the simplest — a single fa-fmax against zero. The zero is
+# reinterpreted from the xzr register through the existing fa-fmov-d-x (fmov d1, xzr = 9e6703e1); no new
+# constant machinery. The SAME fa-fmax is stable-softmax's max-subtract and, with fa-fmin, the clamp — relu
+# is their smallest runnable witness.
+#
+# Path:
+#   1. Form kernel emits fam-relu's 3-instruction (12-byte) arm64 program, then wraps it via form-macho's
+#      mo-object-sym into a Mach-O .o exporting `_recipe`.
+#   2. `ld -dylib` links + ad-hoc signs the .o into a dlopen-able dylib (the recipe-dylib path, no clang).
+#   3. A tiny C harness dlopens it, casts `_recipe` to the ABI  double recipe(double x)  (arm64 arg lands
+#      in d0, result in d0 — exactly the recipe's register plan), and calls it with real scalars.
+#   4. Assert recipe(x) == (x > 0.0 ? x : 0.0), bit-for-bit — plain relu, which fa-fmax computes exactly for
+#      every finite input (differing from clang's fmaxnm only on NaN, which relu never sees). Signed-zero and
+#      the boundary x=0 are checked (relu(-0.0) = 0.0, relu(0.0) = 0.0).
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORM="$ROOT/form"; GO="$FORM/form-kernel-go/bin-go"
+[[ -x "$GO" ]] || (cd "$FORM/form-kernel-go" && go build -o bin-go .)
+[[ "$(uname -m)" == "arm64" && "$(uname -s)" == "Darwin" ]] || { echo "arm64 macOS witness; skipping on $(uname -m)/$(uname -s)"; exit 0; }
+command -v ld >/dev/null || { echo "need ld (the linker); skipping"; exit 0; }
+command -v clang >/dev/null || { echo "need clang for the loader harness; skipping"; exit 0; }
+work="$(mktemp -d "${TMPDIR:-/tmp}/frelu.XXXXXX")"; trap 'rm -rf "$work"' EXIT
+
+MATVEC="$FORM/form-stdlib/form-asm-matvec.fk"
+[[ -f "$MATVEC" ]] || { echo "FAIL: form-asm-matvec.fk not found"; exit 1; }
+
+# Form: emit fam-relu bytes, wrap as a Mach-O .o exporting _recipe (mo-object-sym), hex.
+{ echo "(do"
+  echo '    (defn append (xs ys) (if (nil? xs) ys (cons (head xs) (append (tail xs) ys))))'
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-asm.fk"
+  sed '1,/^(do$/d;$ d' "$MATVEC"
+  sed '1,/^(do$/d;$ d' "$FORM/form-stdlib/form-macho.fk"
+  cat <<'DRV'
+    (defn hx1 (n) (nth (list "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" "a" "b" "c" "d" "e" "f") n))
+    (defn hx2 (b) (str_concat (hx1 (div b 16)) (hx1 (mod b 16))))
+    (defn hxb (bs) (if (eq (len bs) 0) "" (str_concat (hx2 (head bs)) (hxb (tail bs)))))
+    (let code (fam-relu))
+    (print (str_concat "FNBYTES " (hxb code)))
+    ; _recipe = 95 114 101 99 105 112 101 (the recipe-dylib export name)
+    (print (str_concat "MACHO " (hxb (mo-object-sym code (list 95 114 101 99 105 112 101)))))
+    0)
+DRV
+} > "$work/emit.fk"
+
+out="$(cd "$FORM" && "$GO" "$work/emit.fk" 2>/dev/null)"
+fnbytes="$(echo "$out" | grep '^FNBYTES ' | sed 's/^FNBYTES //')"
+hex="$(echo "$out" | grep '^MACHO ' | sed 's/^MACHO //')"
+[[ -n "$hex" ]] || { echo "FAIL: Form emitted no object"; cd "$FORM" && "$GO" "$work/emit.fk" 2>&1 | head; exit 1; }
+echo "fam-relu program: $(( ${#fnbytes} / 2 )) bytes (no rustc/clang in this compute)"
+echo "  arm64 bytes: $fnbytes"
+
+echo "$hex" | xxd -r -p > "$work/recipe.o"
+echo "Form-emitted Mach-O object: $(wc -c < "$work/recipe.o" | tr -d ' ') bytes, $(file "$work/recipe.o" | sed 's/^[^:]*: //')"
+echo "  exported symbol: $(nm "$work/recipe.o" 2>/dev/null | tr -s ' ')"
+# The arm64 assembler IS the byte oracle: confirm the emitted words disassemble to fmax (oracle-as-teacher).
+echo "  disassembly (otool — the assembler confirms the words):"
+otool -tvVj "$work/recipe.o" 2>/dev/null | grep -E 'fmov|fmax|ret' | sed 's/^/    /'
+
+# ld -dylib links + ad-hoc signs (no clang) — the recipe-dylib path.
+SDK="$(xcrun --sdk macosx --show-sdk-path 2>/dev/null)"
+ld -dylib -arch arm64 -platform_version macos 11.0 11.0 \
+   -o "$work/recipe.dylib" "$work/recipe.o" -lSystem -L"$SDK/usr/lib" -syslibroot "$SDK" 2>/dev/null \
+   || { echo "FAIL: ld -dylib"; exit 1; }
+echo "ld -dylib + ad-hoc sign: $(codesign -dv "$work/recipe.dylib" 2>&1 | grep -E '^CodeDirectory' | sed 's/ hashes.*//')"
+echo
+
+# The dumb loader: dlopen, cast _recipe to the relu ABI, call with real scalars (incl. the x=0 boundary).
+cat > "$work/harness.c" <<'EOF'
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+typedef double (*fn_fn)(double x);
+static int check(fn_fn fn, const char *name, double x) {
+    /* reference: plain relu — fa-fmax computes this exactly for every finite input, so == not epsilon-close */
+    double expect = x > 0.0 ? x : 0.0;
+    double got = fn(x);
+    int ok = (got == expect);
+    printf("EXEC %-8s x=%-12g got=%.17g expected=%.17g %s\n", name, x, got, expect, ok ? "MATCH" : "FAIL");
+    return ok;
+}
+int main(int argc, char **argv) {
+    void *h = dlopen(argv[1], RTLD_NOW);
+    if (!h) { fprintf(stderr, "dlopen fail: %s\n", dlerror()); return 2; }
+    fn_fn fn = (fn_fn)dlsym(h, "recipe");      /* leading _ stripped by dlsym */
+    if (!fn) { fprintf(stderr, "dlsym fail: %s\n", dlerror()); return 3; }
+    int all = 1;
+    all &= check(fn, "3.0",   3.0);        /* positive passes through */
+    all &= check(fn, "-2.0", -2.0);        /* negative clamps to 0 */
+    all &= check(fn, "0.0",   0.0);        /* the boundary: relu(0) = 0 */
+    all &= check(fn, "-0.0", -0.0);        /* signed zero: relu(-0) = 0 */
+    all &= check(fn, "0.5",   0.5);        /* small positive */
+    all &= check(fn, "-1e8", -1e8);        /* large negative clamps to 0 */
+    all &= check(fn, "1e8",   1e8);        /* large positive passes */
+    dlclose(h);
+    return all ? 0 : 1;
+}
+EOF
+clang -o "$work/harness" "$work/harness.c" || { echo "FAIL: harness build"; exit 1; }
+
+"$work/harness" "$work/recipe.dylib"; rc=$?
+echo
+if [[ "$rc" == "0" ]]; then
+    echo "WITNESS: the Form-emitted relu(x) = max(x, 0) RUNS and MATCHES on $(uname -m)."
+    echo "  fam-relu's 12 bytes (form-asm, four-way) -> form-macho .o -> ld -dylib -> dlopen+call."
+    echo "  The first NONLINEARITY on the native lane is sovereign native bytes; the same fa-fmax carries"
+    echo "  stable-softmax's max-subtract and (with fa-fmin) the clamp — the activation floor of a model block."
+else
+    echo "WITNESS FAIL (rc=$rc): the emitted program did not match the reference."
+fi
+exit $rc


### PR DESCRIPTION
## The brick

The form-asm float lane carried arithmetic, the transcendental floor (fsqrt/frintn/fmov-d-x, exp range-reduction), and `fcmp` — but **no min/max**, so no ACTIVATION and no stable-softmax max-subtract. A transformer/MLP block is `(matvec, +bias, NONLINEARITY)`; the matvec is on bytes, the nonlinearity was not.

This adds the plain arm64 FP min/max — `fa-fmax` (0x1E604800) / `fa-fmin` (0x1E605800) — and composes **`relu(x) = max(x, 0)`** as a runnable native function. The zero is reinterpreted from `xzr` through the existing `fa-fmov-d-x` (`fmov d1, xzr`), no new constant machinery. The **same `fa-fmax`** is stable-softmax's max-subtract and, with `fa-fmin`, the clamp.

## Proof — both halves

- **Four-way:** `form-asm-relu` **→ 15, 0 divergent** (Go=Rust=TS=fkwu agree on the 12-byte image). `fa-fmax`/`fa-fmin` encoders byte-exact vs the M4-assembled words.
- **On this M4:** `scripts/form_asm_relu_witness.sh` — fam-relu's 12 bytes → form-macho .o → `ld -dylib` → dlopen+call, **7/7 MATCH**: `relu(x) == (x>0?x:0)` bit-for-bit incl. signed-zero and the x=0 boundary. No rustc/clang in the compute (clang only builds the dumb loader).

## Oracle-as-teacher

clang lowers `x>0?x:0` to `movi`+`fmaxNM` (the NaN-quieting variant) — a **healthy difference**, identical on every finite input; `fmax`/`fmin` are the fundamental primitives the model block composes from.

## Edges
- `form-asm-relu fks 15` registered in `form/fourth-arm-bands.txt`
- Receipt: `docs/system_audit/commit_evidence_2026-07-01_form_asm_relu.json`
- INDEX/MANIFEST regenerated for the new witness script

Next stones: fam-gelu/silu (exp + pooled Horner now on bytes), fam-softmax-max reduction over ll-buffer (fa-fmax's headline consumer), fam-clamp, then matvec+bias+relu as a real MLP layer end-to-end on bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)