### PR TITLE
tend: the body learns the kernel's new anatomy — build paths follow the restructure

### DIFF
--- a/.github/workflows/thread-gates.yml
+++ b/.github/workflows/thread-gates.yml
@@ -163,8 +163,8 @@ jobs:
           test "$(bin/form-cli eval '(add 20 22)')" = 42
           test "$(bin/form-cli eval '(do (defn sum-to (n) (if (eq n 0) 0 (add n (sum-to (sub n 1))))) (sum-to 10))')" = 55
           test "$(bin/form-cli eval '(list 1 2.5 (list 3 4))')" = '[1, 2.5, [3, 4]]'
-          test "$(form/fkwu --src form/form-stdlib/tests/round-ndigits-band.fk 2>/dev/null)" = 24
-          form/validate.sh form-stdlib/tests/round-ndigits-band.fk
+          test "$(form/fkwu --src form/form/form-stdlib/tests/round-ndigits-band.fk 2>/dev/null)" = 24
+          form/form/validate.sh form-stdlib/tests/round-ndigits-band.fk
 
       - name: Run API tests
         if: steps.changed_surfaces.outputs.api == 'true'

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -37,9 +37,9 @@ RUN printf '%s\n%s\n' "$COHERENCE_SOURCE_SHA" "$COHERENCE_FORM_SHA" \
 # the local wrapper. Build the committed emitted-C carrier here; no Go/runtime
 # compiler enters the final image. A stale emitted carrier fails this image
 # build instead of silently deploying a different trust gate.
-COPY form/form-stdlib /build/form-cli-src/form-stdlib
-COPY form/scripts /build/form-cli-src/scripts
-COPY form/build-form-cli.sh /build/form-cli-src/build-form-cli.sh
+COPY form/form/form-stdlib /build/form-cli-src/form-stdlib
+COPY form/form/scripts /build/form-cli-src/scripts
+COPY form/form/build-form-cli.sh /build/form-cli-src/build-form-cli.sh
 RUN cd /build/form-cli-src \
  && CC=cc FORM_CLI_FORCE_LINK=1 ./build-form-cli.sh /build/form-cli \
  && test "$(printf 'ping\n' | /build/form-cli)" = "pong" \
@@ -120,7 +120,7 @@ COPY api/ ./
 # post-build (substrate ingest). Ship them at build time too so the image
 # is self-contained for local docker runs.
 COPY scripts/ ./scripts/
-COPY form/scripts/ ./form/scripts/
+COPY form/form/scripts/ ./form/scripts/
 COPY bin/form-cli ./bin/form-cli
 COPY bin/form-cli.sha256 ./bin/form-cli.sha256
 RUN chmod +x ./bin/form-cli \
@@ -128,7 +128,7 @@ RUN chmod +x ./bin/form-cli \
 
 # Form stdlib sources are executable runtime material. Direct fkwu evaluation
 # prepends the pinned core before each endpoint recipe.
-COPY form/form-stdlib/ ./form/form-stdlib/
+COPY form/form/form-stdlib/ ./form/form-stdlib/
 # Native carrier selection verifies the image-built binary with the pinned
 # Form proof helper before writing its receipt. Keep those scripts beside the
 # stdlib in the runtime image; they are verification tissue, not a toolchain.
@@ -136,33 +136,33 @@ RUN test "$(./bin/form-cli eval '(add 20 22)')" = 42
 
 # Transmuted-endpoint recipes. api/app/services/form_kernel_bridge.py resolves
 # `load_recipe("endpoint_*_demo.fk")` against
-# <repo-root>/form/form-kernel-ts/seedbank/python-adapter/examples/ — which,
+# <repo-root>/form/form/form-kernel-ts/seedbank/python-adapter/examples/ — which,
 # with api/ flattened onto /app, is /app/form/form-kernel-ts/seedbank/
 # python-adapter/examples/. Without these `.fk` on disk, load_recipe raises
 # FileNotFoundError and route execution fails closed. The complete live shared
 # recipe set is baked from the same coherence-kernel pin as fkwu.
-COPY form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_coherence_weight_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_nodeid_distance_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_nodeid_compatibility_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_weighted_average_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_simpson_diversity_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_idea_score_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_marginal_cc_return_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_breath_balance_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_softmax_weights_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_cost_vector_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_value_vector_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_grounded_roi_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_shannon_entropy_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_idea_marginal_from_record_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_idea_grounding_summary_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_idea_grounded_cost_sum_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_grounded_cost_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_grounded_value_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_concept_match_score_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_tag_match_score_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_worldview_alignment_demo.fk \
-     form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_coherence_summary_score_demo.fk \
+COPY form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_coherence_weight_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_nodeid_distance_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_nodeid_compatibility_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_weighted_average_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_simpson_diversity_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_idea_score_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_marginal_cc_return_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_breath_balance_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_softmax_weights_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_cost_vector_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_value_vector_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_grounded_roi_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_shannon_entropy_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_idea_marginal_from_record_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_idea_grounding_summary_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_idea_grounded_cost_sum_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_grounded_cost_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_grounded_value_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_concept_match_score_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_tag_match_score_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_worldview_alignment_demo.fk \
+     form/form/form-kernel-ts/seedbank/python-adapter/examples/endpoint_coherence_summary_score_demo.fk \
      ./form/form-kernel-ts/seedbank/python-adapter/examples/
 
 # Frontmatter source surfaces (specs, ideas, vision-kb). The deploy script

--- a/Dockerfile.kernel-router
+++ b/Dockerfile.kernel-router
@@ -50,10 +50,10 @@ WORKDIR /build
 # Copy the kernel crate. The crate is self-contained — no workspace, no
 # repo-relative path deps — so this is all the source it needs. This is the
 # SAME source set Dockerfile.api's kernel-builder copies.
-COPY form/form-kernel-rust/Cargo.toml form/form-kernel-rust/Cargo.lock ./
-COPY form/form-kernel-rust/src ./src
-COPY form/form-kernel-rust/libraries ./libraries
-COPY form/form-kernel-rust/recipes ./recipes
+COPY form/form/form-kernel-rust/Cargo.toml form/form/form-kernel-rust/Cargo.lock ./
+COPY form/form/form-kernel-rust/src ./src
+COPY form/form/form-kernel-rust/libraries ./libraries
+COPY form/form/form-kernel-rust/recipes ./recipes
 
 # Build the release binary and strip it — the SAME load-bearing build step
 # Dockerfile.api runs (cargo build --release --bin form-kernel-rust && strip).
@@ -104,7 +104,7 @@ COPY api/config/api.json /app/api/config/api.json
 # source-compiled at load via --stdlib). The default shadow manifest is raw
 # S-expression Form and does NOT touch the source-compiler, but baking the
 # stdlib in lets a BML manifest work later without rebuilding the image.
-COPY form/form-stdlib/ /app/form/form-stdlib/
+COPY form/form/form-stdlib/ /app/form/form-stdlib/
 
 # The route manifests: shadow is the deployable default; production carries the
 # current native route surface and its route metadata so promotion is a runtime
@@ -112,7 +112,7 @@ COPY form/form-stdlib/ /app/form/form-stdlib/
 COPY deploy/kernel-router/shadow-routes.fk /routes/shadow-routes.fk
 COPY deploy/kernel-router/production-routes.fk /routes/production-routes.fk
 COPY deploy/kernel-router/production-routes-data.json /routes/production-routes-data.json
-COPY form/apps/coherence-network/api.bml /routes/api.bml
+COPY form/form/apps/coherence-network/api.bml /routes/api.bml
 
 # Source-backed native routes read the canonical idea markdown index directly.
 # This is not the mutable DB-backed registry; it is the repo source surface that

--- a/deploy/db-api/Dockerfile
+++ b/deploy/db-api/Dockerfile
@@ -20,8 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends clang sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY form/ form/
-RUN cd form/form-kernel-go && go build -o bin-go .
-RUN cd form \
+RUN cd form/form/form-kernel-go && go build -o bin-go .
+RUN cd form/form \
  && { printf '(do\n'; cat form-stdlib/db-api-server.fk; \
       printf '\n(print "==C==")\n(print (das-emit))\n(print "==END==")\n0)\n'; } > /tmp/driver.fk \
  && ./form-kernel-go/bin-go /tmp/driver.fk \

--- a/scripts/ensure_form_cli_native.sh
+++ b/scripts/ensure_form_cli_native.sh
@@ -12,6 +12,9 @@
 set -euo pipefail
 ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FORM_DIR="$ROOT/form"
+# The kernel repo carries the classic tree nested one level down (form/form/…);
+# container images keep the flat lane. Stand on whichever is present.
+[ -d "$FORM_DIR/form-stdlib" ] || FORM_DIR="$ROOT/form/form"
 PRINT_PATH=0
 if [ "${1:-}" = "--print-path" ]; then
   PRINT_PATH=1

--- a/scripts/form-convert.sh
+++ b/scripts/form-convert.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FORM_DIR="$REPO_ROOT/form"
+[ -d "$FORM_DIR/form-stdlib" ] || FORM_DIR="$REPO_ROOT/form/form"
 
 KERNEL="rust"
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## What

The kernel repo restructured — the classic tree (`form-stdlib`, `form-cli`, the four walkers, `apps`, `scripts`) now lives nested at `form/form/…` while `runtime/` and `bootstrap/` stay at the submodule root. The gitlink bump to kernel main ([#3999](https://github.com/seeker71/Coherence-Network/pull/3999)) exposed every old-layout COPY: the API image build failed at `form/form-stdlib` ("not found") and both the CI **Roll forward VPS** step and the manual deploy died on it — production is still breathing on stale `dd57976b`.

This also names the root of the recurring **pin-not-on-main** disease: the previous pin `655b8b3d` was kernel #408's echo living only on `origin/form-submodule` — an old-anatomy hold that kept builds green while kernel main restructured. Healing the build paths un-forks the pin permanently.

## How

- `Dockerfile.api`, `Dockerfile.kernel-router`, `deploy/db-api/Dockerfile`, `.github/workflows/thread-gates.yml`: source paths gain the nested prefix; **in-image destinations untouched** (`/app/form/…` stays the flat lane — nothing inside containers moves, so the API's digest authorities and STDLIB_DIR are unchanged).
- `scripts/ensure_form_cli_native.sh`, `scripts/form-convert.sh`: `FORM_DIR` stands on whichever anatomy is present, so they work in the repo checkout and inside old-layout images alike.
- Every new source path verified present on kernel main by `git cat-file -e` before editing.

## Proof plan

Merge → deploy → verify `deployed_sha` == main head and witness breathing. The build failure that motivated this is fully legible in the deploy log (`COPY form/form-stdlib … not found").

🤖 Generated with [Claude Code](https://claude.com/claude-code)