### PR TITLE
Bind federation transport to native Form graph

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -87,7 +87,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PORT=8000
+    PORT=8000 \
+    COHERENCE_FORM_GRAPH_STORE=/root/.coherence-network/federation-graph
 
 WORKDIR /app
 
@@ -179,7 +180,8 @@ RUN install -d -m 0700 \
       /root/.coherence-network/rag-index \
       /root/.coherence-network/rag-requests \
       /root/.coherence-network/attestation \
-      /root/.coherence-network/api-queries
+      /root/.coherence-network/api-queries \
+      /root/.coherence-network/federation-graph
 
 EXPOSE 8000
 

--- a/README.md
+++ b/README.md
@@ -221,11 +221,14 @@ traps that diverge across kernels (chief among them: `and`/`or` are binary, neve
 
 Federation graph floor, re-witnessed 2026-07-22: native `form-cli` now composes
 a federation message and directed edge as content-addressed Form cells and
-returns the axiom-5 `node` acknowledgement. The local macOS standalone receipt
-is observed; public carrier binding and c-bootstrap Windows/Android receipts
-remain pending. The next movement is not another transport schema: bind the
-existing byte carrier to this native cell on both ends, leaving transport to
-carry bytes and Form to decide graph identity and acknowledgement.
+returns the axiom-5 `node` acknowledgement. The API membrane now carries encoded
+bytes into that cell, stores only its SQL projection, and asks native Form for
+incoming and broadcast adjacency before reading projections. Local macOS
+offer, persistence, `has`, incoming, outgoing, and broadcast receipts are
+observed; the public deployment and c-bootstrap Windows/Android receipts remain
+pending. The north star moved from binding to federation: let independently
+running devices exchange and re-witness these same native graph nodes without
+making one host's database the graph authority.
 
 Four-kernel validation is the Form/BML proof floor. `form/validate.sh` always
 runs Go, Rust, and TypeScript; bands listed in `form/fourth-arm-bands.txt` also

--- a/api/app/routers/federation.py
+++ b/api/app/routers/federation.py
@@ -7,7 +7,6 @@ import logging
 import time
 from datetime import datetime, timezone
 from typing import Any
-from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
@@ -57,6 +56,7 @@ from app.services import federation_substrate_service
 from app.services import federation_value_flow_service
 from app.services.federation_value_flow_service import SignatureRejection
 from app.services import openclaw_node_bridge_service
+from app.services import native_federation_graph_service
 from app.services import unified_db as _udb
 
 router = APIRouter()
@@ -746,7 +746,7 @@ class NodeMessage(BaseModel):
 
 
 def _store_message(msg_dict: dict[str, Any]) -> dict[str, Any]:
-    """Persist a message to PostgreSQL. Falls back to fire-and-forget on DB error."""
+    """Persist the native graph's message projection to PostgreSQL."""
     try:
         from app.services.federation_service import NodeMessageRecord
         from app.services import unified_db as _udb
@@ -764,8 +764,10 @@ def _store_message(msg_dict: dict[str, Any]) -> dict[str, Any]:
             )
             session.add(record)
             session.commit()
+    except RuntimeError:
+        raise
     except Exception as e:
-        _msg_log.warning("Failed to persist message %s: %s", msg_dict.get("id"), e)
+        raise RuntimeError(f"failed to persist message projection {msg_dict.get('id')}: {e}") from e
     return msg_dict
 
 
@@ -790,19 +792,15 @@ def _query_messages(
     limit: int = 50,
     include_self: bool = False,
 ) -> list[dict[str, Any]]:
-    """Query messages from PostgreSQL for a specific node."""
+    """Traverse Form's graph, then load matching PostgreSQL projections."""
     try:
         from app.services.federation_service import NodeMessageRecord
         from app.services import unified_db as _udb
-        from sqlalchemy import or_
-
+        ids = native_federation_graph_service.visible_ids(node_id)
+        if not ids:
+            return []
         with _udb.session() as session:
-            q = session.query(NodeMessageRecord).filter(
-                or_(
-                    NodeMessageRecord.to_node == node_id,
-                    NodeMessageRecord.to_node.is_(None),  # broadcasts
-                )
-            )
+            q = session.query(NodeMessageRecord).filter(NodeMessageRecord.id.in_(ids))
             if not include_self:
                 q = q.filter(NodeMessageRecord.from_node != node_id)
             if since:
@@ -816,6 +814,8 @@ def _query_messages(
                     continue
                 results.append(row)
             return results
+    except RuntimeError:
+        raise
     except Exception as e:
         _msg_log.warning("Failed to query messages for %s: %s", node_id, e)
         return []
@@ -823,12 +823,16 @@ def _query_messages(
 
 def _get_message(message_id: str) -> dict[str, Any] | None:
     try:
+        if not native_federation_graph_service.has(message_id):
+            return None
         from app.services.federation_service import NodeMessageRecord
         from app.services import unified_db as _udb
 
         with _udb.session() as session:
             rec = session.query(NodeMessageRecord).filter(NodeMessageRecord.id == message_id).first()
             return _message_record_to_dict(rec) if rec else None
+    except RuntimeError:
+        raise
     except Exception as e:
         _msg_log.warning("Failed to get message %s: %s", message_id, e)
         return None
@@ -856,15 +860,24 @@ def _mark_messages_read(node_id: str, msg_ids: set[str]) -> None:
 @router.post("/federation/nodes/{node_id}/messages", status_code=201, summary="Send a message from this node. Set to_node=null to broadcast")
 async def send_message(node_id: str, body: NodeMessage):
     """Send a message from this node. Set to_node=null to broadcast."""
+    timestamp = datetime.now(timezone.utc).isoformat()
+    try:
+        graph = native_federation_graph_service.offer(
+            from_node=node_id, to_node=body.to_node, kind=body.type,
+            text=body.text, payload=body.payload, timestamp=timestamp,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     msg = {
-        "id": f"msg_{uuid4().hex[:12]}",
+        "id": graph["message_id"],
         "from_node": node_id,
         "to_node": body.to_node,
         "type": body.type,
         "payload": body.payload,
         "text": body.text,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": timestamp,
         "read_by": [],
+        "graph_ack": graph,
     }
     _store_message(msg)
     _msg_log.info("MSG %s → %s: [%s] %s", node_id, body.to_node or "ALL", body.type, body.text[:100])
@@ -887,13 +900,16 @@ async def get_messages(
     ),
 ):
     """Get messages for this node; observation is consuming only when requested."""
-    results = _query_messages(
-        node_id,
-        since=since,
-        unread_only=unread_only,
-        limit=limit,
-        include_self=include_self,
-    )
+    try:
+        results = _query_messages(
+            node_id,
+            since=since,
+            unread_only=unread_only,
+            limit=limit,
+            include_self=include_self,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
     if mark_read:
         msg_ids = {m["id"] for m in results}
@@ -905,7 +921,10 @@ async def get_messages(
 @router.get("/federation/messages/{message_id}", summary="Read a federation node message by id")
 async def get_message_by_id(message_id: str):
     """Read a federation node message by id."""
-    msg = _get_message(message_id)
+    try:
+        msg = _get_message(message_id)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     if msg is None:
         raise HTTPException(status_code=404, detail="Message not found")
     return msg
@@ -914,15 +933,24 @@ async def get_message_by_id(message_id: str):
 @router.post("/federation/broadcast", status_code=201, summary="Broadcast a message to all nodes")
 async def broadcast_message(body: NodeMessage):
     """Broadcast a message to all nodes."""
+    timestamp = datetime.now(timezone.utc).isoformat()
+    try:
+        graph = native_federation_graph_service.offer(
+            from_node=body.from_node, to_node=None, kind=body.type,
+            text=body.text, payload=body.payload, timestamp=timestamp,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     msg = {
-        "id": f"msg_{uuid4().hex[:12]}",
+        "id": graph["message_id"],
         "from_node": body.from_node,
         "to_node": None,
         "type": body.type,
         "payload": body.payload,
         "text": body.text,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "timestamp": timestamp,
         "read_by": [],
+        "graph_ack": graph,
     }
     _store_message(msg)
     _msg_log.info("BROADCAST from %s: [%s] %s", body.from_node, body.type, body.text[:100])

--- a/api/app/services/native_federation_graph_service.py
+++ b/api/app/services/native_federation_graph_service.py
@@ -1,0 +1,89 @@
+"""Thin byte carrier for the native Form federation graph.
+
+Python owns process transport and the SQL projection. Form owns message
+identity, edge composition, durable graph indexes, and traversal.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_IMAGE_ROOT = Path("/app")
+_LOCK = threading.Lock()
+_ID = re.compile(r"^msg_[0-9a-f]{64}$")
+
+
+def _binary() -> Path:
+    for path in (_IMAGE_ROOT / "form" / "form-cli", _REPO_ROOT / "form" / "form-cli"):
+        if path.is_file() and os.access(path, os.X_OK):
+            return path
+    raise RuntimeError("native Form federation carrier is unavailable")
+
+
+def store_path() -> Path:
+    raw = os.environ.get("COHERENCE_FORM_GRAPH_STORE")
+    path = Path(raw).expanduser() if raw else Path(tempfile.gettempdir()) / "coherence-federation-graph"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _token(value: str) -> str:
+    return base64.urlsafe_b64encode(value.encode()).decode().rstrip("=") or "_"
+
+
+def _run(command: str) -> str:
+    with _LOCK:
+        proc = subprocess.run(
+            [str(_binary())], input=f"fsh {command}\n", text=True,
+            capture_output=True, check=False, timeout=10,
+        )
+    if proc.returncode != 0:
+        raise RuntimeError(f"native Form federation command failed: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def offer(*, from_node: str, to_node: str | None, kind: str, text: str,
+          payload: dict[str, Any], timestamp: str) -> dict[str, str]:
+    # Variable-width user bytes are encoded only for the space-delimited carrier;
+    # Form still receives and hashes every byte and makes every graph decision.
+    command = " ".join((
+        "federation-offer", str(store_path()), _token(from_node),
+        "-" if to_node is None else _token(to_node), _token(kind), _token(text),
+        _token(json.dumps(payload, sort_keys=True, separators=(",", ":"))), _token(timestamp),
+    ))
+    fields = dict(part.split("=", 1) for part in _run(command).split("|") if "=" in part)
+    message_id = fields.get("message_id", "")
+    if fields.get("ack") != "node" or not _ID.fullmatch(message_id):
+        raise RuntimeError(f"native Form federation offer was not witnessed: {fields}")
+    for required in ("persisted", "traversable", "observed"):
+        if fields.get(required) != "1":
+            raise RuntimeError(f"native Form federation receipt lacks {required}=1")
+    return fields
+
+
+def _ids(command: str) -> list[str]:
+    values = [line for line in _run(command).splitlines() if line]
+    if any(not _ID.fullmatch(value) for value in values):
+        raise RuntimeError("native Form federation traversal returned an invalid node id")
+    return values
+
+
+def visible_ids(node_id: str) -> list[str]:
+    store = str(store_path())
+    direct = _ids(f"federation-incoming {store} {_token(node_id)}")
+    broadcasts = _ids(f"federation-broadcasts {store}")
+    return list(dict.fromkeys(direct + broadcasts))
+
+
+def has(message_id: str) -> bool:
+    if not _ID.fullmatch(message_id):
+        return False
+    return _run(f"federation-has {store_path()} {message_id}") == "1"

--- a/api/tests/test_federation_message_readback.py
+++ b/api/tests/test_federation_message_readback.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from uuid import uuid4
+import re
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -39,6 +40,9 @@ async def test_federation_message_can_be_read_back_by_id() -> None:
         )
         assert sent.status_code == 201, sent.text
         msg_id = sent.json()["id"]
+        assert re.fullmatch(r"msg_[0-9a-f]{64}", msg_id)
+        assert sent.json()["graph_ack"]["persisted"] == "1"
+        assert sent.json()["graph_ack"]["traversable"] == "1"
 
         fetched = await client.get(f"/api/federation/messages/{msg_id}")
         assert fetched.status_code == 200, fetched.text

--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -76,7 +76,7 @@ bootstrap_and_verify_local_grounding() {
       sh -lc '
         set -eu
         cd /app
-        for state_dir in rag-index rag-requests attestation api-queries; do
+        for state_dir in rag-index rag-requests attestation api-queries federation-graph; do
           test -d "/root/.coherence-network/$state_dir"
           probe="/root/.coherence-network/$state_dir/.deploy-write-probe.$$"
           : > "$probe"
@@ -519,7 +519,8 @@ install -d -m 0700 \
   "$GROUNDING_STATE_ROOT/rag-index" \
   "$GROUNDING_STATE_ROOT/rag-requests" \
   "$GROUNDING_STATE_ROOT/attestation" \
-  "$GROUNDING_STATE_ROOT/api-queries"
+  "$GROUNDING_STATE_ROOT/api-queries" \
+  "$GROUNDING_STATE_ROOT/federation-graph"
 # The compose service also bind-mounts GROUNDING_TARGET_ROOT read-only. That
 # parent mount hides the image's pre-created directories, so runc can only
 # attach the four narrower writable binds when their target directories exist
@@ -528,7 +529,8 @@ install -d -m 0700 \
   "$GROUNDING_TARGET_ROOT/rag-index" \
   "$GROUNDING_TARGET_ROOT/rag-requests" \
   "$GROUNDING_TARGET_ROOT/attestation" \
-  "$GROUNDING_TARGET_ROOT/api-queries"
+  "$GROUNDING_TARGET_ROOT/api-queries" \
+  "$GROUNDING_TARGET_ROOT/federation-graph"
 chown -R root:root "$GROUNDING_STATE_ROOT"
 
 # The image itself carries immutable parent/form source labels.  Compose must
@@ -649,6 +651,7 @@ mounts = [
     "/root/.coherence-network/runtime/rag-requests:/root/.coherence-network/rag-requests:rw",
     "/root/.coherence-network/runtime/attestation:/root/.coherence-network/attestation:rw",
     "/root/.coherence-network/runtime/api-queries:/root/.coherence-network/api-queries:rw",
+    "/root/.coherence-network/runtime/federation-graph:/root/.coherence-network/federation-graph:rw",
 ]
 targets = tuple(item.split(":", 2)[1] for item in mounts)
 if volumes_index is None:
@@ -697,13 +700,14 @@ expected = {
     "/root/.coherence-network/rag-requests",
     "/root/.coherence-network/attestation",
     "/root/.coherence-network/api-queries",
+    "/root/.coherence-network/federation-graph",
 }
 missing = sorted(target for target in expected if target not in volumes)
 readonly = sorted(target for target in expected if volumes.get(target, {}).get("read_only"))
 if missing or readonly:
     raise SystemExit(f"grounding state bind contract failed missing={missing} readonly={readonly}")
 '
-log "compose API grounding state: four narrow writable binds verified"
+log "compose API grounding state: five narrow writable binds verified"
 # Select the additional services whose source changed. The deployment body
 # always adds API to this set below because the observer requires an image
 # whose immutable revision label equals TARGET_SHA; web and pulse remain

--- a/scripts/test_hostinger_deploy_form_paths.sh
+++ b/scripts/test_hostinger_deploy_form_paths.sh
@@ -653,7 +653,7 @@ fi
 grep -Fq '/root/.coherence-network/rag-index' "$ROOT_DIR/Dockerfile.api" \
   || fail "API image does not pre-create the writable RAG index mountpoint"
 
-for state_dir in rag-index rag-requests attestation api-queries; do
+for state_dir in rag-index rag-requests attestation api-queries federation-graph; do
   grep -Fq "/root/.coherence-network/$state_dir" "$ROOT_DIR/Dockerfile.api" \
     || fail "API image does not pre-create grounding mountpoint: $state_dir"
   grep -Fq 'GROUNDING_TARGET_ROOT="/root/.coherence-network"' "$DEPLOY_SCRIPT" \


### PR DESCRIPTION
The HTTP membrane now carries encoded bytes into the pinned native Form carrier. Form owns content identity, durable message/edge indexes, incoming/broadcast traversal, and presence checks; PostgreSQL is the projection. Adds a narrow production graph-state mount and bumps coherence-kernel to PR #361.\n\nWitnesses: 12 targeted API tests; deploy-path band; native graph 11111112; fsh graph 1111; form-cli 524287; freq-check 65535, all four-way.