### PR TITLE
tend(android): on-device fkwu band receipt runner — recovered from an untracked worktree file

### DIFF
--- a/docs/system_audit/commit_evidence_2026-08-13_android_band_receipt_recovered.json
+++ b/docs/system_audit/commit_evidence_2026-08-13_android_band_receipt_recovered.json
@@ -1,0 +1,97 @@
+{
+  "agent": {
+    "name": "Claude Code",
+    "version": "Fable 5"
+  },
+  "date": "2026-08-13",
+  "thread_branch": "claude/ship-android-band-receipt",
+  "change_intent": "process_only",
+  "commit_scope": "The on-device fkwu band receipt runner — emit fkwu's universal C, cross-compile aarch64 with NDK clang, run the band on the phone, return a verdict — recovered from the mesh-command-design worktree where it sat untracked since June, re-pathed for the kernel-submodule layout, and hardened so the receipt can actually FAIL: adb pushes are checked, the device exit code is read, and the device verdict is compared against the host walker's verdict over the same sources.",
+  "idea_ids": [
+    "agent-cli"
+  ],
+  "spec_ids": [
+    "fkwu-native-host-resources"
+  ],
+  "task_ids": [
+    "task-2026-08-13-android-band-receipt-recovered"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "instruction",
+        "frequency-correction"
+      ]
+    },
+    {
+      "contributor_id": "claude",
+      "contributor_type": "machine",
+      "roles": [
+        "recovery",
+        "re-pathing",
+        "hardening",
+        "receipt-authoring"
+      ]
+    },
+    {
+      "contributor_id": "chatgpt-codex-connector",
+      "contributor_type": "machine",
+      "roles": [
+        "review"
+      ]
+    }
+  ],
+  "change_files": [
+    "docs/system_audit/commit_evidence_2026-08-13_android_band_receipt_recovered.json",
+    "scripts/INDEX.md",
+    "scripts/android_fkwu_band_receipt.sh"
+  ],
+  "files_owned": [
+    "docs/system_audit/commit_evidence_2026-08-13_android_band_receipt_recovered.json",
+    "scripts/INDEX.md",
+    "scripts/android_fkwu_band_receipt.sh"
+  ],
+  "evidence_refs": [
+    "RECOVERY PROVENANCE: found untracked (never committed) in the mesh-command-design worktree during the 2026-08-13 branch cleanup; the worktree's branch itself was verified superseded (mesh-command.form landed via #3739, paths healed via #4002) and composted after this file was rescued.",
+    "RE-PATHING VERIFIED, NOT ASSUMED: every kernel file the script reads (fourth-shim.fk, minimal-surface.fk, hati-os-kernel.fk, hati-os-kernel-emit.fk, field-identity.fk, field-identity-band.fk, form-kernel-go) confirmed present at the new form/form/ submodule paths before the PR opened.",
+    "REVIEW FINDING P1 ACCEPTED AND CLOSED (chatgpt-codex-connector): the recovered script printed whatever the device returned as a 'verdict' and always exited 0 — a receipt that cannot fail. Now: each adb push is status-checked; the on-device run's exit code is read (echo EXIT:$? on the device); a nonzero device exit prints the device's error lines and exits 1; and the device verdict is compared against the host walker's verdict computed over the SAME shim+modules+band sources — mismatch exits 1. The expected-verdict lane was proven live: cat fourth-shim.fk field-identity.fk field-identity-band.fk | bin-go /dev/stdin -> 511, the band's documented expectation.",
+    "REVIEW FINDING P1 (evidence record) ACCEPTED: this file, validated with the prescribed script.",
+    "HONEST FLOOR, NAMED IN THE SCRIPT'S OWN HEADER: NDK clang is the c-bootstrap carrier and Go is the build-time flattener only — neither is in the fkwu runtime path on the device; the standard-receipt android row stays honest-bootstrap until form-elf emits the ELF bytes directly."
+  ],
+  "local_validation": {
+    "status": "pass",
+    "commands": [
+      "bash -n scripts/android_fkwu_band_receipt.sh -> syntax ok",
+      "cat form-stdlib/fourth-shim.fk form-stdlib/field-identity.fk form-stdlib/tests/field-identity-band.fk | form-kernel-go/bin-go /dev/stdin -> 511 (the host-walker expected-verdict lane the new comparison stands on)",
+      "bash scripts/android_fkwu_band_receipt.sh -> 'no adb device; skipping' (graceful no-device exit 0, unchanged)"
+    ],
+    "notes": "The on-device lane itself needs a phone on adb; no device was attached this session, so the device path is exercised up to its guard and the comparison logic is proven at the host-walker end."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "commands": [
+      "gh pr checks 4010 --repo seeker71/Coherence-Network"
+    ],
+    "notes": "validate-thread-process passed on the first commit; windows-floor carries the repo's standing failure (documented in commit_evidence_2026-08-13_hati_os_windows_row_recovered.json and spawned as its own heal task)."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "environment": "none",
+    "notes": "An operator script; nothing deploys. The next real proof is a run with a phone on adb — the standard-receipt android row observation."
+  },
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "scripts/android_fkwu_band_receipt.sh [module.fk ... band.fk] on a Mac with an adb device produces an on-device fkwu verdict that PASSES only when it matches the host walker over the same sources, and fails loudly on push, execution, or verdict divergence.",
+    "public_endpoints": [],
+    "test_flows": [
+      "With a phone attached: bash scripts/android_fkwu_band_receipt.sh -> expected 511, device 511, PASS."
+    ],
+    "notes": "Pending an attached device; the no-device guard and the expected-verdict lane are the parts provable tonight, and both are proven."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false,
+    "reason": "Review findings closed and the comparison lane proven at the host end; the on-device observation itself awaits a phone on adb."
+  }
+}

--- a/scripts/INDEX.md
+++ b/scripts/INDEX.md
@@ -4,7 +4,7 @@
 > purpose comes from the top docstring/comment of the file. To update
 > a description, edit the file's first line and re-run the script.
 
-**Total files**: 405
+**Total files**: 406
 
 | File | Purpose |
 |---|---|
@@ -16,6 +16,7 @@
 | [agent_tooluse_featurize.py](agent_tooluse_featurize.py) | agent_tooluse_featurize.py — CARRIER (data prep only). Turns the real agent corpus |
 | [agent_tooluse_train.sh](agent_tooluse_train.sh) | agent_tooluse_train.sh — a REAL model on REAL data at full scale, natively. |
 | [android_core_axiom_apk_receipt.sh](android_core_axiom_apk_receipt.sh) | Build a native arm64 core-axiom receipt library into the Android APK and |
+| [android_fkwu_band_receipt.sh](android_fkwu_band_receipt.sh) | android_fkwu_band_receipt.sh — the standard-receipt ANDROID row for fkwu: emit the universal |
 | [android_mac_core_axiom_receipt.sh](android_mac_core_axiom_receipt.sh) | Build and run a native Mac + Android core-axiom receipt pair. |
 | [archive_view_events.py](archive_view_events.py) | Move days of asset_view_events into cold-tier storage. |
 | [arrival.py](arrival.py) | Arrival — read first, sense the body, then begin. |

--- a/scripts/android_fkwu_band_receipt.sh
+++ b/scripts/android_fkwu_band_receipt.sh
@@ -48,16 +48,36 @@ printf '(print (fks-table-file (flt-band-sources-fns (list%s) (read_file "%s")) 
 printf '' > "$d/bundle"
 echo "flattened table: $(wc -c < "$d/table.txt") bytes"
 
-# 4. push to the phone and run fkwu ON THE DEVICE
+# 4. the expected verdict, computed by the host walker over the SAME sources —
+#    the receipt is a comparison, so a device failure or a wrong number FAILS.
+EXPECT="$(cat "$FOURTH_SHIM" "${mods[@]}" "$last" | "$GO_BIN" /dev/stdin 2>/dev/null | head -1 | tr -d '\r')"
+case "$EXPECT" in
+    ''|*[!0-9-]*) echo "FAIL: host walker produced no numeric verdict for $last (got: ${EXPECT:-<empty>})"; exit 1 ;;
+esac
+echo "expected verdict (host walker): $EXPECT"
+
+# 5. push to the phone and run fkwu ON THE DEVICE
 R="/data/local/tmp/fkwu-recv-$$"
-adb -s "$DEV" push "$d/fkwu-android" "${R}.bin" >/dev/null 2>&1
-adb -s "$DEV" push "$d/table.txt" "${R}.tbl" >/dev/null 2>&1
-adb -s "$DEV" push "$d/bundle" "${R}.bun" >/dev/null 2>&1
-V="$(adb -s "$DEV" shell "chmod 755 ${R}.bin; cd /data/local/tmp; ./fkwu-recv-$$.bin ${R}.tbl 0 ${R}.bun" 2>&1 | head -1 | tr -d '\r')"
+adb -s "$DEV" push "$d/fkwu-android" "${R}.bin" >/dev/null || { echo "FAIL: adb push binary"; exit 1; }
+adb -s "$DEV" push "$d/table.txt" "${R}.tbl" >/dev/null || { echo "FAIL: adb push table"; exit 1; }
+adb -s "$DEV" push "$d/bundle" "${R}.bun" >/dev/null || { echo "FAIL: adb push bundle"; exit 1; }
+DEVOUT="$(adb -s "$DEV" shell "chmod 755 ${R}.bin && cd /data/local/tmp && ./fkwu-recv-$$.bin ${R}.tbl 0 ${R}.bun; echo EXIT:\$?" 2>&1 | tr -d '\r')"
+V="$(echo "$DEVOUT" | head -1)"
+DEVEXIT="$(echo "$DEVOUT" | sed -n 's/^EXIT://p' | tail -1)"
 DEVMODEL="$(adb -s "$DEV" shell getprop ro.product.model 2>/dev/null | tr -d '\r')"
 ABI="$(adb -s "$DEV" shell getprop ro.product.cpu.abi 2>/dev/null | tr -d '\r')"
 adb -s "$DEV" shell "rm -f ${R}.bin ${R}.tbl ${R}.bun" >/dev/null 2>&1
 echo
 echo "ON-DEVICE fkwu run — $DEVMODEL ($ABI), device $DEV"
 echo "  band: $last"
-echo "  verdict on the phone's fkwu: $V"
+echo "  verdict on the phone's fkwu: $V (device exit ${DEVEXIT:-unknown})"
+if [ "${DEVEXIT:-1}" != "0" ]; then
+    echo "FAIL: on-device fkwu exited nonzero; first output line above is the error, not a verdict"
+    echo "$DEVOUT" | sed -n '1,8p' | sed 's/^/    /'
+    exit 1
+fi
+if [ "$V" != "$EXPECT" ]; then
+    echo "FAIL: device verdict $V != host walker verdict $EXPECT"
+    exit 1
+fi
+echo "  PASS: device verdict matches the host walker ($EXPECT)"

--- a/scripts/android_fkwu_band_receipt.sh
+++ b/scripts/android_fkwu_band_receipt.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# android_fkwu_band_receipt.sh — the standard-receipt ANDROID row for fkwu: emit the universal
+# walker C (fkwu, Form-emitted), cross-compile it for aarch64-android with the NDK clang into an
+# ELF, push it to the phone with a flattened band table, and run the band ON THE DEVICE -> a verdict.
+#
+# The fkwu binary has NO Go/Rust/TS/python in its runtime path. Go appears only as the build-time
+# FLATTENER (the band table); NDK clang only as the C bootstrap (the standard-receipt c-bootstrap
+# row, honest until form-elf emits the ELF bytes directly and drops clang too). This is the
+# "observe what the on-device fkwu run actually does" loop — implement, run, adjust.
+#
+# Usage: android_fkwu_band_receipt.sh [module.fk ... band.fk]   (default: field-identity, expect 511)
+set -u
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT/form/form" || exit 3
+export GO_BIN="$ROOT/form/form/form-kernel-go/bin-go"; export TMPDIR="${TMPDIR:-/tmp}"
+[ -x "$GO_BIN" ] || (cd form-kernel-go && go build -o bin-go .) >/dev/null 2>&1 || true
+RECIPES=("$@"); [ "${#RECIPES[@]}" -ge 1 ] || RECIPES=(form-stdlib/field-identity.fk form-stdlib/tests/field-identity-band.fk)
+last="${RECIPES[$((${#RECIPES[@]}-1))]}"; mods=("${RECIPES[@]:0:$((${#RECIPES[@]}-1))}")
+
+DEV="$(adb devices 2>/dev/null | awk 'NR>1 && $2=="device"{print $1; exit}')"
+[ -n "$DEV" ] || { echo "no adb device; skipping"; exit 0; }
+NDK="${ANDROID_NDK_HOME:-$(ls -d /opt/homebrew/Caskroom/android-ndk/*/AndroidNDK*.app/Contents/NDK 2>/dev/null | head -1)}"
+CC="$(ls "$NDK"/toolchains/llvm/prebuilt/*/bin/aarch64-linux-android*-clang 2>/dev/null | sort -V | tail -1)"
+[ -x "$CC" ] || { echo "no NDK aarch64 clang; skipping"; exit 0; }
+
+set +u; . scripts/fourth-arm.sh; set -u
+FOURTH_SHIM="form-stdlib/fourth-shim.fk"
+d="$(mktemp -d "${TMPDIR}/afkwu.XXXXXX")"; trap 'rm -rf "$d"' EXIT
+
+# 1. emit the universal walker C (Form-emitted: fkc-emit-universal)
+cat form-stdlib/minimal-surface.fk form-stdlib/hati-os-kernel.fk form-stdlib/hati-os-kernel-emit.fk > "$d/uni-driver.fk"
+printf '(do (print "==UNI==") (print (fkc-emit-universal)) (print "==END==") 0)\n' >> "$d/uni-driver.fk"
+"$GO_BIN" "$d/uni-driver.fk" 2>/dev/null | sed -n '/^==UNI==$/,/^==END==$/p' | sed -e '1d' -e '$d' > "$d/uni.c"
+[ -s "$d/uni.c" ] || { echo "FAIL: emit produced no C"; exit 1; }
+echo "emitted fkwu C: $(wc -l < "$d/uni.c") lines"
+
+# 2. cross-compile the SAME C for aarch64-android (the only clang in the loop, the c-bootstrap)
+"$CC" -O2 -Wno-implicit-function-declaration -Wno-incompatible-library-redeclaration -pthread \
+    -o "$d/fkwu-android" "$d/uni.c" 2>"$d/cc.err" || { echo "FAIL: android compile:"; sed -n '1,15p' "$d/cc.err"; exit 1; }
+file "$d/fkwu-android" | sed 's/^/  /'
+
+# 3. flatten the band into an fkwu node-table (Go = build-time flattener only)
+modexpr=" (read_file \"$FOURTH_SHIM\")"; for m in "${mods[@]}"; do modexpr="$modexpr (read_file \"$m\")"; done
+cat "${FOURTH_CHAIN[@]}" > "$d/fdriver.fk"
+printf '(print (fks-table-file (flt-band-sources-fns (list%s) (read_file "%s")) (flt-band-sources-pool (list%s) (read_file "%s"))))\n' \
+    "$modexpr" "$last" "$modexpr" "$last" >> "$d/fdriver.fk"
+"$GO_BIN" "$d/fdriver.fk" 2>/dev/null > "$d/table.txt"
+[ -s "$d/table.txt" ] || { echo "FAIL: flatten produced no table"; exit 1; }
+printf '' > "$d/bundle"
+echo "flattened table: $(wc -c < "$d/table.txt") bytes"
+
+# 4. push to the phone and run fkwu ON THE DEVICE
+R="/data/local/tmp/fkwu-recv-$$"
+adb -s "$DEV" push "$d/fkwu-android" "${R}.bin" >/dev/null 2>&1
+adb -s "$DEV" push "$d/table.txt" "${R}.tbl" >/dev/null 2>&1
+adb -s "$DEV" push "$d/bundle" "${R}.bun" >/dev/null 2>&1
+V="$(adb -s "$DEV" shell "chmod 755 ${R}.bin; cd /data/local/tmp; ./fkwu-recv-$$.bin ${R}.tbl 0 ${R}.bun" 2>&1 | head -1 | tr -d '\r')"
+DEVMODEL="$(adb -s "$DEV" shell getprop ro.product.model 2>/dev/null | tr -d '\r')"
+ABI="$(adb -s "$DEV" shell getprop ro.product.cpu.abi 2>/dev/null | tr -d '\r')"
+adb -s "$DEV" shell "rm -f ${R}.bin ${R}.tbl ${R}.bun" >/dev/null 2>&1
+echo
+echo "ON-DEVICE fkwu run — $DEVMODEL ($ABI), device $DEV"
+echo "  band: $last"
+echo "  verdict on the phone's fkwu: $V"


### PR DESCRIPTION
Recovered during the branch cleanup: `android_fkwu_band_receipt.sh` sat untracked in the mesh-command-design worktree since June — the standard-receipt Android row's observe-loop (emit fkwu's universal C, NDK cross-compile, run the band on the phone, return a verdict). Paths ported `form/` → `form/form/` for the kernel-submodule layout; every referenced kernel file verified present at the new paths; syntax-checked; graceful no-adb skip verified. INDEX edge in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)