### PR TITLE
[codex] aggregate noisy runtime activity telemetry

### DIFF
--- a/api/app/config_loader.py
+++ b/api/app/config_loader.py
@@ -158,6 +158,8 @@ def _default_runtime_config() -> dict[str, Any]:
             "endpoint_cache_ttl_seconds": 120.0,
             "endpoint_cache_max_workers": 4,
             "telemetry_enabled": True,
+            "aggregate_noisy_routes": True,
+            "aggregate_bucket_seconds": 60.0,
         },
         "friction": {
             "events_path": None,

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -112,6 +112,11 @@ from app.middleware.request_outcomes import RequestOutcomesMiddleware
 from app.models.runtime import RuntimeEventCreate
 from app.services import runtime_service
 _startup_logger = logging.getLogger("coherence.api.slow")
+_RUNTIME_AGGREGATE_LOCK = threading.Lock()
+_RUNTIME_AGGREGATE_BUCKETS: dict[tuple[str, str, str, int, int], dict[str, object]] = {}
+_RUNTIME_AGGREGATED_ROUTES = {
+    ("POST", "/api/agent/tasks/{task_id}/activity"),
+}
 
 def _startup_compat_row(node: dict) -> dict:
     row = dict(node)
@@ -516,6 +521,117 @@ def _runtime_event_source(request) -> str:
     ):
         return "web_api"
     return "api"
+
+
+def _runtime_aggregate_bucket_seconds() -> int:
+    configured = get_float("runtime", "aggregate_bucket_seconds", 60.0)
+    return max(10, min(int(configured), 3600))
+
+
+def _runtime_aggregate_enabled() -> bool:
+    return get_bool("runtime", "aggregate_noisy_routes", True)
+
+
+def _should_aggregate_runtime_event(payload: RuntimeEventCreate) -> bool:
+    if not _runtime_aggregate_enabled():
+        return False
+    return (payload.method.upper(), payload.endpoint) in _RUNTIME_AGGREGATED_ROUTES
+
+
+def _runtime_bucket_payload(bucket: dict[str, object]) -> RuntimeEventCreate:
+    count = max(1, int(bucket.get("count") or 1))
+    total_ms = float(bucket.get("total_runtime_ms") or 0.0)
+    avg_ms = max(0.1, total_ms / count)
+    bucket_start = int(bucket.get("bucket_start") or 0)
+    bucket_seconds = int(bucket.get("bucket_seconds") or _runtime_aggregate_bucket_seconds())
+    metadata = {
+        "tracking_kind": "api_route_request_aggregate",
+        "aggregate_kind": "minute_bucket",
+        "compressed_from": "api_route_request",
+        "event_count": count,
+        "sample_count": count,
+        "total_runtime_ms": round(total_ms, 4),
+        "average_runtime_ms": round(avg_ms, 4),
+        "min_runtime_ms": round(float(bucket.get("min_runtime_ms") or avg_ms), 4),
+        "max_runtime_ms": round(float(bucket.get("max_runtime_ms") or avg_ms), 4),
+        "bucket_start_epoch": bucket_start,
+        "bucket_seconds": bucket_seconds,
+        "first_seen_at": str(bucket.get("first_seen_at") or ""),
+        "last_seen_at": str(bucket.get("last_seen_at") or ""),
+        "sample_raw_endpoint": str(bucket.get("sample_raw_endpoint") or ""),
+        "sample_req_id": str(bucket.get("sample_req_id") or ""),
+    }
+    return RuntimeEventCreate(
+        source=str(bucket.get("source") or "api"),  # type: ignore[arg-type]
+        endpoint=str(bucket.get("endpoint") or "/api/unknown"),
+        raw_endpoint=str(bucket.get("endpoint") or "/api/unknown"),
+        method=str(bucket.get("method") or "GET"),
+        status_code=int(bucket.get("status_code") or 200),
+        runtime_ms=avg_ms,
+        idea_id=str(bucket.get("idea_id") or "") or None,
+        metadata=metadata,
+    )
+
+
+def _flush_due_runtime_aggregates(now_ts: float | None = None, *, flush_all: bool = False) -> list[RuntimeEventCreate]:
+    bucket_seconds = _runtime_aggregate_bucket_seconds()
+    current_bucket = int((now_ts if now_ts is not None else time.time()) // bucket_seconds) * bucket_seconds
+    due: list[dict[str, object]] = []
+    with _RUNTIME_AGGREGATE_LOCK:
+        for key, bucket in list(_RUNTIME_AGGREGATE_BUCKETS.items()):
+            bucket_start = int(bucket.get("bucket_start") or 0)
+            if flush_all or bucket_start < current_bucket:
+                due.append(bucket)
+                _RUNTIME_AGGREGATE_BUCKETS.pop(key, None)
+    return [_runtime_bucket_payload(bucket) for bucket in due]
+
+
+def _record_or_aggregate_runtime_event(payload: RuntimeEventCreate, now_ts: float | None = None) -> list[RuntimeEventCreate]:
+    out = _flush_due_runtime_aggregates(now_ts)
+    if not _should_aggregate_runtime_event(payload):
+        out.append(payload)
+        return out
+
+    bucket_seconds = _runtime_aggregate_bucket_seconds()
+    now_value = now_ts if now_ts is not None else time.time()
+    bucket_start = int(now_value // bucket_seconds) * bucket_seconds
+    key = (
+        payload.source,
+        payload.endpoint,
+        payload.method.upper(),
+        int(payload.status_code),
+        bucket_start,
+    )
+    seen_at = datetime.fromtimestamp(now_value, tz=timezone.utc).isoformat()
+    runtime_ms = max(0.1, float(payload.runtime_ms))
+    metadata = payload.metadata if isinstance(payload.metadata, dict) else {}
+    with _RUNTIME_AGGREGATE_LOCK:
+        bucket = _RUNTIME_AGGREGATE_BUCKETS.get(key)
+        if bucket is None:
+            bucket = {
+                "source": payload.source,
+                "endpoint": payload.endpoint,
+                "method": payload.method.upper(),
+                "status_code": int(payload.status_code),
+                "idea_id": payload.idea_id or "",
+                "bucket_start": bucket_start,
+                "bucket_seconds": bucket_seconds,
+                "count": 0,
+                "total_runtime_ms": 0.0,
+                "min_runtime_ms": runtime_ms,
+                "max_runtime_ms": runtime_ms,
+                "first_seen_at": seen_at,
+                "last_seen_at": seen_at,
+                "sample_raw_endpoint": payload.raw_endpoint or payload.endpoint,
+                "sample_req_id": str(metadata.get("req_id") or ""),
+            }
+            _RUNTIME_AGGREGATE_BUCKETS[key] = bucket
+        bucket["count"] = int(bucket.get("count") or 0) + 1
+        bucket["total_runtime_ms"] = float(bucket.get("total_runtime_ms") or 0.0) + runtime_ms
+        bucket["min_runtime_ms"] = min(float(bucket.get("min_runtime_ms") or runtime_ms), runtime_ms)
+        bucket["max_runtime_ms"] = max(float(bucket.get("max_runtime_ms") or runtime_ms), runtime_ms)
+        bucket["last_seen_at"] = seen_at
+    return out
 
 
 def _safe_int_or_none(value: str | None) -> int | None:
@@ -1055,18 +1171,18 @@ async def capture_runtime_metrics(request: Request, call_next):
                     "web_route": str(request.headers.get("x-web-route") or "").strip(),
                     "web_proxy": str(request.headers.get("x-coherence-web-proxy") or "").strip(),
                 }
-                runtime_service.record_event(
-                    RuntimeEventCreate(
-                        source=_runtime_event_source(request),
-                        endpoint=capture_path,
-                        raw_endpoint=raw_path,
-                        method=method,
-                        status_code=status_code,
-                        runtime_ms=max(0.1, elapsed_ms),
-                        idea_id=request.headers.get("x-idea-id"),
-                        metadata=metadata,
-                    )
+                runtime_payload = RuntimeEventCreate(
+                    source=_runtime_event_source(request),
+                    endpoint=capture_path,
+                    raw_endpoint=raw_path,
+                    method=method,
+                    status_code=status_code,
+                    runtime_ms=max(0.1, elapsed_ms),
+                    idea_id=request.headers.get("x-idea-id"),
+                    metadata=metadata,
                 )
+                for event_payload in _record_or_aggregate_runtime_event(runtime_payload):
+                    runtime_service.record_event(event_payload)
             except Exception:
                 # Telemetry should not affect request success.
                 logger.debug("Telemetry recording failed", exc_info=True)

--- a/api/app/services/data_retention_service.py
+++ b/api/app/services/data_retention_service.py
@@ -133,6 +133,34 @@ def _parse_ts(ts_raw: Any) -> datetime:
     return _now_utc()
 
 
+def _runtime_row_metadata(row: RuntimeEventRecord) -> dict[str, Any]:
+    try:
+        metadata = json.loads(row.metadata_json) if row.metadata_json else {}
+    except Exception:
+        metadata = {}
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _runtime_row_event_count(row: RuntimeEventRecord) -> int:
+    metadata = _runtime_row_metadata(row)
+    raw_count = metadata.get("event_count") or metadata.get("sample_count") or 1
+    try:
+        return max(1, int(raw_count))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _runtime_row_total_ms(row: RuntimeEventRecord) -> float:
+    metadata = _runtime_row_metadata(row)
+    raw_total = metadata.get("total_runtime_ms")
+    if raw_total is not None:
+        try:
+            return max(0.0, float(raw_total))
+        except (TypeError, ValueError):
+            pass
+    return float(row.runtime_ms or 0.0) * _runtime_row_event_count(row)
+
+
 def _append_backup(table: str, records: list[dict[str, Any]]) -> int:
     """Append records to monthly JSONL backup files. Returns count written."""
     if not records:
@@ -361,12 +389,12 @@ def _compute_daily_runtime_summary(date_str: str) -> dict[str, Any] | None:
         )
     if not rows:
         return None
-    count = len(rows)
-    total_ms = sum(float(r.runtime_ms or 0) for r in rows)
-    error_count = sum(1 for r in rows if int(r.status_code or 0) >= 400)
+    count = sum(_runtime_row_event_count(r) for r in rows)
+    total_ms = sum(_runtime_row_total_ms(r) for r in rows)
+    error_count = sum(_runtime_row_event_count(r) for r in rows if int(r.status_code or 0) >= 400)
     ep_counts: dict[str, int] = defaultdict(int)
     for r in rows:
-        ep_counts[r.endpoint] += 1
+        ep_counts[r.endpoint] += _runtime_row_event_count(r)
     top = sorted(ep_counts.items(), key=lambda x: x[1], reverse=True)[:10]
     return {
         "date": date_str,

--- a/api/app/services/runtime_service.py
+++ b/api/app/services/runtime_service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import time
 import base64
 import hashlib
@@ -808,6 +807,37 @@ def live_change_token(force_refresh: bool = False) -> dict[str, Any]:
     return dict(payload)
 
 
+def _event_count_weight(event: RuntimeEvent) -> int:
+    metadata = event.metadata if isinstance(event.metadata, dict) else {}
+    raw_count = metadata.get("event_count") or metadata.get("sample_count") or 1
+    try:
+        return max(1, int(raw_count))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _event_total_runtime_ms(event: RuntimeEvent) -> float:
+    metadata = event.metadata if isinstance(event.metadata, dict) else {}
+    raw_total = metadata.get("total_runtime_ms")
+    if raw_total is not None:
+        try:
+            return max(0.0, float(raw_total))
+        except (TypeError, ValueError):
+            pass
+    return float(event.runtime_ms or 0.0) * _event_count_weight(event)
+
+
+def _event_total_runtime_cost(event: RuntimeEvent) -> float:
+    metadata = event.metadata if isinstance(event.metadata, dict) else {}
+    raw_total = metadata.get("total_runtime_cost_estimate")
+    if raw_total is not None:
+        try:
+            return max(0.0, float(raw_total))
+        except (TypeError, ValueError):
+            pass
+    return float(event.runtime_cost_estimate or 0.0) * _event_count_weight(event)
+
+
 def summarize_by_idea(
     seconds: int = 3600,
     event_limit: int = 2000,
@@ -828,17 +858,18 @@ def summarize_by_idea(
 
     summaries: list[IdeaRuntimeSummary] = []
     for idea_id, events in grouped.items():
-        total_runtime = round(sum(e.runtime_ms for e in events), 4)
-        total_cost = round(sum(e.runtime_cost_estimate for e in events), 8)
+        event_count = sum(_event_count_weight(e) for e in events)
+        total_runtime = round(sum(_event_total_runtime_ms(e) for e in events), 4)
+        total_cost = round(sum(_event_total_runtime_cost(e) for e in events), 8)
         by_source: dict[str, int] = {}
         for event in events:
-            by_source[event.source] = by_source.get(event.source, 0) + 1
+            by_source[event.source] = by_source.get(event.source, 0) + _event_count_weight(event)
         summaries.append(
             IdeaRuntimeSummary(
                 idea_id=idea_id,
-                event_count=len(events),
+                event_count=event_count,
                 total_runtime_ms=total_runtime,
-                average_runtime_ms=round(total_runtime / len(events), 4),
+                average_runtime_ms=round(total_runtime / event_count, 4) if event_count else 0.0,
                 runtime_cost_estimate=total_cost,
                 by_source=by_source,
             )
@@ -1590,33 +1621,36 @@ def summarize_by_endpoint(
         paid_tool_failure_count = 0
         paid_tool_runtime_ms = 0.0
         paid_tool_runtime_cost = 0.0
+        event_count = 0
 
         for event in events:
-            by_source[event.source] = by_source.get(event.source, 0) + 1
+            weight = _event_count_weight(event)
+            event_count += weight
+            by_source[event.source] = by_source.get(event.source, 0) + weight
             status_key = str(event.status_code)
-            status_counts[status_key] = status_counts.get(status_key, 0) + 1
+            status_counts[status_key] = status_counts.get(status_key, 0) + weight
             idea_key = str(event.idea_id or "unmapped")
-            idea_counts[idea_key] = idea_counts.get(idea_key, 0) + 1
+            idea_counts[idea_key] = idea_counts.get(idea_key, 0) + weight
 
             metadata = event.metadata if isinstance(event.metadata, dict) else {}
             if bool(metadata.get("is_paid_provider")):
-                paid_tool_event_count += 1
-                paid_tool_runtime_ms += float(event.runtime_ms or 0.0)
+                paid_tool_event_count += weight
+                paid_tool_runtime_ms += _event_total_runtime_ms(event)
                 raw_runtime_cost = metadata.get("runtime_cost_usd")
                 if raw_runtime_cost is not None:
                     try:
-                        paid_tool_runtime_cost += float(raw_runtime_cost)
+                        paid_tool_runtime_cost += float(raw_runtime_cost) * weight
                     except (TypeError, ValueError):
-                        paid_tool_runtime_cost += float(event.runtime_cost_estimate)
+                        paid_tool_runtime_cost += _event_total_runtime_cost(event)
                 else:
-                    paid_tool_runtime_cost += float(event.runtime_cost_estimate)
+                    paid_tool_runtime_cost += _event_total_runtime_cost(event)
                 if event.status_code >= 400:
-                    paid_tool_failure_count += 1
+                    paid_tool_failure_count += weight
 
         primary_idea_id = max(idea_counts.items(), key=lambda item: item[1])[0]
-        total_runtime = round(sum(e.runtime_ms for e in events), 4)
-        total_cost = round(sum(e.runtime_cost_estimate for e in events), 8)
-        paid_tool_ratio = float(paid_tool_event_count) / float(len(events)) if events else 0.0
+        total_runtime = round(sum(_event_total_runtime_ms(e) for e in events), 4)
+        total_cost = round(sum(_event_total_runtime_cost(e) for e in events), 8)
+        paid_tool_ratio = float(paid_tool_event_count) / float(event_count) if event_count else 0.0
         paid_tool_average_runtime_ms = (
             round((paid_tool_runtime_ms / paid_tool_event_count), 4) if paid_tool_event_count else 0.0
         )
@@ -1626,9 +1660,9 @@ def summarize_by_endpoint(
                 methods=methods,
                 idea_id=primary_idea_id,
                 origin_idea_id=resolve_origin_idea_id(primary_idea_id),
-                event_count=len(events),
+                event_count=event_count,
                 total_runtime_ms=total_runtime,
-                average_runtime_ms=round(total_runtime / len(events), 4),
+                average_runtime_ms=round(total_runtime / event_count, 4) if event_count else 0.0,
                 runtime_cost_estimate=total_cost,
                 paid_tool_event_count=paid_tool_event_count,
                 paid_tool_failure_count=paid_tool_failure_count,

--- a/api/config/api.json
+++ b/api/config/api.json
@@ -224,7 +224,9 @@
     "tool_success_streak_target": 3,
     "endpoint_cache_ttl_seconds": 120.0,
     "endpoint_cache_max_workers": 4,
-    "telemetry_enabled": true
+    "telemetry_enabled": true,
+    "aggregate_noisy_routes": true,
+    "aggregate_bucket_seconds": 60.0
   },
 
   "api": {

--- a/api/tests/test_runtime_mode_and_events.py
+++ b/api/tests/test_runtime_mode_and_events.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import pytest
+from datetime import datetime, timezone
 
-from app.models.runtime import RuntimeEventCreate
+from app.models.runtime import RuntimeEvent, RuntimeEventCreate
+from app.services import runtime_service
 from app.services import idea_service
 from app.services.runtime import cache as runtime_cache
 from app.services.runtime import events as runtime_events
@@ -49,6 +50,74 @@ def test_record_event_uses_normalized_endpoint_value(monkeypatch):
     assert event.raw_endpoint == "/api/ideas/demo-123"
     assert event.metadata["normalized_from"] == "/api/ideas/demo-123"
     assert store["events"], "record_event should persist the event payload"
+
+
+def test_noisy_activity_runtime_events_flush_as_bucket_summary(monkeypatch):
+    from app import main as api_main
+
+    api_main._RUNTIME_AGGREGATE_BUCKETS.clear()
+    monkeypatch.setattr(api_main, "_runtime_aggregate_bucket_seconds", lambda: 60)
+    monkeypatch.setattr(api_main, "_runtime_aggregate_enabled", lambda: True)
+
+    first = RuntimeEventCreate(
+        source="api",
+        endpoint="/api/agent/tasks/{task_id}/activity",
+        raw_endpoint="/api/agent/tasks/task-a/activity",
+        method="POST",
+        status_code=201,
+        runtime_ms=10.0,
+        metadata={"req_id": "req-a"},
+    )
+    second = first.model_copy(update={"runtime_ms": 20.0})
+
+    assert api_main._record_or_aggregate_runtime_event(first, now_ts=60.0) == []
+    assert api_main._record_or_aggregate_runtime_event(second, now_ts=65.0) == []
+
+    flushed = api_main._flush_due_runtime_aggregates(now_ts=120.0)
+    api_main._RUNTIME_AGGREGATE_BUCKETS.clear()
+
+    assert len(flushed) == 1
+    summary = flushed[0]
+    assert summary.endpoint == "/api/agent/tasks/{task_id}/activity"
+    assert summary.runtime_ms == 15.0
+    assert summary.metadata["tracking_kind"] == "api_route_request_aggregate"
+    assert summary.metadata["event_count"] == 2
+    assert summary.metadata["total_runtime_ms"] == 30.0
+
+
+def test_endpoint_summary_weights_aggregate_runtime_events(monkeypatch):
+    now = datetime.now(timezone.utc)
+    rows = [
+        RuntimeEvent(
+            id="rt_aggregate",
+            source="api",
+            endpoint="/api/agent/tasks/{task_id}/activity",
+            raw_endpoint="/api/agent/tasks/{task_id}/activity",
+            method="POST",
+            status_code=201,
+            runtime_ms=15.0,
+            idea_id="oss-interface-alignment",
+            origin_idea_id="oss-interface-alignment",
+            metadata={
+                "tracking_kind": "api_route_request_aggregate",
+                "event_count": 4,
+                "total_runtime_ms": 60.0,
+            },
+            runtime_cost_estimate=0.01,
+            recorded_at=now,
+        )
+    ]
+
+    monkeypatch.setattr(runtime_service, "list_events", lambda **_: rows)
+    monkeypatch.setattr(runtime_service, "resolve_origin_idea_id", lambda idea_id: idea_id)
+
+    summary = runtime_service.summarize_by_endpoint(seconds=3600)[0]
+
+    assert summary.event_count == 4
+    assert summary.total_runtime_ms == 60.0
+    assert summary.average_runtime_ms == 15.0
+    assert summary.by_source == {"api": 4}
+    assert summary.status_counts == {"201": 4}
 
 
 def test_runtime_route_registry_covers_live_idea_realization_family():

--- a/docs/system_audit/commit_evidence_2026-07-02_runtime_event_aggregation.json
+++ b/docs/system_audit/commit_evidence_2026-07-02_runtime_event_aggregation.json
@@ -1,0 +1,147 @@
+{
+  "date": "2026-07-02",
+  "thread_branch": "codex/vps-disk-cleanup-20260702",
+  "commit_scope": "runtime telemetry flood cleanup and aggregation",
+  "change_intent": "runtime_fix",
+  "files_owned": [
+    "api/app/main.py",
+    "api/app/services/runtime_service.py",
+    "api/app/services/data_retention_service.py",
+    "api/app/config_loader.py",
+    "api/config/api.json",
+    "api/tests/test_runtime_mode_and_events.py",
+    "docs/system_audit/commit_evidence_2026-07-02_runtime_event_aggregation.json"
+  ],
+  "change_files": [
+    "api/app/main.py",
+    "api/app/services/runtime_service.py",
+    "api/app/services/data_retention_service.py",
+    "api/app/config_loader.py",
+    "api/config/api.json",
+    "api/tests/test_runtime_mode_and_events.py",
+    "docs/system_audit/commit_evidence_2026-07-02_runtime_event_aggregation.json"
+  ],
+  "change_summary": [
+    "Cleaned Hostinger VPS disk pressure by pruning BuildKit/containerd cache, old dump backups, and stale runtime_events telemetry.",
+    "Aggregates POST /api/agent/tasks/{task_id}/activity request telemetry into 60-second in-memory buckets before durable runtime_events writes.",
+    "Preserves represented event_count and total_runtime_ms in aggregate metadata, and weights runtime endpoint/idea/daily retention summaries by those counts."
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      {
+        "command": "make prompt-guide",
+        "result": "passed after attaching detached worktree to codex/vps-disk-cleanup-20260702"
+      },
+      {
+        "command": "make wellness",
+        "result": "passed; deploy aligned and witness trace within budget"
+      },
+      {
+        "command": "cd api && python3 -m ruff check app/main.py app/services/runtime_service.py app/services/data_retention_service.py tests/test_runtime_mode_and_events.py",
+        "result": "All checks passed"
+      },
+      {
+        "command": "cd api && python3 -m pytest -q tests/test_runtime_mode_and_events.py",
+        "result": "7 passed"
+      },
+      {
+        "command": "python3 -m json.tool api/config/api.json >/dev/null",
+        "result": "passed"
+      },
+      {
+        "command": "cd api && python3 -m pytest -q tests/test_runtime_api.py tests/test_request_outcomes_middleware.py",
+        "result": "13 passed"
+      },
+      {
+        "command": "cd form/form-kernel-rust && cargo build --release --quiet",
+        "result": "passed; restored local form-kernel-rust binary required by full API vitality tests"
+      },
+      {
+        "command": "cd api && python3 -m pytest -q tests/test_portfolio_governance.py::test_vitality_returns_six_signals tests/test_flow_vitality.py::test_vitality_and_meeting_flow",
+        "result": "2 passed"
+      },
+      {
+        "command": "THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh",
+        "result": "passed"
+      },
+      {
+        "command": "python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main",
+        "result": "passed; ready_for_push=True"
+      }
+    ],
+    "notes": "api/.venv was absent in this worktree, so focused checks were run through host python3 where pytest 9.0.2 and ruff 0.15.8 were available."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "notes": "Pending push/PR checks."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "notes": "Pre-change production health passed; deployment of aggregation patch pending."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "Production should stop writing one runtime_events row per task activity ping; the noisy endpoint should produce at most one aggregate row per minute/status/source while preserving represented event_count.",
+    "public_endpoints": [
+      "https://api.coherencycoin.com/api/health",
+      "https://coherencycoin.com/api/health-proxy",
+      "https://api.coherencycoin.com/api/runtime/endpoints/summary"
+    ],
+    "test_flows": [
+      "Call task activity route repeatedly and verify runtime_events records aggregate metadata rather than one durable row per call.",
+      "Read runtime endpoint summary and verify aggregate rows count by represented event_count."
+    ]
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "CI and deploy validation are pending."
+  },
+  "idea_ids": [
+    "agent-pipeline",
+    "knowledge-and-resonance"
+  ],
+  "spec_ids": [
+    "runtime-telemetry-db-precedence",
+    "grounded-cost-value-measurement"
+  ],
+  "task_ids": [
+    "vps-disk-cleanup-20260702",
+    "runtime-event-aggregation-20260702"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "seeker71",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "production-operator"
+      ]
+    },
+    {
+      "contributor_id": "codex",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "vps-cleanup",
+        "validation"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "GPT-5"
+  },
+  "evidence_refs": [
+    "VPS before cleanup: / 193G size, 157G used, 37G available, 81% used",
+    "VPS after cleanup: / 193G size, 69G used, 125G available, 36% used",
+    "Postgres before DB cleanup: coherence database 10GB; runtime_events 10073MB and 15058565 rows",
+    "Postgres after DB cleanup: coherence database 1378MB; runtime_events 862MB and 1241157 rows",
+    "Docker cleanup: docker builder prune -af reclaimed 82.8GB; containerd fell from 95G to 19G",
+    "Backup cleanup: retained dump backups from 2026-06-18 through 2026-07-02; backup directory fell from 9.8G to 6.3G",
+    "Public health pre-deploy: /api/health and /api/health-proxy returned status=ok on deployed_sha 6e762a9f4736ffac1bc43ff48181fe8e765c5837",
+    "Form-first lookup: form-cli ask had path:native grounded:no suffic:no, so direct VPS evidence was used"
+  ],
+  "risk": "Aggregate buckets live in process memory and flush after the bucket closes on the next captured request; a hard process kill can lose at most one current noisy-route bucket. That is acceptable for request telemetry and prevents durable flood logging.",
+  "next_attention": "Move the Python bridge aggregation into the Form/runtime observation cell and add a scheduled retention/compaction routine so high-volume telemetry rolls up without manual VPS intervention."
+}


### PR DESCRIPTION
## What changed
- Cleaned Hostinger VPS disk pressure from Docker/BuildKit cache, old DB dumps, and oversized runtime telemetry.
- Added write-time aggregation for `POST /api/agent/tasks/{task_id}/activity` so it emits one aggregate runtime event per 60-second bucket/status/source instead of one durable row per activity ping.
- Weighted runtime endpoint, idea, and retention daily summaries by aggregate `event_count` so high-level usage counts survive compression.

## Root cause
`runtime_events` was storing every task activity ping as a full durable request row. That endpoint produced about 9.29M rows in 14 days and made `runtime_events` account for nearly the entire 10GB Postgres database.

## Production cleanup already done
- `/` moved from `157G used / 37G free / 81%` to `69G used / 125G free / 36%`.
- Postgres moved from `10GB` to `1378MB`.
- `runtime_events` moved from `10073MB / 15058565 rows` to `862MB / 1241157 rows`.
- BuildKit/containerd prune reclaimed `82.8GB`; old dump backups older than 14 days were removed.

## Validation
- `make prompt-guide`
- `make wellness`
- `cd api && python3 -m ruff check app/main.py app/services/runtime_service.py app/services/data_retention_service.py tests/test_runtime_mode_and_events.py`
- `cd api && python3 -m pytest -q tests/test_runtime_mode_and_events.py`
- `python3 -m json.tool api/config/api.json >/dev/null`
- `cd api && python3 -m pytest -q tests/test_runtime_api.py tests/test_request_outcomes_middleware.py`
- `cd form/form-kernel-rust && cargo build --release --quiet`
- `cd api && python3 -m pytest -q tests/test_portfolio_governance.py::test_vitality_returns_six_signals tests/test_flow_vitality.py::test_vitality_and_meeting_flow`
- `THREAD_RUNTIME_START_SERVERS=1 ./scripts/verify_worktree_local_web.sh`
- `python3 scripts/worktree_pr_guard.py --mode local --base-ref origin/main`