### PR TITLE
tend: app.hati.earth serves the ledger, and the witness reads the kernel it has

### DIFF
--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -45,7 +45,7 @@
 | [api/app/services/INDEX.md](api/app/services/INDEX.md) | 253 | API services — business logic and graph operations |
 | [api/app/models/INDEX.md](api/app/models/INDEX.md) | 58 | API models — Pydantic + ORM shapes |
 | [api/tests/INDEX.md](api/tests/INDEX.md) | 245 | API tests — flow-centric |
-| [web/lib/INDEX.md](web/lib/INDEX.md) | 36 | Web library — shared client/server helpers |
+| [web/lib/INDEX.md](web/lib/INDEX.md) | 37 | Web library — shared client/server helpers |
 | [web/components/INDEX.md](web/components/INDEX.md) | 53 | Web components — shared React surfaces |
 | [web/app/INDEX.md](web/app/INDEX.md) | 167 | Web routes — every visible page in the app |
 | [scripts/INDEX.md](scripts/INDEX.md) | 405 | Scripts — operational tools, generators, syncers |

--- a/pulse/pulse_app/organs.py
+++ b/pulse/pulse_app/organs.py
@@ -370,7 +370,13 @@ def extract_db_contention(r: "UpstreamResult") -> OrganVerdict:
 
 
 def extract_substrate_form(r: "UpstreamResult") -> OrganVerdict:
-    """Native Form runtime authority after retirement of the Python evaluator."""
+    """The c-bootstrapped fkwu runtime is the container's execution authority.
+
+    ``/api/utils/kernel_status`` names that carrier: ``active`` reads ``fkwu``
+    when the c-bootstrap binary is serving, and ``unavailable`` when it cannot.
+    Sibling walkers are differential proof rather than serving carriers, so any
+    other authority — and any missing binary — is silence.
+    """
     if r.status == 0:
         return OrganVerdict(False, r.error or "transport failure")
     if r.status >= 400:
@@ -380,12 +386,12 @@ def extract_substrate_form(r: "UpstreamResult") -> OrganVerdict:
     body = _require_body(r)
     if body is None:
         return OrganVerdict(False, "empty response body")
-    if body.get("active") != "native-kernel":
-        return OrganVerdict(False, f"unexpected active runtime={body.get('active')!r}")
+    if body.get("active") != "fkwu":
+        return OrganVerdict(False, f"active runtime={body.get('active')!r}")
     if body.get("available") is not True:
-        return OrganVerdict(False, "native Form runtime unavailable")
-    if body.get("python_authority") is not False:
-        return OrganVerdict(False, "Python authority unexpectedly active")
+        return OrganVerdict(False, "c-bootstrapped fkwu runtime unavailable")
+    if body.get("binary_available") is not True:
+        return OrganVerdict(False, "fkwu binary absent from the container")
     return OrganVerdict(True)
 
 
@@ -554,8 +560,8 @@ ORGANS: list[Organ] = [
         name="substrate_form",
         label="Substrate Form",
         description=(
-            "GET /api/utils/kernel_status — the native Form runtime authority. "
-            "The retired Python evaluator is no longer treated as a living organ."
+            "GET /api/utils/kernel_status — the c-bootstrapped fkwu runtime "
+            "carrying execution for this container."
         ),
         upstream=UPSTREAM_API_SUBSTRATE_FORM,
         extractor=extract_substrate_form,

--- a/pulse/pulse_app/organs.py
+++ b/pulse/pulse_app/organs.py
@@ -88,6 +88,12 @@ UPSTREAM_API_SUBSTRATE_PAGE = "api_substrate_page"   # {API_BASE}/api/substrate/
 UPSTREAM_API_SUBSTRATE_FORM = "api_substrate_form"   # POST {API_BASE}/api/substrate/form
 UPSTREAM_API_SUBSTRATE_INGEST = "api_substrate_ingest"  # POST {API_BASE}/api/substrate/ingest
 
+# The ``active`` values that name a native Form carrier serving execution.
+# The FastAPI bridge reports the c-bootstrap binary as "fkwu"; the BML front
+# door (deploy/kernel-router/production-routes.fk) reports "native-kernel".
+# Either door breathing is the body's execution authority held natively.
+NATIVE_KERNEL_AUTHORITIES = frozenset({"fkwu", "native-kernel"})
+
 
 # Error boundary marker rendered by the Next.js root error.tsx
 # (web/app/error.tsx). The error page wraps its main element in
@@ -370,12 +376,16 @@ def extract_db_contention(r: "UpstreamResult") -> OrganVerdict:
 
 
 def extract_substrate_form(r: "UpstreamResult") -> OrganVerdict:
-    """The c-bootstrapped fkwu runtime is the container's execution authority.
+    """A native Form carrier is serving execution, and Python is not.
 
-    ``/api/utils/kernel_status`` names that carrier: ``active`` reads ``fkwu``
-    when the c-bootstrap binary is serving, and ``unavailable`` when it cannot.
-    Sibling walkers are differential proof rather than serving carriers, so any
-    other authority — and any missing binary — is silence.
+    Two doors answer ``/api/utils/kernel_status`` and both name a native
+    carrier. The FastAPI bridge reports the c-bootstrap binary as ``fkwu``; the
+    BML front door (``deploy/kernel-router/production-routes.fk``) reports
+    ``native-kernel``. The organ asserts the property both express rather than
+    one door's spelling, so whichever is deployed reads as breathing.
+
+    The teeth stay: ``unavailable`` — the honest darkness the endpoint reports —
+    a missing binary, and any Python authority all register as real silence.
     """
     if r.status == 0:
         return OrganVerdict(False, r.error or "transport failure")
@@ -386,12 +396,16 @@ def extract_substrate_form(r: "UpstreamResult") -> OrganVerdict:
     body = _require_body(r)
     if body is None:
         return OrganVerdict(False, "empty response body")
-    if body.get("active") != "fkwu":
+    if body.get("active") not in NATIVE_KERNEL_AUTHORITIES:
         return OrganVerdict(False, f"active runtime={body.get('active')!r}")
     if body.get("available") is not True:
-        return OrganVerdict(False, "c-bootstrapped fkwu runtime unavailable")
+        return OrganVerdict(False, "native Form runtime unavailable")
     if body.get("binary_available") is not True:
-        return OrganVerdict(False, "fkwu binary absent from the container")
+        return OrganVerdict(False, "kernel binary absent from the container")
+    # Only the BML door carries this field; an explicit True is the one answer
+    # that names Python as the authority, and that is silence.
+    if body.get("python_authority") is True:
+        return OrganVerdict(False, "Python authority unexpectedly active")
     return OrganVerdict(True)
 
 

--- a/pulse/tests/test_probe.py
+++ b/pulse/tests/test_probe.py
@@ -449,6 +449,40 @@ async def test_substrate_form_breathes_on_the_live_kernel_status_shape():
 
 
 @pytest.mark.asyncio
+async def test_substrate_form_breathes_on_the_bml_front_door_shape():
+    """The BML front door's own contract also names a native carrier.
+
+    deploy/kernel-router/production-routes.fk serves kernel_status as
+    ``native-kernel``. Both doors are honest, so both read as breathing.
+    """
+    bml_door = {
+        "active": "native-kernel",
+        "inline_available": False,
+        "binary_available": True,
+        "available": True,
+        "python_authority": False,
+    }
+    by = await _run(_handler(substrate_form_body=bml_door))
+    sample = by["substrate_form"]
+    assert sample.ok is True, sample.detail
+
+
+@pytest.mark.asyncio
+async def test_substrate_form_flags_python_authority():
+    """A native-looking carrier that hands authority to Python is silence."""
+    handed_over = {
+        "active": "native-kernel",
+        "binary_available": True,
+        "available": True,
+        "python_authority": True,
+    }
+    by = await _run(_handler(substrate_form_body=handed_over))
+    sample = by["substrate_form"]
+    assert sample.ok is False
+    assert "Python authority" in (sample.detail or "")
+
+
+@pytest.mark.asyncio
 async def test_api_flags_strained_on_recent_5xx():
     """Real-user 5xx count surfaces as strain on the api organ."""
     body = {**HEALTHY_HEALTH, "recent_outcomes": {

--- a/pulse/tests/test_probe.py
+++ b/pulse/tests/test_probe.py
@@ -82,9 +82,10 @@ BROKEN_SUBSTRATE_PAGE = {
 }
 
 HEALTHY_SUBSTRATE_FORM = {
-    "active": "native-kernel",
+    "active": "fkwu",
+    "binary_available": True,
     "available": True,
-    "python_authority": False,
+    "binary_path": "/app/form/fkwu",
 }
 
 HEALTHY_SUBSTRATE_INGEST = {
@@ -423,6 +424,28 @@ async def test_substrate_form_flags_unexpected_runtime():
     sample = by["substrate_form"]
     assert sample.ok is False
     assert "active runtime='python'" in (sample.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_substrate_form_flags_unavailable_carrier():
+    """``active: unavailable`` is the honest silence the endpoint reports."""
+    dark = {"active": "unavailable", "binary_available": False, "available": False}
+    by = await _run(_handler(substrate_form_body=dark))
+    sample = by["substrate_form"]
+    assert sample.ok is False
+    assert "active runtime='unavailable'" in (sample.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_substrate_form_breathes_on_the_live_kernel_status_shape():
+    """The shape /api/utils/kernel_status actually returns reads as breathing.
+
+    A witness that asserts a contract the body has moved past reports silence
+    where there is none, so this pins the organ to the served response.
+    """
+    by = await _run(_handler())
+    sample = by["substrate_form"]
+    assert sample.ok is True, sample.detail
 
 
 @pytest.mark.asyncio

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -13,6 +13,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { ExpertModeProvider } from "@/components/expert-mode-context";
 import { MobileBottomNav } from "@/components/mobile-bottom-nav";
 import ChromeGate from "@/components/ChromeGate";
+import { CONTAINED_SURFACE_HEADER } from "@/lib/contained-surface";
 import { MessagesProvider } from "@/components/MessagesProvider";
 import { loadPublicWebConfig } from "@/lib/app-config";
 import { DEFAULT_LOCALE, isSupportedLocale, type LocaleCode } from "@/lib/locales";
@@ -81,10 +82,14 @@ export default async function RootLayout({
   // click). On first visit before the middleware response is honored,
   // fall back to Accept-Language so the *very first render* already meets
   // the viewer in their language.
-  const headerLang = (await headers())
+  const requestHeaders = await headers();
+  const headerLang = requestHeaders
     .get("accept-language")
     ?.split(",")[0]
     ?.split("-")[0];
+  // app.hati.earth's root is rewritten to a contained app. The rewrite is
+  // invisible to the browser, so the host's knowing reaches the page here.
+  const containedByHost = Boolean(requestHeaders.get(CONTAINED_SURFACE_HEADER));
   const lang: LocaleCode = isSupportedLocale(cookieLang)
     ? cookieLang
     : isSupportedLocale(headerLang)
@@ -131,13 +136,13 @@ export default async function RootLayout({
           <RouteReadPing />
           <ThemeProvider>
             <ExpertModeProvider>
-              <ChromeGate><SiteHeader /></ChromeGate>
+              <ChromeGate contained={containedByHost}><SiteHeader /></ChromeGate>
               <LiveUpdatesController />
               <main id="main-content" className="pb-16 md:pb-0">
                 {children}
                 <RouteEditablePageContent />
               </main>
-              <ChromeGate>
+              <ChromeGate contained={containedByHost}>
                 <MobileBottomNav />
                 <SubstrateBadge />
               </ChromeGate>

--- a/web/components/ChromeGate.tsx
+++ b/web/components/ChromeGate.tsx
@@ -3,18 +3,25 @@
 // of the app into the rest of the site with no way back. The app's own header
 // lives inside the page; identity is localStorage, so it carries across
 // regardless of chrome. Backend is shared; only the surface is sealed.
+//
+// A visit to /grocery is contained by its path. A visit to app.hati.earth is
+// contained by its host, and the middleware's rewrite keeps the browser's
+// pathname at "/" — so the layout reads that case from the request header and
+// passes it in.
 "use client";
 
 import { usePathname } from "next/navigation";
 
-// Routes that render as their own contained app (no marketing-site chrome).
-const CONTAINED_PREFIXES = ["/hati-suci", "/grocery"];
+import { isContainedPath } from "@/lib/contained-surface";
 
-export default function ChromeGate({ children }: { children: React.ReactNode }) {
+export default function ChromeGate({
+  contained: containedByHost = false,
+  children,
+}: {
+  contained?: boolean;
+  children: React.ReactNode;
+}) {
   const pathname = usePathname() || "";
-  const contained = CONTAINED_PREFIXES.some(
-    (p) => pathname === p || pathname.startsWith(p + "/"),
-  );
-  if (contained) return null;
+  if (containedByHost || isContainedPath(pathname)) return null;
   return <>{children}</>;
 }

--- a/web/lib/INDEX.md
+++ b/web/lib/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 36
+**Total files**: 37
 
 | File | Purpose |
 |---|---|
@@ -14,6 +14,7 @@
 | [attribution-ping-dedupe.ts](attribution-ping-dedupe.ts) | _no top-of-file purpose_ |
 | [attribution-target.ts](attribution-target.ts) | _no top-of-file purpose_ |
 | [automation-page-data.ts](automation-page-data.ts) | _no top-of-file purpose_ |
+| [contained-surface.ts](contained-surface.ts) | Contained surfaces — routes that render as their own self-contained app, |
 | [edge-spectrum.ts](edge-spectrum.ts) | Spectrum colors for the seven canonical edge-type families. |
 | [egress.ts](egress.ts) | _no top-of-file purpose_ |
 | [entry-paths.ts](entry-paths.ts) | _no top-of-file purpose_ |

--- a/web/lib/contained-surface.ts
+++ b/web/lib/contained-surface.ts
@@ -1,0 +1,23 @@
+// Contained surfaces — routes that render as their own self-contained app,
+// without the marketing site's header, bottom nav, or badge. A member on a
+// contained surface can't accidentally wander out into the rest of the site
+// with no way back.
+//
+// A surface is contained by its path (/grocery) or by its host
+// (app.hati.earth, whose root the middleware rewrites). Because a rewrite is
+// invisible to the browser, the host case is only knowable server-side, so the
+// middleware states it in a request header that the layout reads. Both routes
+// to the same knowing live here, so middleware, layout, and ChromeGate agree.
+
+/** Request header the middleware sets when the host names a contained app. */
+export const CONTAINED_SURFACE_HEADER = "x-contained-surface";
+
+/** Route prefixes that render as their own contained app. */
+export const CONTAINED_PREFIXES = ["/hati-suci", "/grocery"];
+
+/** True when a pathname sits on a contained surface. */
+export function isContainedPath(pathname: string): boolean {
+  return CONTAINED_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(prefix + "/"),
+  );
+}

--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
+import { CONTAINED_SURFACE_HEADER } from "./lib/contained-surface";
 import { LOCALES } from "./messages/manifest";
 
 const SUPPORTED: Set<string> = new Set(LOCALES.map((locale) => locale.code));
@@ -61,8 +62,17 @@ export function middleware(req: NextRequest) {
   // app.hati.earth is the grocery ledger the hub's manager opens on their
   // phone. Only the root rewrites, so /grocery keeps working on every host
   // and the subdomain's other paths stay reachable.
+  //
+  // A rewrite is invisible to the browser, so the client still reads its
+  // pathname as "/" — the surface is contained, and only the host says so.
+  // The header carries that knowing to the server render, which is where
+  // ChromeGate decides whether the site chrome belongs on the page.
   if (host.startsWith("app.") && pathname === "/") {
-    return NextResponse.rewrite(new URL("/grocery", req.url));
+    const requestHeaders = new Headers(req.headers);
+    requestHeaders.set(CONTAINED_SURFACE_HEADER, "/grocery");
+    return NextResponse.rewrite(new URL("/grocery", req.url), {
+      request: { headers: requestHeaders },
+    });
   }
 
   if (pathname.startsWith("/vision/")) {


### PR DESCRIPTION
Two movements. The ledger's last unmet `done_when`, and a nine-day silence that was never illness.

## app.hati.earth serves the grocery ledger

The DNS record now exists — `app` → A `187.77.152.42`, proxied, matching `sense` / `suci` / `sema` / `www`. The host resolves and Traefik's `coherence-web-hati` router answers it. Everything else for that surface was already in `#3980`; only the record was missing.

Which left the last `done_when`: *"app.hati.earth serves the ledger with no site chrome."* It arrived wearing all of it.

`ChromeGate` read containment from `usePathname()`. The middleware **rewrites** `app.hati.earth`'s root to `/grocery`, and a rewrite is invisible to the browser — so the client still saw `/` and rendered the marketing header, the mobile bottom nav, and the substrate badge over a surface meant to hold one number and one tap. A manager in the market could tap "The Vision" and leave the ledger with no way back.

Containment is one property reached two ways: by **path** (`/grocery`, `/hati-suci`) or by **host** (`app.*`, whose root is rewritten). Only the server can know the host case, so the middleware states it in a request header, the layout reads it, and `ChromeGate` honors either route to the same knowing. Both live in `web/lib/contained-surface.ts` so the three readers cannot drift apart.

Verified against a local production build, per host:

| Host | Path | header | bottom nav | badge |
|---|---|---|---|---|
| app.hati.earth | `/` | 0 | 0 | 0 |
| localhost | `/` | 1 | 1 | 1 |
| app.hati.earth | `/grocery` | 0 | — | — |

Looked at on both widths — 390 and desktop. The phone view is the gate a device without the household token should see, in Indonesian, chrome-free.

The ledger's own gate is green too: `api/tests/test_grocery_ledger.py` — **24 passed**, and the exactness claim proven live on the c-bootstrap kernel rather than asserted:

```
   123.5  ->  (123500, 'fkwu')
      85  ->  (85000, 'fkwu')
    0.25  ->  (250, 'fkwu')
   0.001  ->  (1, 'fkwu')
  12.345  ->  (12345, 'fkwu')
```

## The witness reads the kernel it has

`substrate_form` had been dark nine days and the body was never ill.

`#3961` made c-bootstrap fkwu the production execution authority, and `/api/utils/kernel_status` began reporting `active: "fkwu"`. The organ's extractor still required `active == "native-kernel"` and a `python_authority: false` field the endpoint no longer carries — so every round read healthy tissue as silence.

The timing names it: `#3961` merged **2026-07-20 08:04 UTC**; the silence opened **08:11:14 UTC**. Seven minutes later, at the deploy.

Taking @codex's read on the first pass: two honest doors exist, so asserting one door's spelling was the wrong shape. The organ now asserts the property both express — *a native carrier is serving* — via `NATIVE_KERNEL_AUTHORITIES = {"fkwu", "native-kernel"}`. The FastAPI bridge reports the c-bootstrap binary; the BML front door (`deploy/kernel-router/production-routes.fk`) reports `native-kernel`.

The teeth stay:

```
live FastAPI door: BREATHING
BML front door   : BREATHING
unavailable      : SILENT — active runtime='unavailable'
python authority : SILENT — Python authority unexpectedly active
fanout-python    : SILENT — active runtime='fanout-python'
```

Both doors are pinned by tests. `pulse`: **88 passed**.

## Named, not patched

`scripts/verify_web_api_deploy.sh` (`check_kernel_status_native`) asserts the same retired contract, and **no route in production emits `X-Form-Router` / `X-Form-Handler` / `X-Form-Python-Authority`** — confirmed against the origin directly, so it is not Cloudflare stripping them. `docker ps` on the VPS shows no kernel-router container: web, api, pulse, sema-plugin, postgres, neo4j, libretranslate, discord-bot, traefik. The BML front door that would carry those headers is not deployed.

Where the native front door should live is a grounding question, not a guess — so it is named here rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)