### PR TITLE
feat(dialogue): persist both sides of public threads

### DIFF
--- a/api/app/form_recipes/public_dialogue_thread_window.fk
+++ b/api/app/form_recipes/public_dialogue_thread_window.fk
@@ -1,0 +1,118 @@
+; public_dialogue_thread_window.fk — bounded connected-turn selection in Form.
+(do
+  (defn dialogue-thread-node-id (node) (nth node 0))
+  (defn dialogue-thread-parent-id (node) (nth node 1))
+
+  (defn dialogue-thread-member (value values)
+    (if (eq (len values) 0) 0
+        (if (str_eq value (head values)) 1
+            (dialogue-thread-member value (tail values)))))
+
+  (defn dialogue-thread-parent (node-id nodes)
+    (if (eq (len nodes) 0) ""
+        (if (str_eq node-id (dialogue-thread-node-id (head nodes)))
+            (dialogue-thread-parent-id (head nodes))
+            (dialogue-thread-parent node-id (tail nodes)))))
+
+  (defn dialogue-thread-ancestry (node-id nodes remaining path)
+    (if (le remaining 1) path
+        (do
+          (let parent-id (dialogue-thread-parent node-id nodes))
+          (if (str_eq parent-id "") path
+              (if (eq (dialogue-thread-member parent-id path) 1) path
+                  (dialogue-thread-ancestry
+                    parent-id nodes (sub remaining 1) (cons parent-id path)))))))
+
+  (defn dialogue-thread-append (values value)
+    (if (eq (len values) 0) (list value)
+        (cons (head values) (dialogue-thread-append (tail values) value))))
+
+  (defn dialogue-thread-scan (nodes selected maximum truncated)
+    (if (eq (len nodes) 0) (list selected truncated)
+        (do
+          (let node (head nodes))
+          (let node-id (dialogue-thread-node-id node))
+          (let parent-id (dialogue-thread-parent-id node))
+          (if (eq (dialogue-thread-member node-id selected) 1)
+              (dialogue-thread-scan (tail nodes) selected maximum truncated)
+              (if (eq (dialogue-thread-member parent-id selected) 1)
+                  (if (lt (len selected) maximum)
+                      (dialogue-thread-scan
+                        (tail nodes)
+                        (dialogue-thread-append selected node-id)
+                        maximum truncated)
+                      (dialogue-thread-scan (tail nodes) selected maximum 1))
+                  (dialogue-thread-scan
+                    (tail nodes) selected maximum truncated))))))
+
+  (defn dialogue-thread-join (values out)
+    (if (eq (len values) 0) out
+        (dialogue-thread-join
+          (tail values)
+          (if (str_eq out "") (head values)
+              (str_concat out (str_concat "," (head values)))))))
+
+  (defn dialogue-thread-pipe (left right)
+    (str_concat left (str_concat "|" right)))
+
+  (defn dialogue-thread-window (nodes anchor-id maximum)
+    (do
+      (let ancestry
+        (dialogue-thread-ancestry anchor-id nodes maximum (list anchor-id)))
+      (let oldest-id (head ancestry))
+      (let continuation-id (dialogue-thread-parent oldest-id nodes))
+      (let scan
+        (dialogue-thread-scan
+          nodes ancestry maximum
+          (if (str_eq continuation-id "") 0 1)))
+      (let selected (nth scan 0))
+      (let truncated (nth scan 1))
+      (list
+        (if (str_eq continuation-id "") oldest-id "")
+        (head selected)
+        continuation-id
+        anchor-id
+        selected
+        truncated)))
+
+  (defn dialogue-thread-window-receipt (nodes anchor-id maximum)
+    (do
+      (let window (dialogue-thread-window nodes anchor-id maximum))
+      (let selected (nth window 4))
+      (dialogue-thread-pipe (nth window 0)
+        (dialogue-thread-pipe (nth window 1)
+          (dialogue-thread-pipe (nth window 2)
+            (dialogue-thread-pipe (nth window 3)
+              (dialogue-thread-pipe
+                (dialogue-thread-join selected "")
+                (if (eq (nth window 5) 1) "1" "0"))))))))
+
+  (defn dialogue-thread-window-band ()
+    (do
+      (let nodes
+        (list
+          (list "72" "")
+          (list "61" "72")
+          (list "62" "72")
+          (list "63" "61")))
+      (let branch (dialogue-thread-window nodes "61" 3))
+      (let deep (dialogue-thread-window nodes "63" 2))
+      (add
+        (if (str_eq (nth branch 0) "72") 1 0)
+        (add
+          (if (str_eq (nth branch 1) "72") 2 0)
+          (add
+            (if (str_eq (nth branch 2) "") 4 0)
+            (add
+              (if (eq (dialogue-thread-member "61" (nth branch 4)) 1) 8 0)
+              (add
+                (if (eq (dialogue-thread-member "62" (nth branch 4)) 1) 16 0)
+                (add
+                  (if (eq (dialogue-thread-member "63" (nth branch 4)) 0) 32 0)
+                  (add
+                    (if (eq (nth branch 5) 1) 64 0)
+                    (add
+                      (if (str_eq (nth deep 0) "") 128 0)
+                      (if (str_eq (nth deep 2) "72") 256 0)))))))))))
+
+  (dialogue-thread-window-band))

--- a/api/app/routers/dialogues.py
+++ b/api/app/routers/dialogues.py
@@ -6,7 +6,7 @@ import re
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Request, Response, status
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from starlette.concurrency import run_in_threadpool
 
 from app.services import dialogue_service
@@ -21,12 +21,15 @@ def _public_origin(request: Request) -> str:
     return request.client.host if request.client else "unknown"
 
 
-class DialogueCreate(BaseModel):
+class DialogueOffer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     question: str = Field(..., min_length=1, max_length=1200)
     point_of_view: str = Field(..., min_length=1, max_length=240)
     locale: str = Field(..., min_length=1, max_length=80)
-    public_disclosure_ack: Literal["public-unlisted-v1"]
-    parent_dialogue_id: str | None = Field(default=None, max_length=80)
+    public_disclosure_ack: Literal[
+        "public-unlisted-v1", "public-unlisted-thread-v2"
+    ]
     channel_timeout_seconds: int = Field(default=90, ge=10, le=120)
 
     @field_validator("question", "point_of_view")
@@ -42,6 +45,14 @@ class DialogueCreate(BaseModel):
     def locale_is_bcp47(cls, value: str) -> str:
         dialogue_service.canonicalize_locale(value)
         return value.strip()
+
+
+class DialogueCreate(DialogueOffer):
+    parent_dialogue_id: str | None = Field(default=None, max_length=80)
+
+
+class DialogueReply(DialogueOffer):
+    public_disclosure_ack: Literal["public-unlisted-thread-v2"]
 
 
 class DialogueRelease(BaseModel):
@@ -72,6 +83,69 @@ async def start_dialogue(body: DialogueCreate, request: Request, response: Respo
             detail=str(exc),
             headers={"Retry-After": "15"},
         ) from exc
+
+
+@router.post(
+    "/{dialogue_id}/replies",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Reply to an unlisted public dialogue turn",
+)
+async def reply_dialogue(
+    dialogue_id: str,
+    body: DialogueReply,
+    request: Request,
+    response: Response,
+) -> dict:
+    """Persist a child turn while the path fixes the parent edge."""
+    response.headers["Cache-Control"] = "no-store"
+    try:
+        return await run_in_threadpool(
+            dialogue_service.submit_dialogue,
+            **body.model_dump(),
+            network_peer=_public_origin(request),
+            parent_dialogue_id=dialogue_id,
+        )
+    except dialogue_service.DialogueRateLimitError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=str(exc),
+            headers={"Retry-After": str(exc.retry_after)},
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=str(exc),
+            headers={"Retry-After": "15"},
+        ) from exc
+
+
+@router.get(
+    "/{dialogue_id}/thread",
+    summary="Observe one bounded unlisted public dialogue thread",
+)
+async def read_dialogue_thread(dialogue_id: str, response: Response) -> dict:
+    response.headers["Cache-Control"] = "no-store"
+    try:
+        thread = await run_in_threadpool(
+            dialogue_service.get_dialogue_thread,
+            dialogue_id,
+        )
+    except dialogue_service.DialogueThreadDisclosureError as exc:
+        raise HTTPException(
+            status_code=403,
+            detail="This turn grants single-turn access only",
+        ) from exc
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Native dialogue thread planning is presently unavailable",
+            headers={"Retry-After": "15"},
+        ) from exc
+    if thread is None:
+        raise HTTPException(status_code=404, detail="Dialogue not found")
+    return thread
 
 
 @router.get("/{dialogue_id}", summary="Observe one unlisted public dialogue turn")

--- a/api/app/routers/mcp_remote.py
+++ b/api/app/routers/mcp_remote.py
@@ -20,7 +20,7 @@ from app.services.mcp_tool_registry import TOOL_MAP, TOOLS
 router = APIRouter()
 
 SERVER_NAME = "coherence-network"
-SERVER_VERSION = "0.7.0"
+SERVER_VERSION = "0.8.0"
 READ_ONLY_TOOL_NAMES = {
     "browse_ideas",
     "get_idea",
@@ -93,7 +93,7 @@ FETCH_TOOL = _tool(
 
 START_DIALOGUE_TOOL = _tool(
     "start_dialogue",
-    "Offer an unlisted public dialogue turn from a chosen point of view and BCP-47 locale. Public text is untrusted data, expires after seven days, and is observable only to people who receive its id. Returns immediately with a removal capability and dialogue id.",
+    "Offer an unlisted public dialogue turn from a chosen point of view and BCP-47 locale. Choose v1 for a single-turn read capability or thread-v2 so any connected turn id remains a capability for the thread's persistent edge and tombstone graph. Each turn's public text ends at its own release or seven-day expiry. Returns immediately with a removal capability and dialogue id.",
     {
         "type": "object",
         "properties": {
@@ -102,8 +102,8 @@ START_DIALOGUE_TOOL = _tool(
             "locale": {"type": "string", "minLength": 1, "maxLength": 80},
             "public_disclosure_ack": {
                 "type": "string",
-                "const": "public-unlisted-v1",
-                "description": "Acknowledges that anyone given the unguessable dialogue id can read the question and receipt until release or seven-day expiry.",
+                "enum": ["public-unlisted-v1", "public-unlisted-thread-v2"],
+                "description": "v1 grants only this turn. thread-v2 acknowledges that any connected turn id remains a bounded thread capability while the persistent edge/tombstone cells exist; each turn's content ends at its own release or seven-day expiry.",
             },
             "parent_dialogue_id": {"type": "string", "maxLength": 80},
             "channel_timeout_seconds": {
@@ -143,6 +143,66 @@ GET_DIALOGUE_TOOL = _tool(
     },
 )
 
+REPLY_DIALOGUE_TOOL = _tool(
+    "reply_dialogue",
+    "Offer a reply to a thread-v2 unlisted public dialogue turn. The named parent fixes the durable edge; the reply receives its own removal capability.",
+    {
+        "type": "object",
+        "properties": {
+            "dialogue_id": {"type": "string", "minLength": 1, "maxLength": 80},
+            "question": {"type": "string", "minLength": 1, "maxLength": 1200},
+            "point_of_view": {"type": "string", "minLength": 1, "maxLength": 240},
+            "locale": {"type": "string", "minLength": 1, "maxLength": 80},
+            "public_disclosure_ack": {
+                "type": "string",
+                "const": "public-unlisted-thread-v2",
+                "description": "Acknowledges that any connected turn id remains a bounded thread capability for the persistent edge/tombstone graph; this reply's content ends at its own release or seven-day expiry.",
+            },
+            "channel_timeout_seconds": {
+                "type": "integer",
+                "minimum": 10,
+                "maximum": 120,
+                "default": 90,
+            },
+        },
+        "required": [
+            "dialogue_id",
+            "question",
+            "point_of_view",
+            "locale",
+            "public_disclosure_ack",
+        ],
+        "additionalProperties": False,
+    },
+    annotations={
+        "title": "Reply to public dialogue",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+
+GET_DIALOGUE_THREAD_TOOL = _tool(
+    "get_dialogue_thread",
+    "Observe a bounded connected public dialogue thread from any thread-v2 turn id. Legacy v1 ids remain single-turn-only.",
+    {
+        "type": "object",
+        "properties": {
+            "dialogue_id": {"type": "string", "minLength": 1, "maxLength": 80}
+        },
+        "required": ["dialogue_id"],
+        "additionalProperties": False,
+    },
+    annotations={
+        "title": "Get public dialogue thread",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+
 REMOVE_DIALOGUE_TOOL = _tool(
     "remove_dialogue",
     "Release the public text of one dialogue using the removal capability returned only when it was started. The durable cell remains as a content-free tombstone.",
@@ -170,6 +230,8 @@ def _remote_tools() -> list[dict[str, Any]]:
         FETCH_TOOL,
         START_DIALOGUE_TOOL,
         GET_DIALOGUE_TOOL,
+        REPLY_DIALOGUE_TOOL,
+        GET_DIALOGUE_THREAD_TOOL,
         REMOVE_DIALOGUE_TOOL,
     ]
     for item in TOOLS:
@@ -302,8 +364,11 @@ def _start_dialogue(arguments: dict[str, Any], *, public_origin: str) -> dict[st
             "parent_dialogue_id",
             optional=True,
         )
-        if public_disclosure_ack != "public-unlisted-v1":
-            return {"error": "public_disclosure_ack must equal 'public-unlisted-v1'"}
+        if public_disclosure_ack not in (
+            "public-unlisted-v1",
+            "public-unlisted-thread-v2",
+        ):
+            return {"error": "public_disclosure_ack names an unsupported version"}
         raw_timeout = (
             arguments["channel_timeout_seconds"]
             if "channel_timeout_seconds" in arguments
@@ -315,7 +380,7 @@ def _start_dialogue(arguments: dict[str, Any], *, public_origin: str) -> dict[st
             question=question,
             point_of_view=point_of_view,
             locale=locale,
-            public_disclosure_ack="public-unlisted-v1",
+            public_disclosure_ack=public_disclosure_ack,
             network_peer=public_origin,
             parent_dialogue_id=parent_dialogue_id or None,
             channel_timeout_seconds=raw_timeout,
@@ -337,6 +402,66 @@ def _get_dialogue(arguments: dict[str, Any]) -> dict[str, Any]:
         return {"error": "dialogue_id is required"}
     dialogue = dialogue_service.get_dialogue(dialogue_id)
     return dialogue if dialogue is not None else {"error": "Dialogue not found"}
+
+
+def _reply_dialogue(arguments: dict[str, Any], *, public_origin: str) -> dict[str, Any]:
+    from app.services import dialogue_service
+
+    try:
+        dialogue_id = _string_argument(arguments, "dialogue_id").strip()
+        question = _string_argument(arguments, "question")
+        point_of_view = _string_argument(arguments, "point_of_view")
+        locale = _string_argument(arguments, "locale")
+        public_disclosure_ack = _string_argument(
+            arguments,
+            "public_disclosure_ack",
+        )
+        if not dialogue_id:
+            return {"error": "dialogue_id is required"}
+        if public_disclosure_ack != "public-unlisted-thread-v2":
+            return {
+                "error": (
+                    "public_disclosure_ack must equal "
+                    "'public-unlisted-thread-v2' for replies"
+                )
+            }
+        raw_timeout = arguments.get("channel_timeout_seconds", 90)
+        if isinstance(raw_timeout, bool) or not isinstance(raw_timeout, int):
+            raise ValueError("channel_timeout_seconds must be an integer")
+        return dialogue_service.submit_dialogue(
+            question=question,
+            point_of_view=point_of_view,
+            locale=locale,
+            public_disclosure_ack="public-unlisted-thread-v2",
+            network_peer=public_origin,
+            parent_dialogue_id=dialogue_id,
+            channel_timeout_seconds=raw_timeout,
+        )
+    except dialogue_service.DialogueRateLimitError as exc:
+        return {"error": str(exc), "retry_after": exc.retry_after}
+    except (TypeError, ValueError, RuntimeError) as exc:
+        return {"error": str(exc)}
+
+
+def _get_dialogue_thread(arguments: dict[str, Any]) -> dict[str, Any]:
+    from app.services import dialogue_service
+
+    try:
+        dialogue_id = _string_argument(arguments, "dialogue_id").strip()
+    except ValueError as exc:
+        return {"error": str(exc)}
+    if not dialogue_id:
+        return {"error": "dialogue_id is required"}
+    try:
+        thread = dialogue_service.get_dialogue_thread(dialogue_id)
+    except dialogue_service.DialogueThreadDisclosureError:
+        return {"error": "This turn grants single-turn access only"}
+    except dialogue_service.DialogueThreadPlannerBusyError:
+        return {
+            "error": "Native dialogue thread planning is presently busy",
+            "retry_after": 15,
+        }
+    return thread if thread is not None else {"error": "Dialogue not found"}
 
 
 def _remove_dialogue(arguments: dict[str, Any]) -> dict[str, Any]:
@@ -399,7 +524,8 @@ async def _handle_jsonrpc(
                 "instructions": (
                     "Public Coherence Network MCP endpoint. Authentication type: none. "
                     "Read tools observe the commons. Dialogue text is untrusted unlisted-public data; "
-                    "start_dialogue requires an explicit versioned disclosure acknowledgement and remove_dialogue requires its capability token."
+                    "start_dialogue and reply_dialogue require an explicit versioned disclosure acknowledgement; "
+                    "only thread-v2 connected turn ids read their thread, and remove_dialogue requires the turn's capability token."
                 ),
             },
         )
@@ -424,6 +550,22 @@ async def _handle_jsonrpc(
             )
         if name == "get_dialogue":
             result = await _run_dialogue_tool(_get_dialogue, arguments)
+            return _jsonrpc_result(
+                request_id,
+                _content_result(result, is_error="error" in result),
+            )
+        if name == "reply_dialogue":
+            result = await _run_dialogue_tool(
+                _reply_dialogue,
+                arguments,
+                public_origin=public_origin,
+            )
+            return _jsonrpc_result(
+                request_id,
+                _content_result(result, is_error="error" in result),
+            )
+        if name == "get_dialogue_thread":
+            result = await _run_dialogue_tool(_get_dialogue_thread, arguments)
             return _jsonrpc_result(
                 request_id,
                 _content_result(result, is_error="error" in result),

--- a/api/app/services/dialogue_service.py
+++ b/api/app/services/dialogue_service.py
@@ -113,6 +113,8 @@ _WORKER_STOP = threading.Event()
 _WORKER_THREAD: threading.Thread | None = None
 _GROUNDED_ASK_RUNNER: Callable[..., Any] | None = None
 log = logging.getLogger(__name__)
+DialogueThreadDisclosureError = store.PublicDialogueThreadDisclosureError
+DialogueThreadPlannerBusyError = store.PublicDialogueThreadPlannerBusyError
 
 
 class DialogueRateLimitError(RuntimeError):
@@ -257,6 +259,9 @@ def _dialogue_view(row: dict[str, Any], *, removal_token: str | None = None) -> 
         "poll_url": f"/api/dialogues/{row['id']}",
         "release_url": f"/api/dialogues/{row['id']}",
     }
+    if row["disclosure_ack"] == store.PUBLIC_DISCLOSURE_ACK:
+        view["reply_url"] = f"/api/dialogues/{row['id']}/replies"
+        view["thread_url"] = f"/api/dialogues/{row['id']}/thread"
     if removal_token is not None:
         view["removal_token"] = removal_token
         view["removal_token_note"] = (
@@ -276,9 +281,13 @@ def submit_dialogue(
     channel_timeout_seconds: int = 90,
 ) -> dict[str, Any]:
     """Persist one unlisted public turn and wake the attending CPU worker."""
-    if public_disclosure_ack != store.PUBLIC_DISCLOSURE_ACK:
+    if public_disclosure_ack not in store.PUBLIC_DISCLOSURE_ACKS:
         raise ValueError(
-            f"public_disclosure_ack must equal {store.PUBLIC_DISCLOSURE_ACK!r}"
+            "public_disclosure_ack must name a supported disclosure version"
+        )
+    if parent_dialogue_id is not None and public_disclosure_ack != store.PUBLIC_DISCLOSURE_ACK:
+        raise ValueError(
+            f"thread replies require public_disclosure_ack {store.PUBLIC_DISCLOSURE_ACK!r}"
         )
     question = question.strip()
     point_of_view = point_of_view.strip()
@@ -327,6 +336,7 @@ def submit_dialogue(
                 requested_locale=requested_locale,
                 canonical_locale=canonical_locale,
                 parent_dialogue_id=parent_dialogue_id,
+                public_disclosure_ack=public_disclosure_ack,
                 channel_timeout_seconds=channel_timeout_seconds,
                 network_peer_sha256=network_peer_sha256,
                 expires_at=expires_at,
@@ -349,6 +359,30 @@ def get_dialogue(dialogue_id: str) -> dict[str, Any] | None:
         return None
     _WORKER_WAKE.set()
     return _dialogue_view(row)
+
+
+def get_dialogue_thread(dialogue_id: str) -> dict[str, Any] | None:
+    """Observe the bounded connected thread named by one unlisted turn id."""
+    ensure_dialogue_worker()
+    thread = store.get_dialogue_thread(dialogue_id)
+    if thread is None:
+        return None
+    _WORKER_WAKE.set()
+    return {
+        "root_dialogue_id": thread["root_dialogue_id"],
+        "oldest_observed_dialogue_id": thread["oldest_observed_dialogue_id"],
+        "continuation_parent_dialogue_id": thread[
+            "continuation_parent_dialogue_id"
+        ],
+        "anchor_dialogue_id": thread["anchor_dialogue_id"],
+        "turns": [_dialogue_view(row) for row in thread["turns"]],
+        "turn_count": thread["turn_count"],
+        "truncated": thread["truncated"],
+        "read_capability_note": (
+            "Any thread-v2 turn id remains an unlisted capability for the connected "
+            "tombstone graph; each turn's content ends at its own release or expiry."
+        ),
+    }
 
 
 def release_dialogue(dialogue_id: str, removal_token: str) -> bool:

--- a/api/app/services/public_dialogue_store.py
+++ b/api/app/services/public_dialogue_store.py
@@ -13,20 +13,34 @@ import secrets
 import threading
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Iterator
 
 from sqlalchemy import DateTime, Integer, String, Text, case, func, select, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
-from app.services import unified_db
+from app.services import form_kernel_bridge, unified_db
 
 
-PUBLIC_DISCLOSURE_ACK = "public-unlisted-v1"
+PUBLIC_SINGLE_TURN_DISCLOSURE_ACK = "public-unlisted-v1"
+PUBLIC_DISCLOSURE_ACK = "public-unlisted-thread-v2"
+PUBLIC_DISCLOSURE_ACKS = frozenset(
+    (PUBLIC_SINGLE_TURN_DISCLOSURE_ACK, PUBLIC_DISCLOSURE_ACK)
+)
+MAX_THREAD_TURNS = 128
 ACTIVE_STATES = ("pending", "running", "releasing")
 TERMINAL_STATES = ("answered", "miss", "failed", "tombstoned")
 _ADMISSION_LOCK_KEY = 0x434F484449414C47  # "COHDIALG"
 _ADMISSION_LOCK = threading.RLock()
+_THREAD_PLANNER_LOCK_KEY = 0x434F484454485250  # "COHDTHRP"
+_THREAD_PLANNER_SLOT = threading.Lock()
+_THREAD_WINDOW_RECIPE = (
+    Path(__file__).resolve().parent.parent
+    / "form_recipes"
+    / "public_dialogue_thread_window.fk"
+)
+_THREAD_WINDOW_BAND_ENTRY = "  (dialogue-thread-window-band))"
 
 
 class PublicDialogueRateLimitError(RuntimeError):
@@ -38,6 +52,16 @@ class PublicDialogueRateLimitError(RuntimeError):
 class PublicDialogueAdmissionBusyError(RuntimeError):
     def __init__(self):
         super().__init__("the public dialogue admission lane is presently attending another offer")
+
+
+class PublicDialogueThreadDisclosureError(ValueError):
+    def __init__(self):
+        super().__init__("this turn grants single-turn access only")
+
+
+class PublicDialogueThreadPlannerBusyError(RuntimeError):
+    def __init__(self):
+        super().__init__("the native dialogue thread planner is presently attending another read")
 
 
 class PublicDialogueRecord(Base):
@@ -140,6 +164,25 @@ def _admission_lock(session: Any) -> None:
         session.execute(text("BEGIN IMMEDIATE"))
 
 
+@contextmanager
+def _thread_planning_slot() -> Iterator[Any]:
+    """Bound fkwu planning once per process and, on production, once per DB."""
+    if not _THREAD_PLANNER_SLOT.acquire(blocking=False):
+        raise PublicDialogueThreadPlannerBusyError()
+    try:
+        with unified_db.session() as session:
+            if session.bind is not None and session.bind.dialect.name == "postgresql":
+                acquired = session.scalar(
+                    text("SELECT pg_try_advisory_xact_lock(:lock_key)"),
+                    {"lock_key": _THREAD_PLANNER_LOCK_KEY},
+                )
+                if not acquired:
+                    raise PublicDialogueThreadPlannerBusyError()
+            yield session
+    finally:
+        _THREAD_PLANNER_SLOT.release()
+
+
 def _check_admission(
     session: Any,
     *,
@@ -175,6 +218,10 @@ def _check_admission(
         if parent is None or parent.state in ("tombstoned", "releasing"):
             raise ValueError(
                 "parent_dialogue_id does not name an available public dialogue"
+            )
+        if parent.disclosure_ack != PUBLIC_DISCLOSURE_ACK:
+            raise ValueError(
+                "parent_dialogue_id names a single-turn-only public dialogue"
             )
         expires_at = parent.expires_at
         if expires_at.tzinfo is None:
@@ -218,6 +265,7 @@ def create_dialogue(
     requested_locale: str,
     canonical_locale: str,
     parent_dialogue_id: str | None,
+    public_disclosure_ack: str = PUBLIC_DISCLOSURE_ACK,
     channel_timeout_seconds: int,
     network_peer_sha256: str,
     expires_at: datetime,
@@ -242,6 +290,7 @@ def create_dialogue(
                 requested_locale=requested_locale,
                 canonical_locale=canonical_locale,
                 parent_dialogue_id=parent_dialogue_id,
+                public_disclosure_ack=public_disclosure_ack,
                 channel_timeout_seconds=channel_timeout_seconds,
                 network_peer_sha256=network_peer_sha256,
                 expires_at=expires_at,
@@ -251,6 +300,8 @@ def create_dialogue(
                 admission_session=session,
             )
 
+    if public_disclosure_ack not in PUBLIC_DISCLOSURE_ACKS:
+        raise ValueError("unknown public dialogue disclosure acknowledgement")
     now = _now()
     dialogue_id = "dlg_" + secrets.token_urlsafe(18)
     removal_token = secrets.token_urlsafe(32)
@@ -264,7 +315,7 @@ def create_dialogue(
         canonical_locale=canonical_locale,
         parent_dialogue_id=parent_dialogue_id,
         channel_timeout_seconds=channel_timeout_seconds,
-        disclosure_ack=PUBLIC_DISCLOSURE_ACK,
+        disclosure_ack=public_disclosure_ack,
         visibility="unlisted-public",
         network_peer_sha256=network_peer_sha256,
         removal_token_sha256=hashlib.sha256(removal_token.encode("utf-8")).hexdigest(),
@@ -303,6 +354,206 @@ def get_dialogue(dialogue_id: str) -> dict[str, Any] | None:
                 return _expired_running_view(row)
             _tombstone(row, now=now)
         return _row(row)
+
+
+def _thread_child_candidates(
+    session: Any,
+    frontier: list[str],
+    seen_ids: set[str],
+    limit: int,
+) -> list[PublicDialogueRecord]:
+    return list(
+        session.scalars(
+            select(PublicDialogueRecord)
+            .where(
+                PublicDialogueRecord.parent_dialogue_id.in_(frontier),
+                PublicDialogueRecord.id.notin_(seen_ids),
+            )
+            .order_by(
+                PublicDialogueRecord.created_at.asc(),
+                PublicDialogueRecord.id.asc(),
+            )
+            .limit(limit)
+        )
+    )
+
+
+def _thread_candidates(
+    session: Any,
+    anchor: PublicDialogueRecord,
+    max_turns: int,
+) -> list[PublicDialogueRecord]:
+    root = anchor
+    ancestry = [anchor]
+    ancestor_ids = {anchor.id}
+    while root.parent_dialogue_id and len(ancestry) < max_turns:
+        parent = session.scalar(
+            select(PublicDialogueRecord).where(
+                PublicDialogueRecord.id == root.parent_dialogue_id
+            )
+        )
+        if parent is None or parent.id in ancestor_ids:
+            break
+        ancestor_ids.add(parent.id)
+        ancestry.append(parent)
+        root = parent
+
+    rows = list(reversed(ancestry))
+    seen_ids = {row.id for row in rows}
+    frontier = list(seen_ids)
+    while frontier and len(rows) < max_turns + 1:
+        remaining = max_turns + 1 - len(rows)
+        fresh = _thread_child_candidates(session, frontier, seen_ids, remaining)
+        if not fresh:
+            break
+        rows.extend(fresh)
+        frontier = [child.id for child in fresh]
+        seen_ids.update(frontier)
+    return rows
+
+
+def _native_thread_window(
+    candidates: list[PublicDialogueRecord],
+    anchor_id: str,
+    max_turns: int,
+) -> dict[str, Any]:
+    """Let Form choose topology and truncation over persistence-carried rows."""
+    source = _THREAD_WINDOW_RECIPE.read_text(encoding="utf-8")
+    if source.count(_THREAD_WINDOW_BAND_ENTRY) != 1:
+        raise RuntimeError("native Form dialogue thread entry is unavailable")
+    identifiers: dict[str, str] = {}
+    nodes = []
+    for row in candidates:
+        node_id = row.id.encode("utf-8").hex()
+        parent_id = (row.parent_dialogue_id or "").encode("utf-8").hex()
+        identifiers[node_id] = row.id
+        identifiers[parent_id] = row.parent_dialogue_id or ""
+        nodes.append(f'(list "{node_id}" "{parent_id}")')
+    anchor_hex = anchor_id.encode("utf-8").hex()
+    invocation = (
+        "(dialogue-thread-window-receipt (list "
+        + " ".join(nodes)
+        + f') "{anchor_hex}" {max_turns})'
+    )
+    receipt = form_kernel_bridge.run_recipe(
+        source.replace(_THREAD_WINDOW_BAND_ENTRY, f"  {invocation})"),
+        timeout=10,
+    )
+    pieces = receipt.split("|")
+    if len(pieces) != 6 or pieces[5] not in ("0", "1"):
+        raise RuntimeError("native Form dialogue thread returned an invalid verdict")
+    selected_hex = pieces[4].split(",") if pieces[4] else []
+    if (
+        not selected_hex
+        or len(selected_hex) > max_turns
+        or len(selected_hex) != len(set(selected_hex))
+        or anchor_hex not in selected_hex
+        or any(value not in identifiers for value in selected_hex)
+    ):
+        raise RuntimeError("native Form dialogue thread returned an invalid window")
+
+    def identity(value: str) -> str | None:
+        if not value:
+            return None
+        if value not in identifiers:
+            raise RuntimeError("native Form dialogue thread returned an unknown identity")
+        return identifiers[value]
+
+    selected = [identifiers[value] for value in selected_hex]
+    root_id = identity(pieces[0])
+    oldest_id = identity(pieces[1])
+    continuation_id = identity(pieces[2])
+    if identity(pieces[3]) != anchor_id or oldest_id != selected[0]:
+        raise RuntimeError("native Form dialogue thread returned an unbound window")
+    if (root_id is None) == (continuation_id is None):
+        raise RuntimeError("native Form dialogue thread returned an ambiguous root")
+    return {
+        "root_dialogue_id": root_id,
+        "oldest_observed_dialogue_id": oldest_id,
+        "continuation_parent_dialogue_id": continuation_id,
+        "anchor_dialogue_id": anchor_id,
+        "selected_ids": selected,
+        "truncated": pieces[5] == "1",
+    }
+
+
+def _observe_thread_rows(
+    rows: list[PublicDialogueRecord],
+    *,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    observed: list[dict[str, Any]] = []
+    for row in rows:
+        if row.state == "releasing":
+            observed.append(_released_owned_view(row))
+            continue
+        expires_at = row.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if row.state != "tombstoned" and expires_at <= now:
+            if row.state == "running":
+                observed.append(_expired_running_view(row))
+                continue
+            _tombstone(row, now=now)
+        observed.append(_row(row))
+    return observed
+
+
+def get_dialogue_thread(
+    dialogue_id: str,
+    *,
+    max_turns: int = MAX_THREAD_TURNS,
+) -> dict[str, Any] | None:
+    """Read one bounded unlisted dialogue tree from any turn capability."""
+    if isinstance(max_turns, bool) or not 1 <= max_turns <= MAX_THREAD_TURNS:
+        raise ValueError(f"max_turns must be between 1 and {MAX_THREAD_TURNS}")
+    ensure_schema()
+    with _thread_planning_slot() as session:
+        anchor = session.scalar(
+            select(PublicDialogueRecord).where(PublicDialogueRecord.id == dialogue_id)
+        )
+        if anchor is None:
+            return None
+        if anchor.disclosure_ack != PUBLIC_DISCLOSURE_ACK:
+            raise PublicDialogueThreadDisclosureError()
+        candidates = _thread_candidates(session, anchor, max_turns)
+        if any(row.disclosure_ack != PUBLIC_DISCLOSURE_ACK for row in candidates):
+            raise PublicDialogueThreadDisclosureError()
+        plan = _native_thread_window(candidates, dialogue_id, max_turns)
+    with unified_db.session() as session:
+        lock_order = case(
+            {
+                row_id: position
+                for position, row_id in enumerate(plan["selected_ids"])
+            },
+            value=PublicDialogueRecord.id,
+            else_=len(plan["selected_ids"]),
+        )
+        locked = list(
+            session.scalars(
+                select(PublicDialogueRecord)
+                .where(PublicDialogueRecord.id.in_(plan["selected_ids"]))
+                .order_by(lock_order)
+                .with_for_update()
+                .execution_options(populate_existing=True)
+            )
+        )
+        locked_by_id = {row.id: row for row in locked}
+        if set(locked_by_id) != set(plan["selected_ids"]):
+            raise RuntimeError("dialogue thread changed before its native window locked")
+        rows = [locked_by_id[row_id] for row_id in plan["selected_ids"]]
+        observed = _observe_thread_rows(rows, now=_now())
+        return {
+            "root_dialogue_id": plan["root_dialogue_id"],
+            "oldest_observed_dialogue_id": plan["oldest_observed_dialogue_id"],
+            "continuation_parent_dialogue_id": plan[
+                "continuation_parent_dialogue_id"
+            ],
+            "anchor_dialogue_id": plan["anchor_dialogue_id"],
+            "turns": observed,
+            "turn_count": len(observed),
+            "truncated": plan["truncated"],
+        }
 
 
 def _expired_running_view(row: PublicDialogueRecord) -> dict[str, Any]:

--- a/api/tests/test_kernel_submodule_contract.py
+++ b/api/tests/test_kernel_submodule_contract.py
@@ -22,6 +22,7 @@ APP_RECIPES = {
     "endpoint_reaction_resonance.fk",
     "endpoint_request_progress.fk",
     "public_dialogue_envelope.fk",
+    "public_dialogue_thread_window.fk",
     "public_federation_graph_cli.fk",
 }
 

--- a/api/tests/test_mcp_remote_no_oauth.py
+++ b/api/tests/test_mcp_remote_no_oauth.py
@@ -23,7 +23,15 @@ async def test_mcp_info_declares_no_auth_and_no_challenge(path: str):
     body = response.json()
     assert body["auth_required"] is False
     assert body["auth_schemes"] == ["none"]
-    assert {"search", "fetch", "start_dialogue", "get_dialogue", "remove_dialogue"} <= set(body["tools"])
+    assert {
+        "search",
+        "fetch",
+        "start_dialogue",
+        "get_dialogue",
+        "reply_dialogue",
+        "get_dialogue_thread",
+        "remove_dialogue",
+    } <= set(body["tools"])
 
 
 @pytest.mark.parametrize("path", ["/mcp", "/api/mcp"])
@@ -58,14 +66,32 @@ async def test_mcp_tools_list_marks_public_dialogue_read_and_write_surfaces():
 
     assert response.status_code == 200
     tools = {tool["name"]: tool for tool in response.json()["result"]["tools"]}
-    assert {"search", "fetch", "browse_ideas", "browse_specs", "start_dialogue", "get_dialogue", "remove_dialogue"} <= set(tools)
+    assert {
+        "search",
+        "fetch",
+        "browse_ideas",
+        "browse_specs",
+        "start_dialogue",
+        "get_dialogue",
+        "reply_dialogue",
+        "get_dialogue_thread",
+        "remove_dialogue",
+    } <= set(tools)
     assert "publish_idea" not in tools
     assert "create_spec" not in tools
     assert tools["start_dialogue"]["annotations"]["readOnlyHint"] is False
     assert tools["start_dialogue"]["annotations"]["openWorldHint"] is True
     assert tools["start_dialogue"]["annotations"]["idempotentHint"] is False
     assert tools["get_dialogue"]["annotations"]["readOnlyHint"] is True
+    assert tools["reply_dialogue"]["annotations"]["readOnlyHint"] is False
+    assert tools["get_dialogue_thread"]["annotations"]["readOnlyHint"] is True
     assert tools["remove_dialogue"]["annotations"]["destructiveHint"] is True
+    assert tools["start_dialogue"]["inputSchema"]["properties"][
+        "public_disclosure_ack"
+    ]["enum"] == ["public-unlisted-v1", "public-unlisted-thread-v2"]
+    assert tools["reply_dialogue"]["inputSchema"]["properties"][
+        "public_disclosure_ack"
+    ]["const"] == "public-unlisted-thread-v2"
 
 
 @pytest.mark.asyncio
@@ -166,6 +192,118 @@ async def test_mcp_start_and_get_dialogue(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_mcp_reply_and_thread_read_persist_both_directions(monkeypatch):
+    from app.services import dialogue_service
+
+    captured = {}
+
+    def submit(**values):
+        captured.update(values)
+        return {
+            "id": "dlg_reply",
+            "state": "pending",
+            "parent_dialogue_id": values["parent_dialogue_id"],
+            "removal_token": "reply-removal-token-long-enough",
+        }
+
+    monkeypatch.setattr(dialogue_service, "submit_dialogue", submit)
+    monkeypatch.setattr(
+        dialogue_service,
+        "get_dialogue_thread",
+        lambda dialogue_id: {
+            "root_dialogue_id": "dlg_root",
+            "anchor_dialogue_id": dialogue_id,
+            "turns": [
+                {"id": "dlg_root", "question": "first"},
+                {
+                    "id": "dlg_reply",
+                    "question": "second",
+                    "parent_dialogue_id": "dlg_root",
+                },
+            ],
+            "turn_count": 2,
+            "truncated": False,
+        },
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as client:
+        replied = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": "reply",
+                "method": "tools/call",
+                "params": {
+                    "name": "reply_dialogue",
+                    "arguments": {
+                        "dialogue_id": "dlg_root",
+                        "question": "second",
+                        "point_of_view": "water",
+                        "locale": "en",
+                        "public_disclosure_ack": "public-unlisted-thread-v2",
+                    },
+                },
+            },
+        )
+        observed = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": "thread",
+                "method": "tools/call",
+                "params": {
+                    "name": "get_dialogue_thread",
+                    "arguments": {"dialogue_id": "dlg_reply"},
+                },
+            },
+        )
+
+    reply_payload = replied.json()["result"]["structuredContent"]
+    thread_payload = observed.json()["result"]["structuredContent"]
+    assert reply_payload["parent_dialogue_id"] == "dlg_root"
+    assert captured["parent_dialogue_id"] == "dlg_root"
+    assert thread_payload["anchor_dialogue_id"] == "dlg_reply"
+    assert [turn["question"] for turn in thread_payload["turns"]] == [
+        "first",
+        "second",
+    ]
+    assert "removal_token" not in json.dumps(thread_payload)
+
+
+@pytest.mark.asyncio
+async def test_mcp_thread_planner_contention_returns_retry_guidance(monkeypatch):
+    from app.services import dialogue_service
+
+    monkeypatch.setattr(
+        dialogue_service,
+        "get_dialogue_thread",
+        lambda _dialogue_id: (_ for _ in ()).throw(
+            dialogue_service.DialogueThreadPlannerBusyError()
+        ),
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE) as client:
+        response = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": "thread-busy",
+                "method": "tools/call",
+                "params": {
+                    "name": "get_dialogue_thread",
+                    "arguments": {"dialogue_id": "dlg_busy"},
+                },
+            },
+        )
+
+    result = response.json()["result"]
+    assert result["isError"] is True
+    assert result["structuredContent"] == {
+        "error": "Native dialogue thread planning is presently busy",
+        "retry_after": 15,
+    }
+
+
+@pytest.mark.asyncio
 async def test_mcp_dialogue_storage_failures_stay_inside_each_tool_result(monkeypatch):
     from app.services import dialogue_service
 
@@ -250,7 +388,7 @@ async def test_mcp_start_keeps_the_event_loop_available(monkeypatch):
                             "question": "What does the river see?",
                             "point_of_view": "river",
                             "locale": "en",
-                            "public_disclosure_ack": "public-unlisted-v1",
+                            "public_disclosure_ack": "public-unlisted-thread-v2",
                         },
                     },
                 },
@@ -440,6 +578,18 @@ async def test_mcp_start_dialogue_rejects_non_string_fields_before_storage(
     ("tool_name", "arguments", "field"),
     [
         ("get_dialogue", {"dialogue_id": ["dlg"]}, "dialogue_id"),
+        ("get_dialogue_thread", {"dialogue_id": ["dlg"]}, "dialogue_id"),
+        (
+            "reply_dialogue",
+            {
+                "dialogue_id": {"id": "dlg"},
+                "question": "hello",
+                "point_of_view": "river",
+                "locale": "en",
+                "public_disclosure_ack": "public-unlisted-v1",
+            },
+            "dialogue_id",
+        ),
         (
             "remove_dialogue",
             {"dialogue_id": "dlg", "removal_token": {"token": "release"}},

--- a/api/tests/test_public_dialogues.py
+++ b/api/tests/test_public_dialogues.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import os
 import sys
 import threading
@@ -52,7 +53,9 @@ def dialogue_store(monkeypatch):
             "canonical_locale": values["canonical_locale"],
             "parent_dialogue_id": parent_id,
             "channel_timeout_seconds": values["channel_timeout_seconds"],
-            "disclosure_ack": store.PUBLIC_DISCLOSURE_ACK,
+            "disclosure_ack": values.get(
+                "public_disclosure_ack", store.PUBLIC_DISCLOSURE_ACK
+            ),
             "visibility": "unlisted-public",
             "output": {},
             "claimed_by": None,
@@ -209,7 +212,7 @@ def _offer(**changes):
         "question": "Apakah cache bagian dari tubuh?",
         "point_of_view": "cache termodinamik",
         "locale": "id",
-        "public_disclosure_ack": "public-unlisted-v1",
+        "public_disclosure_ack": "public-unlisted-thread-v2",
         "network_peer": "test-peer",
         "channel_timeout_seconds": 90,
     }
@@ -299,6 +302,19 @@ def test_disclosure_ack_is_versioned_and_persists_zero_rows_when_absent(dialogue
     assert dialogue_store == {}
 
 
+def test_single_turn_disclosure_advertises_only_single_turn_actions(dialogue_store):
+    offered = _offer(
+        question="This receipt stays one turn.",
+        public_disclosure_ack=store.PUBLIC_SINGLE_TURN_DISCLOSURE_ACK,
+    )
+
+    assert offered["public_disclosure_ack"] == store.PUBLIC_SINGLE_TURN_DISCLOSURE_ACK
+    assert "reply_url" not in offered
+    assert "thread_url" not in offered
+    assert offered["poll_url"].endswith(offered["id"])
+    assert offered["release_url"].endswith(offered["id"])
+
+
 def test_form_receives_the_real_dialogue_envelope_before_persistence(
     dialogue_store, monkeypatch
 ):
@@ -322,7 +338,7 @@ def test_form_receives_the_real_dialogue_envelope_before_persistence(
         "locale": "id",
         "point": "akar bakau",
         "question": "Apa yang dirasakan akar bakau?",
-        "disclosure": "public-unlisted-v1",
+        "disclosure": "public-unlisted-thread-v2",
         "parent": "",
         "timeout_seconds": 60,
     }
@@ -477,6 +493,61 @@ def test_postgres_admission_contention_is_nonblocking_and_explicit():
         "",
     )
     assert observed["params"] == {"lock_key": store._ADMISSION_LOCK_KEY}
+
+
+def test_thread_planner_contention_is_bounded_locally(monkeypatch):
+    @contextlib.contextmanager
+    def session():
+        yield SimpleNamespace(bind=SimpleNamespace(dialect=SimpleNamespace(name="sqlite")))
+
+    monkeypatch.setattr(store.unified_db, "session", session)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def hold_planner():
+        with store._thread_planning_slot():
+            entered.set()
+            assert release.wait(2)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(hold_planner)
+        assert entered.wait(1)
+        try:
+            with pytest.raises(
+                store.PublicDialogueThreadPlannerBusyError,
+                match="presently attending",
+            ):
+                with store._thread_planning_slot():
+                    pass
+        finally:
+            release.set()
+        first.result(timeout=2)
+
+
+def test_postgres_thread_planner_contention_is_nonblocking_and_explicit(monkeypatch):
+    observed = {}
+
+    def scalar(statement, params):
+        observed.update(statement=str(statement), params=params)
+        return False
+
+    @contextlib.contextmanager
+    def session():
+        yield SimpleNamespace(
+            bind=SimpleNamespace(dialect=SimpleNamespace(name="postgresql")),
+            scalar=scalar,
+        )
+
+    monkeypatch.setattr(store.unified_db, "session", session)
+    with pytest.raises(
+        store.PublicDialogueThreadPlannerBusyError,
+        match="presently attending",
+    ):
+        with store._thread_planning_slot():
+            pass
+
+    assert "pg_try_advisory_xact_lock" in observed["statement"]
+    assert observed["params"] == {"lock_key": store._THREAD_PLANNER_LOCK_KEY}
 
 
 def test_form_dialogue_refusal_persists_nothing(dialogue_store, monkeypatch):
@@ -953,6 +1024,107 @@ async def test_http_membrane_starts_reads_releases_and_has_no_public_list(monkey
 
 
 @pytest.mark.asyncio
+async def test_http_reply_fixes_parent_and_thread_read_exposes_no_capabilities(monkeypatch):
+    captured = {}
+
+    def submit(**values):
+        captured.update(values)
+        return {
+            "id": "dlg_reply",
+            "state": "pending",
+            "parent_dialogue_id": values["parent_dialogue_id"],
+            "removal_token": "reply-removal-token-long-enough",
+        }
+
+    monkeypatch.setattr(dialogue_service, "submit_dialogue", submit)
+    monkeypatch.setattr(
+        dialogue_service,
+        "get_dialogue_thread",
+        lambda dialogue_id: {
+            "root_dialogue_id": "dlg_root",
+            "anchor_dialogue_id": dialogue_id,
+            "turns": [
+                {"id": "dlg_root", "parent_dialogue_id": None},
+                {"id": "dlg_reply", "parent_dialogue_id": "dlg_root"},
+            ],
+            "turn_count": 2,
+            "truncated": False,
+        },
+    )
+    body = {
+        "question": "The river replies.",
+        "point_of_view": "river",
+        "locale": "en",
+        "public_disclosure_ack": "public-unlisted-thread-v2",
+    }
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        rejected_override = await client.post(
+            "/api/dialogues/dlg_root/replies",
+            json={**body, "parent_dialogue_id": "dlg_other"},
+        )
+        replied = await client.post(
+            "/api/dialogues/dlg_root/replies",
+            json=body,
+        )
+        observed = await client.get("/api/dialogues/dlg_reply/thread")
+
+    assert rejected_override.status_code == 422
+    assert replied.status_code == 202
+    assert replied.headers["cache-control"] == "no-store"
+    assert captured["parent_dialogue_id"] == "dlg_root"
+    assert observed.status_code == 200
+    assert observed.headers["cache-control"] == "no-store"
+    assert observed.json()["turn_count"] == 2
+    assert "removal_token" not in json.dumps(observed.json())
+
+
+@pytest.mark.asyncio
+async def test_http_thread_read_contains_native_planner_failure(monkeypatch):
+    monkeypatch.setattr(
+        dialogue_service,
+        "get_dialogue_thread",
+        lambda _dialogue_id: (_ for _ in ()).throw(
+            RuntimeError("private native carrier detail")
+        ),
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/api/dialogues/dlg_native/thread")
+
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "15"
+    assert response.json()["detail"] == (
+        "Native dialogue thread planning is presently unavailable"
+    )
+    assert "private native carrier detail" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_http_legacy_disclosure_stays_single_turn_only(monkeypatch):
+    monkeypatch.setattr(
+        dialogue_service,
+        "get_dialogue_thread",
+        lambda _dialogue_id: (_ for _ in ()).throw(
+            dialogue_service.DialogueThreadDisclosureError()
+        ),
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/api/dialogues/dlg_legacy/thread")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "This turn grants single-turn access only"
+
+
+@pytest.mark.asyncio
 async def test_http_membrane_preserves_distinct_public_peers_through_trusted_proxies(monkeypatch):
     origins: list[str] = []
 
@@ -1258,6 +1430,43 @@ def test_dedicated_store_round_trip_claim_finish_and_release(monkeypatch, tmp_pa
     assert released["tombstoned_at"] == first_release.isoformat()
     monkeypatch.setattr(store, "_now", real_now)
 
+    legacy, legacy_token = store.create_dialogue(
+        question="This id grants one-turn access only.",
+        question_sha256="9" * 64,
+        point_of_view="legacy disclosure",
+        requested_locale="en",
+        canonical_locale="en",
+        parent_dialogue_id=None,
+        public_disclosure_ack=store.PUBLIC_SINGLE_TURN_DISCLOSURE_ACK,
+        channel_timeout_seconds=30,
+        network_peer_sha256="9" * 64,
+        expires_at=real_now() + timedelta(days=7),
+        max_active=8,
+        starts_per_window=6,
+        start_window_seconds=60,
+    )
+    assert store.get_dialogue(legacy["id"])["disclosure_ack"] == (
+        store.PUBLIC_SINGLE_TURN_DISCLOSURE_ACK
+    )
+    with pytest.raises(store.PublicDialogueThreadDisclosureError):
+        store.get_dialogue_thread(legacy["id"])
+    with pytest.raises(ValueError, match="single-turn-only"):
+        store.create_dialogue(
+            question="A reply cannot widen the earlier disclosure.",
+            question_sha256="8" * 64,
+            point_of_view="consent boundary",
+            requested_locale="en",
+            canonical_locale="en",
+            parent_dialogue_id=legacy["id"],
+            channel_timeout_seconds=30,
+            network_peer_sha256="8" * 64,
+            expires_at=real_now() + timedelta(days=7),
+            max_active=8,
+            starts_per_window=6,
+            start_window_seconds=60,
+        )
+    assert dialogue_service.release_dialogue(legacy["id"], legacy_token) is True
+
     expiry_boundary = datetime(2026, 8, 22, 1, 2, 3, tzinfo=timezone.utc)
     expiring_row, _ = store.create_dialogue(
         question="What remains visible at the expiry boundary?",
@@ -1493,3 +1702,160 @@ def test_dedicated_store_round_trip_claim_finish_and_release(monkeypatch, tmp_pa
             start_window_seconds=60,
         )
     engine.dispose()
+
+
+def test_dialogue_thread_survives_database_restart_and_keeps_expiry_boundary(
+    monkeypatch,
+    tmp_path,
+):
+    database_path = tmp_path / "dialogue-thread.db"
+    first_engine = create_engine(f"sqlite+pysqlite:///{database_path}")
+    store.PublicDialogueRecord.__table__.create(bind=first_engine, checkfirst=True)
+
+    def session_for(engine):
+        factory = sessionmaker(bind=engine, expire_on_commit=False)
+
+        @contextlib.contextmanager
+        def session():
+            value = factory()
+            try:
+                yield value
+                value.commit()
+            except Exception:
+                value.rollback()
+                raise
+            finally:
+                value.close()
+
+        return session
+
+    monkeypatch.setattr(store.unified_db, "ensure_schema", lambda: None)
+    monkeypatch.setattr(store.unified_db, "session", session_for(first_engine))
+    expiry_boundary = datetime.now(timezone.utc) + timedelta(seconds=30)
+    root, root_token = store.create_dialogue(
+        question="What does the river see?",
+        question_sha256="a" * 64,
+        point_of_view="river",
+        requested_locale="en",
+        canonical_locale="en",
+        parent_dialogue_id=None,
+        channel_timeout_seconds=30,
+        network_peer_sha256="a" * 64,
+        expires_at=expiry_boundary,
+        max_active=8,
+        starts_per_window=6,
+        start_window_seconds=60,
+    )
+    reply, reply_token = store.create_dialogue(
+        question="I see the banks that let me move.",
+        question_sha256="b" * 64,
+        point_of_view="water",
+        requested_locale="en",
+        canonical_locale="en",
+        parent_dialogue_id=root["id"],
+        channel_timeout_seconds=30,
+        network_peer_sha256="b" * 64,
+        expires_at=expiry_boundary + timedelta(days=7),
+        max_active=8,
+        starts_per_window=6,
+        start_window_seconds=60,
+    )
+    assert root_token != reply_token
+    first_engine.dispose()
+
+    restarted_engine = create_engine(f"sqlite+pysqlite:///{database_path}")
+    monkeypatch.setattr(store.unified_db, "session", session_for(restarted_engine))
+    persisted = store.get_dialogue_thread(reply["id"])
+    assert persisted is not None
+    assert persisted["root_dialogue_id"] == root["id"]
+    assert persisted["anchor_dialogue_id"] == reply["id"]
+    assert [turn["id"] for turn in persisted["turns"]] == [root["id"], reply["id"]]
+    assert persisted["turns"][1]["parent_dialogue_id"] == root["id"]
+    assert "removal_token" not in json.dumps(persisted)
+
+    monkeypatch.setattr(store, "_now", lambda: expiry_boundary)
+    expired = store.get_dialogue_thread(reply["id"])
+    assert expired is not None
+    assert expired["turns"][0]["state"] == "tombstoned"
+    assert expired["turns"][0]["question"] == "[released]"
+    assert expired["turns"][1]["question"] == reply["question"]
+    bounded = store.get_dialogue_thread(root["id"], max_turns=1)
+    assert bounded is not None
+    assert bounded["turn_count"] == 1
+    assert bounded["truncated"] is True
+
+    third, _ = store.create_dialogue(
+        question="The banks answer the water.",
+        question_sha256="c" * 64,
+        point_of_view="riverbank",
+        requested_locale="en",
+        canonical_locale="en",
+        parent_dialogue_id=reply["id"],
+        channel_timeout_seconds=30,
+        network_peer_sha256="c" * 64,
+        expires_at=expiry_boundary + timedelta(days=7),
+        max_active=8,
+        starts_per_window=6,
+        start_window_seconds=60,
+    )
+    with session_for(restarted_engine)() as skewed_session:
+        skewed_session.get(store.PublicDialogueRecord, root["id"]).created_at = (
+            expiry_boundary + timedelta(seconds=3)
+        )
+        skewed_session.get(store.PublicDialogueRecord, reply["id"]).created_at = (
+            expiry_boundary + timedelta(seconds=2)
+        )
+        skewed_session.get(store.PublicDialogueRecord, third["id"]).created_at = (
+            expiry_boundary + timedelta(seconds=1)
+        )
+    skewed_clock_thread = store.get_dialogue_thread(third["id"])
+    assert [turn["id"] for turn in skewed_clock_thread["turns"]] == [
+        root["id"],
+        reply["id"],
+        third["id"],
+    ]
+    ancestry_window = store.get_dialogue_thread(third["id"], max_turns=2)
+    assert ancestry_window is not None
+    assert ancestry_window["root_dialogue_id"] is None
+    assert ancestry_window["continuation_parent_dialogue_id"] == root["id"]
+    assert [turn["id"] for turn in ancestry_window["turns"]] == [
+        reply["id"],
+        third["id"],
+    ]
+    assert ancestry_window["anchor_dialogue_id"] == third["id"]
+    assert ancestry_window["truncated"] is True
+    restarted_engine.dispose()
+
+
+def test_dialogue_thread_window_semantics_execute_on_native_fkwu():
+    created = datetime(2026, 8, 17, tzinfo=timezone.utc)
+    candidates = [
+        SimpleNamespace(id="dlg_root", parent_dialogue_id=None, created_at=created),
+        SimpleNamespace(
+            id="dlg_anchor",
+            parent_dialogue_id="dlg_root",
+            created_at=created + timedelta(seconds=1),
+        ),
+        SimpleNamespace(
+            id="dlg_sibling",
+            parent_dialogue_id="dlg_root",
+            created_at=created + timedelta(seconds=2),
+        ),
+        SimpleNamespace(
+            id="dlg_child",
+            parent_dialogue_id="dlg_anchor",
+            created_at=created + timedelta(seconds=3),
+        ),
+    ]
+
+    plan = store._native_thread_window(candidates, "dlg_anchor", 3)
+
+    assert form_kernel_bridge.active_runtime() == "fkwu"
+    assert plan == {
+        "root_dialogue_id": "dlg_root",
+        "oldest_observed_dialogue_id": "dlg_root",
+        "continuation_parent_dialogue_id": None,
+        "anchor_dialogue_id": "dlg_anchor",
+        "selected_ids": ["dlg_root", "dlg_anchor", "dlg_sibling"],
+        "truncated": True,
+    }

--- a/docs/system_audit/commit_evidence_2026-08-16_public-dialogue-thread-persistence.json
+++ b/docs/system_audit/commit_evidence_2026-08-16_public-dialogue-thread-persistence.json
@@ -1,0 +1,107 @@
+{
+  "date": "2026-08-16T23:00:00+08:00",
+  "thread_branch": "codex/dialogue-thread-persistence",
+  "commit_scope": "Persist both directions of an unlisted public dialogue through explicit HTTP and MCP reply and bounded thread-read surfaces, with each turn independently releasable and all edges surviving carrier restart.",
+  "files_owned": [
+    "api/app/form_recipes/public_dialogue_thread_window.fk",
+    "api/app/routers/dialogues.py",
+    "api/app/routers/mcp_remote.py",
+    "api/app/services/dialogue_service.py",
+    "api/app/services/public_dialogue_store.py",
+    "api/tests/test_kernel_submodule_contract.py",
+    "api/tests/test_mcp_remote_no_oauth.py",
+    "api/tests/test_public_dialogues.py",
+    "docs/system_audit/commit_evidence_2026-08-16_public-dialogue-thread-persistence.json",
+    "specs/INDEX.md",
+    "specs/public-dialogue-cpu-organ.md"
+  ],
+  "local_validation": {
+    "status": "pass",
+    "details": "The focused warning-strict HTTP, durable-store, worker, and MCP band passes 85 tests, and the complete warning-strict API body passes all 406 tests. The connected-window recipe returns 511 on the Go, Rust, and TypeScript sibling walkers and 511 through the direct fkwu source runner; the API test also executes the semantic window on the active fkwu runtime. A real SQLite file receives a root turn and reply with different one-time removal capabilities, is closed, reopened through a fresh SQLAlchemy engine/session carrier, and returns both questions and the directed parent edge from the reply id. The same witness moves the root through its exact expiry boundary into a durable content-free tombstone while the unexpired reply remains visible, proves the one-turn descendant bound reports truncation, retains parent-before-child selection, database lock, and response order under deliberately skewed creation clocks, and retains the requested anchor without mislabeling a partial window as the root. Form owns ancestry, connected descendant admission, bounded selection, continuation, root, and truncation; Python retrieves and locks persistence rows, applies expiry, and validates the native receipt without minting a competing topology verdict. Review is embodied by preserving public-unlisted-v1 as a single-turn-only capability with no inapplicable reply or thread links, requiring explicit public-unlisted-thread-v2 consent for replies and connected reads, placing every fkwu thread planner behind a nonblocking process slot plus organism-wide PostgreSQL advisory lease, preserving MCP retry guidance, and stating accurately that each turn's content ends independently while v2 ids and content-free edges persist as capabilities for the observable tombstone graph. HTTP refuses a body-level parent override, contains native-planner failures behind a retryable public receipt, and HTTP/MCP thread responses contain no removal capability. Ruff, strict spec quality, evidence, and git diff validation pass on the touched surface; maintainability regression and the local PR guard are re-witnessed on the amended head."
+  },
+  "ci_validation": {
+    "status": "pending",
+    "details": "A PR and exact-head independent AI review will be requested after rebase onto the merged public dialogue release."
+  },
+  "deploy_validation": {
+    "status": "pending",
+    "details": "Production acceptance will create a root and reply, restart the API carrier, read both turns from the connected thread, then independently release both rows."
+  },
+  "phase_gate": {
+    "can_move_next_phase": false
+  },
+  "idea_ids": [
+    "agent-pipeline"
+  ],
+  "spec_ids": [
+    "public-dialogue-cpu-organ"
+  ],
+  "task_ids": [
+    "public-dialogue-thread-persistence-2026-08-16"
+  ],
+  "contributors": [
+    {
+      "contributor_id": "urs",
+      "contributor_type": "human",
+      "roles": [
+        "direction",
+        "acceptance-shaping"
+      ]
+    },
+    {
+      "contributor_id": "codex-gpt-5",
+      "contributor_type": "machine",
+      "roles": [
+        "implementation",
+        "adversarial-validation",
+        "receipt-authoring"
+      ]
+    }
+  ],
+  "agent": {
+    "name": "Codex",
+    "version": "GPT-5"
+  },
+  "evidence_refs": [
+    "specs/public-dialogue-cpu-organ.md",
+    "api/app/form_recipes/public_dialogue_thread_window.fk::dialogue-thread-window-band",
+    "api/tests/test_public_dialogues.py::test_dialogue_thread_window_semantics_execute_on_native_fkwu",
+    "api/tests/test_public_dialogues.py::test_thread_planner_contention_is_bounded_locally",
+    "api/tests/test_public_dialogues.py::test_postgres_thread_planner_contention_is_nonblocking_and_explicit",
+    "api/tests/test_public_dialogues.py::test_http_legacy_disclosure_stays_single_turn_only",
+    "api/tests/test_public_dialogues.py::test_single_turn_disclosure_advertises_only_single_turn_actions",
+    "api/tests/test_mcp_remote_no_oauth.py::test_mcp_thread_planner_contention_returns_retry_guidance",
+    "api/tests/test_kernel_submodule_contract.py::test_network_endpoint_recipes_are_owned_by_the_api",
+    "api/tests/test_public_dialogues.py::test_dialogue_thread_survives_database_restart_and_keeps_expiry_boundary",
+    "api/tests/test_public_dialogues.py::test_http_reply_fixes_parent_and_thread_read_exposes_no_capabilities",
+    "api/tests/test_mcp_remote_no_oauth.py::test_mcp_reply_and_thread_read_persist_both_directions"
+  ],
+  "change_files": [
+    "api/app/form_recipes/public_dialogue_thread_window.fk",
+    "api/app/routers/dialogues.py",
+    "api/app/routers/mcp_remote.py",
+    "api/app/services/dialogue_service.py",
+    "api/app/services/public_dialogue_store.py",
+    "api/tests/test_kernel_submodule_contract.py",
+    "api/tests/test_mcp_remote_no_oauth.py",
+    "api/tests/test_public_dialogues.py",
+    "docs/system_audit/commit_evidence_2026-08-16_public-dialogue-thread-persistence.json",
+    "specs/INDEX.md",
+    "specs/public-dialogue-cpu-organ.md"
+  ],
+  "change_intent": "runtime_feature",
+  "e2e_validation": {
+    "status": "pending",
+    "expected_behavior_delta": "A person or MCP connector can add a durable reply to a public dialogue, read the bounded connected thread from either turn id after an API restart, and release only the turn for which it holds the one-time removal capability.",
+    "public_endpoints": [
+      "POST /api/dialogues/{dialogue_id}/replies",
+      "GET /api/dialogues/{dialogue_id}/thread",
+      "POST /mcp tools: reply_dialogue, get_dialogue_thread"
+    ],
+    "test_flows": [
+      "start root, reply from a second point of view, restart storage carrier, and read both turns with their parent edge",
+      "read from either connected turn id without exposing either removal capability",
+      "release each turn with its distinct capability and preserve content-free tombstones"
+    ]
+  }
+}

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -83,7 +83,7 @@
 - [form-question-effects-kernel-conformance](form-question-effects-kernel-conformance.md) — Form Question Effects Kernel Conformance
 - [pipeline-observability-and-auto-review](pipeline-observability-and-auto-review.md) — Pipeline Observability and Auto-Review
 - [project-manager-pipeline](project-manager-pipeline.md) — Project Manager Pipeline
-- [public-dialogue-cpu-organ](public-dialogue-cpu-organ.md) — one observable Form-grounded turn at a time
+- [public-dialogue-cpu-organ](public-dialogue-cpu-organ.md) — persistent Form-grounded turns in both directions
 - [split-review-deploy-verify-phases](split-review-deploy-verify-phases.md) — Split Review Into code-review → deploy → verify-production
 - [symphony-alignment-orchestration](symphony-alignment-orchestration.md) — Symphony Alignment for Coherence Orchestration
 

--- a/specs/public-dialogue-cpu-organ.md
+++ b/specs/public-dialogue-cpu-organ.md
@@ -4,36 +4,38 @@ status: active
 source:
   - file: api/app/form_recipes/public_dialogue_envelope.fk
     symbols: [dialogue-envelope, dialogue-offered]
+  - file: api/app/form_recipes/public_dialogue_thread_window.fk
+    symbols: [dialogue-thread-window, dialogue-thread-window-receipt, dialogue-thread-window-band]
   - file: api/app/services/public_dialogue_store.py
-    symbols: [PublicDialogueRecord, create_dialogue, claim_next_dialogue, tombstone_dialogue]
+    symbols: [PublicDialogueRecord, create_dialogue, get_dialogue_thread, claim_next_dialogue, tombstone_dialogue]
   - file: api/app/services/dialogue_service.py
-    symbols: [submit_dialogue, get_dialogue, process_dialogue_once, release_dialogue]
+    symbols: [submit_dialogue, get_dialogue, get_dialogue_thread, process_dialogue_once, release_dialogue]
   - file: api/app/routers/dialogues.py
-    symbols: [start_dialogue, read_dialogue, release_dialogue]
+    symbols: [start_dialogue, reply_dialogue, read_dialogue, read_dialogue_thread, release_dialogue]
   - file: api/app/routers/mcp_remote.py
-    symbols: [START_DIALOGUE_TOOL, GET_DIALOGUE_TOOL, REMOVE_DIALOGUE_TOOL]
+    symbols: [START_DIALOGUE_TOOL, REPLY_DIALOGUE_TOOL, GET_DIALOGUE_TOOL, GET_DIALOGUE_THREAD_TOOL, REMOVE_DIALOGUE_TOOL]
   - file: api/tests/test_public_dialogues.py
     symbols: [test_dialogue_lifecycle_keeps_source_and_projection_digests, test_rented_miss_is_admitted_only_on_dialogue_lane]
 requirements:
-  - "A caller can offer a question with a point of view, BCP-47 locale, optional parent turn, bounded channel timeout, and versioned acknowledgement that the turn is unlisted-public."
+  - "A caller can offer a question with a point of view, BCP-47 locale, optional parent turn, bounded channel timeout, and a versioned acknowledgement that keeps v1 single-turn-only or explicitly grants thread-v2 visibility."
   - "HTTP returns a persistent dialogue cell immediately; one organism-wide CPU lease realizes queued turns outside the request path."
   - "Only an allowlisted public source path can produce an answer; every other result becomes an attributed miss or controlled failure without publishing carrier output."
-  - "The no-auth MCP endpoint exposes start, get, and removal-capability tools with tested read, write, destructive, idempotent, and open-world annotations."
+  - "The no-auth MCP endpoint exposes start, reply, single-turn read, bounded thread read, and removal-capability tools with tested read, write, destructive, idempotent, and open-world annotations."
 done_when:
-  - "The Form envelope returns 63 on Go, Rust, and TypeScript sibling kernels and 63 on the direct fkwu witness, with the source preflight clean."
+  - "The Form envelope returns 63 and the thread-window recipe returns 511 on Go, Rust, and TypeScript sibling kernels and on the direct fkwu witness, with both source parses clean."
   - "Failure-oriented tests prove disclosure acknowledgement, data isolation, hostile-input containment, queue and timeout bounds, process-group reaping, interrupted-turn recovery, locale provenance, public-source gating, log hygiene, and removal."
-  - "MCP tests prove a connector can start, read, and release a dialogue and receives untrusted structured content."
+  - "HTTP and MCP tests prove two participants can start, reply, restart the database carrier, read both turns in edge order, and independently release their own turn."
   - "A production question returns 202 promptly, remains observable by its unguessable id, and reaches a terminal answered, miss, or failed receipt while API health stays responsive."
-test: "cd form/form && ./validate.sh ../../api/app/form_recipes/public_dialogue_envelope.fk && cd ../.. && python3 -m pytest -q api/tests/test_public_dialogues.py api/tests/test_mcp_remote_no_oauth.py"
+test: "cd form/form && ./validate.sh ../../api/app/form_recipes/public_dialogue_envelope.fk ../../api/app/form_recipes/public_dialogue_thread_window.fk && ../fkwu ../../api/app/form_recipes/public_dialogue_thread_window.fk && cd ../.. && python3 -m pytest -q api/tests/test_public_dialogues.py api/tests/test_mcp_remote_no_oauth.py"
 constraints:
-  - "Form owns the six-field dialogue envelope; Python carries HTTP, bounded process attendance, and the dedicated dialogue table in the existing unified database."
-  - "One PostgreSQL advisory lease spans all API processes and replicas; each native carrier is an isolated process group whose pid is persisted, killed on timeout, and reaped before interrupted work resumes."
+  - "Form owns the six-field dialogue envelope and the connected-thread window, anchor, root, continuation, selection, and truncation verdicts; Python is the retiring carrier for HTTP, bounded process attendance, row retrieval/locking, expiry mutation, and the dedicated dialogue table."
+  - "Separate PostgreSQL advisory leases span all API processes and replicas for queued generation and thread planning; each generation carrier is an isolated process group whose pid is persisted, killed on timeout, and reaped before interrupted work resumes."
   - "A rented escalation is admitted only as an empty dialogue-lane miss; it never becomes an answer or changes the ordinary grounded-ask lane."
   - "Question text is staged only as data, never placed in a shell command or Form source, and never appears in operational logs or failure receipts."
-  - "Public visibility is unlisted-by-id, expires after seven days, and can be released earlier into a content-free tombstone with the creation-time removal capability."
+  - "Public content is unlisted-by-turn-id for v1 and unlisted-by-connected-turn-id for thread-v2, ends after seven days, and can be released earlier into a content-free tombstone with its own creation-time removal capability; v2 ids and edges persist as thread capabilities for the observable tombstone graph."
 ---
 
-# Public Dialogue CPU Organ — one observable Form-grounded turn at a time
+# Public Dialogue CPU Organ — persistent Form-grounded turns in both directions
 
 ## Purpose
 
@@ -53,16 +55,34 @@ no grounded Form-native locale projection exists.
 
 `POST /api/dialogues` accepts `question`, `point_of_view`, `locale`, optional
 `parent_dialogue_id`, `channel_timeout_seconds` from 10 through 120, and the
-literal acknowledgement `public_disclosure_ack: public-unlisted-v1`. The
-acknowledgement means anyone given the unguessable id can read the question and
-receipt. It is a disclosure statement, not proof of identity or third-party
-consent. Missing or different acknowledgement values persist no row.
+versioned acknowledgement `public_disclosure_ack`. `public-unlisted-v1` means
+anyone given the unguessable id can read only that turn's question and receipt.
+`public-unlisted-thread-v2` additionally means anyone given any connected v2
+turn id can read the bounded persistent edge and tombstone graph. A turn's text
+ends at its own release or seven-day expiry, while its id and content-free cell
+remain part of that graph and therefore remain a thread capability. These are
+disclosure statements, not proof of identity or third-party consent. Missing or
+unknown acknowledgement values persist no row, v1 rows remain single-turn-only,
+and no reply may widen a v1 parent into a v2 thread without a new explicit offer.
 
 The response is `202` with a dialogue id, poll URL, seven-day expiry, and a
 removal token shown once. `GET /api/dialogues/{id}` observes `pending`, `running`,
 `answered`, `miss`, `failed`, or `tombstoned`. There is deliberately no public
 list endpoint: an unlisted receipt becomes visible to another person only when
 someone shares its id.
+
+`POST /api/dialogues/{id}/replies` requires `public-unlisted-thread-v2` and
+fixes the parent edge from the path; a caller cannot substitute another parent
+inside the body or attach to a v1 parent. The reply is a new durable row with
+its own one-time removal capability. `GET /api/dialogues/{id}/thread` accepts
+only a v2 turn id, follows it to its root, then reads at most 128 connected turns
+in stable creation order. The response includes parent edges and content-free
+tombstones, never removal capabilities. Any connected v2 turn id is therefore
+the unlisted read capability for that whole connected thread. A self-described
+point of view remains public data, not an authenticated identity. The anchor
+and its ancestry are retained inside the bound; if ancestry alone exceeds it,
+`root_dialogue_id` is null and `continuation_parent_dialogue_id` names the next
+unobserved edge rather than mislabeling a partial window as the root.
 
 `DELETE /api/dialogues/{id}` with the removal token releases question, point of
 view, and result content. The durable row becomes a content-free tombstone so
@@ -82,12 +102,25 @@ it does not copy conversation state or attach to internal/private task ids. An
 expired or releasing parent is unavailable even before the background expiry
 sweep reaches it.
 
+Thread reads apply the same synchronous expiry boundary to every observed row
+before returning text. Dialogue rows and their parent edges live in the unified
+database, so API or worker restarts do not erase either participant's turn.
+
 ## Form shape
 
 `api/app/form_recipes/public_dialogue_envelope.fk` makes six neutral fields one
 cell: locale, point of view, question, disclosure acknowledgement, parent, and
 chosen timeout. `dialogue-offered` accepts only the disclosed, present shape.
 Its band value is `63`, including parent-turn continuity.
+
+`api/app/form_recipes/public_dialogue_thread_window.fk` receives neutral
+`[turn-id, parent-id]` cells in stable creation order plus the anchor and bound.
+Form follows ancestry, preserves the anchor, admits connected descendants while
+room remains, and returns root-or-continuation, the selected turn identities,
+and truncation. Its band value is `511`. The Python store retrieves at most one
+extra persistence row, offers those neutral cells to this recipe on `fkwu`,
+then locks and projects only the identities Form selected. Python validates the
+receipt shape but does not mint a competing topology or truncation verdict.
 
 ## CPU and restart shape
 
@@ -98,6 +131,11 @@ Each API process may host one lightweight attending thread, but a session-level
 PostgreSQL advisory lock permits only one of those threads across all processes
 and deployment replicas to claim native work. SQLite/local development uses a
 process lock and does not make a cross-host claim.
+
+Thread reads use a separate nonblocking local slot plus PostgreSQL advisory
+transaction lease. Across every API process and replica, at most one request
+may launch the fkwu thread-window recipe at a time; contention returns a
+retryable controlled receipt before another subprocess starts.
 
 The worker records the native carrier process-group id before waiting. A normal
 timeout sends TERM, then KILL when necessary, and reaps the group before writing
@@ -159,7 +197,11 @@ The remote no-auth MCP door exposes:
 
 - `start_dialogue`: non-idempotent, non-destructive, open-world write requiring
   the versioned disclosure acknowledgement;
+- `reply_dialogue`: non-idempotent write that fixes a parent edge and returns a
+  distinct removal capability for the new turn;
 - `get_dialogue`: idempotent read of an unlisted receipt by id;
+- `get_dialogue_thread`: idempotent bounded read of the connected thread named
+  by any one of its unlisted turn ids;
 - `remove_dialogue`: idempotent destructive release requiring the capability
   token.
 
@@ -178,36 +220,44 @@ capacity, source, timeout, and removal gates.
 - [x] Accept canonical BCP-47 locale tags while distinguishing locale routing from unproven input-language understanding and projection.
 - [x] Keep receipts unlisted, bounded by capacity and time, automatically expiring, and removable into content-free tombstones.
 - [x] Pace HTTP and MCP atomically across production replicas without retaining raw peer addresses.
-- [x] Expose start, get, and remove through HTTP and no-auth MCP with server-side gates and accurate annotations.
+- [x] Expose start, reply, single-turn read, bounded thread read, and remove through HTTP and no-auth MCP with server-side gates and accurate annotations.
+- [x] Persist both sides of a dialogue and its directed parent edges across a fresh database engine/API restart without exposing either removal capability.
+- [x] Execute bounded thread topology and truncation as a Form recipe on fkwu, with Go/Rust/TypeScript sibling agreement and Python retained only as the retiring SQL/HTTP carrier.
+- [x] Preserve v1 ids as single-turn-only capabilities, require a new thread-v2 acknowledgement before connected reads or replies, and bound thread-planner subprocesses across every API replica.
 
 ## Files to Create/Modify
 
 - `api/app/form_recipes/public_dialogue_envelope.fk` — Form-neutral six-field envelope.
-- `api/app/services/public_dialogue_store.py` — dedicated persistent cell and atomic claim/terminal transitions.
-- `api/app/services/dialogue_service.py` — global worker lease, public-source gate, recovery, and receipts.
-- `api/app/routers/dialogues.py` — bounded HTTP start, observation, and release membrane.
-- `api/app/routers/mcp_remote.py` — connector-visible start/get/remove tools.
+- `api/app/form_recipes/public_dialogue_thread_window.fk` — Form-native connected topology, bounded selection, continuation, and truncation.
+- `api/app/services/public_dialogue_store.py` — dedicated persistent cell, bounded thread traversal, and atomic claim/terminal transitions.
+- `api/app/services/dialogue_service.py` — global worker lease, public-source gate, thread views, recovery, and receipts.
+- `api/app/routers/dialogues.py` — bounded HTTP start/reply, observation, thread-read, and release membrane.
+- `api/app/routers/mcp_remote.py` — connector-visible start/reply/get/thread/remove tools.
 - `api/app/routers/substrate.py` — carrier start witness plus shared process-group reaper.
 - `api/tests/test_public_dialogues.py` and `api/tests/test_mcp_remote_no_oauth.py` — adversarial proof bands.
+- `api/tests/test_kernel_submodule_contract.py` — API ownership inventory for the thread-window Form recipe.
 
 ## Acceptance Tests
 
 `api/tests/test_public_dialogues.py` covers real dedicated-store persistence,
-hostile text, source disclosure, restart recovery, timeout reaping, capacity,
-locale provenance, log canaries, and removal. `api/tests/test_mcp_remote_no_oauth.py`
+hostile text, source disclosure, worker restart recovery, database restart
+persistence of both turns, timeout reaping, bounded traversal, capacity, locale
+provenance, log canaries, and removal. `api/tests/test_mcp_remote_no_oauth.py`
 covers tool discovery, annotation values, structured content, acknowledgement,
-and the complete start/read/release lifecycle.
+and the complete start/reply/thread-read/release lifecycle.
 
 Production acceptance additionally offers one Indonesian mangrove-root question,
-observes `202` before native work completes, polls the receipt to a terminal
-state, confirms `/api/health` remains responsive during native CPU use, then
-uses the returned capability to release the public content.
+replies from a second point of view, restarts the API carrier, observes both
+turns and their edge from either turn id, confirms `/api/health` remains
+responsive during native CPU use, then uses each distinct capability to release
+its own public content.
 
 ## Verification
 
 ```sh
 cd form/form && ./validate.sh ../../api/app/form_recipes/public_dialogue_envelope.fk
-form/fkwu api/app/form_recipes/public_dialogue_envelope.fk
+cd form/form && ./validate.sh ../../api/app/form_recipes/public_dialogue_thread_window.fk
+cd form/form && ../fkwu ../../api/app/form_recipes/public_dialogue_thread_window.fk
 python3 -m pytest -q api/tests/test_public_dialogues.py api/tests/test_mcp_remote_no_oauth.py
 python3 scripts/validate_spec_quality.py --file specs/public-dialogue-cpu-organ.md --strict
 git diff --check
@@ -245,6 +295,7 @@ goal: Open bounded unlisted-public Form-grounded dialogues from a chosen point o
 files_allowed:
   - specs/public-dialogue-cpu-organ.md
   - api/app/form_recipes/public_dialogue_envelope.fk
+  - api/app/form_recipes/public_dialogue_thread_window.fk
   - api/app/services/public_dialogue_store.py
   - api/app/services/dialogue_service.py
   - api/app/services/unified_models.py
@@ -255,20 +306,23 @@ files_allowed:
   - api/app/models/accessible_ontology.py
   - api/tests/test_public_dialogues.py
   - api/tests/test_mcp_remote_no_oauth.py
+  - api/tests/test_kernel_submodule_contract.py
   - specs/INDEX.md
   - api/app/routers/INDEX.md
   - api/app/services/INDEX.md
   - api/tests/INDEX.md
 done_when:
-  - Form envelope returns 63 with clean preflight and named kernel witnesses.
+  - Form envelope returns 63 and thread window returns 511 with clean source parses and named kernel witnesses.
   - Failure-oriented API and MCP gates pass.
   - Production returns 202 promptly, API health remains responsive, and the receipt becomes terminal and removable.
 commands:
   - cd form/form && ./validate.sh ../../api/app/form_recipes/public_dialogue_envelope.fk
+  - cd form/form && ./validate.sh ../../api/app/form_recipes/public_dialogue_thread_window.fk
   - python3 -m pytest -q api/tests/test_public_dialogues.py api/tests/test_mcp_remote_no_oauth.py
+  - python3 -m pytest -q api/tests/test_kernel_submodule_contract.py
   - python3 scripts/validate_spec_quality.py --file specs/public-dialogue-cpu-organ.md
 constraints:
   - Existing unified database only; no second persistence substrate.
-  - One organism-wide CPU lease; no unbounded public process fanout.
+  - Separate organism-wide generation and thread-planning leases; no unbounded public process fanout.
   - Preserve misses, source language, and locale fallbacks without invented meaning.
 ```


### PR DESCRIPTION
## Embodied movement
- add explicit HTTP and no-auth MCP reply surfaces
- add bounded connected-thread reads from any unlisted turn id
- preserve parent edges and both participant turns across database/API restart
- retain independent one-time removal capabilities without exposing them in thread reads

## Working observations
- 78 focused warning-strict dialogue/MCP tests pass
- 406 complete warning-strict API tests pass
- real SQLite close/reopen witness preserves root, reply, and directed edge
- local PR guard is clear, including maintainability and web runtime

## Honest boundary
A point-of-view label is public data, not authenticated identity. Any connected turn id is the unlisted read capability for its bounded thread.