### PR TITLE
Witness grounded ask failures during deploy

### DIFF
--- a/deploy/hostinger/auto-deploy.sh
+++ b/deploy/hostinger/auto-deploy.sh
@@ -88,7 +88,12 @@ bootstrap_and_verify_local_grounding() {
         out="$(mktemp)"
         err="$(mktemp)"
         trap '\''rm -f "$out" "$err"'\'' EXIT
-        bin/form-cli ask "observed auto learning reversible experiment champion challenger" >"$out" 2>"$err"
+        if ! bin/form-cli ask "observed auto learning reversible experiment champion challenger" >"$out" 2>"$err"; then
+          cat "$err" >&2
+          cat "$out"
+          echo "local native grounded ask exited non-zero" >&2
+          exit 1
+        fi
         grep -Eq "^trust  path:native  grounded:yes .*suffic:yes" "$err"
         grep -Eq "^grounded:@[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$" "$out"
         cat "$err"


### PR DESCRIPTION
Preserve and print the native grounded-ask stdout/stderr when the post-re-ground witness exits non-zero, so the remaining deployment failure becomes actionable rather than silent.