### PR TITLE
tend: a stored place can be renamed and forgotten

### DIFF
--- a/api/app/routers/grocery.py
+++ b/api/app/routers/grocery.py
@@ -150,6 +150,12 @@ def _to_rupiah(typed: str) -> tuple[int, str]:
 
 class ShopResponse(PlaceResponse):
     default_description: str = ""
+    # Which starting suggestion (if any) this shop was first created from —
+    # stamped once at creation, untouched by any later rename. The web layer
+    # reads this across every device to know a suggestion has been used, so
+    # renaming "Bali Buda" away doesn't resurrect it as a ghost duplicate on
+    # a household member's *other* phone, where a per-device flag never was.
+    origin_suggestion: str | None = None
 
 
 class ShopBody(BaseModel):
@@ -158,6 +164,7 @@ class ShopBody(BaseModel):
     default_description: str = Field(min_length=1, max_length=200)
     lat: int | None = None   # micro-degrees, as the phone's GPS gives
     lon: int | None = None
+    origin_suggestion: str | None = Field(default=None, max_length=80)
 
 
 def _node_to_shop(node: dict) -> ShopResponse:
@@ -165,6 +172,7 @@ def _node_to_shop(node: dict) -> ShopResponse:
     return ShopResponse(
         **base.model_dump(),
         default_description=_s(node.get("default_description")) or base.name,
+        origin_suggestion=_s(node.get("origin_suggestion")) or None,
     )
 
 
@@ -199,6 +207,8 @@ async def save_shop(body: ShopBody) -> ShopResponse:
         "default_description": body.default_description,
         "created_at": _now(),
     }
+    if body.origin_suggestion:
+        props["origin_suggestion"] = body.origin_suggestion
     if body.lat is not None and body.lon is not None:
         props["lat"] = int(body.lat)
         props["lon"] = int(body.lon)
@@ -217,6 +227,10 @@ class ShopEdit(BaseModel):
     actor_token: str = Field(min_length=1)
     name: str | None = Field(default=None, min_length=1, max_length=80)
     default_description: str | None = Field(default=None, min_length=1, max_length=200)
+    # Set only when the client knows the shop's PRE-rename name matched a
+    # starting suggestion — heals a shop saved before origin_suggestion
+    # existed, so a legacy rename doesn't resurrect a ghost either.
+    origin_suggestion: str | None = Field(default=None, max_length=80)
 
 
 @router.patch(
@@ -246,6 +260,8 @@ async def edit_shop(shop_id: str, body: ShopEdit) -> ShopResponse:
         # let win over the column just updated above. Clearing it here heals
         # that node the first time it is ever edited, no migration needed.
         updates["properties"]["name"] = body.name
+    if body.origin_suggestion and not node.get("origin_suggestion"):
+        updates["properties"]["origin_suggestion"] = body.origin_suggestion
     graph_service.update_node(shop_id, **updates)
     node = graph_service.get_node(shop_id) or node
     return _node_to_shop(node)

--- a/api/app/routers/grocery.py
+++ b/api/app/routers/grocery.py
@@ -191,8 +191,10 @@ async def list_shops(token: str | None = Query(default=None)) -> list[ShopRespon
 async def save_shop(body: ShopBody) -> ShopResponse:
     _require_writer(body.actor_token)
     shop_id = f"place-shop-{uuid.uuid4().hex[:10]}"
+    # `name` is not duplicated into properties: Node.to_dict() merges
+    # properties over the top-level columns, so a copy here would freeze
+    # the name at creation and outlive any later rename via PATCH.
     props: dict[str, Any] = {
-        "name": body.name,
         "kind": _SHOP_KIND,
         "default_description": body.default_description,
         "created_at": _now(),
@@ -209,6 +211,65 @@ async def save_shop(body: ShopBody) -> ShopResponse:
     )
     node = graph_service.get_node(shop_id) or {"id": shop_id, **props}
     return _node_to_shop(node)
+
+
+class ShopEdit(BaseModel):
+    actor_token: str = Field(min_length=1)
+    name: str | None = Field(default=None, min_length=1, max_length=80)
+    default_description: str | None = Field(default=None, min_length=1, max_length=200)
+
+
+@router.patch(
+    "/grocery/shops/{shop_id}",
+    response_model=ShopResponse,
+    summary="Rename a stored shop, or change what it fills in — never a new place",
+)
+async def edit_shop(shop_id: str, body: ShopEdit) -> ShopResponse:
+    _require_writer(body.actor_token)
+    if body.name is None and body.default_description is None:
+        raise HTTPException(status_code=400, detail="nothing to change")
+    node = graph_service.get_node(shop_id)
+    if not node or node.get("kind") != _SHOP_KIND:
+        raise HTTPException(status_code=404, detail=f"shop {shop_id!r} not found")
+    # Spends already recorded keep the description they were written with —
+    # editing a shop only changes what the NEXT visit fills in, never what a
+    # past entry says. `name` and `default_description` default to each
+    # other so the two rarely drift back apart.
+    new_name = body.name or node.get("name") or ""
+    new_desc = body.default_description or new_name
+    updates: dict[str, Any] = {"properties": {"default_description": new_desc}}
+    if body.name is not None:
+        updates["name"] = body.name
+        updates["description"] = new_desc
+        # A shop saved before this endpoint existed may carry a copy of its
+        # name inside properties too, which Node.to_dict() would otherwise
+        # let win over the column just updated above. Clearing it here heals
+        # that node the first time it is ever edited, no migration needed.
+        updates["properties"]["name"] = body.name
+    graph_service.update_node(shop_id, **updates)
+    node = graph_service.get_node(shop_id) or node
+    return _node_to_shop(node)
+
+
+class ShopDeleteResponse(BaseModel):
+    deleted: str
+
+
+@router.delete(
+    "/grocery/shops/{shop_id}",
+    response_model=ShopDeleteResponse,
+    summary="Forget a stored shop — past entries keep what they already said",
+)
+async def forget_shop(
+    shop_id: str,
+    actor_token: str = Query(..., description="the device token of the recorder or a resident"),
+) -> ShopDeleteResponse:
+    _require_writer(actor_token)
+    node = graph_service.get_node(shop_id)
+    if not node or node.get("kind") != _SHOP_KIND:
+        raise HTTPException(status_code=404, detail=f"shop {shop_id!r} not found")
+    graph_service.delete_node(shop_id)
+    return ShopDeleteResponse(deleted=shop_id)
 
 
 @router.get(

--- a/api/tests/test_grocery_ledger.py
+++ b/api/tests/test_grocery_ledger.py
@@ -203,6 +203,65 @@ def test_a_stored_shop_is_renamed_without_touching_past_entries(client):
     assert earlier["description"] == "Toko Lama"
 
 
+def test_a_rename_survives_on_every_device_not_just_the_one_that_made_it(client):
+    """origin_suggestion is server state, not localStorage - the whole point.
+
+    A household has more than one phone. If "already used" lived only in the
+    browser that did the renaming, the OTHER phone would still offer the
+    starting suggestion as a ghost duplicate after a rename. Reading the shop
+    back through a second, independent client call is the real test: the
+    graph itself, not any one device, has to carry the answer.
+    """
+    resident = client.post("/api/household/bootstrap", json={"name": "Sri"})
+    if resident.status_code == 409:
+        pytest.skip("a resident already exists in this graph; bootstrap-dependent flow skipped")
+    token = resident.json()["token"]
+
+    created = client.post("/api/grocery/shops", json={
+        "actor_token": token, "name": "Bali Buda", "default_description": "Bali Buda",
+        "origin_suggestion": "Bali Buda",
+    })
+    assert created.json()["origin_suggestion"] == "Bali Buda"
+    shop_id = created.json()["id"]
+
+    client.patch(f"/api/grocery/shops/{shop_id}", json={
+        "actor_token": token, "name": "Bali Buda Ubud",
+    })
+
+    # A fresh, independent read - standing in for Ita's phone reading the
+    # same household state Urs's phone just changed.
+    from_elsewhere = client.get(f"/api/grocery/shops?token={token}")
+    shop = [s for s in from_elsewhere.json() if s["id"] == shop_id][0]
+    assert shop["name"] == "Bali Buda Ubud"
+    assert shop["origin_suggestion"] == "Bali Buda"
+
+
+def test_a_rename_heals_a_shop_saved_before_origin_suggestion_existed(client):
+    resident = client.post("/api/household/bootstrap", json={"name": "Ketut"})
+    if resident.status_code == 409:
+        pytest.skip("a resident already exists in this graph; bootstrap-dependent flow skipped")
+    token = resident.json()["token"]
+
+    # No origin_suggestion sent - as every shop created before this field
+    # existed looks today.
+    legacy = client.post("/api/grocery/shops", json={
+        "actor_token": token, "name": "Pasar", "default_description": "Pasar",
+    })
+    assert legacy.json()["origin_suggestion"] is None
+    shop_id = legacy.json()["id"]
+
+    healed = client.patch(f"/api/grocery/shops/{shop_id}", json={
+        "actor_token": token, "name": "Pasar Ubud", "origin_suggestion": "Pasar",
+    })
+    assert healed.json()["origin_suggestion"] == "Pasar"
+
+    # A second rename must not let a caller overwrite an origin already set.
+    again = client.patch(f"/api/grocery/shops/{shop_id}", json={
+        "actor_token": token, "name": "Pasar Ubud Pusat", "origin_suggestion": "Something Else",
+    })
+    assert again.json()["origin_suggestion"] == "Pasar"
+
+
 def test_editing_a_shop_needs_write_access_and_something_to_change(client):
     resident = client.post("/api/household/bootstrap", json={"name": "Kadek"})
     if resident.status_code == 409:

--- a/api/tests/test_grocery_ledger.py
+++ b/api/tests/test_grocery_ledger.py
@@ -166,6 +166,101 @@ def test_a_spend_records_with_the_shop_filling_in_the_description(client):
     assert totals.json()["day_count"] >= 2
 
 
+def test_a_stored_shop_is_renamed_without_touching_past_entries(client):
+    resident = client.post("/api/household/bootstrap", json={"name": "Wayan"})
+    if resident.status_code == 409:
+        pytest.skip("a resident already exists in this graph; bootstrap-dependent flow skipped")
+    token = resident.json()["token"]
+
+    shop = client.post("/api/grocery/shops", json={
+        "actor_token": token, "name": "Toko Lama", "default_description": "Toko Lama",
+    })
+    shop_id = shop.json()["id"]
+
+    # An entry recorded before the rename keeps what it already said.
+    before = client.post("/api/grocery/spend", json={
+        "actor_token": token, "amount": "50", "place_id": shop_id,
+    })
+    assert before.json()["description"] == "Toko Lama"
+
+    edit = client.patch(f"/api/grocery/shops/{shop_id}", json={
+        "actor_token": token, "name": "Toko Baru",
+    })
+    assert edit.status_code == 200, edit.text
+    assert edit.json()["name"] == "Toko Baru"
+    # default_description follows the new name when only name was given.
+    assert edit.json()["default_description"] == "Toko Baru"
+
+    # A later entry at the same place fills in the new name.
+    after = client.post("/api/grocery/spend", json={
+        "actor_token": token, "amount": "60", "place_id": shop_id,
+    })
+    assert after.json()["description"] == "Toko Baru"
+
+    # The earlier entry's own record is untouched.
+    same_day = client.get(f"/api/grocery/spend?token={token}&on={grocery._today_local()}")
+    earlier = [s for s in same_day.json() if s["id"] == before.json()["id"]][0]
+    assert earlier["description"] == "Toko Lama"
+
+
+def test_editing_a_shop_needs_write_access_and_something_to_change(client):
+    resident = client.post("/api/household/bootstrap", json={"name": "Kadek"})
+    if resident.status_code == 409:
+        pytest.skip("a resident already exists in this graph; bootstrap-dependent flow skipped")
+    token = resident.json()["token"]
+    shop = client.post("/api/grocery/shops", json={
+        "actor_token": token, "name": "Warung", "default_description": "Warung",
+    })
+    shop_id = shop.json()["id"]
+
+    member = client.post("/api/household/members", json={"name": "Rina"})
+    read_only_token = member.json()["token"]
+    refused = client.patch(f"/api/grocery/shops/{shop_id}", json={
+        "actor_token": read_only_token, "name": "Warung Baru",
+    })
+    assert refused.status_code == 403
+
+    empty = client.patch(f"/api/grocery/shops/{shop_id}", json={"actor_token": token})
+    assert empty.status_code == 400
+
+    missing = client.patch("/api/grocery/shops/place-shop-doesnotexist", json={
+        "actor_token": token, "name": "Anything",
+    })
+    assert missing.status_code == 404
+
+
+def test_forgetting_a_shop_keeps_what_past_entries_already_said(client):
+    resident = client.post("/api/household/bootstrap", json={"name": "Made"})
+    if resident.status_code == 409:
+        pytest.skip("a resident already exists in this graph; bootstrap-dependent flow skipped")
+    token = resident.json()["token"]
+
+    shop = client.post("/api/grocery/shops", json={
+        "actor_token": token, "name": "Toko Sementara", "default_description": "Toko Sementara",
+    })
+    shop_id = shop.json()["id"]
+    spend = client.post("/api/grocery/spend", json={
+        "actor_token": token, "amount": "40", "place_id": shop_id,
+    })
+    assert spend.json()["description"] == "Toko Sementara"
+
+    gone = client.delete(f"/api/grocery/shops/{shop_id}?actor_token={token}")
+    assert gone.status_code == 200, gone.text
+    assert gone.json()["deleted"] == shop_id
+
+    # The past entry's own text is unaffected by the shop no longer existing.
+    same_day = client.get(f"/api/grocery/spend?token={token}&on={grocery._today_local()}")
+    earlier = [s for s in same_day.json() if s["id"] == spend.json()["id"]][0]
+    assert earlier["description"] == "Toko Sementara"
+
+    # It no longer appears in the stored list, and a second delete is honest
+    # about there being nothing left to forget.
+    shops = client.get(f"/api/grocery/shops?token={token}")
+    assert shop_id not in [s["id"] for s in shops.json()]
+    twice = client.delete(f"/api/grocery/shops/{shop_id}?actor_token={token}")
+    assert twice.status_code == 404
+
+
 def test_zero_is_not_a_spend_and_an_unknown_category_is_refused(client):
     resident = client.post("/api/household/bootstrap", json={"name": "Nyoman"})
     if resident.status_code == 409:

--- a/docs/system_audit/commit_evidence_2026-07-30_grocery_shop_edit.json
+++ b/docs/system_audit/commit_evidence_2026-07-30_grocery_shop_edit.json
@@ -1,0 +1,93 @@
+{
+  "agent": {
+    "name": "Claude Code",
+    "version": "Opus 5"
+  },
+  "date": "2026-07-30",
+  "thread_branch": "claude/grocery-edit-locations",
+  "change_intent": "runtime_feature",
+  "commit_scope": "Add PATCH/DELETE for a stored shop (rename or forget a place without touching past entries), and stamp origin_suggestion server-side so a starting suggestion stays fulfilled across every device in the household, not only the one that used it.",
+  "idea_ids": [
+    "light-hub-membrane"
+  ],
+  "spec_ids": [
+    "hati-grocery-ledger"
+  ],
+  "task_ids": [
+    "hati-grocery-ledger-2026-07-30-shop-edit"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "claude",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "validation",
+        "receipt-authoring"
+      ]
+    }
+  ],
+  "change_files": [
+    "api/app/routers/grocery.py",
+    "api/tests/test_grocery_ledger.py",
+    "docs/system_audit/commit_evidence_2026-07-30_grocery_shop_edit.json",
+    "web/app/grocery/page.tsx"
+  ],
+  "files_owned": [
+    "api/app/routers/grocery.py",
+    "api/tests/test_grocery_ledger.py",
+    "web/app/grocery/page.tsx"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "cd api && python -m pytest tests/test_grocery_ledger.py -q",
+      "cd web && npm run build"
+    ],
+    "summary": "29 flow tests pass, 5 new (rename preserves past entries; a rename survives on a second, independent client read standing in for a second phone; a legacy shop's origin heals on its first rename and cannot be overwritten afterward; write-access/not-found/nothing-to-change refusals; forget preserves past entries and is idempotent-honest on a second delete). web build is clean."
+  },
+  "four_way_validation": {
+    "status": "not_applicable",
+    "band": null,
+    "arms": {},
+    "cases": [],
+    "note": "PATCH/DELETE /grocery/shops carry no numeric computation — rename/default-filling and delete are pure graph CRUD, the same shape as the sibling GET/POST shop endpoints already shipped in this file, none of which have a Form recipe either. AGENTS.md's standing rule is that new logic belongs in a Form recipe with proof across every kernel arm, not in Python, and that a step only a host carrier reaches today must be named as the retiring bridge — never quietly kept as the shape. This note is that naming: a Python-carrier bridge, not the destination. Migrating this whole file's CRUD surface to Form recipes is a real, separate follow-up; it was not undertaken here because the household needed this live today (a resident's own explicit ask), and a rushed, unproven recipe would violate the same principle it claims to satisfy."
+  },
+  "ci_validation": {
+    "status": "pass",
+    "commands": [
+      "GitHub Actions on PR #3986"
+    ],
+    "summary": "windows-floor and GitGuardian Security Checks pass. validate-thread-process fails on test_runtime_policy_pin_matches_the_reusable_workflow_call — a pre-existing deployment-observer trust-pin mismatch on main (named in #3980, still unresolved on main as of this commit), unrelated to any file this commit touches."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "commands": [
+      "./scripts/verify_web_api_deploy.sh https://api.coherencycoin.com https://coherencycoin.com"
+    ],
+    "summary": "Not yet deployed at authoring time. The resident asked directly for this on production, since a second household member (the manager) needs it live; deploy is the very next step after merge."
+  },
+  "e2e_validation": {
+    "expected_behavior_delta": "A resident can rename a stored shop (e.g. \"Bali Buda\" -> \"Bali Buda Ubud\") or forget it entirely, from a small \"Ubah tempat\" panel below the place chips; neither changes what any already-recorded spend says, only what the next visit fills in. A starting suggestion, once used to create a shop, does not reappear as a ghost duplicate after that shop is renamed — on any device in the household, because the fact lives on the shop node itself (origin_suggestion), not in one phone's local storage.",
+    "public_endpoints": [
+      "/api/grocery/shops/{shop_id} (PATCH)",
+      "/api/grocery/shops/{shop_id} (DELETE)"
+    ],
+    "status": "pass",
+    "test_flows": [
+      "tapped the real 'Bali Buda' suggestion chip against a locally running API with this code (production does not have these routes yet) -> created via rememberPlace",
+      "opened 'Ubah tempat', renamed it to 'Bali Buda Ubud' -> confirmed via a fresh API read (not the same request) that the name actually changed and origin_suggestion carried across",
+      "recorded a spend at 'Pasar', deleted 'Pasar' via the trash icon -> confirmed the past entry still reads 'Pasar' and the shop list no longer offers it",
+      "pytest: a second, independent client.get() standing in for a second phone confirms origin_suggestion is readable from server state alone, not from the browser that made the change"
+    ]
+  },
+  "evidence_refs": [
+    "specs/hati-grocery-ledger.md",
+    "AGENTS.md#L31",
+    "https://github.com/seeker71/Coherence-Network/pull/3986"
+  ],
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Live for the resident's own use is the immediate need; not yet deployed at authoring time. Still open: migrate this file's shop CRUD (GET/POST/PATCH/DELETE) to a proven Form recipe per the standing BML-first mandate — named here as a real, tracked gap rather than resolved or hidden."
+  }
+}

--- a/web/app/grocery/page.tsx
+++ b/web/app/grocery/page.tsx
@@ -80,11 +80,18 @@ type Draft = {
 const TOKEN_KEY = "hatiSuci.token";
 const QUEUE_KEY = "hatiGrocery.queue";
 const LANG_KEY = "hatiGrocery.lang";
+const FULFILLED_KEY = "hatiGrocery.fulfilledStarting";
 
 // The two places the hub actually shops, offered as taps on a ledger that has
 // no stored places yet. They are a starting point, not a fixture: tapping one
 // stores it like any other place, and the row is whatever the household has
 // saved from then on.
+//
+// A suggestion is marked fulfilled — and stays gone — the moment it is ever
+// used to create a shop, tracked by name at that moment rather than derived
+// live from the current shop list. A live derivation reads "Bali Buda" as
+// unfulfilled the instant someone renames it to "Bali Buda Ubud", offering a
+// ghost duplicate of a place that already exists under its new name.
 const STARTING_PLACES = ["Bali Buda", "Pasar"];
 
 type Lang = "en" | "id";
@@ -116,6 +123,12 @@ const T = {
     newPlace: "New place",
     placeName: "Name of the place",
     addNote: "Add a note",
+    managePlaces: "Edit places",
+    donePlaces: "Done",
+    renamePlace: "Rename",
+    saveRename: "Save the new name",
+    forgetPlace: "Forget this place",
+    confirmForget: "Forget it? Past entries keep what they already said.",
     locating: "Finding you…",
     sheet: "Sheet",
     csv: "Download CSV",
@@ -159,6 +172,12 @@ const T = {
     newPlace: "Tempat baru",
     placeName: "Nama tempatnya",
     addNote: "Tambah catatan",
+    managePlaces: "Ubah tempat",
+    donePlaces: "Selesai",
+    renamePlace: "Ganti nama",
+    saveRename: "Simpan nama baru",
+    forgetPlace: "Lupakan tempat ini",
+    confirmForget: "Lupakan? Catatan lama tetap seperti semula.",
     locating: "Mencari lokasi…",
     sheet: "Sheet",
     csv: "Unduh CSV",
@@ -232,6 +251,10 @@ export default function GroceryPage() {
   const [shopName, setShopName] = useState("");
   const [shops, setShops] = useState<Shop[]>([]);
   const [noteOpen, setNoteOpen] = useState(false);
+  const [fulfilledStarting, setFulfilledStarting] = useState<string[]>([]);
+  const [managingPlaces, setManagingPlaces] = useState(false);
+  const [editingPlaceId, setEditingPlaceId] = useState<string | null>(null);
+  const [editPlaceName, setEditPlaceName] = useState("");
   const amountRef = useRef<HTMLInputElement>(null);
 
   const idr = useMemo(() => previewIdr(amount), [amount]);
@@ -241,12 +264,15 @@ export default function GroceryPage() {
   // tap away on the first day and stop being suggested once they are real.
   const places = useMemo<Shop[]>(() => {
     const held = new Set(shops.map((s) => s.name.trim().toLowerCase()));
-    const suggestions = STARTING_PLACES.filter((n) => !held.has(n.toLowerCase())).map(
-      (name) =>
-        ({ id: "", name, kind: "shop", default_description: name, pinned: false }) as Shop,
-    );
+    const fulfilled = new Set(fulfilledStarting.map((n) => n.toLowerCase()));
+    const suggestions = STARTING_PLACES
+      .filter((n) => !held.has(n.toLowerCase()) && !fulfilled.has(n.toLowerCase()))
+      .map(
+        (name) =>
+          ({ id: "", name, kind: "shop", default_description: name, pinned: false }) as Shop,
+      );
     return [...shops, ...suggestions];
-  }, [shops]);
+  }, [shops, fulfilledStarting]);
 
   // ---- identity: the same device token the house board uses ----------------
   useEffect(() => {
@@ -262,6 +288,8 @@ export default function GroceryPage() {
       saved = localStorage.getItem(TOKEN_KEY);
       const savedLang = localStorage.getItem(LANG_KEY);
       if (savedLang === "en" || savedLang === "id") setLang(savedLang);
+      const fulfilled = JSON.parse(localStorage.getItem(FULFILLED_KEY) || "[]");
+      if (Array.isArray(fulfilled)) setFulfilledStarting(fulfilled);
     } catch {
       /* private mode — the ledger still works, it just won't remember */
     }
@@ -490,12 +518,80 @@ export default function GroceryPage() {
         setShop(s);
         setAddingShop(false);
         setShopName("");
+        const startingHit = STARTING_PLACES.find((p) => p.toLowerCase() === clean.toLowerCase());
+        if (startingHit) {
+          setFulfilledStarting((prev) => {
+            if (prev.includes(startingHit)) return prev;
+            const next = [...prev, startingHit];
+            try { localStorage.setItem(FULFILLED_KEY, JSON.stringify(next)); } catch { /* private mode */ }
+            return next;
+          });
+        }
       }
     } catch {
       /* the place can be saved again later; the entry never depended on it */
     }
     setBusy(false);
   }, [token, shops, coords]);
+
+  // Renaming changes what the NEXT visit fills in; nothing already recorded
+  // is touched, since a spend's description is written at the moment it is
+  // saved, not read live from the place each time.
+  const renamePlace = useCallback(async (id: string, name: string) => {
+    const clean = name.trim();
+    if (!token || !clean) return;
+    // A rename that moves a shop away from a starting suggestion's exact name
+    // must mark that suggestion fulfilled here too — otherwise the live
+    // held-names check in `places` no longer matches the old string, and the
+    // suggestion reappears as a ghost duplicate of the place that just moved.
+    const before = shops.find((s) => s.id === id);
+    const startingHit = before
+      ? STARTING_PLACES.find((p) => p.toLowerCase() === before.name.trim().toLowerCase())
+      : undefined;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/grocery/shops/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ actor_token: token, name: clean }),
+      });
+      if (res.ok) {
+        const updated = (await res.json()) as Shop;
+        setShops((prev) => prev.map((s) => (s.id === id ? updated : s)));
+        setShop((cur) => (cur?.id === id ? updated : cur));
+        if (startingHit) {
+          setFulfilledStarting((prev) => {
+            if (prev.includes(startingHit)) return prev;
+            const next = [...prev, startingHit];
+            try { localStorage.setItem(FULFILLED_KEY, JSON.stringify(next)); } catch { /* private mode */ }
+            return next;
+          });
+        }
+      }
+    } catch {
+      /* the rename can be tried again; nothing else depends on it landing */
+    }
+    setBusy(false);
+    setEditingPlaceId(null);
+  }, [token, shops]);
+
+  const forgetPlace = useCallback(async (id: string) => {
+    if (!token) return;
+    setBusy(true);
+    try {
+      const res = await fetch(
+        `/api/grocery/shops/${encodeURIComponent(id)}?actor_token=${encodeURIComponent(token)}`,
+        { method: "DELETE" },
+      );
+      if (res.ok) {
+        setShops((prev) => prev.filter((s) => s.id !== id));
+        setShop((cur) => (cur?.id === id ? null : cur));
+      }
+    } catch {
+      /* still listed; the manager can try again */
+    }
+    setBusy(false);
+  }, [token]);
 
   // ---- the door ------------------------------------------------------------
   if (!resolved) {
@@ -653,6 +749,70 @@ export default function GroceryPage() {
                   </button>
                 )}
               </div>
+
+              {/* ---- editing a place is rare; recording a buy is constant ----
+                  so managing places lives behind one small link rather than an
+                  icon on every chip, and the fast path above never changes shape. */}
+              {shops.length > 0 && (
+                <button
+                  onClick={() => setManagingPlaces((v) => !v)}
+                  className="mt-2 min-h-[44px] text-sm text-neutral-500 hover:text-neutral-300"
+                >
+                  {managingPlaces ? t.donePlaces : t.managePlaces}
+                </button>
+              )}
+              {managingPlaces && (
+                <div className="mt-1 grid gap-2 rounded-xl border border-neutral-800 bg-neutral-900/40 p-3">
+                  {shops.map((s) => (
+                    <div key={s.id} className="flex items-center gap-2">
+                      {editingPlaceId === s.id ? (
+                        <>
+                          <input
+                            value={editPlaceName}
+                            onChange={(e) => setEditPlaceName(e.target.value)}
+                            onKeyDown={(e) => { if (e.key === "Enter") void renamePlace(s.id, editPlaceName); }}
+                            autoFocus
+                            className="min-h-[44px] flex-1 rounded-lg border border-amber-500/50 bg-neutral-950 px-3 text-base outline-none"
+                          />
+                          <button
+                            onClick={() => void renamePlace(s.id, editPlaceName)}
+                            disabled={busy || !editPlaceName.trim()}
+                            aria-label={t.saveRename}
+                            className="min-h-[44px] min-w-[44px] rounded-lg border border-amber-500/50 bg-amber-500/10 text-amber-300 disabled:opacity-40"
+                          >
+                            ✓
+                          </button>
+                          <button
+                            onClick={() => setEditingPlaceId(null)}
+                            aria-label={t.cancel}
+                            className="min-h-[44px] min-w-[44px] text-neutral-500"
+                          >
+                            ✕
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <button
+                            onClick={() => { setEditingPlaceId(s.id); setEditPlaceName(s.name); }}
+                            aria-label={`${t.renamePlace} ${s.name}`}
+                            className="min-h-[44px] flex-1 truncate rounded-lg px-3 text-left text-base text-neutral-200 hover:bg-neutral-800/60"
+                          >
+                            {s.name}
+                          </button>
+                          <button
+                            onClick={() => { if (window.confirm(t.confirmForget)) void forgetPlace(s.id); }}
+                            disabled={busy}
+                            aria-label={`${t.forgetPlace}: ${s.name}`}
+                            className="min-h-[44px] min-w-[44px] rounded-lg text-neutral-600 hover:text-red-400 disabled:opacity-40"
+                          >
+                            🗑
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
             )}
 

--- a/web/app/grocery/page.tsx
+++ b/web/app/grocery/page.tsx
@@ -25,6 +25,7 @@ type Shop = {
   lon?: number | null;
   default_description: string;
   pinned: boolean;
+  origin_suggestion?: string | null;
 };
 
 type Category = { key: string; emoji: string; en: string; id: string };
@@ -80,18 +81,19 @@ type Draft = {
 const TOKEN_KEY = "hatiSuci.token";
 const QUEUE_KEY = "hatiGrocery.queue";
 const LANG_KEY = "hatiGrocery.lang";
-const FULFILLED_KEY = "hatiGrocery.fulfilledStarting";
 
 // The two places the hub actually shops, offered as taps on a ledger that has
 // no stored places yet. They are a starting point, not a fixture: tapping one
 // stores it like any other place, and the row is whatever the household has
 // saved from then on.
 //
-// A suggestion is marked fulfilled — and stays gone — the moment it is ever
-// used to create a shop, tracked by name at that moment rather than derived
-// live from the current shop list. A live derivation reads "Bali Buda" as
-// unfulfilled the instant someone renames it to "Bali Buda Ubud", offering a
-// ghost duplicate of a place that already exists under its new name.
+// A suggestion is fulfilled — and stays gone, on every device — the moment
+// it is ever used to create a shop, stamped server-side on that shop's own
+// `origin_suggestion` and never touched by a later rename. A check against
+// only the *current* name would read "Bali Buda" as unfulfilled the instant
+// it's renamed to "Bali Buda Ubud" on Ita's phone, offering Urs a ghost
+// duplicate of the same place on his — the graph is what both devices read,
+// so that is where "already used" has to live.
 const STARTING_PLACES = ["Bali Buda", "Pasar"];
 
 type Lang = "en" | "id";
@@ -251,7 +253,6 @@ export default function GroceryPage() {
   const [shopName, setShopName] = useState("");
   const [shops, setShops] = useState<Shop[]>([]);
   const [noteOpen, setNoteOpen] = useState(false);
-  const [fulfilledStarting, setFulfilledStarting] = useState<string[]>([]);
   const [managingPlaces, setManagingPlaces] = useState(false);
   const [editingPlaceId, setEditingPlaceId] = useState<string | null>(null);
   const [editPlaceName, setEditPlaceName] = useState("");
@@ -264,7 +265,11 @@ export default function GroceryPage() {
   // tap away on the first day and stop being suggested once they are real.
   const places = useMemo<Shop[]>(() => {
     const held = new Set(shops.map((s) => s.name.trim().toLowerCase()));
-    const fulfilled = new Set(fulfilledStarting.map((n) => n.toLowerCase()));
+    const fulfilled = new Set(
+      shops
+        .map((s) => (s.origin_suggestion || "").trim().toLowerCase())
+        .filter(Boolean),
+    );
     const suggestions = STARTING_PLACES
       .filter((n) => !held.has(n.toLowerCase()) && !fulfilled.has(n.toLowerCase()))
       .map(
@@ -272,7 +277,7 @@ export default function GroceryPage() {
           ({ id: "", name, kind: "shop", default_description: name, pinned: false }) as Shop,
       );
     return [...shops, ...suggestions];
-  }, [shops, fulfilledStarting]);
+  }, [shops]);
 
   // ---- identity: the same device token the house board uses ----------------
   useEffect(() => {
@@ -288,8 +293,6 @@ export default function GroceryPage() {
       saved = localStorage.getItem(TOKEN_KEY);
       const savedLang = localStorage.getItem(LANG_KEY);
       if (savedLang === "en" || savedLang === "id") setLang(savedLang);
-      const fulfilled = JSON.parse(localStorage.getItem(FULFILLED_KEY) || "[]");
-      if (Array.isArray(fulfilled)) setFulfilledStarting(fulfilled);
     } catch {
       /* private mode — the ledger still works, it just won't remember */
     }
@@ -500,6 +503,10 @@ export default function GroceryPage() {
       return;
     }
     setBusy(true);
+    // Naming which starting suggestion this is (if any) is stamped on the
+    // shop itself, server-side, so the OTHER phone in the house reads
+    // "already used" too — not just this one.
+    const startingHit = STARTING_PLACES.find((p) => p.toLowerCase() === clean.toLowerCase());
     try {
       const res = await fetch("/api/grocery/shops", {
         method: "POST",
@@ -510,6 +517,7 @@ export default function GroceryPage() {
           default_description: clean,
           lat: coords?.lat ?? null,
           lon: coords?.lon ?? null,
+          origin_suggestion: startingHit ?? null,
         }),
       });
       if (res.ok) {
@@ -518,15 +526,6 @@ export default function GroceryPage() {
         setShop(s);
         setAddingShop(false);
         setShopName("");
-        const startingHit = STARTING_PLACES.find((p) => p.toLowerCase() === clean.toLowerCase());
-        if (startingHit) {
-          setFulfilledStarting((prev) => {
-            if (prev.includes(startingHit)) return prev;
-            const next = [...prev, startingHit];
-            try { localStorage.setItem(FULFILLED_KEY, JSON.stringify(next)); } catch { /* private mode */ }
-            return next;
-          });
-        }
       }
     } catch {
       /* the place can be saved again later; the entry never depended on it */
@@ -541,32 +540,30 @@ export default function GroceryPage() {
     const clean = name.trim();
     if (!token || !clean) return;
     // A rename that moves a shop away from a starting suggestion's exact name
-    // must mark that suggestion fulfilled here too — otherwise the live
-    // held-names check in `places` no longer matches the old string, and the
-    // suggestion reappears as a ghost duplicate of the place that just moved.
+    // is told to the server as origin_suggestion, so every device — not just
+    // this one — reads "already used" from the shop itself afterward. Only
+    // sent for a shop saved before that property existed (it never overwrites
+    // a value already set at creation).
     const before = shops.find((s) => s.id === id);
-    const startingHit = before
-      ? STARTING_PLACES.find((p) => p.toLowerCase() === before.name.trim().toLowerCase())
-      : undefined;
+    const startingHit =
+      before && !before.origin_suggestion
+        ? STARTING_PLACES.find((p) => p.toLowerCase() === before.name.trim().toLowerCase())
+        : undefined;
     setBusy(true);
     try {
       const res = await fetch(`/api/grocery/shops/${encodeURIComponent(id)}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ actor_token: token, name: clean }),
+        body: JSON.stringify({
+          actor_token: token,
+          name: clean,
+          origin_suggestion: startingHit ?? null,
+        }),
       });
       if (res.ok) {
         const updated = (await res.json()) as Shop;
         setShops((prev) => prev.map((s) => (s.id === id ? updated : s)));
         setShop((cur) => (cur?.id === id ? updated : cur));
-        if (startingHit) {
-          setFulfilledStarting((prev) => {
-            if (prev.includes(startingHit)) return prev;
-            const next = [...prev, startingHit];
-            try { localStorage.setItem(FULFILLED_KEY, JSON.stringify(next)); } catch { /* private mode */ }
-            return next;
-          });
-        }
       }
     } catch {
       /* the rename can be tried again; nothing else depends on it landing */


### PR DESCRIPTION
Urs, already a resident, asked for exactly what a resident should have: history, remaining balance, and now — editing a location. The first two already worked; the third was a real gap, not a permissions issue: `POST /grocery/shops` only ever minted a new place, with no PATCH or DELETE for an existing one.

## What's new

- `PATCH /grocery/shops/{id}` — renames a place or changes what it fills in
- `DELETE /grocery/shops/{id}` — forgets it

Neither touches history: a spend's description is written at the moment it is recorded, never read live from the place afterward — renaming or forgetting a place changes only what the **next** visit fills in.

## Why the UI stays out of the way

Editing a place is rare; recording a buy is constant. The edit surface lives behind one small "Ubah tempat" / "Edit places" link below the place chips, not an icon on every chip — the fast path (type a number, tap a place, Catat) never changes shape.

## Two real bugs, found by actually running it

**A rename that silently didn't rename.** `Node.to_dict()` merges `properties` over the top-level columns, and `save_shop` wrote `name` into both. A PATCH updating the top-level column was quietly overridden by the untouched copy in `properties` — the API call returned 200, and the stored name never changed. Fixed by not duplicating `name` into `properties` going forward, and having the edit endpoint clear any stale copy on a shop saved before this existed.

**A ghost duplicate after renaming a starting suggestion.** Renaming "Bali Buda" to "Bali Buda Ubud" resurrected "Bali Buda" as a dashed suggestion chip, since the suggestion logic matched by *current* name. Fulfillment is now tracked once, by name, the moment a starting suggestion is ever used to create a shop or renamed away from — independent of what it's later renamed to.

## Verified end-to-end, not just by inspection

Production doesn't have these routes yet, so I ran a local API with this code and drove the actual UI:

1. Tapped the real "Bali Buda" suggestion chip → created via `rememberPlace`
2. Opened "Ubah tempat" → renamed it to "Bali Buda Ubud" → confirmed via API the name actually changed, and confirmed no ghost chip reappeared
3. Recorded a spend at "Pasar" → deleted "Pasar" via the trash icon → confirmed the past entry still reads `"Pasar"`, and the shop list no longer offers it

```
past spend still says Pasar? -> Pasar place-shop-09a051602a
```

`api/tests/test_grocery_ledger.py`: **27 passed** (3 new — rename preserves past entries; write-access / not-found / nothing-to-change refusals; forget preserves past entries and is idempotent-honest on a second delete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)