### PR TITLE
tend: the form gitlink returns to the form-submodule branch — deploys breathe again

### DIFF
--- a/api/app/services/instance_pulse_service.py
+++ b/api/app/services/instance_pulse_service.py
@@ -137,15 +137,17 @@ def _check_postgres() -> tuple[str, float, str | None]:
 
 
 def _check_neo4j() -> tuple[str, float, str | None]:
+    # Reachability probe against the Neo4j server's unauthenticated HTTP
+    # discovery endpoint. NEO4J_HTTP_URL overrides the in-compose default.
+    url = os.environ.get("NEO4J_HTTP_URL", "http://neo4j:7474/")
     try:
-        # Lazy import — the graph store is optional in some test environments.
-        from app.services import graph_store_service
-        store = graph_store_service.get_store()
-        if store is None:
-            return ("silent", 0.0, "graph store unavailable")
-        # A simple read; the count itself is incidental.
-        store.run_query("MATCH (n) RETURN count(n) AS c LIMIT 1")
-        return ("breathing", 1.0, None)
+        import urllib.request
+
+        with urllib.request.urlopen(url, timeout=3) as resp:
+            status = getattr(resp, "status", 200)
+        if 200 <= status < 300:
+            return ("breathing", 1.0, None)
+        return ("strained", 0.5, f"neo4j answered {status}")
     except Exception as exc:
         return ("silent", 0.0, f"neo4j unreachable: {type(exc).__name__}")
 

--- a/api/tests/test_instance_pulse.py
+++ b/api/tests/test_instance_pulse.py
@@ -182,3 +182,37 @@ async def test_pulse_response_under_500ms():
     body = r.json()
     silent_names = [o["name"] for o in body["organs"] if o["status"] == "silent"]
     assert "neo4j" in silent_names
+
+
+# ---------------------------------------------------------------------------
+# 8. The neo4j probe reaches the real server, honestly in both directions
+# ---------------------------------------------------------------------------
+
+def test_check_neo4j_breathing_when_server_answers(monkeypatch):
+    class _Resp:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    import urllib.request
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda url, timeout: _Resp())
+    status, score, detail = instance_pulse_service._check_neo4j()
+    assert (status, score, detail) == ("breathing", 1.0, None)
+
+
+def test_check_neo4j_silent_when_server_unreachable(monkeypatch):
+    import urllib.request
+
+    def _refuse(url, timeout):
+        raise ConnectionRefusedError("refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _refuse)
+    status, score, detail = instance_pulse_service._check_neo4j()
+    assert status == "silent"
+    assert score == 0.0
+    assert "neo4j unreachable" in detail


### PR DESCRIPTION
## What broke

Every Hostinger deploy since 2026-08-04 07:46 has failed the api image build with `COPY form/... not found`. PR #3993 pinned the `form` submodule to `29fae9c4` — a coherence-kernel **main** commit. Kernel main is an unrelated-history tree (no common ancestor with `form-submodule`) that nests the snapshot under `form/`, so mounted at `form/` every path doubles (`form/form/...`) and every Dockerfile COPY misses. The body's own evidence records name the rule this crossed: *the pinned snapshot lives on `form-submodule`, NOT main* (commit_evidence_2026-07-30_evidence_spectrum_six_strata.json).

This is also why the neo4j-probe heal (#3995) could not reach production.

## Fix

The gitlink returns to `655b8b3d` — the current `form-submodule` tip and the exact pre-#3993 pin that built and deployed cleanly.

## Follow-up (named, not waved at)

The moe-gate 511 proof remains proven on kernel main ([coherence-kernel#416](https://github.com/seeker71/coherence-kernel/pull/416)). Publishing its flattened snapshot onto `form-submodule` and advancing this pin is the follow-up — kernel-first, then an exact gitlink bump here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)