### PR TITLE
tend: the neo4j organ probe reaches the real server — the ImportError silence heals

### DIFF
--- a/api/app/services/instance_pulse_service.py
+++ b/api/app/services/instance_pulse_service.py
@@ -137,15 +137,17 @@ def _check_postgres() -> tuple[str, float, str | None]:
 
 
 def _check_neo4j() -> tuple[str, float, str | None]:
+    # Reachability probe against the Neo4j server's unauthenticated HTTP
+    # discovery endpoint. NEO4J_HTTP_URL overrides the in-compose default.
+    url = os.environ.get("NEO4J_HTTP_URL", "http://neo4j:7474/")
     try:
-        # Lazy import — the graph store is optional in some test environments.
-        from app.services import graph_store_service
-        store = graph_store_service.get_store()
-        if store is None:
-            return ("silent", 0.0, "graph store unavailable")
-        # A simple read; the count itself is incidental.
-        store.run_query("MATCH (n) RETURN count(n) AS c LIMIT 1")
-        return ("breathing", 1.0, None)
+        import urllib.request
+
+        with urllib.request.urlopen(url, timeout=3) as resp:
+            status = getattr(resp, "status", 200)
+        if 200 <= status < 300:
+            return ("breathing", 1.0, None)
+        return ("strained", 0.5, f"neo4j answered {status}")
     except Exception as exc:
         return ("silent", 0.0, f"neo4j unreachable: {type(exc).__name__}")
 

--- a/api/tests/test_instance_pulse.py
+++ b/api/tests/test_instance_pulse.py
@@ -182,3 +182,37 @@ async def test_pulse_response_under_500ms():
     body = r.json()
     silent_names = [o["name"] for o in body["organs"] if o["status"] == "silent"]
     assert "neo4j" in silent_names
+
+
+# ---------------------------------------------------------------------------
+# 8. The neo4j probe reaches the real server, honestly in both directions
+# ---------------------------------------------------------------------------
+
+def test_check_neo4j_breathing_when_server_answers(monkeypatch):
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda url, timeout: _Resp())
+    status, score, detail = instance_pulse_service._check_neo4j()
+    assert (status, score, detail) == ("breathing", 1.0, None)
+
+
+def test_check_neo4j_silent_when_server_unreachable(monkeypatch):
+    import urllib.request
+
+    def _refuse(url, timeout):
+        raise ConnectionRefusedError("refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _refuse)
+    status, score, detail = instance_pulse_service._check_neo4j()
+    assert status == "silent"
+    assert score == 0.0
+    assert "neo4j unreachable" in detail


### PR DESCRIPTION
## What

The production pulse read `neo4j: silent — neo4j unreachable: ImportError` while the neo4j container itself was up, healthy, and answering. The probe in `instance_pulse_service._check_neo4j` imported `app.services.graph_store_service` — a module that never existed in the tree — so the check has died on ImportError at every breath since it shipped in #1974.

## Fix

The probe now touches the Neo4j server's unauthenticated HTTP discovery endpoint (`http://neo4j:7474/` on the compose network, `NEO4J_HTTP_URL` to override) with a bounded 3s timeout, and answers breathing / strained / silent from what the server actually says. Verified from inside the prod api container: the endpoint answers 200.

## Proof

- `api/tests/test_instance_pulse.py` — two new direct tests pin the probe in both directions (server answers → breathing; connection refused → silent); all 9 tests in the file pass.
- Post-deploy: `/api/pulse/now` overall returns to `breathing`; witness at pulse.coherencycoin.com clears the downstream silences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)